### PR TITLE
refactor: replace endpoint permission variants with named actions

### DIFF
--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -30,8 +30,10 @@ pub use common::{
     static_user_provider_from_option, user_provider_from_option, userinfo_by_name,
 };
 pub use permission::{
-    DefaultPermissionChecker, PermissionChecker, PermissionReq, PermissionResp,
-    PermissionTableTarget, PermissionTableTargets,
+    ALL_ACTIONS, AccessMode, DASHBOARD_DELETE, DASHBOARD_QUERY, DASHBOARD_SAVE,
+    DefaultPermissionChecker, JAEGER_QUERY, PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY,
+    PermissionChecker, PermissionReq, PermissionResp, PermissionTableTarget,
+    PermissionTableTargets,
 };
 pub use user_info::UserInfo;
 pub use user_provider::static_user_provider::StaticUserProvider;

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -31,9 +31,10 @@ pub use common::{
 };
 pub use permission::{
     ALL_ACTIONS, AccessMode, DASHBOARD_DELETE, DASHBOARD_QUERY, DASHBOARD_SAVE,
-    DefaultPermissionChecker, JAEGER_QUERY, PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY,
-    PermissionChecker, PermissionReq, PermissionResp, PermissionTableTarget,
-    PermissionTableTargets,
+    DefaultPermissionChecker, INFLUXDB_WRITE, JAEGER_QUERY, LOG_QUERY, LOG_WRITE, OPENTSDB_WRITE,
+    OTLP_WRITE, PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY, PROM_STORE_READ,
+    PROM_STORE_WRITE, PROMQL_QUERY, PermissionAction, PermissionChecker, PermissionReq,
+    PermissionResp, PermissionTableTarget, PermissionTableTargets,
 };
 pub use user_info::UserInfo;
 pub use user_provider::static_user_provider::StaticUserProvider;

--- a/src/auth/src/permission.rs
+++ b/src/auth/src/permission.rs
@@ -93,6 +93,32 @@ impl PermissionTableTargets {
     }
 }
 
+/// The access mode of a named permission action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessMode {
+    Read,
+    Write,
+}
+
+pub const JAEGER_QUERY: &str = "jaeger.query";
+pub const PIPELINE_QUERY: &str = "pipeline.query";
+pub const PIPELINE_INSERT: &str = "pipeline.insert";
+pub const PIPELINE_DELETE: &str = "pipeline.delete";
+pub const DASHBOARD_QUERY: &str = "dashboard.query";
+pub const DASHBOARD_SAVE: &str = "dashboard.save";
+pub const DASHBOARD_DELETE: &str = "dashboard.delete";
+
+/// All named permission actions and their access modes.
+pub const ALL_ACTIONS: &[(&str, AccessMode)] = &[
+    (JAEGER_QUERY, AccessMode::Read),
+    (PIPELINE_QUERY, AccessMode::Read),
+    (PIPELINE_INSERT, AccessMode::Write),
+    (PIPELINE_DELETE, AccessMode::Write),
+    (DASHBOARD_QUERY, AccessMode::Read),
+    (DASHBOARD_SAVE, AccessMode::Write),
+    (DASHBOARD_DELETE, AccessMode::Write),
+];
+
 #[derive(Debug, Clone)]
 pub enum PermissionReq<'a> {
     GrpcRequest(&'a Request),
@@ -105,11 +131,8 @@ pub enum PermissionReq<'a> {
     PromStoreRead,
     Otlp,
     LogWrite,
-    JaegerQuery,
-    PipelineQuery,
-    PipelineManage,
-    DashboardQuery,
-    DashboardManage,
+    ReadAction(&'static str),
+    WriteAction(&'static str),
     BulkInsert {
         catalog: &'a str,
         schema: &'a str,
@@ -127,9 +150,7 @@ impl<'a> PermissionReq<'a> {
             PermissionReq::PromQuery
             | PermissionReq::LogQuery
             | PermissionReq::PromStoreRead
-            | PermissionReq::JaegerQuery
-            | PermissionReq::PipelineQuery
-            | PermissionReq::DashboardQuery => true,
+            | PermissionReq::ReadAction(_) => true,
             PermissionReq::SqlStatement(stmt) => stmt.is_readonly(),
 
             PermissionReq::GrpcRequest(_)
@@ -138,8 +159,7 @@ impl<'a> PermissionReq<'a> {
             | PermissionReq::PromStoreWrite
             | PermissionReq::Otlp
             | PermissionReq::LogWrite
-            | PermissionReq::PipelineManage
-            | PermissionReq::DashboardManage
+            | PermissionReq::WriteAction(_)
             | PermissionReq::BulkInsert { .. } => false,
         }
     }
@@ -500,20 +520,33 @@ mod tests {
     }
 
     #[test]
-    fn test_management_request_access_modes() {
-        for req in [
-            PermissionReq::JaegerQuery,
-            PermissionReq::PipelineQuery,
-            PermissionReq::DashboardQuery,
-        ] {
-            assert!(req.is_readonly());
-        }
+    fn test_action_access_modes() {
+        let checker = DefaultPermissionChecker;
 
-        for req in [
-            PermissionReq::PipelineManage,
-            PermissionReq::DashboardManage,
-        ] {
-            assert!(req.is_write());
+        for &(action, access_mode) in ALL_ACTIONS {
+            let req = match access_mode {
+                AccessMode::Read => PermissionReq::ReadAction(action),
+                AccessMode::Write => PermissionReq::WriteAction(action),
+            };
+            assert_eq!(
+                access_mode == AccessMode::Read,
+                req.is_readonly(),
+                "{action}"
+            );
+
+            for (permission_mode, allowed) in [
+                (PermissionMode::ReadOnly, access_mode == AccessMode::Read),
+                (PermissionMode::WriteOnly, access_mode == AccessMode::Write),
+                (PermissionMode::ReadWrite, true),
+            ] {
+                let user = DefaultUserInfo::with_name_and_permission("test_user", permission_mode);
+                let result = checker.check_permission(user, req.clone()).unwrap();
+                assert_eq!(
+                    allowed,
+                    matches!(result, PermissionResp::Allow),
+                    "{permission_mode:?}: {action}"
+                );
+            }
         }
     }
 

--- a/src/auth/src/permission.rs
+++ b/src/auth/src/permission.rs
@@ -100,7 +100,7 @@ pub enum AccessMode {
     Write,
 }
 
-/// A server-defined permission action.
+/// A named permission action.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PermissionAction {
     name: &'static str,
@@ -108,14 +108,16 @@ pub struct PermissionAction {
 }
 
 impl PermissionAction {
-    const fn read(name: &'static str) -> Self {
+    /// Creates a read action with a stable name.
+    pub const fn read(name: &'static str) -> Self {
         Self {
             name,
             access_mode: AccessMode::Read,
         }
     }
 
-    const fn write(name: &'static str) -> Self {
+    /// Creates a write action with a stable name.
+    pub const fn write(name: &'static str) -> Self {
         Self {
             name,
             access_mode: AccessMode::Write,
@@ -149,7 +151,10 @@ pub const DASHBOARD_QUERY: PermissionAction = PermissionAction::read("dashboard.
 pub const DASHBOARD_SAVE: PermissionAction = PermissionAction::write("dashboard.save");
 pub const DASHBOARD_DELETE: PermissionAction = PermissionAction::write("dashboard.delete");
 
-/// All named permission actions and their access modes.
+/// All permission actions built into GreptimeDB.
+///
+/// Downstream crates may define additional actions with [`PermissionAction::read`] and
+/// [`PermissionAction::write`].
 pub const ALL_ACTIONS: &[PermissionAction] = &[
     PROMQL_QUERY,
     LOG_QUERY,

--- a/src/auth/src/permission.rs
+++ b/src/auth/src/permission.rs
@@ -100,39 +100,79 @@ pub enum AccessMode {
     Write,
 }
 
-pub const JAEGER_QUERY: &str = "jaeger.query";
-pub const PIPELINE_QUERY: &str = "pipeline.query";
-pub const PIPELINE_INSERT: &str = "pipeline.insert";
-pub const PIPELINE_DELETE: &str = "pipeline.delete";
-pub const DASHBOARD_QUERY: &str = "dashboard.query";
-pub const DASHBOARD_SAVE: &str = "dashboard.save";
-pub const DASHBOARD_DELETE: &str = "dashboard.delete";
+/// A server-defined permission action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PermissionAction {
+    name: &'static str,
+    access_mode: AccessMode,
+}
+
+impl PermissionAction {
+    const fn read(name: &'static str) -> Self {
+        Self {
+            name,
+            access_mode: AccessMode::Read,
+        }
+    }
+
+    const fn write(name: &'static str) -> Self {
+        Self {
+            name,
+            access_mode: AccessMode::Write,
+        }
+    }
+
+    /// Returns the stable action name.
+    pub const fn name(self) -> &'static str {
+        self.name
+    }
+
+    /// Returns the action's access mode.
+    pub const fn access_mode(self) -> AccessMode {
+        self.access_mode
+    }
+}
+
+pub const PROMQL_QUERY: PermissionAction = PermissionAction::read("promql.query");
+pub const LOG_QUERY: PermissionAction = PermissionAction::read("log.query");
+pub const OPENTSDB_WRITE: PermissionAction = PermissionAction::write("opentsdb.write");
+pub const INFLUXDB_WRITE: PermissionAction = PermissionAction::write("influxdb.write");
+pub const PROM_STORE_WRITE: PermissionAction = PermissionAction::write("prom_store.write");
+pub const PROM_STORE_READ: PermissionAction = PermissionAction::read("prom_store.read");
+pub const OTLP_WRITE: PermissionAction = PermissionAction::write("otlp.write");
+pub const LOG_WRITE: PermissionAction = PermissionAction::write("log.write");
+pub const JAEGER_QUERY: PermissionAction = PermissionAction::read("jaeger.query");
+pub const PIPELINE_QUERY: PermissionAction = PermissionAction::read("pipeline.query");
+pub const PIPELINE_INSERT: PermissionAction = PermissionAction::write("pipeline.insert");
+pub const PIPELINE_DELETE: PermissionAction = PermissionAction::write("pipeline.delete");
+pub const DASHBOARD_QUERY: PermissionAction = PermissionAction::read("dashboard.query");
+pub const DASHBOARD_SAVE: PermissionAction = PermissionAction::write("dashboard.save");
+pub const DASHBOARD_DELETE: PermissionAction = PermissionAction::write("dashboard.delete");
 
 /// All named permission actions and their access modes.
-pub const ALL_ACTIONS: &[(&str, AccessMode)] = &[
-    (JAEGER_QUERY, AccessMode::Read),
-    (PIPELINE_QUERY, AccessMode::Read),
-    (PIPELINE_INSERT, AccessMode::Write),
-    (PIPELINE_DELETE, AccessMode::Write),
-    (DASHBOARD_QUERY, AccessMode::Read),
-    (DASHBOARD_SAVE, AccessMode::Write),
-    (DASHBOARD_DELETE, AccessMode::Write),
+pub const ALL_ACTIONS: &[PermissionAction] = &[
+    PROMQL_QUERY,
+    LOG_QUERY,
+    OPENTSDB_WRITE,
+    INFLUXDB_WRITE,
+    PROM_STORE_WRITE,
+    PROM_STORE_READ,
+    OTLP_WRITE,
+    LOG_WRITE,
+    JAEGER_QUERY,
+    PIPELINE_QUERY,
+    PIPELINE_INSERT,
+    PIPELINE_DELETE,
+    DASHBOARD_QUERY,
+    DASHBOARD_SAVE,
+    DASHBOARD_DELETE,
 ];
 
 #[derive(Debug, Clone)]
 pub enum PermissionReq<'a> {
     GrpcRequest(&'a Request),
     SqlStatement(&'a Statement),
-    PromQuery,
-    LogQuery,
-    Opentsdb,
-    LineProtocol,
-    PromStoreWrite,
-    PromStoreRead,
-    Otlp,
-    LogWrite,
-    ReadAction(&'static str),
-    WriteAction(&'static str),
+    Action(PermissionAction),
     BulkInsert {
         catalog: &'a str,
         schema: &'a str,
@@ -147,20 +187,10 @@ impl<'a> PermissionReq<'a> {
             PermissionReq::GrpcRequest(Request::Query(query_request)) => {
                 !matches!(query_request.query, Some(Query::InsertIntoPlan(_)))
             }
-            PermissionReq::PromQuery
-            | PermissionReq::LogQuery
-            | PermissionReq::PromStoreRead
-            | PermissionReq::ReadAction(_) => true,
             PermissionReq::SqlStatement(stmt) => stmt.is_readonly(),
+            PermissionReq::Action(action) => action.access_mode() == AccessMode::Read,
 
-            PermissionReq::GrpcRequest(_)
-            | PermissionReq::Opentsdb
-            | PermissionReq::LineProtocol
-            | PermissionReq::PromStoreWrite
-            | PermissionReq::Otlp
-            | PermissionReq::LogWrite
-            | PermissionReq::WriteAction(_)
-            | PermissionReq::BulkInsert { .. } => false,
+            PermissionReq::GrpcRequest(_) | PermissionReq::BulkInsert { .. } => false,
         }
     }
 
@@ -329,6 +359,8 @@ impl PermissionChecker for DefaultPermissionChecker {
 }
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
     use crate::error::{Error, InternalStateSnafu};
     use crate::user_info::PermissionMode;
@@ -350,7 +382,7 @@ mod tests {
             req: PermissionReq,
             targets: PermissionTableTargets,
         ) -> Result<PermissionResp> {
-            if !matches!(req, PermissionReq::PromStoreRead) {
+            if !matches!(req, PermissionReq::Action(PROM_STORE_READ)) {
                 return Ok(PermissionResp::Reject);
             }
             let PermissionTableTargets::Resolved(targets) = targets else {
@@ -450,8 +482,8 @@ mod tests {
         let user_info =
             DefaultUserInfo::with_name_and_permission("test_user", PermissionMode::ReadWrite);
 
-        let read_req = PermissionReq::PromQuery;
-        let write_req = PermissionReq::PromStoreWrite;
+        let read_req = PermissionReq::Action(PROMQL_QUERY);
+        let write_req = PermissionReq::Action(PROM_STORE_WRITE);
 
         let read_result = checker
             .check_permission(user_info.clone(), read_req)
@@ -468,8 +500,8 @@ mod tests {
         let user_info =
             DefaultUserInfo::with_name_and_permission("readonly_user", PermissionMode::ReadOnly);
 
-        let read_req = PermissionReq::PromQuery;
-        let write_req = PermissionReq::PromStoreWrite;
+        let read_req = PermissionReq::Action(PROMQL_QUERY);
+        let write_req = PermissionReq::Action(PROM_STORE_WRITE);
 
         let read_result = checker
             .check_permission(user_info.clone(), read_req)
@@ -486,8 +518,8 @@ mod tests {
         let user_info =
             DefaultUserInfo::with_name_and_permission("writeonly_user", PermissionMode::WriteOnly);
 
-        let read_req = PermissionReq::LogQuery;
-        let write_req = PermissionReq::LogWrite;
+        let read_req = PermissionReq::Action(LOG_QUERY);
+        let write_req = PermissionReq::Action(LOG_WRITE);
 
         let read_result = checker
             .check_permission(user_info.clone(), read_req)
@@ -522,16 +554,21 @@ mod tests {
     #[test]
     fn test_action_access_modes() {
         let checker = DefaultPermissionChecker;
+        let mut names = HashSet::new();
 
-        for &(action, access_mode) in ALL_ACTIONS {
-            let req = match access_mode {
-                AccessMode::Read => PermissionReq::ReadAction(action),
-                AccessMode::Write => PermissionReq::WriteAction(action),
-            };
+        for &action in ALL_ACTIONS {
+            assert!(
+                names.insert(action.name()),
+                "duplicate permission action: {}",
+                action.name()
+            );
+            let access_mode = action.access_mode();
+            let req = PermissionReq::Action(action);
             assert_eq!(
                 access_mode == AccessMode::Read,
                 req.is_readonly(),
-                "{action}"
+                "{}",
+                action.name()
             );
 
             for (permission_mode, allowed) in [
@@ -544,7 +581,8 @@ mod tests {
                 assert_eq!(
                     allowed,
                     matches!(result, PermissionResp::Allow),
-                    "{permission_mode:?}: {action}"
+                    "{permission_mode:?}: {}",
+                    action.name()
                 );
             }
         }
@@ -559,7 +597,7 @@ mod tests {
         let allowed = checker
             .check_permission_with_table_targets(
                 crate::userinfo_by_name(None),
-                PermissionReq::PromStoreRead,
+                PermissionReq::Action(PROM_STORE_READ),
                 resolved_targets("allowed"),
             )
             .unwrap();
@@ -568,7 +606,7 @@ mod tests {
         let empty = checker
             .check_permission_with_table_targets(
                 crate::userinfo_by_name(None),
-                PermissionReq::PromStoreRead,
+                PermissionReq::Action(PROM_STORE_READ),
                 PermissionTableTargets::resolved(Vec::new()),
             )
             .unwrap();
@@ -576,7 +614,7 @@ mod tests {
 
         let rejected_operation = checker.check_permission_with_table_targets(
             crate::userinfo_by_name(None),
-            PermissionReq::PromStoreWrite,
+            PermissionReq::Action(PROM_STORE_WRITE),
             PermissionTableTargets::resolved(Vec::new()),
         );
         assert!(matches!(
@@ -586,14 +624,14 @@ mod tests {
 
         let rejected = checker.check_permission_with_table_targets(
             crate::userinfo_by_name(None),
-            PermissionReq::PromStoreRead,
+            PermissionReq::Action(PROM_STORE_READ),
             resolved_targets("denied"),
         );
         assert!(matches!(rejected, Err(Error::PermissionDenied { .. })));
 
         let mixed = checker.check_permission_with_table_targets(
             crate::userinfo_by_name(None),
-            PermissionReq::PromStoreRead,
+            PermissionReq::Action(PROM_STORE_READ),
             PermissionTableTargets::resolved(vec![
                 PermissionTableTarget::new("greptime", "public", "allowed"),
                 PermissionTableTarget::new("greptime", "public", "denied"),
@@ -603,7 +641,7 @@ mod tests {
 
         let error = checker.check_permission_with_table_targets(
             crate::userinfo_by_name(None),
-            PermissionReq::PromStoreRead,
+            PermissionReq::Action(PROM_STORE_READ),
             resolved_targets("error"),
         );
         assert!(matches!(error, Err(Error::InternalState { msg }) if msg == "testing"));
@@ -613,7 +651,7 @@ mod tests {
         let allowed = no_checker
             .check_permission_with_table_targets(
                 crate::userinfo_by_name(None),
-                PermissionReq::PromStoreRead,
+                PermissionReq::Action(PROM_STORE_READ),
                 PermissionTableTargets::Unresolved,
             )
             .unwrap();
@@ -626,10 +664,22 @@ mod tests {
         assert!(!checker.uses_table_targets());
 
         for (permission, req) in [
-            (PermissionMode::ReadOnly, PermissionReq::PromQuery),
-            (PermissionMode::ReadOnly, PermissionReq::PromStoreWrite),
-            (PermissionMode::WriteOnly, PermissionReq::PromQuery),
-            (PermissionMode::WriteOnly, PermissionReq::PromStoreWrite),
+            (
+                PermissionMode::ReadOnly,
+                PermissionReq::Action(PROMQL_QUERY),
+            ),
+            (
+                PermissionMode::ReadOnly,
+                PermissionReq::Action(PROM_STORE_WRITE),
+            ),
+            (
+                PermissionMode::WriteOnly,
+                PermissionReq::Action(PROMQL_QUERY),
+            ),
+            (
+                PermissionMode::WriteOnly,
+                PermissionReq::Action(PROM_STORE_WRITE),
+            ),
         ] {
             let user = DefaultUserInfo::with_name_and_permission("test_user", permission);
             let direct = checker.check_permission(user.clone(), req.clone()).unwrap();

--- a/src/auth/tests/mod.rs
+++ b/src/auth/tests/mod.rs
@@ -19,11 +19,14 @@ use api::v1::greptime_request::Request;
 use auth::error::Error::InternalState;
 use auth::error::InternalStateSnafu;
 use auth::{
-    OPENTSDB_WRITE, PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionResp,
-    PermissionTableTargets, UserInfoRef,
+    AccessMode, OPENTSDB_WRITE, PermissionAction, PermissionChecker, PermissionCheckerRef,
+    PermissionReq, PermissionResp, PermissionTableTargets, UserInfoRef,
 };
 use sql::statements::show::{ShowDatabases, ShowKind};
 use sql::statements::statement::Statement;
+
+const DOWNSTREAM_QUERY: PermissionAction = PermissionAction::read("downstream.query");
+const DOWNSTREAM_WRITE: PermissionAction = PermissionAction::write("downstream.write");
 
 struct DummyPermissionChecker;
 
@@ -77,4 +80,15 @@ fn test_permission_checker() {
         PermissionReq::Action(OPENTSDB_WRITE),
     );
     assert_matches!(err_result, Err(InternalState { msg }) if msg == "testing");
+}
+
+#[test]
+fn test_downstream_can_define_permission_actions() {
+    assert_eq!("downstream.query", DOWNSTREAM_QUERY.name());
+    assert_eq!(AccessMode::Read, DOWNSTREAM_QUERY.access_mode());
+    assert!(PermissionReq::Action(DOWNSTREAM_QUERY).is_readonly());
+
+    assert_eq!("downstream.write", DOWNSTREAM_WRITE.name());
+    assert_eq!(AccessMode::Write, DOWNSTREAM_WRITE.access_mode());
+    assert!(PermissionReq::Action(DOWNSTREAM_WRITE).is_write());
 }

--- a/src/auth/tests/mod.rs
+++ b/src/auth/tests/mod.rs
@@ -19,8 +19,8 @@ use api::v1::greptime_request::Request;
 use auth::error::Error::InternalState;
 use auth::error::InternalStateSnafu;
 use auth::{
-    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionResp, PermissionTableTargets,
-    UserInfoRef,
+    OPENTSDB_WRITE, PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionResp,
+    PermissionTableTargets, UserInfoRef,
 };
 use sql::statements::show::{ShowDatabases, ShowKind};
 use sql::statements::statement::Statement;
@@ -72,7 +72,9 @@ fn test_permission_checker() {
     );
     assert_matches!(sql_result, Ok(PermissionResp::Reject));
 
-    let err_result =
-        checker.check_permission(auth::userinfo_by_name(None), PermissionReq::Opentsdb);
+    let err_result = checker.check_permission(
+        auth::userinfo_by_name(None),
+        PermissionReq::Action(OPENTSDB_WRITE),
+    );
     assert_matches!(err_result, Err(InternalState { msg }) if msg == "testing");
 }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -1667,9 +1667,13 @@ mod tests {
     use api::prom_store::remote::label_matcher::Type as PromMatcherType;
     use api::prom_store::remote::{LabelMatcher, Query as RemoteQuery, ReadRequest};
     use api::v1::meta::{ProcedureDetailResponse, ReconcileRequest, ReconcileResponse};
-    use auth::{PermissionResp, UserInfoRef};
+    use auth::{
+        AccessMode, DASHBOARD_DELETE, DASHBOARD_QUERY, DASHBOARD_SAVE, JAEGER_QUERY,
+        PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY, PermissionResp, UserInfoRef,
+    };
     use catalog::process_manager::{ProcessManager, QueryStatement, SlowQueryTimer};
     use common_base::Plugins;
+    use common_catalog::consts::DEFAULT_PRIVATE_SCHEMA_NAME;
     use common_error::ext::{BoxedError, PlainError};
     use common_error::status_code::StatusCode;
     use common_event_recorder::{Event, EventRecorder, EventTypeFilter, EventTypeFilterRef};
@@ -1692,11 +1696,11 @@ mod tests {
     use datafusion_expr::{LogicalPlanBuilder, LogicalTableSource};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema as GtSchema, SchemaRef as GtSchemaRef};
-    use datatypes::vectors::{StringVector, VectorRef};
+    use datatypes::vectors::{StringVector, TimestampNanosecondVector, VectorRef};
     use log_query::LogQuery;
     use query::query_engine::options::QueryOptions;
     use servers::query_handler::{
-        DashboardHandler, JaegerQueryHandler, LogQueryHandler, PipelineHandler,
+        DashboardHandler, JaegerQueryHandler, LogQueryHandler, PipelineHandler, PipelineHandlerRef,
         PromStoreProtocolHandler,
     };
     use session::context::{Channel, ConnInfo, QueryContext, QueryContextBuilder};
@@ -1952,7 +1956,39 @@ mod tests {
         }
     }
 
-    struct RejectEndpointPermissionChecker;
+    #[derive(Debug, PartialEq, Eq)]
+    struct CheckedAction {
+        access_mode: AccessMode,
+        action: &'static str,
+        targets: Option<PermissionTableTargets>,
+    }
+
+    #[derive(Default)]
+    struct RejectEndpointPermissionChecker {
+        checks: std::sync::Mutex<Vec<CheckedAction>>,
+    }
+
+    impl RejectEndpointPermissionChecker {
+        fn reject(
+            &self,
+            access_mode: AccessMode,
+            action: &'static str,
+            targets: Option<PermissionTableTargets>,
+        ) -> PermissionResp {
+            self.checks.lock().unwrap().push(CheckedAction {
+                access_mode,
+                action,
+                targets,
+            });
+            PermissionResp::Reject
+        }
+
+        fn take_check(&self) -> CheckedAction {
+            let mut checks = self.checks.lock().unwrap();
+            assert_eq!(1, checks.len());
+            checks.pop().unwrap()
+        }
+    }
 
     impl PermissionChecker for RejectEndpointPermissionChecker {
         fn check_permission(
@@ -1960,43 +1996,53 @@ mod tests {
             _user_info: UserInfoRef,
             req: PermissionReq,
         ) -> auth::error::Result<PermissionResp> {
-            Ok(
-                if matches!(
-                    req,
-                    PermissionReq::PipelineQuery
-                        | PermissionReq::PipelineManage
-                        | PermissionReq::DashboardQuery
-                        | PermissionReq::DashboardManage
-                ) {
-                    PermissionResp::Reject
-                } else {
-                    PermissionResp::Allow
-                },
-            )
+            Ok(match req {
+                PermissionReq::ReadAction(action) => self.reject(AccessMode::Read, action, None),
+                PermissionReq::WriteAction(action) => self.reject(AccessMode::Write, action, None),
+                _ => PermissionResp::Allow,
+            })
+        }
+
+        fn check_permission_with_table_targets(
+            &self,
+            _user_info: UserInfoRef,
+            req: PermissionReq,
+            targets: PermissionTableTargets,
+        ) -> auth::error::Result<PermissionResp> {
+            Ok(match req {
+                PermissionReq::ReadAction(action) => {
+                    self.reject(AccessMode::Read, action, Some(targets))
+                }
+                PermissionReq::WriteAction(action) => {
+                    self.reject(AccessMode::Write, action, Some(targets))
+                }
+                _ => PermissionResp::Allow,
+            })
+        }
+    }
+
+    struct WriteOnlyPermissionChecker;
+
+    impl PermissionChecker for WriteOnlyPermissionChecker {
+        fn check_permission(
+            &self,
+            _user_info: UserInfoRef,
+            req: PermissionReq,
+        ) -> auth::error::Result<PermissionResp> {
+            Ok(if req.is_readonly() {
+                PermissionResp::Reject
+            } else {
+                PermissionResp::Allow
+            })
         }
 
         fn check_permission_with_table_targets(
             &self,
             user_info: UserInfoRef,
             req: PermissionReq,
-            targets: PermissionTableTargets,
+            _targets: PermissionTableTargets,
         ) -> auth::error::Result<PermissionResp> {
-            match req {
-                PermissionReq::JaegerQuery => {
-                    let reject = match targets {
-                        PermissionTableTargets::Unresolved => true,
-                        PermissionTableTargets::Resolved(targets) => {
-                            targets.iter().any(|target| target.table == "denied")
-                        }
-                    };
-                    Ok(if reject {
-                        PermissionResp::Reject
-                    } else {
-                        PermissionResp::Allow
-                    })
-                }
-                req => self.check_permission(user_info, req),
-            }
+            self.check_permission(user_info, req)
         }
     }
 
@@ -2354,6 +2400,38 @@ mod tests {
         )
     }
 
+    fn test_pipeline_table() -> TableRef {
+        let schema = Arc::new(GtSchema::new(vec![
+            ColumnSchema::new("name", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("schema", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("content_type", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("pipeline", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(
+                "created_at",
+                ConcreteDataType::timestamp_nanosecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+        ]));
+        let columns: Vec<VectorRef> = vec![
+            Arc::new(StringVector::from(vec!["pipeline"])),
+            Arc::new(StringVector::from(vec!["public"])),
+            Arc::new(StringVector::from(vec!["application/yaml"])),
+            Arc::new(StringVector::from(vec![
+                "transform:\n- field: ts\n  type: timestamp, ns\n  index: time\n",
+            ])),
+            Arc::new(TimestampNanosecondVector::from_values([1])),
+        ];
+        let record_batch = RecordBatch::new(schema, columns).unwrap();
+        MemTable::new_with_catalog(
+            "pipelines",
+            record_batch,
+            2049,
+            "greptime".to_string(),
+            DEFAULT_PRIVATE_SCHEMA_NAME.to_string(),
+        )
+    }
+
     fn pending_table(
         table_id: u32,
         table_name: &str,
@@ -2485,6 +2563,22 @@ mod tests {
         assert_eq!(StatusCode::PermissionDenied, err.status_code());
     }
 
+    fn assert_action_checked(
+        checker: &RejectEndpointPermissionChecker,
+        access_mode: AccessMode,
+        action: &'static str,
+        targets: Option<PermissionTableTargets>,
+    ) {
+        assert_eq!(
+            CheckedAction {
+                access_mode,
+                action,
+                targets,
+            },
+            checker.take_check()
+        );
+    }
+
     #[tokio::test]
     async fn test_event_recorder_is_exposed() -> TestResult<()> {
         let instance =
@@ -2498,8 +2592,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_restricted_endpoint_handlers_check_permissions() -> TestResult<()> {
+        let checker = Arc::new(RejectEndpointPermissionChecker::default());
         let plugins = Plugins::new();
-        plugins.insert::<PermissionCheckerRef>(Arc::new(RejectEndpointPermissionChecker));
+        plugins.insert::<PermissionCheckerRef>(checker.clone());
         let instance = test_instance_with_plugins(
             test_table(1024, "denied")?,
             test_table(1025, "target")?,
@@ -2511,13 +2606,34 @@ mod tests {
             servers::http::jaeger::JAEGER_QUERY_TABLE_NAME_KEY,
             "denied".to_string(),
         );
+        let jaeger_targets = Some(PermissionTableTargets::resolved(vec![
+            PermissionTableTarget::new("greptime", "public", "denied"),
+        ]));
 
         assert_permission_denied(JaegerQueryHandler::get_services(&instance, ctx.clone()).await);
+        assert_action_checked(
+            &checker,
+            AccessMode::Read,
+            JAEGER_QUERY,
+            jaeger_targets.clone(),
+        );
         assert_permission_denied(
             JaegerQueryHandler::get_operations(&instance, ctx.clone(), "service", None).await,
         );
+        assert_action_checked(
+            &checker,
+            AccessMode::Read,
+            JAEGER_QUERY,
+            jaeger_targets.clone(),
+        );
         assert_permission_denied(
             JaegerQueryHandler::get_trace(&instance, ctx.clone(), "trace", None, None, None).await,
+        );
+        assert_action_checked(
+            &checker,
+            AccessMode::Read,
+            JAEGER_QUERY,
+            jaeger_targets.clone(),
         );
         assert_permission_denied(
             JaegerQueryHandler::find_traces(
@@ -2530,10 +2646,12 @@ mod tests {
             )
             .await,
         );
+        assert_action_checked(&checker, AccessMode::Read, JAEGER_QUERY, jaeger_targets);
 
         assert_permission_denied(
             PipelineHandler::get_pipeline_str(&instance, "pipeline", None, ctx.clone()).await,
         );
+        assert_action_checked(&checker, AccessMode::Read, PIPELINE_QUERY, None);
         assert_permission_denied(
             PipelineHandler::insert_pipeline(
                 &instance,
@@ -2544,9 +2662,11 @@ mod tests {
             )
             .await,
         );
+        assert_action_checked(&checker, AccessMode::Write, PIPELINE_INSERT, None);
         assert_permission_denied(
             PipelineHandler::delete_pipeline(&instance, "pipeline", None, ctx.clone()).await,
         );
+        assert_action_checked(&checker, AccessMode::Write, PIPELINE_DELETE, None);
         let app = axum::Router::new()
             .route(
                 "/pipelines/_dryrun",
@@ -2568,14 +2688,79 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(axum::http::StatusCode::FORBIDDEN, response.status());
+        assert_action_checked(&checker, AccessMode::Read, PIPELINE_QUERY, None);
 
         assert_permission_denied(
             DashboardHandler::save(&instance, "dashboard", "{}", ctx.clone()).await,
         );
+        assert_action_checked(&checker, AccessMode::Write, DASHBOARD_SAVE, None);
         assert_permission_denied(DashboardHandler::list(&instance, ctx.clone()).await);
+        assert_action_checked(&checker, AccessMode::Read, DASHBOARD_QUERY, None);
         assert_permission_denied(
             DashboardHandler::delete(&instance, "dashboard", ctx.clone()).await,
         );
+        assert_action_checked(&checker, AccessMode::Write, DASHBOARD_DELETE, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_only_ingestion_loads_named_pipeline() -> TestResult<()> {
+        let plugins = Plugins::new();
+        plugins.insert::<PermissionCheckerRef>(Arc::new(WriteOnlyPermissionChecker));
+        let instance = test_instance_with_plugins(
+            test_table(1024, "source")?,
+            test_table(1025, "target")?,
+            plugins,
+        )
+        .await?;
+        instance
+            .catalog_manager()
+            .as_any()
+            .downcast_ref::<catalog::memory::MemoryCatalogManager>()
+            .unwrap()
+            .register_table_sync(catalog::RegisterTableRequest {
+                catalog: "greptime".to_string(),
+                schema: DEFAULT_PRIVATE_SCHEMA_NAME.to_string(),
+                table_name: "pipelines".to_string(),
+                table_id: 2049,
+                table: test_pipeline_table(),
+            })
+            .with_context(|_| RegisterTableSnafu {
+                table_name: "pipelines".to_string(),
+            })?;
+        let ctx = test_query_ctx(1);
+        let handler: PipelineHandlerRef = Arc::new(instance.clone());
+
+        handler
+            .get_pipeline("pipeline", None, ctx.clone())
+            .await
+            .unwrap();
+        assert_permission_denied(
+            PipelineHandler::get_pipeline_str(&instance, "pipeline", None, ctx.clone()).await,
+        );
+
+        let app = axum::Router::new()
+            .route(
+                "/pipelines/_dryrun",
+                axum::routing::post(servers::http::event::pipeline_dryrun),
+            )
+            .with_state(servers::http::event::LogState {
+                log_handler: handler,
+                log_validator: None,
+                ingest_interceptor: None,
+            })
+            .layer(axum::Extension((*ctx).clone()));
+        let response = app
+            .oneshot(
+                axum::http::Request::post("/pipelines/_dryrun")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(axum::http::StatusCode::FORBIDDEN, response.status());
 
         Ok(())
     }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -35,7 +35,7 @@ use std::time::{Duration, SystemTime};
 use async_stream::stream;
 use async_trait::async_trait;
 use auth::{
-    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    PROMQL_QUERY, PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
     PermissionTableTargets,
 };
 use catalog::CatalogManagerRef;
@@ -1067,7 +1067,10 @@ impl Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(query_ctx.current_user(), PermissionReq::PromQuery)
+            .check_permission(
+                query_ctx.current_user(),
+                PermissionReq::Action(PROMQL_QUERY),
+            )
             .context(AuthSnafu)?;
         Ok(())
     }
@@ -1319,7 +1322,7 @@ impl PrometheusHandler for Instance {
         let targets = self
             .resolve_query_permission_targets(targets, query_ctx)
             .await?;
-        self.check_table_permission(query_ctx, PermissionReq::PromQuery, targets)
+        self.check_table_permission(query_ctx, PermissionReq::Action(PROMQL_QUERY), targets)
             .context(AuthSnafu)?;
         Ok(())
     }
@@ -1341,7 +1344,7 @@ impl PrometheusHandler for Instance {
                 .as_ref()
                 .check_permission_with_table_targets(
                     query_ctx.current_user(),
-                    PermissionReq::PromQuery,
+                    PermissionReq::Action(PROMQL_QUERY),
                     PermissionTableTargets::resolved(vec![target]),
                 )
                 .context(AuthSnafu);
@@ -1365,7 +1368,7 @@ impl PrometheusHandler for Instance {
                 .as_ref()
                 .check_permission_with_table_targets(
                     query_ctx.current_user(),
-                    PermissionReq::PromQuery,
+                    PermissionReq::Action(PROMQL_QUERY),
                     PermissionTableTargets::resolved(vec![target]),
                 )
                 .context(AuthSnafu)
@@ -1668,8 +1671,8 @@ mod tests {
     use api::prom_store::remote::{LabelMatcher, Query as RemoteQuery, ReadRequest};
     use api::v1::meta::{ProcedureDetailResponse, ReconcileRequest, ReconcileResponse};
     use auth::{
-        AccessMode, DASHBOARD_DELETE, DASHBOARD_QUERY, DASHBOARD_SAVE, JAEGER_QUERY,
-        PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY, PermissionResp, UserInfoRef,
+        DASHBOARD_DELETE, DASHBOARD_QUERY, DASHBOARD_SAVE, JAEGER_QUERY, PIPELINE_DELETE,
+        PIPELINE_INSERT, PIPELINE_QUERY, PermissionAction, PermissionResp, UserInfoRef,
     };
     use catalog::process_manager::{ProcessManager, QueryStatement, SlowQueryTimer};
     use common_base::Plugins;
@@ -1958,8 +1961,7 @@ mod tests {
 
     #[derive(Debug, PartialEq, Eq)]
     struct CheckedAction {
-        access_mode: AccessMode,
-        action: &'static str,
+        action: PermissionAction,
         targets: Option<PermissionTableTargets>,
     }
 
@@ -1971,15 +1973,13 @@ mod tests {
     impl RejectEndpointPermissionChecker {
         fn reject(
             &self,
-            access_mode: AccessMode,
-            action: &'static str,
+            action: PermissionAction,
             targets: Option<PermissionTableTargets>,
         ) -> PermissionResp {
-            self.checks.lock().unwrap().push(CheckedAction {
-                access_mode,
-                action,
-                targets,
-            });
+            self.checks
+                .lock()
+                .unwrap()
+                .push(CheckedAction { action, targets });
             PermissionResp::Reject
         }
 
@@ -1997,8 +1997,7 @@ mod tests {
             req: PermissionReq,
         ) -> auth::error::Result<PermissionResp> {
             Ok(match req {
-                PermissionReq::ReadAction(action) => self.reject(AccessMode::Read, action, None),
-                PermissionReq::WriteAction(action) => self.reject(AccessMode::Write, action, None),
+                PermissionReq::Action(action) => self.reject(action, None),
                 _ => PermissionResp::Allow,
             })
         }
@@ -2010,12 +2009,7 @@ mod tests {
             targets: PermissionTableTargets,
         ) -> auth::error::Result<PermissionResp> {
             Ok(match req {
-                PermissionReq::ReadAction(action) => {
-                    self.reject(AccessMode::Read, action, Some(targets))
-                }
-                PermissionReq::WriteAction(action) => {
-                    self.reject(AccessMode::Write, action, Some(targets))
-                }
+                PermissionReq::Action(action) => self.reject(action, Some(targets)),
                 _ => PermissionResp::Allow,
             })
         }
@@ -2565,18 +2559,10 @@ mod tests {
 
     fn assert_action_checked(
         checker: &RejectEndpointPermissionChecker,
-        access_mode: AccessMode,
-        action: &'static str,
+        action: PermissionAction,
         targets: Option<PermissionTableTargets>,
     ) {
-        assert_eq!(
-            CheckedAction {
-                access_mode,
-                action,
-                targets,
-            },
-            checker.take_check()
-        );
+        assert_eq!(CheckedAction { action, targets }, checker.take_check());
     }
 
     #[tokio::test]
@@ -2611,30 +2597,15 @@ mod tests {
         ]));
 
         assert_permission_denied(JaegerQueryHandler::get_services(&instance, ctx.clone()).await);
-        assert_action_checked(
-            &checker,
-            AccessMode::Read,
-            JAEGER_QUERY,
-            jaeger_targets.clone(),
-        );
+        assert_action_checked(&checker, JAEGER_QUERY, jaeger_targets.clone());
         assert_permission_denied(
             JaegerQueryHandler::get_operations(&instance, ctx.clone(), "service", None).await,
         );
-        assert_action_checked(
-            &checker,
-            AccessMode::Read,
-            JAEGER_QUERY,
-            jaeger_targets.clone(),
-        );
+        assert_action_checked(&checker, JAEGER_QUERY, jaeger_targets.clone());
         assert_permission_denied(
             JaegerQueryHandler::get_trace(&instance, ctx.clone(), "trace", None, None, None).await,
         );
-        assert_action_checked(
-            &checker,
-            AccessMode::Read,
-            JAEGER_QUERY,
-            jaeger_targets.clone(),
-        );
+        assert_action_checked(&checker, JAEGER_QUERY, jaeger_targets.clone());
         assert_permission_denied(
             JaegerQueryHandler::find_traces(
                 &instance,
@@ -2646,12 +2617,12 @@ mod tests {
             )
             .await,
         );
-        assert_action_checked(&checker, AccessMode::Read, JAEGER_QUERY, jaeger_targets);
+        assert_action_checked(&checker, JAEGER_QUERY, jaeger_targets);
 
         assert_permission_denied(
             PipelineHandler::get_pipeline_str(&instance, "pipeline", None, ctx.clone()).await,
         );
-        assert_action_checked(&checker, AccessMode::Read, PIPELINE_QUERY, None);
+        assert_action_checked(&checker, PIPELINE_QUERY, None);
         assert_permission_denied(
             PipelineHandler::insert_pipeline(
                 &instance,
@@ -2662,11 +2633,11 @@ mod tests {
             )
             .await,
         );
-        assert_action_checked(&checker, AccessMode::Write, PIPELINE_INSERT, None);
+        assert_action_checked(&checker, PIPELINE_INSERT, None);
         assert_permission_denied(
             PipelineHandler::delete_pipeline(&instance, "pipeline", None, ctx.clone()).await,
         );
-        assert_action_checked(&checker, AccessMode::Write, PIPELINE_DELETE, None);
+        assert_action_checked(&checker, PIPELINE_DELETE, None);
         let app = axum::Router::new()
             .route(
                 "/pipelines/_dryrun",
@@ -2688,18 +2659,18 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(axum::http::StatusCode::FORBIDDEN, response.status());
-        assert_action_checked(&checker, AccessMode::Read, PIPELINE_QUERY, None);
+        assert_action_checked(&checker, PIPELINE_QUERY, None);
 
         assert_permission_denied(
             DashboardHandler::save(&instance, "dashboard", "{}", ctx.clone()).await,
         );
-        assert_action_checked(&checker, AccessMode::Write, DASHBOARD_SAVE, None);
+        assert_action_checked(&checker, DASHBOARD_SAVE, None);
         assert_permission_denied(DashboardHandler::list(&instance, ctx.clone()).await);
-        assert_action_checked(&checker, AccessMode::Read, DASHBOARD_QUERY, None);
+        assert_action_checked(&checker, DASHBOARD_QUERY, None);
         assert_permission_denied(
             DashboardHandler::delete(&instance, "dashboard", ctx.clone()).await,
         );
-        assert_action_checked(&checker, AccessMode::Write, DASHBOARD_DELETE, None);
+        assert_action_checked(&checker, DASHBOARD_DELETE, None);
 
         Ok(())
     }

--- a/src/frontend/src/instance/dashboard.rs
+++ b/src/frontend/src/instance/dashboard.rs
@@ -393,17 +393,17 @@ impl servers::query_handler::DashboardHandler for Instance {
         definition: &str,
         ctx: QueryContextRef,
     ) -> servers::error::Result<()> {
-        self.check_permission(&ctx, PermissionReq::WriteAction(DASHBOARD_SAVE))?;
+        self.check_permission(&ctx, PermissionReq::Action(DASHBOARD_SAVE))?;
         self.insert_dashboard(name, definition, ctx).await
     }
 
     async fn list(&self, ctx: QueryContextRef) -> servers::error::Result<Vec<DashboardDefinition>> {
-        self.check_permission(&ctx, PermissionReq::ReadAction(DASHBOARD_QUERY))?;
+        self.check_permission(&ctx, PermissionReq::Action(DASHBOARD_QUERY))?;
         self.list_dashboards(ctx).await
     }
 
     async fn delete(&self, name: &str, ctx: QueryContextRef) -> servers::error::Result<()> {
-        self.check_permission(&ctx, PermissionReq::WriteAction(DASHBOARD_DELETE))?;
+        self.check_permission(&ctx, PermissionReq::Action(DASHBOARD_DELETE))?;
         self.delete_dashboard(name, ctx).await
     }
 }

--- a/src/frontend/src/instance/dashboard.rs
+++ b/src/frontend/src/instance/dashboard.rs
@@ -21,7 +21,7 @@ use api::v1::{
     RowInsertRequests, Rows, SemanticType,
 };
 use async_trait::async_trait;
-use auth::PermissionReq;
+use auth::{DASHBOARD_DELETE, DASHBOARD_QUERY, DASHBOARD_SAVE, PermissionReq};
 use common_catalog::consts::{DEFAULT_PRIVATE_SCHEMA_NAME, default_engine};
 use common_error::ext::BoxedError;
 use common_query::OutputData;
@@ -393,17 +393,17 @@ impl servers::query_handler::DashboardHandler for Instance {
         definition: &str,
         ctx: QueryContextRef,
     ) -> servers::error::Result<()> {
-        self.check_permission(&ctx, PermissionReq::DashboardManage)?;
+        self.check_permission(&ctx, PermissionReq::WriteAction(DASHBOARD_SAVE))?;
         self.insert_dashboard(name, definition, ctx).await
     }
 
     async fn list(&self, ctx: QueryContextRef) -> servers::error::Result<Vec<DashboardDefinition>> {
-        self.check_permission(&ctx, PermissionReq::DashboardQuery)?;
+        self.check_permission(&ctx, PermissionReq::ReadAction(DASHBOARD_QUERY))?;
         self.list_dashboards(ctx).await
     }
 
     async fn delete(&self, name: &str, ctx: QueryContextRef) -> servers::error::Result<()> {
-        self.check_permission(&ctx, PermissionReq::DashboardManage)?;
+        self.check_permission(&ctx, PermissionReq::WriteAction(DASHBOARD_DELETE))?;
         self.delete_dashboard(name, ctx).await
     }
 }

--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, RowInsertRequests, SemanticType};
 use async_trait::async_trait;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{INFLUXDB_WRITE, PermissionChecker, PermissionCheckerRef, PermissionReq};
 use catalog::CatalogManagerRef;
 use client::Output;
 use common_error::ext::BoxedError;
@@ -60,14 +60,14 @@ impl InfluxdbLineProtocolHandler for Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::LineProtocol)
+            .check_permission(ctx.current_user(), PermissionReq::Action(INFLUXDB_WRITE))
             .context(AuthSnafu)?;
 
         let interceptor_ref = self.plugins.get::<LineProtocolInterceptorRef<Error>>();
         interceptor_ref.pre_execute(&request.lines, ctx.clone())?;
 
         let requests = request.try_into()?;
-        self.check_row_insert_permission(&requests, &ctx, PermissionReq::LineProtocol)
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Action(INFLUXDB_WRITE))
             .context(AuthSnafu)?;
 
         let aligner = InfluxdbLineTimestampAligner {
@@ -80,7 +80,7 @@ impl InfluxdbLineProtocolHandler for Instance {
             .await?;
 
         let ctx = Arc::new(ctx.fork());
-        self.check_row_insert_permission(&requests, &ctx, PermissionReq::LineProtocol)
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Action(INFLUXDB_WRITE))
             .context(AuthSnafu)?;
 
         let ctx = ctx_with_default_merge_mode(ctx, self.influxdb_default_merge_mode);

--- a/src/frontend/src/instance/jaeger.rs
+++ b/src/frontend/src/instance/jaeger.rs
@@ -70,7 +70,7 @@ impl Instance {
             table,
         )]);
         let targets = self.resolve_query_permission_targets(targets, ctx).await?;
-        self.check_table_permission(ctx, PermissionReq::ReadAction(JAEGER_QUERY), targets)
+        self.check_table_permission(ctx, PermissionReq::Action(JAEGER_QUERY), targets)
             .context(AuthSnafu)?;
         Ok(())
     }

--- a/src/frontend/src/instance/jaeger.rs
+++ b/src/frontend/src/instance/jaeger.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use auth::{PermissionReq, PermissionTableTarget, PermissionTableTargets};
+use auth::{JAEGER_QUERY, PermissionReq, PermissionTableTarget, PermissionTableTargets};
 use catalog::CatalogManagerRef;
 use common_catalog::consts::{
     TRACE_TABLE_NAME, trace_operations_table_name, trace_services_table_name,
@@ -70,7 +70,7 @@ impl Instance {
             table,
         )]);
         let targets = self.resolve_query_permission_targets(targets, ctx).await?;
-        self.check_table_permission(ctx, PermissionReq::JaegerQuery, targets)
+        self.check_table_permission(ctx, PermissionReq::ReadAction(JAEGER_QUERY), targets)
             .context(AuthSnafu)?;
         Ok(())
     }

--- a/src/frontend/src/instance/log_handler.rs
+++ b/src/frontend/src/instance/log_handler.rs
@@ -16,7 +16,10 @@ use std::sync::Arc;
 
 use api::v1::RowInsertRequests;
 use async_trait::async_trait;
-use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use auth::{
+    PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY, PermissionChecker, PermissionCheckerRef,
+    PermissionReq,
+};
 use client::Output;
 use common_error::ext::BoxedError;
 use datatypes::timestamp::TimestampNanosecond;
@@ -85,7 +88,7 @@ impl PipelineHandler for Instance {
     }
 
     fn check_pipeline_query_permission(&self, query_ctx: &QueryContextRef) -> ServerResult<()> {
-        self.check_permission(query_ctx, PermissionReq::PipelineQuery)
+        self.check_permission(query_ctx, PermissionReq::ReadAction(PIPELINE_QUERY))
     }
 
     async fn get_pipeline(
@@ -107,7 +110,7 @@ impl PipelineHandler for Instance {
         pipeline: &str,
         query_ctx: QueryContextRef,
     ) -> ServerResult<PipelineInfo> {
-        self.check_permission(&query_ctx, PermissionReq::PipelineManage)?;
+        self.check_permission(&query_ctx, PermissionReq::WriteAction(PIPELINE_INSERT))?;
         self.pipeline_operator
             .insert_pipeline(name, content_type, pipeline, query_ctx)
             .await
@@ -120,7 +123,7 @@ impl PipelineHandler for Instance {
         version: PipelineVersion,
         ctx: QueryContextRef,
     ) -> ServerResult<Option<()>> {
-        self.check_permission(&ctx, PermissionReq::PipelineManage)?;
+        self.check_permission(&ctx, PermissionReq::WriteAction(PIPELINE_DELETE))?;
         self.pipeline_operator
             .delete_pipeline(name, version, ctx)
             .await
@@ -149,7 +152,7 @@ impl PipelineHandler for Instance {
         version: PipelineVersion,
         query_ctx: QueryContextRef,
     ) -> ServerResult<(String, TimestampNanosecond)> {
-        self.check_permission(&query_ctx, PermissionReq::PipelineQuery)?;
+        self.check_permission(&query_ctx, PermissionReq::ReadAction(PIPELINE_QUERY))?;
         self.pipeline_operator
             .get_pipeline_str(name, version, query_ctx)
             .await

--- a/src/frontend/src/instance/log_handler.rs
+++ b/src/frontend/src/instance/log_handler.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use api::v1::RowInsertRequests;
 use async_trait::async_trait;
 use auth::{
-    PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY, PermissionChecker, PermissionCheckerRef,
-    PermissionReq,
+    LOG_WRITE, PIPELINE_DELETE, PIPELINE_INSERT, PIPELINE_QUERY, PermissionChecker,
+    PermissionCheckerRef, PermissionReq,
 };
 use client::Output;
 use common_error::ext::BoxedError;
@@ -45,7 +45,7 @@ impl Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::LogWrite)
+            .check_permission(ctx.current_user(), PermissionReq::Action(LOG_WRITE))
             .context(AuthSnafu)?;
 
         let log = self
@@ -54,7 +54,7 @@ impl Instance {
             .as_ref()
             .pre_ingest(log, ctx.clone())?;
 
-        self.check_row_insert_permission(&log, &ctx, PermissionReq::LogWrite)
+        self.check_row_insert_permission(&log, &ctx, PermissionReq::Action(LOG_WRITE))
             .context(AuthSnafu)?;
 
         Ok(log)
@@ -88,7 +88,7 @@ impl PipelineHandler for Instance {
     }
 
     fn check_pipeline_query_permission(&self, query_ctx: &QueryContextRef) -> ServerResult<()> {
-        self.check_permission(query_ctx, PermissionReq::ReadAction(PIPELINE_QUERY))
+        self.check_permission(query_ctx, PermissionReq::Action(PIPELINE_QUERY))
     }
 
     async fn get_pipeline(
@@ -110,7 +110,7 @@ impl PipelineHandler for Instance {
         pipeline: &str,
         query_ctx: QueryContextRef,
     ) -> ServerResult<PipelineInfo> {
-        self.check_permission(&query_ctx, PermissionReq::WriteAction(PIPELINE_INSERT))?;
+        self.check_permission(&query_ctx, PermissionReq::Action(PIPELINE_INSERT))?;
         self.pipeline_operator
             .insert_pipeline(name, content_type, pipeline, query_ctx)
             .await
@@ -123,7 +123,7 @@ impl PipelineHandler for Instance {
         version: PipelineVersion,
         ctx: QueryContextRef,
     ) -> ServerResult<Option<()>> {
-        self.check_permission(&ctx, PermissionReq::WriteAction(PIPELINE_DELETE))?;
+        self.check_permission(&ctx, PermissionReq::Action(PIPELINE_DELETE))?;
         self.pipeline_operator
             .delete_pipeline(name, version, ctx)
             .await
@@ -152,7 +152,7 @@ impl PipelineHandler for Instance {
         version: PipelineVersion,
         query_ctx: QueryContextRef,
     ) -> ServerResult<(String, TimestampNanosecond)> {
-        self.check_permission(&query_ctx, PermissionReq::ReadAction(PIPELINE_QUERY))?;
+        self.check_permission(&query_ctx, PermissionReq::Action(PIPELINE_QUERY))?;
         self.pipeline_operator
             .get_pipeline_str(name, version, query_ctx)
             .await

--- a/src/frontend/src/instance/logs.rs
+++ b/src/frontend/src/instance/logs.rs
@@ -14,7 +14,7 @@
 
 use std::ops::Deref;
 
-use auth::{PermissionReq, PermissionTableTarget, PermissionTableTargets};
+use auth::{LOG_QUERY, PermissionReq, PermissionTableTarget, PermissionTableTargets};
 use client::Output;
 use common_error::ext::BoxedError;
 use log_query::LogQuery;
@@ -41,7 +41,7 @@ impl LogQueryHandler for Instance {
         )]);
         let targets = self.resolve_query_permission_targets(targets, &ctx).await?;
 
-        self.check_table_permission(&ctx, PermissionReq::LogQuery, targets)
+        self.check_table_permission(&ctx, PermissionReq::Action(LOG_QUERY), targets)
             .context(AuthSnafu)?;
 
         interceptor.as_ref().pre_query(&request, ctx.clone())?;

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use auth::{
-    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    OPENTSDB_WRITE, PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
     PermissionTableTargets,
 };
 use common_error::ext::BoxedError;
@@ -51,7 +51,7 @@ impl OpentsdbProtocolHandler for Instance {
     ) -> server_error::Result<()> {
         self.check_table_permission(
             &ctx,
-            PermissionReq::Opentsdb,
+            PermissionReq::Action(OPENTSDB_WRITE),
             permission_targets(data_points, &ctx),
         )
         .context(AuthSnafu)?;
@@ -67,11 +67,11 @@ impl OpentsdbProtocolHandler for Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::Opentsdb)
+            .check_permission(ctx.current_user(), PermissionReq::Action(OPENTSDB_WRITE))
             .context(AuthSnafu)?;
 
         let (requests, _) = data_point_to_grpc_row_insert_requests(data_points)?;
-        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Opentsdb)
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Action(OPENTSDB_WRITE))
             .context(AuthSnafu)?;
 
         let ctx = {

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use auth::{
-    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
+    OTLP_WRITE, PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
     PermissionTableTargets,
 };
 use client::Output;
@@ -94,7 +94,7 @@ impl OpenTelemetryProtocolHandler for Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::Otlp)
+            .check_permission(ctx.current_user(), PermissionReq::Action(OTLP_WRITE))
             .context(AuthSnafu)?;
 
         let interceptor_ref = self
@@ -122,7 +122,7 @@ impl OpenTelemetryProtocolHandler for Instance {
 
         let (requests, rows, semantic_index) =
             otlp::metrics::to_grpc_insert_requests(request, &mut metric_ctx)?;
-        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Otlp)
+        self.check_row_insert_permission(&requests, &ctx, PermissionReq::Action(OTLP_WRITE))
             .context(AuthSnafu)?;
         self.cache_otlp_legacy(&input_names, &ctx, is_legacy)?;
         OTLP_METRICS_ROWS.inc_by(rows as u64);
@@ -173,7 +173,7 @@ impl OpenTelemetryProtocolHandler for Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::Otlp)
+            .check_permission(ctx.current_user(), PermissionReq::Action(OTLP_WRITE))
             .context(AuthSnafu)?;
 
         let interceptor_ref = self
@@ -186,7 +186,7 @@ impl OpenTelemetryProtocolHandler for Instance {
         let conventions = trace_conventions(&request);
         let spans = otlp::trace::span::parse(request);
         let targets = trace_permission_targets(&table_name, &spans, &ctx);
-        self.check_table_permission(&ctx, PermissionReq::Otlp, targets)
+        self.check_table_permission(&ctx, PermissionReq::Action(OTLP_WRITE), targets)
             .context(AuthSnafu)?;
         self.ingest_trace_spans(
             pipeline_handler,
@@ -213,7 +213,7 @@ impl OpenTelemetryProtocolHandler for Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::Otlp)
+            .check_permission(ctx.current_user(), PermissionReq::Action(OTLP_WRITE))
             .context(AuthSnafu)?;
 
         let interceptor_ref = self
@@ -243,7 +243,7 @@ impl OpenTelemetryProtocolHandler for Instance {
 
         let batches = opt_req.as_req_iter(ctx).collect::<Vec<_>>();
         for (temp_ctx, requests) in &batches {
-            self.check_row_insert_permission(requests, temp_ctx, PermissionReq::Otlp)
+            self.check_row_insert_permission(requests, temp_ctx, PermissionReq::Action(OTLP_WRITE))
                 .context(AuthSnafu)?;
         }
 

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -24,8 +24,8 @@ use api::v1::{
 };
 use async_trait::async_trait;
 use auth::{
-    PermissionChecker, PermissionCheckerRef, PermissionReq, PermissionTableTarget,
-    PermissionTableTargets,
+    PROM_STORE_READ, PROM_STORE_WRITE, PermissionChecker, PermissionCheckerRef, PermissionReq,
+    PermissionTableTarget, PermissionTableTargets,
 };
 use client::OutputData;
 use common_catalog::{format_full_table_name, parse_optional_catalog_and_schema_from_db_string};
@@ -412,13 +412,13 @@ impl PromStoreProtocolHandler for Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::PromStoreWrite)
+            .check_permission(ctx.current_user(), PermissionReq::Action(PROM_STORE_WRITE))
             .context(AuthSnafu)?;
         let interceptor_ref = self
             .plugins
             .get::<PromStoreProtocolInterceptorRef<servers::error::Error>>();
         interceptor_ref.pre_write(request, ctx.clone())?;
-        self.check_row_insert_permission(request, &ctx, PermissionReq::PromStoreWrite)
+        self.check_row_insert_permission(request, &ctx, PermissionReq::Action(PROM_STORE_WRITE))
             .context(AuthSnafu)?;
         Ok(())
     }
@@ -474,7 +474,7 @@ impl PromStoreProtocolHandler for Instance {
         self.plugins
             .get::<PermissionCheckerRef>()
             .as_ref()
-            .check_permission(ctx.current_user(), PermissionReq::PromStoreRead)
+            .check_permission(ctx.current_user(), PermissionReq::Action(PROM_STORE_READ))
             .context(AuthSnafu)?;
 
         let interceptor_ref = self
@@ -512,7 +512,7 @@ impl PromStoreProtocolHandler for Instance {
                 &ctx,
             )
             .await?;
-        self.check_table_permission(&ctx, PermissionReq::PromStoreRead, targets)
+        self.check_table_permission(&ctx, PermissionReq::Action(PROM_STORE_READ), targets)
             .context(AuthSnafu)?;
 
         let response_type = negotiate_response_type(&request.accepted_response_types)?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request updates `PermissionReq` to retain structured SQL, gRPC, and bulk-insert requests while representing context-free protocol and endpoint permissions with closed, typed `PermissionAction` constants.

It centralizes stable action names and access modes in `ALL_ACTIONS`, prevents raw-string and mode mismatches, and preserves table-target and read/write authorization behavior. A companion enterprise change maps every declared action to `SqlSelect`, `SqlInsert`, or `SqlDelete`, with future unmapped actions requiring `Admin`.

This changes the public Rust `PermissionReq` API: downstream callers using the removed context-free variants must migrate to `PermissionReq::Action(...)`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
