### PR TITLE
chore: bump release version to 1.2.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -936,7 +936,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "catalog",
  "common-error",
@@ -1622,7 +1622,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -1957,7 +1957,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -2048,7 +2048,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.6",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "common-base"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "anymap2",
@@ -2268,14 +2268,14 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "const_format",
 ]
 
 [[package]]
 name = "common-config"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-macro",
  "http 1.3.1",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2384,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -2469,7 +2469,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "common-base",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "greptime-proto",
  "once_cell",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "common-memory-manager"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anymap2",
  "api",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-grpc",
@@ -2664,11 +2664,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 
 [[package]]
 name = "common-pprof"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-stream",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "serde",
  "strum 0.27.1",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "common-sql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "common-stat"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-runtime",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "backtrace",
  "common-base",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "client",
  "common-grpc",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "cargo-manifest",
  "const_format",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "common-telemetry",
  "serde",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -4487,7 +4487,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "datatypes"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-array 58.3.0",
@@ -5224,7 +5224,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-engine"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -5355,7 +5355,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -5424,7 +5424,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -5507,7 +5507,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -7898,7 +7898,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -7910,7 +7910,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8229,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8261,7 +8261,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8361,7 +8361,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -8462,7 +8462,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "bytes",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -9277,7 +9277,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9846,7 +9846,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -9905,7 +9905,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-util",
@@ -10190,7 +10190,7 @@ checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
 
 [[package]]
 name = "partition"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "async-trait",
@@ -10584,7 +10584,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10741,7 +10741,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "auth",
  "catalog",
@@ -11081,7 +11081,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -11434,7 +11434,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -11496,7 +11496,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -11566,7 +11566,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -13176,7 +13176,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13316,7 +13316,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13669,7 +13669,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-buffer 58.3.0",
@@ -13730,7 +13730,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -14012,7 +14012,7 @@ dependencies = [
 
 [[package]]
 name = "standalone"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "catalog",
@@ -14058,7 +14058,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-api"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -14251,7 +14251,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -14373,7 +14373,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -14656,7 +14656,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests-fuzz"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -14704,7 +14704,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "1.2.0"
+version = "1.2.0-beta.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -14784,7 +14784,7 @@ dependencies = [
  "sqlx",
  "standalone",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.2.0-beta.1",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.0-beta.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Bump `[workspace.package].version` from `1.2.0` to `1.2.0-beta.1` for the recreated `release/v1.2` beta release.
- This PR is based on exact upstream commit `9776d88dc8b38c748a793a232a9676aaebfbec4d`.
- The scope is limited to root `Cargo.toml` and regenerated `Cargo.lock`.
- Regenerated the lockfile with `cargo update --workspace`. Semantic lock inventory audit confirmed 1,365 package blocks, 71 source-less workspace packages, 1,294 external name/version/source/checksum identities, and 853 qualified internal references. Package count, workspace package names, and every external identity are unchanged; all workspace versions and qualified internal references moved to `1.2.0-beta.1`.
- Validated with `cargo metadata --locked --no-deps`, `make check-toml`, and `git diff --check`. The workspace version matches the existing `v1.2.0-beta.1` tag name; `v1.2.0` is absent locally.
- No API, schema, data, source, test, workflow, or documentation changes are included.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (Not applicable: no source changes.)
- [x] I have added the necessary unit tests and integration tests. (Not applicable: version-only metadata change.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible. (No API changes.)
- [x] Schema or data changes are backward compatible. (No schema or data changes.)
