### PR TITLE
refactor(mito2): revise compaction trigger behavior

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -32,7 +32,9 @@ use common_telemetry::{debug, error};
 use common_time::TimeToLive;
 use common_time::range::TimestampRange;
 pub use scheduler::CompactionRequest;
-pub(crate) use scheduler::{CompactionExecution, CompactionPickFinished, CompactionScheduler};
+pub(crate) use scheduler::{
+    CompactionExecution, CompactionPickFinished, CompactionScheduler, CompactionTransition,
+};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use store_api::storage::RegionId;

--- a/src/mito2/src/compaction/scheduler.rs
+++ b/src/mito2/src/compaction/scheduler.rs
@@ -220,8 +220,8 @@ impl CompactionScheduler {
     /// # Effects
     ///
     /// Rejects stale plans, submits a prepared local or remote execution, or
-    /// completes the cycle when planning produced no executable plan. Returned
-    /// The returned transition reports a dispatched automatic follow-up or DDL
+    /// completes the cycle when planning produced no executable plan. The
+    /// returned transition reports a dispatched automatic follow-up or DDL
     /// requests released by the resulting terminal transition.
     ///
     /// # Constraints

--- a/src/mito2/src/compaction/scheduler.rs
+++ b/src/mito2/src/compaction/scheduler.rs
@@ -43,6 +43,7 @@ use crate::error::{
 use crate::region::version::VersionControlRef;
 use crate::region::{ManifestContextRef, RegionLeaderState, RegionRoleState};
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest, WorkerRequestWithTime};
+#[cfg(test)]
 use crate::schedule::RequestCancelResult;
 use crate::schedule::scheduler::SchedulerRef;
 use crate::worker::WorkerListener;

--- a/src/mito2/src/compaction/scheduler.rs
+++ b/src/mito2/src/compaction/scheduler.rs
@@ -66,6 +66,40 @@ pub(crate) struct CompactionScheduler {
     next_plan_id: u64,
 }
 
+/// Describes the immediate action produced by a compaction terminal transition.
+#[derive(Debug)]
+pub(crate) enum CompactionTransition {
+    /// No follow-up work was dispatched and no DDL became ready.
+    NoAction,
+    /// An automatic follow-up planning cycle was dispatched.
+    AutomaticFollowupScheduled,
+    /// DDL requests became ready after the compaction lifecycle terminated.
+    DdlReady(Vec<SenderDdlRequest>),
+}
+
+impl CompactionTransition {
+    fn from_pending_ddls(pending_ddls: Vec<SenderDdlRequest>) -> Self {
+        if pending_ddls.is_empty() {
+            Self::NoAction
+        } else {
+            Self::DdlReady(pending_ddls)
+        }
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        !matches!(self, Self::DdlReady(pending_ddls) if !pending_ddls.is_empty())
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        match self {
+            Self::DdlReady(pending_ddls) => pending_ddls.len(),
+            Self::NoAction | Self::AutomaticFollowupScheduled => 0,
+        }
+    }
+}
+
 // API used by callers outside the compaction scheduler module.
 impl CompactionScheduler {
     /// Creates an empty scheduler bound to one region worker.
@@ -187,7 +221,8 @@ impl CompactionScheduler {
     ///
     /// Rejects stale plans, submits a prepared local or remote execution, or
     /// completes the cycle when planning produced no executable plan. Returned
-    /// DDL requests are released by the resulting terminal transition.
+    /// The returned transition reports a dispatched automatic follow-up or DDL
+    /// requests released by the resulting terminal transition.
     ///
     /// # Constraints
     ///
@@ -199,7 +234,7 @@ impl CompactionScheduler {
         finished: CompactionPickFinished,
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
-    ) -> Vec<SenderDdlRequest> {
+    ) -> CompactionTransition {
         self.handle_compaction_pick_finished_inner(finished, manifest_ctx, schema_metadata_manager)
             .await
     }
@@ -229,8 +264,8 @@ impl CompactionScheduler {
     /// # Effects
     ///
     /// Notifies waiters, schedules a pending manual or explicit automatic
-    /// follow-up, or removes the region status. Returns DDLs that are now safe
-    /// to execute.
+    /// follow-up, or removes the region status. The returned transition reports
+    /// a dispatched automatic follow-up or DDLs that are now safe to execute.
     ///
     /// # Constraints
     ///
@@ -243,9 +278,9 @@ impl CompactionScheduler {
         execution: &CompactionExecution,
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
-    ) -> Vec<SenderDdlRequest> {
+    ) -> CompactionTransition {
         if !self.is_current_execution(region_id, execution) {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         }
         self.on_compaction_finished(region_id, manifest_ctx, schema_metadata_manager)
             .await
@@ -535,9 +570,9 @@ impl CompactionScheduler {
         region_id: RegionId,
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
-    ) -> Vec<SenderDdlRequest> {
+    ) -> CompactionTransition {
         if !self.region_status.contains_key(&region_id) {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         }
 
         if self.handle_pending_compaction_request(
@@ -545,13 +580,13 @@ impl CompactionScheduler {
             manifest_ctx,
             schema_metadata_manager.clone(),
         ) {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         }
 
         // The region status might be removed by the previous steps.
         // So we return empty DDL requests.
         let Some(status) = self.region_status.get_mut(&region_id) else {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         };
         for waiter in status.take_waiters() {
             waiter.send(Ok(0));
@@ -566,15 +601,16 @@ impl CompactionScheduler {
             self.region_status.remove(&region_id);
             // If there are pending DDL requests, we should return them to the caller.
             // And skip try to schedule next compaction task.
-            return pending_ddl_requests;
+            return CompactionTransition::DdlReady(pending_ddl_requests);
         }
 
-        if status.active.reset_automatic_followup() {
-            self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager);
-            return Vec::new();
+        if status.active.reset_automatic_followup()
+            && self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager)
+        {
+            return CompactionTransition::AutomaticFollowupScheduled;
         }
         self.region_status.remove(&region_id);
-        Vec::new()
+        CompactionTransition::NoAction
     }
 
     fn schedule_automatic_followup(

--- a/src/mito2/src/compaction/scheduler.rs
+++ b/src/mito2/src/compaction/scheduler.rs
@@ -686,11 +686,10 @@ impl CompactionScheduler {
 
     #[cfg(test)]
     fn request_cancel(&mut self, region_id: RegionId) -> RequestCancelResult {
-        let Some(status) = self.region_status.get_mut(&region_id) else {
-            return RequestCancelResult::NotRunning;
-        };
-
-        status.request_cancel()
+        self.region_status
+            .get_mut(&region_id)
+            .unwrap()
+            .request_cancel()
     }
 
     fn remove_region_on_failure(&mut self, region_id: RegionId, err: Arc<Error>) {

--- a/src/mito2/src/compaction/scheduler.rs
+++ b/src/mito2/src/compaction/scheduler.rs
@@ -27,7 +27,7 @@ use common_time::range::TimestampRange;
 pub(crate) use planning::CompactionPickFinished;
 pub use planning::CompactionRequest;
 pub(crate) use state::CompactionExecution;
-use state::{ActiveCompaction, CompactionStatus, PendingCompaction};
+use state::{CompactionStatus, CompactionTrigger, PendingCompaction};
 use store_api::storage::RegionId;
 use tokio::sync::mpsc::Sender;
 
@@ -37,8 +37,8 @@ use crate::compaction::memory_manager::CompactionMemoryManager;
 use crate::compaction::task::MAX_PARALLEL_COMPACTION;
 use crate::config::MitoConfig;
 use crate::error::{
-    CompactionCancelledSnafu, Error, RegionClosedSnafu, RegionDroppedSnafu, RegionTruncatedSnafu,
-    Result,
+    CompactionCancelledSnafu, Error, ManualCompactionAlreadyRunningSnafu, RegionClosedSnafu,
+    RegionDroppedSnafu, RegionTruncatedSnafu, Result,
 };
 use crate::region::version::VersionControlRef;
 use crate::region::{ManifestContextRef, RegionLeaderState, RegionRoleState};
@@ -66,14 +66,19 @@ pub(crate) struct CompactionScheduler {
     next_plan_id: u64,
 }
 
-fn requires_pending_compaction_slot(
-    options: &compact_request::Options,
-    time_range: Option<TimestampRange>,
-) -> bool {
-    matches!(options, compact_request::Options::StrictWindow(_)) || time_range.is_some()
-}
-
+// API used by callers outside the compaction scheduler module.
 impl CompactionScheduler {
+    /// Creates an empty scheduler bound to one region worker.
+    ///
+    /// # Effects
+    ///
+    /// Stores the worker request sender and shared scheduling resources. No
+    /// compaction is dispatched until a scheduling method is called.
+    ///
+    /// # Constraints
+    ///
+    /// All lifecycle methods on the returned scheduler must be driven by the
+    /// same worker so region state transitions remain serialized.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         scheduler: SchedulerRef,
@@ -99,6 +104,286 @@ impl CompactionScheduler {
         }
     }
 
+    /// Accepts an automatic compaction trigger for a region.
+    ///
+    /// # Effects
+    ///
+    /// Starts planning when no scheduler status exists for the region.
+    /// Otherwise, an active status coalesces the trigger into one unrestricted
+    /// follow-up cycle. Returns `true` only when this call dispatches planning.
+    ///
+    /// # Constraints
+    ///
+    /// The owning region worker must call this method serially. Automatic
+    /// triggers have no waiter and may be ignored while a DDL fence is active.
+    /// The region identity comes from `version_control`; `access_layer` and
+    /// `manifest_ctx` must belong to the same region.
+    pub(crate) fn schedule_automatic_compaction(
+        &mut self,
+        compact_options: compact_request::Options,
+        version_control: &VersionControlRef,
+        access_layer: &AccessLayerRef,
+        manifest_ctx: &ManifestContextRef,
+        schema_metadata_manager: SchemaMetadataManagerRef,
+    ) -> Result<bool> {
+        self.schedule_compaction(
+            CompactionTrigger::Automatic,
+            compact_options,
+            version_control,
+            access_layer,
+            OptionOutputTx::none(),
+            manifest_ctx,
+            schema_metadata_manager,
+            1, // Default for automatic compaction
+            None,
+        )
+    }
+
+    /// Accepts a manual compaction request for a region.
+    ///
+    /// # Effects
+    ///
+    /// Starts planning when no scheduler status exists for the region. During
+    /// an automatic compaction, queues the request and replaces any older
+    /// pending manual request; during a manual compaction, rejects the new
+    /// request through `waiter`. Returns `true` only when this call dispatches
+    /// planning.
+    ///
+    /// # Constraints
+    ///
+    /// The owning region worker must call this method serially. The supplied
+    /// waiter is completed exactly once by cycle completion, replacement,
+    /// cancellation, failure, or region teardown. The region identity comes
+    /// from `version_control`; `access_layer` and `manifest_ctx` must belong to
+    /// the same region.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn schedule_manual_compaction(
+        &mut self,
+        compact_options: compact_request::Options,
+        version_control: &VersionControlRef,
+        access_layer: &AccessLayerRef,
+        waiter: OptionOutputTx,
+        manifest_ctx: &ManifestContextRef,
+        schema_metadata_manager: SchemaMetadataManagerRef,
+        max_parallelism: usize,
+        time_range: Option<TimestampRange>,
+    ) -> Result<bool> {
+        self.schedule_compaction(
+            CompactionTrigger::Manual,
+            compact_options,
+            version_control,
+            access_layer,
+            waiter,
+            manifest_ctx,
+            schema_metadata_manager,
+            max_parallelism,
+            time_range,
+        )
+    }
+
+    /// Applies a background planning result to the current region state.
+    ///
+    /// # Effects
+    ///
+    /// Rejects stale plans, submits a prepared local or remote execution, or
+    /// completes the cycle when planning produced no executable plan. Returned
+    /// DDL requests are released by the resulting terminal transition.
+    ///
+    /// # Constraints
+    ///
+    /// The owning worker must call this method for planning notifications and
+    /// must execute every returned DDL request. The notification may be stale;
+    /// stale notifications intentionally have no effect.
+    pub(crate) async fn handle_compaction_pick_finished(
+        &mut self,
+        finished: CompactionPickFinished,
+        manifest_ctx: &ManifestContextRef,
+        schema_metadata_manager: SchemaMetadataManagerRef,
+    ) -> Vec<SenderDdlRequest> {
+        self.handle_compaction_pick_finished_inner(finished, manifest_ctx, schema_metadata_manager)
+            .await
+    }
+
+    /// Returns whether a terminal notification belongs to the installed execution.
+    ///
+    /// # Effects
+    ///
+    /// Performs a read-only identity check against the region's current plan.
+    ///
+    /// # Constraints
+    ///
+    /// Callers must check this before applying a compaction edit. Matching only
+    /// the region id is insufficient because close/reopen can replace a status.
+    pub(crate) fn is_current_execution(
+        &self,
+        region_id: RegionId,
+        execution: &CompactionExecution,
+    ) -> bool {
+        self.region_status
+            .get(&region_id)
+            .is_some_and(|status| status.matches_execution(execution))
+    }
+
+    /// Completes the installed execution after its edit has been applied.
+    ///
+    /// # Effects
+    ///
+    /// Notifies waiters, schedules a pending manual or explicit automatic
+    /// follow-up, or removes the region status. Returns DDLs that are now safe
+    /// to execute.
+    ///
+    /// # Constraints
+    ///
+    /// The owning worker must call this only after accepting and applying the
+    /// execution's result, and must execute every returned DDL request. Stale
+    /// executions are ignored.
+    pub(crate) async fn on_execution_finished(
+        &mut self,
+        region_id: RegionId,
+        execution: &CompactionExecution,
+        manifest_ctx: &ManifestContextRef,
+        schema_metadata_manager: SchemaMetadataManagerRef,
+    ) -> Vec<SenderDdlRequest> {
+        if !self.is_current_execution(region_id, execution) {
+            return Vec::new();
+        }
+        self.on_compaction_finished(region_id, manifest_ctx, schema_metadata_manager)
+            .await
+    }
+
+    /// Completes a cooperatively canceled execution.
+    ///
+    /// # Effects
+    ///
+    /// Removes the matching region status, notifies compaction waiters, and
+    /// returns DDLs that were waiting for cancellation.
+    ///
+    /// # Constraints
+    ///
+    /// The owning worker must execute every returned DDL request. A stale
+    /// cancellation is ignored.
+    pub(crate) async fn on_execution_cancelled(
+        &mut self,
+        region_id: RegionId,
+        execution: &CompactionExecution,
+    ) -> Vec<SenderDdlRequest> {
+        if !self.is_current_execution(region_id, execution) {
+            return Vec::new();
+        }
+        self.on_compaction_cancelled(region_id).await
+    }
+
+    /// Records failure of the installed execution.
+    ///
+    /// # Effects
+    ///
+    /// Removes the matching region status and fails all compaction waiters and
+    /// dependent DDL requests with the supplied error.
+    ///
+    /// # Constraints
+    ///
+    /// A stale execution failure is ignored so it cannot tear down replacement
+    /// state.
+    pub(crate) fn on_execution_failed(
+        &mut self,
+        region_id: RegionId,
+        execution: &CompactionExecution,
+        err: Arc<Error>,
+    ) {
+        if !self.is_current_execution(region_id, execution) {
+            return;
+        }
+        self.on_compaction_failed(region_id, err);
+    }
+
+    /// Removes compaction state because the region was dropped.
+    ///
+    /// # Effects
+    ///
+    /// Fails all compaction and DDL waiters owned by the status.
+    ///
+    /// # Constraints
+    ///
+    /// The owning worker must invoke this as part of serialized region teardown.
+    pub(crate) fn on_region_dropped(&mut self, region_id: RegionId) {
+        self.remove_region_on_failure(
+            region_id,
+            Arc::new(RegionDroppedSnafu { region_id }.build()),
+        );
+    }
+
+    /// Removes compaction state because the region was closed.
+    ///
+    /// # Effects
+    ///
+    /// Fails all compaction and DDL waiters owned by the status.
+    ///
+    /// # Constraints
+    ///
+    /// The owning worker must invoke this as part of serialized region teardown.
+    pub(crate) fn on_region_closed(&mut self, region_id: RegionId) {
+        self.remove_region_on_failure(region_id, Arc::new(RegionClosedSnafu { region_id }.build()));
+    }
+
+    /// Removes compaction state because the region was truncated.
+    ///
+    /// # Effects
+    ///
+    /// Fails all compaction and DDL waiters owned by the status.
+    ///
+    /// # Constraints
+    ///
+    /// The owning worker must invoke this after truncate completes.
+    pub(crate) fn on_region_truncated(&mut self, region_id: RegionId) {
+        self.remove_region_on_failure(
+            region_id,
+            Arc::new(RegionTruncatedSnafu { region_id }.build()),
+        );
+    }
+
+    /// Cancels a running compaction and queues its dependent DDL atomically.
+    ///
+    /// # Effects
+    ///
+    /// Requests cancellation when the active phase can still stop, then queues
+    /// the DDL. The queued DDL forms a scheduling fence for subsequent
+    /// compaction triggers. If no compaction is running, returns the sender and
+    /// typed request unchanged.
+    ///
+    /// # Constraints
+    ///
+    /// Production callers use this only for [`DdlRequest::Truncate`] and
+    /// [`DdlRequest::EnterStaging`]. `Ok(())` means the caller must wait for a
+    /// terminal callback to receive and execute the queued DDL; `Err` means the
+    /// caller must execute the returned request directly.
+    pub(crate) fn try_cancel_and_add_ddl<T>(
+        &mut self,
+        region_id: RegionId,
+        sender: OptionOutputTx,
+        request: T,
+        into_ddl_request: impl FnOnce(T) -> DdlRequest,
+    ) -> std::result::Result<(), (OptionOutputTx, T)> {
+        let Some(status) = self.region_status.get_mut(&region_id) else {
+            return Err((sender, request));
+        };
+        status.request_cancel();
+
+        let request = SenderDdlRequest {
+            region_id,
+            sender,
+            request: into_ddl_request(request),
+        };
+        debug!(
+            "Added pending DDL request for region: {}, ddl: {:?}",
+            request.region_id, request.request
+        );
+        status.pending_ddl_requests.push(request);
+        Ok(())
+    }
+}
+
+// Internal state-machine helpers.
+impl CompactionScheduler {
     /// Returns the current plan id and advances the counter.
     ///
     /// Takes the counter instead of `&mut self` so callers can bump it while
@@ -109,38 +394,10 @@ impl CompactionScheduler {
         plan_id
     }
 
-    /// Schedules a compaction for the region.
-    /// Returns whether a compaction is scheduled.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn schedule_compaction(
+    fn schedule_compaction(
         &mut self,
-        region_id: RegionId,
-        compact_options: compact_request::Options,
-        version_control: &VersionControlRef,
-        access_layer: &AccessLayerRef,
-        waiter: OptionOutputTx,
-        manifest_ctx: &ManifestContextRef,
-        schema_metadata_manager: SchemaMetadataManagerRef,
-        max_parallelism: usize,
-    ) -> Result<bool> {
-        self.schedule_compaction_with_time_range(
-            region_id,
-            compact_options,
-            version_control,
-            access_layer,
-            waiter,
-            manifest_ctx,
-            schema_metadata_manager,
-            max_parallelism,
-            None,
-        )
-    }
-
-    /// Schedules a compaction constrained by an optional time range.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn schedule_compaction_with_time_range(
-        &mut self,
-        region_id: RegionId,
+        trigger: CompactionTrigger,
         compact_options: compact_request::Options,
         version_control: &VersionControlRef,
         access_layer: &AccessLayerRef,
@@ -150,7 +407,7 @@ impl CompactionScheduler {
         max_parallelism: usize,
         time_range: Option<TimestampRange>,
     ) -> Result<bool> {
-        // skip compaction if region is in staging state
+        let region_id = version_control.region_id();
         let current_state = manifest_ctx.current_state();
         if current_state == RegionRoleState::Leader(RegionLeaderState::Staging) {
             info!(
@@ -163,9 +420,7 @@ impl CompactionScheduler {
 
         if let Some(status) = self.region_status.get_mut(&region_id) {
             // Pending Truncate/EnterStaging requests form a scheduling fence. Any later
-            // compaction with a waiter is an explicit request and receives CompactionCancelled;
-            // automatic triggers have no waiter, so sending the error is a no-op and the trigger
-            // is simply ignored.
+            // manual request receives CompactionCancelled; automatic triggers are ignored.
             if !status.pending_ddl_requests.is_empty() {
                 waiter.send(CompactionCancelledSnafu.fail());
                 info!(
@@ -175,27 +430,40 @@ impl CompactionScheduler {
                 return Ok(false);
             }
 
-            if requires_pending_compaction_slot(&compact_options, time_range) {
-                // Incoming compaction request is manually triggered.
-                status.set_pending_request(PendingCompaction {
-                    options: compact_options,
-                    waiter,
-                    max_parallelism,
-                    time_range,
-                });
-                info!(
-                    "Region {} is compacting, manually compaction will be re-scheduled.",
-                    region_id
-                );
-            } else {
-                status.merge_regular_trigger(waiter);
+            match trigger {
+                CompactionTrigger::Automatic => status.mark_automatic_trigger(),
+                CompactionTrigger::Manual if status.is_manual_compaction() => {
+                    waiter.send(ManualCompactionAlreadyRunningSnafu { region_id }.fail());
+                    info!(
+                        "Region {} already has a manually triggered compaction running",
+                        region_id
+                    );
+                }
+                CompactionTrigger::Manual => {
+                    status.set_pending_request(PendingCompaction {
+                        options: compact_options,
+                        waiter,
+                        max_parallelism,
+                        time_range,
+                    });
+                    info!(
+                        "Region {} is running an automatic compaction; manual compaction will be re-scheduled",
+                        region_id
+                    );
+                }
             }
             return Ok(false);
         }
 
         // Publish the picking phase before dispatching background planning.
-        let mut status =
-            CompactionStatus::new(region_id, version_control.clone(), access_layer.clone());
+        let plan_id = Self::next_plan_id(&mut self.next_plan_id);
+        let mut status = CompactionStatus::new(
+            region_id,
+            version_control.clone(),
+            access_layer.clone(),
+            plan_id,
+            trigger,
+        );
         let request = status.new_compaction_request(
             self.request_sender.clone(),
             self.engine_config.clone(),
@@ -205,8 +473,6 @@ impl CompactionScheduler {
             schema_metadata_manager,
             max_parallelism,
         );
-        let plan_id = Self::next_plan_id(&mut self.next_plan_id);
-        status.start_picking_with_time_range(plan_id, time_range);
         status.merge_waiter(waiter);
         self.region_status.insert(region_id, status);
         self.dispatch_compaction_planning(plan_id, request, compact_options, time_range);
@@ -217,7 +483,7 @@ impl CompactionScheduler {
     // Handle pending manual compaction request for the region.
     //
     // Returns true if should early return, false otherwise.
-    pub(crate) fn handle_pending_compaction_request(
+    fn handle_pending_compaction_request(
         &mut self,
         region_id: RegionId,
         manifest_ctx: &ManifestContextRef,
@@ -254,7 +520,7 @@ impl CompactionScheduler {
         // borrow stays alive; nothing could have removed the status since it
         // was fetched above.
         let plan_id = Self::next_plan_id(&mut self.next_plan_id);
-        status.start_picking_with_time_range(plan_id, time_range);
+        status.start_picking_with_trigger(plan_id, CompactionTrigger::Manual);
         self.dispatch_compaction_planning(plan_id, request, options, time_range);
         debug!(
             "Successfully scheduled manual compaction planning for region id: {}",
@@ -270,11 +536,7 @@ impl CompactionScheduler {
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
     ) -> Vec<SenderDdlRequest> {
-        if !self
-            .region_status
-            .get(&region_id)
-            .is_some_and(|s| s.is_busy())
-        {
+        if !self.region_status.contains_key(&region_id) {
             return Vec::new();
         }
 
@@ -291,11 +553,7 @@ impl CompactionScheduler {
         let Some(status) = self.region_status.get_mut(&region_id) else {
             return Vec::new();
         };
-        let Some(mut active) = status.take_active() else {
-            return Vec::new();
-        };
-
-        for waiter in std::mem::take(&mut active.waiters) {
+        for waiter in status.take_waiters() {
             waiter.send(Ok(0));
         }
 
@@ -304,84 +562,22 @@ impl CompactionScheduler {
         // plan/execution cycle, so dispatch the DDLs first.
         let pending_ddl_requests = std::mem::take(&mut status.pending_ddl_requests);
         if !pending_ddl_requests.is_empty() {
-            // The just-finished compaction satisfies any retained regular triggers.
-            for waiter in active.regular_followup_waiters.take().unwrap_or_default() {
-                waiter.send(Ok(0));
-            }
+            // The DDL supersedes any retained automatic follow-up.
             self.region_status.remove(&region_id);
             // If there are pending DDL requests, we should return them to the caller.
             // And skip try to schedule next compaction task.
             return pending_ddl_requests;
         }
 
-        if active.regular_followup_waiters.is_some() {
-            self.schedule_next_compaction_with_active(
-                region_id,
-                manifest_ctx,
-                schema_metadata_manager,
-                Some(active),
-                None,
-            );
+        if status.active.reset_automatic_followup() {
+            self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager);
             return Vec::new();
         }
+        self.region_status.remove(&region_id);
         Vec::new()
     }
 
-    /// Returns whether a terminal notification belongs to the installed execution.
-    /// Background work may finish after its region status has been replaced, so
-    /// matching the region id alone is insufficient.
-    pub(crate) fn is_current_execution(
-        &self,
-        region_id: RegionId,
-        execution: &CompactionExecution,
-    ) -> bool {
-        self.region_status
-            .get(&region_id)
-            .is_some_and(|status| status.matches_execution(execution))
-    }
-
-    pub(crate) async fn on_execution_finished(
-        &mut self,
-        region_id: RegionId,
-        execution: &CompactionExecution,
-        manifest_ctx: &ManifestContextRef,
-        schema_metadata_manager: SchemaMetadataManagerRef,
-    ) -> Vec<SenderDdlRequest> {
-        // A stale finish must not clear the replacement phase or notify its waiters and DDLs.
-        if !self.is_current_execution(region_id, execution) {
-            return Vec::new();
-        }
-        self.on_compaction_finished(region_id, manifest_ctx, schema_metadata_manager)
-            .await
-    }
-
-    pub(crate) fn is_compacting(&self, region_id: RegionId) -> bool {
-        self.region_status
-            .get(&region_id)
-            .map(CompactionStatus::is_busy)
-            .unwrap_or(false)
-    }
-
-    /// Removes the region status if it has no running task.
-    ///
-    /// A finished compaction leaves an idle status (`active = None`) behind when
-    /// there is nothing more to schedule. If the caller decides not to chain
-    /// the next compaction, it must remove the idle status; otherwise the
-    /// status becomes a zombie that makes `schedule_compaction` swallow all
-    /// future compaction triggers of the region.
-    pub(crate) fn remove_idle_status(&mut self, region_id: RegionId) {
-        if self
-            .region_status
-            .get(&region_id)
-            .is_some_and(|status| !status.is_busy())
-        {
-            self.region_status.remove(&region_id);
-        }
-    }
-
-    /// Schedules next compaction upon a finished compaction.
-    /// Returns whether the compaction is scheduled.
-    pub(crate) fn schedule_next_compaction(
+    fn schedule_automatic_followup(
         &mut self,
         region_id: RegionId,
         manifest_ctx: &ManifestContextRef,
@@ -390,34 +586,7 @@ impl CompactionScheduler {
         let Some(status) = self.region_status.get_mut(&region_id) else {
             return false;
         };
-        // A plan is already in flight; treat it as scheduled instead of
-        // overwriting the current phase and orphaning the in-flight planning.
-        if status.is_busy() {
-            return true;
-        }
-
-        let time_range = status.time_range;
-        self.schedule_next_compaction_with_active(
-            region_id,
-            manifest_ctx,
-            schema_metadata_manager,
-            None,
-            time_range,
-        )
-    }
-
-    fn schedule_next_compaction_with_active(
-        &mut self,
-        region_id: RegionId,
-        manifest_ctx: &ManifestContextRef,
-        schema_metadata_manager: SchemaMetadataManagerRef,
-        active: Option<ActiveCompaction>,
-        time_range: Option<TimestampRange>,
-    ) -> bool {
-        let Some(status) = self.region_status.get_mut(&region_id) else {
-            return false;
-        };
-        // We should always try to compact the region until picker returns None.
+        // An external automatic trigger requires one unrestricted follow-up pick.
         let request = status.new_compaction_request(
             self.request_sender.clone(),
             self.engine_config.clone(),
@@ -431,12 +600,12 @@ impl CompactionScheduler {
         // borrow stays alive; nothing could have removed the status since it
         // was fetched above.
         let plan_id = Self::next_plan_id(&mut self.next_plan_id);
-        status.start_regular_picking(plan_id, active, time_range);
+        status.start_regular_picking(plan_id);
         self.dispatch_compaction_planning(
             plan_id,
             request,
             compact_request::Options::Regular(Default::default()),
-            time_range,
+            None,
         );
         debug!(
             "Successfully scheduled next compaction planning for region id: {}",
@@ -450,93 +619,10 @@ impl CompactionScheduler {
         self.remove_region_on_cancel(region_id)
     }
 
-    pub(crate) async fn on_execution_cancelled(
-        &mut self,
-        region_id: RegionId,
-        execution: &CompactionExecution,
-    ) -> Vec<SenderDdlRequest> {
-        // A stale cancellation must not remove a replacement execution's status.
-        if !self.is_current_execution(region_id, execution) {
-            return Vec::new();
-        }
-        self.on_compaction_cancelled(region_id).await
-    }
-
     /// Notifies the scheduler that the compaction job is failed.
     fn on_compaction_failed(&mut self, region_id: RegionId, err: Arc<Error>) {
         error!(err; "Region {} failed to compact, cancel all pending tasks", region_id);
         self.remove_region_on_failure(region_id, err);
-    }
-
-    pub(crate) fn on_execution_failed(
-        &mut self,
-        region_id: RegionId,
-        execution: &CompactionExecution,
-        err: Arc<Error>,
-    ) {
-        // A stale failure must not tear down a replacement execution.
-        if !self.is_current_execution(region_id, execution) {
-            return;
-        }
-        self.on_compaction_failed(region_id, err);
-    }
-
-    /// Notifies the scheduler that the region is dropped.
-    pub(crate) fn on_region_dropped(&mut self, region_id: RegionId) {
-        self.remove_region_on_failure(
-            region_id,
-            Arc::new(RegionDroppedSnafu { region_id }.build()),
-        );
-    }
-
-    /// Notifies the scheduler that the region is closed.
-    pub(crate) fn on_region_closed(&mut self, region_id: RegionId) {
-        self.remove_region_on_failure(region_id, Arc::new(RegionClosedSnafu { region_id }.build()));
-    }
-
-    /// Notifies the scheduler that the region is truncated.
-    pub(crate) fn on_region_truncated(&mut self, region_id: RegionId) {
-        self.remove_region_on_failure(
-            region_id,
-            Arc::new(RegionTruncatedSnafu { region_id }.build()),
-        );
-    }
-
-    /// Cancels the running compaction and queues its dependent DDL atomically.
-    ///
-    /// Production callers currently use this only for [`DdlRequest::Truncate`] and
-    /// [`DdlRequest::EnterStaging`]. If cancellation is still possible, the current picking or
-    /// local execution is asked to stop; otherwise the DDL waits for its terminal notification.
-    /// The worker dispatches the queued DDL only after that notification is handled, preventing
-    /// truncate or enter-staging from racing with compaction planning, execution, or commit.
-    /// Returns the sender and typed request unchanged if compaction is not running.
-    pub(crate) fn try_cancel_and_add_ddl<T>(
-        &mut self,
-        region_id: RegionId,
-        sender: OptionOutputTx,
-        request: T,
-        into_ddl_request: impl FnOnce(T) -> DdlRequest,
-    ) -> std::result::Result<(), (OptionOutputTx, T)> {
-        let Some(status) = self.region_status.get_mut(&region_id) else {
-            return Err((sender, request));
-        };
-        if status.request_cancel() == RequestCancelResult::NotRunning {
-            return Err((sender, request));
-        }
-
-        let request = SenderDdlRequest {
-            region_id,
-            sender,
-            request: into_ddl_request(request),
-        };
-        debug!(
-            "Added pending DDL request for region: {}, ddl: {:?}",
-            request.region_id, request.request
-        );
-        // The first queued Truncate/EnterStaging also fences later regular triggers from
-        // creating more follow-ups ahead of the DDL.
-        status.pending_ddl_requests.push(request);
-        Ok(())
     }
 
     #[cfg(test)]
@@ -549,7 +635,7 @@ impl CompactionScheduler {
     }
 
     #[cfg(test)]
-    pub(crate) fn has_pending_ddls(&self, region_id: RegionId) -> bool {
+    fn has_pending_ddls(&self, region_id: RegionId) -> bool {
         let has_pending = self
             .region_status
             .get(&region_id)
@@ -563,7 +649,7 @@ impl CompactionScheduler {
     }
 
     #[cfg(test)]
-    pub(crate) fn request_cancel(&mut self, region_id: RegionId) -> RequestCancelResult {
+    fn request_cancel(&mut self, region_id: RegionId) -> RequestCancelResult {
         let Some(status) = self.region_status.get_mut(&region_id) else {
             return RequestCancelResult::NotRunning;
         };

--- a/src/mito2/src/compaction/scheduler/planning.rs
+++ b/src/mito2/src/compaction/scheduler/planning.rs
@@ -32,10 +32,10 @@ use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheManagerRef;
 use crate::compaction::compactor::{CompactionRegion, CompactionVersion, DefaultCompactor};
 use crate::compaction::picker::{CompactionTask, PickerOutput, new_picker};
-use crate::compaction::scheduler::CompactionScheduler;
 use crate::compaction::scheduler::state::{
     CompactingFiles, CompactionExecution, CompactionPhase,
 };
+use crate::compaction::scheduler::{CompactionScheduler, CompactionTransition};
 use crate::compaction::task::CompactionTaskImpl;
 use crate::compaction::{CompactionOutput, find_dynamic_options};
 use crate::config::MitoConfig;
@@ -47,9 +47,7 @@ use crate::metrics::{
 };
 use crate::region::ManifestContextRef;
 use crate::region::options::RegionOptions;
-use crate::request::{
-    BackgroundNotify, OutputTx, SenderDdlRequest, WorkerRequest, WorkerRequestWithTime,
-};
+use crate::request::{BackgroundNotify, OutputTx, WorkerRequest, WorkerRequestWithTime};
 use crate::schedule::CancellableTaskState;
 use crate::schedule::remote_job_scheduler::{
     CompactionJob, DefaultNotifier, RemoteJob, RemoteJobSchedulerRef,
@@ -284,31 +282,31 @@ impl CompactionScheduler {
     ///
     /// # Returns
     ///
-    /// DDL requests released when Picking terminates without creating an
-    /// execution, such as after cancellation, `NoPlan`, or a planning error.
-    /// The owning worker must dispatch returned DDLs immediately because no
-    /// execution callback will follow. Returns an empty vector for stale
-    /// notifications, scheduled follow-ups, and successfully submitted
-    /// executions whose terminal callback still owns the DDL fence.
+    /// Reports an automatic follow-up dispatched after Picking, or DDL requests
+    /// released when Picking terminates without creating an execution. The
+    /// owning worker must dispatch returned DDLs immediately because no
+    /// execution callback will follow.
     pub(super) async fn handle_compaction_pick_finished_inner(
         &mut self,
         finished: CompactionPickFinished,
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
-    ) -> Vec<SenderDdlRequest> {
+    ) -> CompactionTransition {
         let region_id = finished.region_id;
         let plan_id = finished.plan_id;
         let Some(status) = self.region_status.get(&region_id) else {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         };
 
         if !status.is_picking(finished.plan_id) {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         }
         // Cancellation during Picking is completed by this notification. No
         // execution callback will follow, so return DDLs released by the fence.
         if !status.accept_plan(finished.plan_id) {
-            return self.remove_region_on_cancel(region_id);
+            return CompactionTransition::from_pending_ddls(
+                self.remove_region_on_cancel(region_id),
+            );
         }
 
         match finished.result {
@@ -338,7 +336,7 @@ impl CompactionScheduler {
                 };
                 prepared.picker_output = picker_output;
                 let Some(status) = self.region_status.get_mut(&region_id) else {
-                    return Vec::new();
+                    return CompactionTransition::NoAction;
                 };
                 let waiters = status.take_waiters();
                 match self
@@ -351,7 +349,7 @@ impl CompactionScheduler {
                         }
                         // The execution now owns the terminal transition. Any
                         // fenced DDLs remain queued until its callback arrives.
-                        Vec::new()
+                        CompactionTransition::NoAction
                     }
                     Ok(None) => {
                         self.finish_compaction_planning(
@@ -364,7 +362,7 @@ impl CompactionScheduler {
                     }
                     Err(err) => {
                         self.remove_region_on_failure(region_id, Arc::new(err));
-                        Vec::new()
+                        CompactionTransition::NoAction
                     }
                 }
             }
@@ -397,9 +395,9 @@ impl CompactionScheduler {
         err: Option<Arc<Error>>,
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
-    ) -> Vec<SenderDdlRequest> {
+    ) -> CompactionTransition {
         let Some(status) = self.region_status.get_mut(&region_id) else {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         };
         for waiter in status.take_waiters() {
             if let Some(err) = &err {
@@ -414,21 +412,24 @@ impl CompactionScheduler {
             manifest_ctx,
             schema_metadata_manager.clone(),
         ) {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         }
 
         let Some(status) = self.region_status.get_mut(&region_id) else {
-            return Vec::new();
+            return CompactionTransition::NoAction;
         };
-        if status.active.reset_automatic_followup() {
-            self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager);
-            return Vec::new();
+        if status.active.reset_automatic_followup()
+            && self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager)
+        {
+            return CompactionTransition::AutomaticFollowupScheduled;
         }
 
-        self.region_status
+        let pending_ddls = self
+            .region_status
             .remove(&region_id)
             .map(|mut status| std::mem::take(&mut status.pending_ddl_requests))
-            .unwrap_or_default()
+            .unwrap_or_default();
+        CompactionTransition::from_pending_ddls(pending_ddls)
     }
 
     async fn submit_prepared_compaction(

--- a/src/mito2/src/compaction/scheduler/planning.rs
+++ b/src/mito2/src/compaction/scheduler/planning.rs
@@ -32,9 +32,7 @@ use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheManagerRef;
 use crate::compaction::compactor::{CompactionRegion, CompactionVersion, DefaultCompactor};
 use crate::compaction::picker::{CompactionTask, PickerOutput, new_picker};
-use crate::compaction::scheduler::state::{
-    CompactingFiles, CompactionExecution, CompactionPhase,
-};
+use crate::compaction::scheduler::state::{CompactingFiles, CompactionExecution, CompactionPhase};
 use crate::compaction::scheduler::{CompactionScheduler, CompactionTransition};
 use crate::compaction::task::CompactionTaskImpl;
 use crate::compaction::{CompactionOutput, find_dynamic_options};
@@ -418,18 +416,23 @@ impl CompactionScheduler {
         let Some(status) = self.region_status.get_mut(&region_id) else {
             return CompactionTransition::NoAction;
         };
+
+        // A queued DDL supersedes a retained automatic follow-up, matching the
+        // execution terminal path in `on_compaction_finished`.
+        let pending_ddls = std::mem::take(&mut status.pending_ddl_requests);
+        if !pending_ddls.is_empty() {
+            self.region_status.remove(&region_id);
+            return CompactionTransition::DdlReady(pending_ddls);
+        }
+
         if status.active.reset_automatic_followup()
             && self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager)
         {
             return CompactionTransition::AutomaticFollowupScheduled;
         }
 
-        let pending_ddls = self
-            .region_status
-            .remove(&region_id)
-            .map(|mut status| std::mem::take(&mut status.pending_ddl_requests))
-            .unwrap_or_default();
-        CompactionTransition::from_pending_ddls(pending_ddls)
+        self.region_status.remove(&region_id);
+        CompactionTransition::NoAction
     }
 
     async fn submit_prepared_compaction(

--- a/src/mito2/src/compaction/scheduler/planning.rs
+++ b/src/mito2/src/compaction/scheduler/planning.rs
@@ -34,7 +34,7 @@ use crate::compaction::compactor::{CompactionRegion, CompactionVersion, DefaultC
 use crate::compaction::picker::{CompactionTask, PickerOutput, new_picker};
 use crate::compaction::scheduler::CompactionScheduler;
 use crate::compaction::scheduler::state::{
-    CompactingFiles, CompactionExecution, CompactionPhase, CompactionStatus,
+    CompactingFiles, CompactionExecution, CompactionPhase,
 };
 use crate::compaction::task::CompactionTaskImpl;
 use crate::compaction::{CompactionOutput, find_dynamic_options};
@@ -280,7 +280,17 @@ impl CompactionScheduler {
         })
     }
 
-    pub(crate) async fn handle_compaction_pick_finished(
+    /// Applies a background planning result to the current compaction lifecycle.
+    ///
+    /// # Returns
+    ///
+    /// DDL requests released when Picking terminates without creating an
+    /// execution, such as after cancellation, `NoPlan`, or a planning error.
+    /// The owning worker must dispatch returned DDLs immediately because no
+    /// execution callback will follow. Returns an empty vector for stale
+    /// notifications, scheduled follow-ups, and successfully submitted
+    /// executions whose terminal callback still owns the DDL fence.
+    pub(super) async fn handle_compaction_pick_finished_inner(
         &mut self,
         finished: CompactionPickFinished,
         manifest_ctx: &ManifestContextRef,
@@ -291,11 +301,12 @@ impl CompactionScheduler {
         let Some(status) = self.region_status.get(&region_id) else {
             return Vec::new();
         };
-        // Picking runs detached from the worker. Its result may arrive after
-        // close/reopen or replanning installed another Picking phase for this region.
+
         if !status.is_picking(finished.plan_id) {
             return Vec::new();
         }
+        // Cancellation during Picking is completed by this notification. No
+        // execution callback will follow, so return DDLs released by the fence.
         if !status.accept_plan(finished.plan_id) {
             return self.remove_region_on_cancel(region_id);
         }
@@ -338,6 +349,8 @@ impl CompactionScheduler {
                         if let Some(status) = self.region_status.get_mut(&region_id) {
                             status.set_phase(phase);
                         }
+                        // The execution now owns the terminal transition. Any
+                        // fenced DDLs remain queued until its callback arrives.
                         Vec::new()
                     }
                     Ok(None) => {
@@ -355,6 +368,8 @@ impl CompactionScheduler {
                     }
                 }
             }
+            // These paths never create an execution. Finish the Picking
+            // lifecycle here and release DDLs if no follow-up was scheduled.
             CompactionPlanningResult::NoPlan => {
                 self.finish_compaction_planning(
                     region_id,
@@ -386,10 +401,7 @@ impl CompactionScheduler {
         let Some(status) = self.region_status.get_mut(&region_id) else {
             return Vec::new();
         };
-        let Some(mut active) = status.take_active() else {
-            return Vec::new();
-        };
-        for waiter in std::mem::take(&mut active.waiters) {
+        for waiter in status.take_waiters() {
             if let Some(err) = &err {
                 waiter.send(Err(err.clone()).context(CompactRegionSnafu { region_id }));
             } else {
@@ -397,7 +409,6 @@ impl CompactionScheduler {
             }
         }
 
-        status.active = Some(active);
         if self.handle_pending_compaction_request(
             region_id,
             manifest_ctx,
@@ -406,21 +417,11 @@ impl CompactionScheduler {
             return Vec::new();
         }
 
-        let Some(active) = self
-            .region_status
-            .get_mut(&region_id)
-            .and_then(CompactionStatus::take_active)
-        else {
+        let Some(status) = self.region_status.get_mut(&region_id) else {
             return Vec::new();
         };
-        if active.regular_followup_waiters.is_some() {
-            self.schedule_next_compaction_with_active(
-                region_id,
-                manifest_ctx,
-                schema_metadata_manager,
-                Some(active),
-                None,
-            );
+        if status.active.reset_automatic_followup() {
+            self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager);
             return Vec::new();
         }
 

--- a/src/mito2/src/compaction/scheduler/state.rs
+++ b/src/mito2/src/compaction/scheduler/state.rs
@@ -81,41 +81,69 @@ pub(super) enum CompactionPhase {
     },
 }
 
+/// Describes how the current compaction cycle was triggered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CompactionTrigger {
+    Automatic,
+    Manual,
+}
+
 #[derive(Debug)]
 pub(super) struct ActiveCompaction {
     pub(super) phase: CompactionPhase,
+    trigger: CompactionTrigger,
     /// Waiters satisfied by the current planning or execution cycle. Picking waiters move into
     /// the submitted task; regular triggers coalesced during execution accumulate here.
     pub(super) waiters: Vec<OutputTx>,
-    /// Requests one fresh regular picking cycle after the current cycle finishes. It is kept
-    /// separate because the current picker snapshot may predate the trigger; `Some(empty)` records
-    /// an automatic trigger without an explicit waiter.
-    pub(super) regular_followup_waiters: Option<Vec<OutputTx>>,
+    /// An automatic trigger arrived during this cycle and requires one unrestricted regular
+    /// picking cycle after the current cycle finishes. Recorded in every phase so an external
+    /// trigger always resets the continuation scope, even during local/remote execution.
+    pub(super) automatic_followup_required: bool,
 }
 
 impl ActiveCompaction {
-    pub(super) fn picking(plan_id: u64, waiters: Vec<OutputTx>) -> Self {
+    pub(super) fn picking(
+        plan_id: u64,
+        waiters: Vec<OutputTx>,
+        trigger: CompactionTrigger,
+    ) -> Self {
         Self {
             phase: CompactionPhase::Picking {
                 plan_id,
                 cancelled: false,
             },
+            trigger,
             waiters,
-            regular_followup_waiters: None,
+            automatic_followup_required: false,
         }
     }
 
-    pub(super) fn start_picking(&mut self, plan_id: u64) {
+    pub(super) fn start_picking(&mut self, plan_id: u64, trigger: CompactionTrigger) {
         self.phase = CompactionPhase::Picking {
             plan_id,
             cancelled: false,
         };
+        self.trigger = trigger;
     }
 
     pub(super) fn start_regular_picking(&mut self, plan_id: u64) {
-        self.waiters
-            .extend(self.regular_followup_waiters.take().unwrap_or_default());
-        self.start_picking(plan_id);
+        self.start_picking(plan_id, CompactionTrigger::Automatic);
+    }
+
+    /// Marks an automatic trigger. The trigger is coalesced into a single unrestricted
+    /// follow-up cycle regardless of the current phase.
+    pub(super) fn mark_automatic_trigger(&mut self) {
+        self.automatic_followup_required = true;
+    }
+
+    /// Resets whether an unrestricted follow-up cycle is required and
+    /// return the previous value.
+    pub(super) fn reset_automatic_followup(&mut self) -> bool {
+        std::mem::take(&mut self.automatic_followup_required)
+    }
+
+    pub(super) fn is_manual(&self) -> bool {
+        self.trigger == CompactionTrigger::Manual
     }
 
     pub(super) fn is_picking(&self, expected_plan_id: u64) -> bool {
@@ -157,17 +185,6 @@ impl ActiveCompaction {
             }
             CompactionPhase::Local { state, .. } => state.request_cancel(),
             CompactionPhase::Remote { .. } => RequestCancelResult::TooLateToCancel,
-        }
-    }
-
-    pub(super) fn merge_regular_trigger(&mut self, mut waiter: OptionOutputTx) {
-        if matches!(self.phase, CompactionPhase::Picking { .. }) {
-            let regular_followup_waiters = self.regular_followup_waiters.get_or_insert_default();
-            if let Some(waiter) = waiter.take_inner() {
-                regular_followup_waiters.push(waiter);
-            }
-        } else {
-            self.merge_waiter(waiter);
         }
     }
 
@@ -241,16 +258,12 @@ pub(super) struct CompactionStatus {
     pub(super) version_control: VersionControlRef,
     /// Access layer of the region.
     pub(super) access_layer: AccessLayerRef,
-    /// Current compaction lifecycle. `None` is the existing transient idle state.
-    // TODO: Remove idle statuses and make ActiveCompaction non-optional once chained
-    // scheduling can recreate the status from region context.
-    pub(super) active: Option<ActiveCompaction>,
-    /// Optional range retained by automatic continuations of the current compaction.
-    pub(super) time_range: Option<TimestampRange>,
-    /// Pending compactions that are supposed to run as soon as current compaction task finished.
+    /// Current compaction lifecycle.
+    pub(super) active: ActiveCompaction,
+    /// A manual compaction waiting for the current automatic compaction to finish.
     ///
-    /// This holds strict-window requests and ranged regular requests. An unrestricted regular
-    /// request is instead merged into `ActiveCompaction::regular_followup_waiters` or `waiters`.
+    /// A manual request is rejected if the current compaction is also manual. Automatic requests
+    /// are merged into the active compaction instead of using this slot.
     pub(super) pending_request: Option<PendingCompaction>,
     /// Pending DDL requests that should run when compaction is done.
     ///
@@ -261,76 +274,66 @@ pub(super) struct CompactionStatus {
 }
 
 impl CompactionStatus {
-    /// Creates a new [CompactionStatus]
+    /// Creates a new picking [CompactionStatus].
     pub(super) fn new(
         region_id: RegionId,
         version_control: VersionControlRef,
         access_layer: AccessLayerRef,
+        plan_id: u64,
+        trigger: CompactionTrigger,
     ) -> CompactionStatus {
         CompactionStatus {
             region_id,
             version_control,
             access_layer,
-            active: None,
-            time_range: None,
+            active: ActiveCompaction::picking(plan_id, Vec::new(), trigger),
             pending_request: None,
             pending_ddl_requests: Vec::new(),
         }
     }
 
     #[cfg(test)]
+    pub(super) fn for_test(
+        region_id: RegionId,
+        version_control: VersionControlRef,
+        access_layer: AccessLayerRef,
+    ) -> Self {
+        Self::new(
+            region_id,
+            version_control,
+            access_layer,
+            0,
+            CompactionTrigger::Automatic,
+        )
+    }
+
+    #[cfg(test)]
     pub(super) fn start_picking(&mut self, plan_id: u64) {
-        self.start_picking_with_time_range(plan_id, None);
+        self.start_picking_with_trigger(plan_id, CompactionTrigger::Automatic);
     }
 
-    pub(super) fn start_picking_with_time_range(
-        &mut self,
-        plan_id: u64,
-        time_range: Option<TimestampRange>,
-    ) {
-        self.time_range = time_range;
-        if let Some(active) = &mut self.active {
-            active.start_picking(plan_id);
-        } else {
-            self.active = Some(ActiveCompaction::picking(plan_id, Vec::new()));
-        }
+    pub(super) fn start_picking_with_trigger(&mut self, plan_id: u64, trigger: CompactionTrigger) {
+        self.active.start_picking(plan_id, trigger);
     }
 
-    pub(super) fn start_regular_picking(
-        &mut self,
-        plan_id: u64,
-        active: Option<ActiveCompaction>,
-        time_range: Option<TimestampRange>,
-    ) {
-        self.time_range = time_range;
-        self.active = Some(if let Some(mut active) = active {
-            active.start_regular_picking(plan_id);
-            active
-        } else {
-            ActiveCompaction::picking(plan_id, Vec::new())
-        });
+    pub(super) fn start_regular_picking(&mut self, plan_id: u64) {
+        self.active.start_regular_picking(plan_id);
     }
 
     pub(super) fn is_picking(&self, expected_plan_id: u64) -> bool {
-        self.active
-            .as_ref()
-            .is_some_and(|active| active.is_picking(expected_plan_id))
+        self.active.is_picking(expected_plan_id)
     }
 
     pub(super) fn accept_plan(&self, expected_plan_id: u64) -> bool {
-        self.active
-            .as_ref()
-            .is_some_and(|active| active.accept_plan(expected_plan_id))
+        self.active.accept_plan(expected_plan_id)
     }
 
-    pub(super) fn is_busy(&self) -> bool {
-        self.active.is_some()
+    pub(super) fn is_manual_compaction(&self) -> bool {
+        self.active.is_manual()
     }
 
     pub(super) fn matches_execution(&self, execution: &CompactionExecution) -> bool {
-        self.active
-            .as_ref()
-            .is_some_and(|active| active.matches_execution(execution))
+        self.active.matches_execution(execution)
     }
 
     #[cfg(test)]
@@ -341,15 +344,7 @@ impl CompactionStatus {
             state: state.clone(),
             execution,
         };
-        if let Some(active) = &mut self.active {
-            active.phase = phase;
-        } else {
-            self.active = Some(ActiveCompaction {
-                phase,
-                waiters: Vec::new(),
-                regular_followup_waiters: None,
-            });
-        }
+        self.active.phase = phase;
         state
     }
 
@@ -357,72 +352,39 @@ impl CompactionStatus {
     pub(super) fn start_remote_task(&mut self) {
         let execution = CompactionExecution::new(0, CompactingFiles::empty());
         let phase = CompactionPhase::Remote { execution };
-        if let Some(active) = &mut self.active {
-            active.phase = phase;
-        } else {
-            self.active = Some(ActiveCompaction {
-                phase,
-                waiters: Vec::new(),
-                regular_followup_waiters: None,
-            });
-        }
+        self.active.phase = phase;
     }
 
     pub(super) fn request_cancel(&mut self) -> RequestCancelResult {
-        let Some(active) = &mut self.active else {
-            return RequestCancelResult::NotRunning;
-        };
-        active.request_cancel()
+        self.active.request_cancel()
     }
 
-    #[cfg(test)]
-    pub(super) fn clear_running_task(&mut self) -> bool {
-        self.active.take().is_some()
-    }
-
-    pub(super) fn merge_regular_trigger(&mut self, waiter: OptionOutputTx) {
-        if let Some(active) = &mut self.active {
-            active.merge_regular_trigger(waiter);
-        }
+    pub(super) fn mark_automatic_trigger(&mut self) {
+        self.active.mark_automatic_trigger();
     }
 
     /// Merge the waiter to the pending compaction.
     pub(super) fn merge_waiter(&mut self, waiter: OptionOutputTx) {
-        if let Some(active) = &mut self.active {
-            active.merge_waiter(waiter);
-        }
-    }
-
-    pub(super) fn take_active(&mut self) -> Option<ActiveCompaction> {
-        self.active.take()
+        self.active.merge_waiter(waiter);
     }
 
     pub(super) fn take_waiters(&mut self) -> Vec<OutputTx> {
-        self.active
-            .as_mut()
-            .map(|active| std::mem::take(&mut active.waiters))
-            .unwrap_or_default()
+        std::mem::take(&mut self.active.waiters)
     }
 
     pub(super) fn extend_waiters(&mut self, waiters: Vec<OutputTx>) {
-        if let Some(active) = &mut self.active {
-            active.waiters.extend(waiters);
-        }
+        self.active.waiters.extend(waiters);
     }
 
     pub(super) fn append_waiters(&mut self, waiters: &mut Vec<OutputTx>) {
-        if let Some(active) = &mut self.active {
-            active.waiters.append(waiters);
-        }
+        self.active.waiters.append(waiters);
     }
 
     pub(super) fn set_phase(&mut self, phase: CompactionPhase) {
-        if let Some(active) = &mut self.active {
-            active.phase = phase;
-        }
+        self.active.phase = phase;
     }
 
-    /// Set pending compaction request or replace current value if already exist.
+    /// Sets a pending manual compaction request, replacing an older pending request.
     pub(super) fn set_pending_request(&mut self, pending: PendingCompaction) {
         if let Some(prev) = self.pending_request.replace(pending) {
             debug!(
@@ -434,16 +396,10 @@ impl CompactionStatus {
     }
 
     pub(super) fn on_failure(mut self, err: Arc<Error>) {
-        if let Some(mut active) = self.active.take() {
-            for waiter in active
-                .waiters
-                .drain(..)
-                .chain(active.regular_followup_waiters.take().unwrap_or_default())
-            {
-                waiter.send(Err(err.clone()).context(CompactRegionSnafu {
-                    region_id: self.region_id,
-                }));
-            }
+        for waiter in self.active.waiters.drain(..) {
+            waiter.send(Err(err.clone()).context(CompactRegionSnafu {
+                region_id: self.region_id,
+            }));
         }
 
         if let Some(pending_compaction) = self.pending_request {
@@ -465,14 +421,8 @@ impl CompactionStatus {
 
     #[must_use]
     pub(super) fn on_cancel(mut self) -> Vec<SenderDdlRequest> {
-        if let Some(mut active) = self.active.take() {
-            for waiter in active
-                .waiters
-                .drain(..)
-                .chain(active.regular_followup_waiters.take().unwrap_or_default())
-            {
-                waiter.send(CompactionCancelledSnafu.fail());
-            }
+        for waiter in self.active.waiters.drain(..) {
+            waiter.send(CompactionCancelledSnafu.fail());
         }
 
         if let Some(pending_compaction) = self.pending_request {
@@ -516,8 +466,7 @@ impl CompactionStatus {
     }
 }
 
-/// Pending compaction request that is supposed to run after current task is finished,
-/// typically used for manual compactions.
+/// A manual compaction request waiting for an automatic compaction to finish.
 pub(super) struct PendingCompaction {
     /// Compaction options.
     pub(crate) options: compact_request::Options,

--- a/src/mito2/src/compaction/scheduler_test.rs
+++ b/src/mito2/src/compaction/scheduler_test.rs
@@ -1946,7 +1946,7 @@ async fn test_on_compaction_finished_returns_pending_ddl_requests() {
 }
 
 #[tokio::test]
-async fn test_on_compaction_finished_replays_pending_ddl_after_manual_noop() {
+async fn test_planning_terminal_prioritizes_pending_ddl_over_automatic_followup() {
     let env = SchedulerEnv::new().await;
     let (tx, mut rx) = mpsc::channel(4);
     let mut scheduler = env.mock_compaction_scheduler(tx);
@@ -1961,7 +1961,9 @@ async fn test_on_compaction_finished_replays_pending_ddl_after_manual_noop() {
     let (manual_tx, manual_rx) = oneshot::channel();
     let mut status =
         CompactionStatus::for_test(region_id, version_control.clone(), env.access_layer.clone());
-    status.start_local_task();
+    let state = status.start_local_task();
+    assert!(state.mark_commit_started());
+    status.mark_automatic_trigger();
     status.set_pending_request(PendingCompaction {
         options: compact_request::Options::Regular(Default::default()),
         waiter: OptionOutputTx::from(manual_tx),
@@ -1971,16 +1973,16 @@ async fn test_on_compaction_finished_replays_pending_ddl_after_manual_noop() {
     scheduler.region_status.insert(region_id, status);
 
     let (ddl_tx, _ddl_rx) = oneshot::channel();
-    scheduler.add_ddl_request_to_pending(SenderDdlRequest {
-        region_id,
-        sender: OptionOutputTx::from(ddl_tx),
-        request: crate::request::DdlRequest::EnterStaging(
-            store_api::region_request::EnterStagingRequest {
-                partition_directive:
-                    store_api::region_request::StagingPartitionDirective::RejectAllWrites,
-            },
-        ),
-    });
+    let result =
+        scheduler.try_cancel_and_add_ddl(region_id, OptionOutputTx::from(ddl_tx), (), |_| {
+            crate::request::DdlRequest::EnterStaging(
+                store_api::region_request::EnterStagingRequest {
+                    partition_directive:
+                        store_api::region_request::StagingPartitionDirective::RejectAllWrites,
+                },
+            )
+        });
+    assert!(result.is_ok());
 
     let pending_ddls = scheduler
         .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())

--- a/src/mito2/src/compaction/scheduler_test.rs
+++ b/src/mito2/src/compaction/scheduler_test.rs
@@ -43,28 +43,6 @@ use crate::test_util::mock_schema_metadata_manager;
 use crate::test_util::scheduler_util::{SchedulerEnv, VecScheduler};
 use crate::test_util::version_util::{VersionControlBuilder, apply_edit};
 
-#[test]
-fn test_requires_pending_compaction_slot() {
-    let time_range = TimestampRange::new(
-        Timestamp::new_millisecond(1_000),
-        Timestamp::new_millisecond(2_000),
-    )
-    .unwrap();
-
-    assert!(!requires_pending_compaction_slot(
-        &compact_request::Options::Regular(Default::default()),
-        None,
-    ));
-    assert!(requires_pending_compaction_slot(
-        &compact_request::Options::Regular(Default::default()),
-        Some(time_range),
-    ));
-    assert!(requires_pending_compaction_slot(
-        &compact_request::Options::StrictWindow(StrictWindow { window_seconds: 60 }),
-        None,
-    ));
-}
-
 struct FailingScheduler;
 
 struct FailingRemoteScheduler;
@@ -114,22 +92,18 @@ async fn begin_pick_result(
     ManifestContextRef,
     SchemaMetadataManagerRef,
 ) {
-    let region_id = version_control.current().version.metadata.region_id;
     let manifest_ctx = env
         .mock_manifest_context(version_control.current().version.metadata.clone())
         .await;
     let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
     assert!(
         scheduler
-            .schedule_compaction(
-                region_id,
+            .schedule_automatic_compaction(
                 Options::Regular(Default::default()),
                 version_control,
                 &env.access_layer,
-                OptionOutputTx::none(),
                 &manifest_ctx,
                 schema_metadata_manager.clone(),
-                1,
             )
             .unwrap()
     );
@@ -357,8 +331,7 @@ async fn test_schedule_empty() {
         .mock_manifest_context(version_control.current().version.metadata.clone())
         .await;
     let scheduled = scheduler
-        .schedule_compaction(
-            builder.region_id(),
+        .schedule_manual_compaction(
             compact_request::Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
@@ -366,6 +339,7 @@ async fn test_schedule_empty() {
             &manifest_ctx,
             schema_metadata_manager.clone(),
             1,
+            None,
         )
         .unwrap();
     assert!(scheduled);
@@ -383,8 +357,7 @@ async fn test_schedule_empty() {
     let (output_tx, output_rx) = oneshot::channel();
     let waiter = OptionOutputTx::from(output_tx);
     let scheduled = scheduler
-        .schedule_compaction(
-            builder.region_id(),
+        .schedule_manual_compaction(
             compact_request::Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
@@ -392,6 +365,7 @@ async fn test_schedule_empty() {
             &manifest_ctx,
             schema_metadata_manager.clone(),
             1,
+            None,
         )
         .unwrap();
     assert!(scheduled);
@@ -440,15 +414,12 @@ async fn test_schedule_compaction_returns_true_when_task_scheduled() {
         .await;
 
     let scheduled = scheduler
-        .schedule_compaction(
-            region_id,
+        .schedule_automatic_compaction(
             Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
-            OptionOutputTx::none(),
             &manifest_ctx,
             schema_metadata_manager.clone(),
-            1,
         )
         .unwrap();
 
@@ -478,7 +449,7 @@ async fn test_planning_panic_notifies_and_clears_status() {
     let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
     let (waiter_tx, waiter_rx) = oneshot::channel();
     let mut status =
-        CompactionStatus::new(region_id, version_control.clone(), env.access_layer.clone());
+        CompactionStatus::for_test(region_id, version_control.clone(), env.access_layer.clone());
     status.start_picking(7);
     status.merge_waiter(OptionOutputTx::from(waiter_tx));
     scheduler.region_status.insert(region_id, status);
@@ -515,15 +486,14 @@ async fn test_ddl_fence_prevents_repeated_regular_followups() {
         .await;
     let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
     let mut status =
-        CompactionStatus::new(region_id, version_control.clone(), env.access_layer.clone());
+        CompactionStatus::for_test(region_id, version_control.clone(), env.access_layer.clone());
     status.start_picking(7);
     scheduler.region_status.insert(region_id, status);
 
     let (pre_fence_tx, pre_fence_rx) = oneshot::channel();
     assert!(
         !scheduler
-            .schedule_compaction(
-                region_id,
+            .schedule_manual_compaction(
                 compact_request::Options::Regular(Default::default()),
                 &version_control,
                 &env.access_layer,
@@ -531,6 +501,7 @@ async fn test_ddl_fence_prevents_repeated_regular_followups() {
                 &manifest_ctx,
                 schema_metadata_manager.clone(),
                 1,
+                None,
             )
             .unwrap()
     );
@@ -568,8 +539,7 @@ async fn test_ddl_fence_prevents_repeated_regular_followups() {
     let (post_fence_tx, post_fence_rx) = oneshot::channel();
     assert!(
         !scheduler
-            .schedule_compaction(
-                region_id,
+            .schedule_manual_compaction(
                 compact_request::Options::Regular(Default::default()),
                 &version_control,
                 &env.access_layer,
@@ -577,6 +547,7 @@ async fn test_ddl_fence_prevents_repeated_regular_followups() {
                 &manifest_ctx,
                 schema_metadata_manager.clone(),
                 1,
+                None,
             )
             .unwrap()
     );
@@ -618,16 +589,7 @@ async fn test_pick_result_mismatched_token_keeps_status_and_waiter_untouched() {
         .await;
 
     assert_eq!(job_scheduler.num_jobs(), 0);
-    assert!(scheduler.region_status[&region_id].is_busy());
-    assert_eq!(
-        scheduler.region_status[&region_id]
-            .active
-            .as_ref()
-            .unwrap()
-            .waiters
-            .len(),
-        1
-    );
+    assert_eq!(scheduler.region_status[&region_id].active.waiters.len(), 1);
     assert_matches!(
         waiter_rx.try_recv(),
         Err(oneshot::error::TryRecvError::Empty)
@@ -784,11 +746,8 @@ async fn test_remote_fallback_uses_new_execution_plan_id() {
 
     assert_eq!(job_scheduler.num_jobs(), 1);
     assert!(matches!(
-        scheduler.region_status[&region_id]
-            .active
-            .as_ref()
-            .map(|active| &active.phase),
-        Some(CompactionPhase::Local { .. })
+        &scheduler.region_status[&region_id].active.phase,
+        CompactionPhase::Local { .. }
     ));
     assert!(
         !scheduler.region_status[&region_id]
@@ -819,7 +778,7 @@ async fn test_stale_plan_execution_does_not_affect_replacement_status() {
         .await;
     let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
     let (waiter_tx, mut waiter_rx) = oneshot::channel();
-    let mut status = CompactionStatus::new(
+    let mut status = CompactionStatus::for_test(
         region_id,
         replacement_version_control,
         env.access_layer.clone(),
@@ -837,13 +796,13 @@ async fn test_stale_plan_execution_does_not_affect_replacement_status() {
         )
         .await;
     assert!(pending_ddls.is_empty());
-    assert!(scheduler.region_status[&region_id].is_busy());
+    assert!(scheduler.region_status.contains_key(&region_id));
     scheduler.on_execution_failed(
         region_id,
         &stale_execution,
         Arc::new(InvalidSchedulerStateSnafu.build()),
     );
-    assert!(scheduler.region_status[&region_id].is_busy());
+    assert!(scheduler.region_status.contains_key(&region_id));
     assert_matches!(
         waiter_rx.try_recv(),
         Err(oneshot::error::TryRecvError::Empty)
@@ -889,8 +848,7 @@ async fn test_schedule_compaction_skips_task_exceeding_memory_limit() {
     let rejected_before = rejected.get();
 
     let scheduled = scheduler
-        .schedule_compaction(
-            region_id,
+        .schedule_manual_compaction(
             Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
@@ -898,6 +856,7 @@ async fn test_schedule_compaction_skips_task_exceeding_memory_limit() {
             &manifest_ctx,
             schema_metadata_manager.clone(),
             1,
+            None,
         )
         .unwrap();
 
@@ -915,7 +874,7 @@ async fn test_schedule_compaction_skips_task_exceeding_memory_limit() {
 }
 
 #[tokio::test]
-async fn test_schedule_on_finished() {
+async fn test_execution_finished_without_followup_removes_status() {
     common_telemetry::init_default_ut_logging();
     let job_scheduler = Arc::new(VecScheduler::default());
     let env = SchedulerEnv::new().await.scheduler(job_scheduler.clone());
@@ -952,15 +911,12 @@ async fn test_schedule_on_finished() {
         .mock_manifest_context(version_control.current().version.metadata.clone())
         .await;
     let scheduled = scheduler
-        .schedule_compaction(
-            region_id,
+        .schedule_automatic_compaction(
             compact_request::Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
-            OptionOutputTx::none(),
             &manifest_ctx,
             schema_metadata_manager.clone(),
-            1,
         )
         .unwrap();
     // Should schedule 1 compaction.
@@ -986,135 +942,12 @@ async fn test_schedule_on_finished() {
         &file_metas,
         purger.clone(),
     );
-    // The task is pending.
-    let (tx, _rx) = oneshot::channel();
-    let scheduled = scheduler
-        .schedule_compaction(
-            region_id,
-            compact_request::Options::Regular(Default::default()),
-            &version_control,
-            &env.access_layer,
-            OptionOutputTx::new(Some(OutputTx::new(tx))),
-            &manifest_ctx,
-            schema_metadata_manager.clone(),
-            1,
-        )
-        .unwrap();
-    assert!(!scheduled);
-    assert_eq!(1, scheduler.region_status.len());
-    assert_eq!(1, job_scheduler.num_jobs());
-    assert!(
-        !scheduler
-            .region_status
-            .get(&builder.region_id())
-            .unwrap()
-            .active
-            .as_ref()
-            .unwrap()
-            .waiters
-            .is_empty()
-    );
-
-    // On compaction finished and schedule next compaction.
+    // A completed execution without an explicit follow-up removes its status.
     scheduler
         .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
         .await;
-    let scheduled = scheduler.schedule_next_compaction(
-        region_id,
-        &manifest_ctx,
-        schema_metadata_manager.clone(),
-    );
-    assert!(scheduled);
-    assert_eq!(1, scheduler.region_status.len());
+    assert!(scheduler.region_status.is_empty());
     assert_eq!(1, job_scheduler.num_jobs());
-    let finished = recv_compaction_pick_finished(&mut rx).await;
-    scheduler
-        .handle_compaction_pick_finished(finished, &manifest_ctx, schema_metadata_manager.clone())
-        .await;
-    assert_eq!(2, job_scheduler.num_jobs());
-
-    // 5 files for next compaction.
-    apply_edit(
-        &version_control,
-        &[(0, end), (20, end), (40, end), (60, end), (80, end)],
-        &[],
-        purger.clone(),
-    );
-    let (tx, _rx) = oneshot::channel();
-    // The task is pending.
-    let scheduled = scheduler
-        .schedule_compaction(
-            region_id,
-            compact_request::Options::Regular(Default::default()),
-            &version_control,
-            &env.access_layer,
-            OptionOutputTx::new(Some(OutputTx::new(tx))),
-            &manifest_ctx,
-            schema_metadata_manager,
-            1,
-        )
-        .unwrap();
-    assert!(!scheduled);
-    assert_eq!(2, job_scheduler.num_jobs());
-    assert!(
-        !scheduler
-            .region_status
-            .get(&builder.region_id())
-            .unwrap()
-            .active
-            .as_ref()
-            .unwrap()
-            .waiters
-            .is_empty()
-    );
-}
-
-#[tokio::test]
-async fn test_remove_idle_status_allows_rescheduling() {
-    let env = SchedulerEnv::new().await;
-    let (tx, _rx) = mpsc::channel(4);
-    let mut scheduler = env.mock_compaction_scheduler(tx);
-    let builder = VersionControlBuilder::new();
-    let region_id = builder.region_id();
-    let version_control = Arc::new(builder.build());
-    let manifest_ctx = env
-        .mock_manifest_context(version_control.current().version.metadata.clone())
-        .await;
-    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
-    scheduler.region_status.insert(
-        region_id,
-        CompactionStatus::new(region_id, version_control.clone(), env.access_layer.clone()),
-    );
-
-    assert!(
-        !scheduler
-            .schedule_compaction(
-                region_id,
-                compact_request::Options::Regular(Default::default()),
-                &version_control,
-                &env.access_layer,
-                OptionOutputTx::none(),
-                &manifest_ctx,
-                schema_metadata_manager.clone(),
-                1,
-            )
-            .unwrap()
-    );
-    scheduler.remove_idle_status(region_id);
-    assert!(
-        scheduler
-            .schedule_compaction(
-                region_id,
-                compact_request::Options::Regular(Default::default()),
-                &version_control,
-                &env.access_layer,
-                OptionOutputTx::none(),
-                &manifest_ctx,
-                schema_metadata_manager,
-                1,
-            )
-            .unwrap()
-    );
 }
 
 #[tokio::test]
@@ -1170,15 +1003,12 @@ async fn test_time_range_compaction_when_compaction_in_progress() {
     );
 
     scheduler
-        .schedule_compaction(
-            region_id,
+        .schedule_automatic_compaction(
             compact_request::Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
-            OptionOutputTx::none(),
             &manifest_ctx,
             schema_metadata_manager.clone(),
-            1,
         )
         .unwrap();
     // Should schedule 1 compaction.
@@ -1206,8 +1036,7 @@ async fn test_time_range_compaction_when_compaction_in_progress() {
     .unwrap();
     let (tx, _rx) = oneshot::channel();
     scheduler
-        .schedule_compaction_with_time_range(
-            region_id,
+        .schedule_manual_compaction(
             compact_request::Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
@@ -1235,6 +1064,13 @@ async fn test_time_range_compaction_when_compaction_in_progress() {
         .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
         .await;
     assert_eq!(1, scheduler.region_status.len());
+    assert!(
+        scheduler
+            .region_status
+            .get(&region_id)
+            .unwrap()
+            .is_manual_compaction()
+    );
     assert_eq!(1, job_scheduler.num_jobs());
     let finished = recv_compaction_pick_finished(&mut rx).await;
     scheduler
@@ -1247,7 +1083,108 @@ async fn test_time_range_compaction_when_compaction_in_progress() {
 }
 
 #[tokio::test]
-async fn test_ranged_compaction_continuation_preserves_time_range() {
+async fn test_automatic_compaction_merges_with_manual_compaction() {
+    let env = SchedulerEnv::new().await;
+    let (tx, _rx) = mpsc::channel(4);
+    let mut scheduler = env.mock_compaction_scheduler(tx);
+    let builder = VersionControlBuilder::new();
+    let region_id = builder.region_id();
+    let version_control = Arc::new(builder.build());
+    let manifest_ctx = env
+        .mock_manifest_context(version_control.current().version.metadata.clone())
+        .await;
+    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
+
+    scheduler
+        .schedule_manual_compaction(
+            compact_request::Options::StrictWindow(StrictWindow { window_seconds: 60 }),
+            &version_control,
+            &env.access_layer,
+            OptionOutputTx::none(),
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            1,
+            None,
+        )
+        .unwrap();
+    scheduler
+        .schedule_automatic_compaction(
+            compact_request::Options::Regular(Default::default()),
+            &version_control,
+            &env.access_layer,
+            &manifest_ctx,
+            schema_metadata_manager,
+        )
+        .unwrap();
+
+    let status = scheduler.region_status.get(&region_id).unwrap();
+    assert!(status.is_manual_compaction());
+    assert!(status.pending_request.is_none());
+    assert!(status.active.automatic_followup_required);
+}
+
+#[tokio::test]
+async fn test_manual_compaction_rejects_another_manual_compaction() {
+    let env = SchedulerEnv::new().await;
+    let (tx, _rx) = mpsc::channel(4);
+    let mut scheduler = env.mock_compaction_scheduler(tx);
+    let builder = VersionControlBuilder::new();
+    let region_id = builder.region_id();
+    let version_control = Arc::new(builder.build());
+    let manifest_ctx = env
+        .mock_manifest_context(version_control.current().version.metadata.clone())
+        .await;
+    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
+
+    scheduler
+        .schedule_manual_compaction(
+            compact_request::Options::StrictWindow(StrictWindow { window_seconds: 60 }),
+            &version_control,
+            &env.access_layer,
+            OptionOutputTx::none(),
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            1,
+            None,
+        )
+        .unwrap();
+
+    let (second_tx, mut second_rx) = oneshot::channel();
+    scheduler
+        .schedule_manual_compaction(
+            compact_request::Options::Regular(Default::default()),
+            &version_control,
+            &env.access_layer,
+            OptionOutputTx::from(second_tx),
+            &manifest_ctx,
+            schema_metadata_manager,
+            1,
+            None,
+        )
+        .unwrap();
+
+    let err = second_rx
+        .try_recv()
+        .expect("a concurrent manual compaction should fail immediately")
+        .expect_err("a concurrent manual compaction should return an error");
+    assert_matches!(
+        err,
+        crate::error::Error::ManualCompactionAlreadyRunning {
+            region_id: running_region_id
+        } if running_region_id == region_id
+    );
+    assert!(
+        scheduler
+            .region_status
+            .get(&region_id)
+            .unwrap()
+            .pending_request
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn test_ranged_compaction_stops_without_followup() {
     let job_scheduler = Arc::new(VecScheduler::default());
     let env = SchedulerEnv::new().await.scheduler(job_scheduler.clone());
     let (tx, mut rx) = mpsc::channel(4);
@@ -1290,8 +1227,7 @@ async fn test_ranged_compaction_continuation_preserves_time_range() {
     .unwrap();
 
     scheduler
-        .schedule_compaction_with_time_range(
-            region_id,
+        .schedule_manual_compaction(
             compact_request::Options::StrictWindow(StrictWindow {
                 window_seconds: 3_600,
             }),
@@ -1318,23 +1254,103 @@ async fn test_ranged_compaction_continuation_preserves_time_range() {
     scheduler
         .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
         .await;
-    assert!(scheduler.schedule_next_compaction(region_id, &manifest_ctx, schema_metadata_manager,));
+    assert!(!scheduler.region_status.contains_key(&region_id));
+    assert_eq!(1, job_scheduler.num_jobs());
+}
+
+#[tokio::test]
+async fn test_automatic_trigger_during_execution_clears_continuation_scope() {
+    let job_scheduler = Arc::new(VecScheduler::default());
+    let env = SchedulerEnv::new().await.scheduler(job_scheduler.clone());
+    let (tx, mut rx) = mpsc::channel(4);
+    let mut scheduler = env.mock_compaction_scheduler(tx);
+
+    let mut builder = VersionControlBuilder::new();
+    for offset in [0, 10, 20, 30] {
+        builder.push_l0_file(offset, 1_000);
+    }
+    for offset in [0, 10, 20, 30] {
+        builder.push_l0_file(2 * 3_600_000 + offset, 2 * 3_600_000 + 1_000);
+    }
+    let region_id = builder.region_id();
+    let version_control = Arc::new(builder.build());
+    let manifest_ctx = env
+        .mock_manifest_context(version_control.current().version.metadata.clone())
+        .await;
+    let (schema_metadata_manager, kv_backend) = mock_schema_metadata_manager();
+    let mut schema_value = SchemaNameValue::default();
+    schema_value
+        .extra_options
+        .insert("compaction.type".to_string(), "twcs".to_string());
+    schema_value
+        .extra_options
+        .insert("compaction.twcs.time_window".to_string(), "1h".to_string());
+    schema_metadata_manager
+        .register_region_table_info(
+            region_id.table_id(),
+            "t",
+            "c",
+            "s",
+            Some(schema_value),
+            kv_backend,
+        )
+        .await;
+    let time_range = TimestampRange::new(
+        Timestamp::new_millisecond(0),
+        Timestamp::new_millisecond(3_600_000),
+    )
+    .unwrap();
+
+    scheduler
+        .schedule_manual_compaction(
+            compact_request::Options::StrictWindow(StrictWindow {
+                window_seconds: 3_600,
+            }),
+            &version_control,
+            &env.access_layer,
+            OptionOutputTx::none(),
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            1,
+            Some(time_range),
+        )
+        .unwrap();
+    let first = recv_compaction_pick_finished(&mut rx).await;
+    scheduler
+        .handle_compaction_pick_finished(first, &manifest_ctx, schema_metadata_manager.clone())
+        .await;
+    // The manual compaction is now in the local execution phase.
+    assert_eq!(1, job_scheduler.num_jobs());
+
+    // An unrestricted automatic trigger (e.g. caused by a flush) arrives during execution.
+    scheduler
+        .schedule_automatic_compaction(
+            compact_request::Options::Regular(Default::default()),
+            &version_control,
+            &env.access_layer,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+        )
+        .unwrap();
+
+    // Finishing the manual execution must chain an unrestricted follow-up instead of
+    // continuing with the manual request's time range.
+    scheduler
+        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
+        .await;
 
     let continuation = recv_compaction_pick_finished(&mut rx).await;
-    match continuation.result {
-        CompactionPlanningResult::NoPlan => {}
-        CompactionPlanningResult::Prepared(prepared) => assert!(
-            prepared
-                .picker_output
-                .outputs
-                .iter()
-                .flat_map(|output| &output.inputs)
-                .all(|file| file.time_range().1 < Timestamp::new_millisecond(3_600_000))
-        ),
-        CompactionPlanningResult::Error(err) => {
-            panic!("unexpected compaction planning error: {err}")
-        }
-    }
+    let CompactionPlanningResult::Prepared(prepared) = continuation.result else {
+        panic!("expected the unrestricted follow-up to select out-of-range windows");
+    };
+    assert!(
+        prepared
+            .picker_output
+            .outputs
+            .iter()
+            .flat_map(|output| &output.inputs)
+            .any(|file| file.time_range().1 >= Timestamp::new_millisecond(2 * 3_600_000))
+    );
 }
 
 #[tokio::test]
@@ -1346,7 +1362,6 @@ async fn test_compaction_bypass_in_staging_mode() {
     // Create version control and manifest context for staging mode
     let builder = VersionControlBuilder::new();
     let version_control = Arc::new(builder.build());
-    let region_id = version_control.current().version.metadata.region_id;
 
     // Create staging manifest context using the same pattern as SchedulerEnv
     let staging_manifest_ctx = {
@@ -1378,8 +1393,7 @@ async fn test_compaction_bypass_in_staging_mode() {
     // Test regular compaction bypass in staging mode
     let (tx, rx) = oneshot::channel();
     scheduler
-        .schedule_compaction(
-            region_id,
+        .schedule_manual_compaction(
             compact_request::Options::Regular(Default::default()),
             &version_control,
             &env.access_layer,
@@ -1387,11 +1401,12 @@ async fn test_compaction_bypass_in_staging_mode() {
             &staging_manifest_ctx,
             schema_metadata_manager,
             1,
+            None,
         )
         .unwrap();
 
     let result = rx.await.unwrap();
-    assert_eq!(result.unwrap(), 0); // is there a better way to check this?
+    assert_eq!(result.unwrap(), 0);
     assert_eq!(0, scheduler.region_status.len());
 }
 
@@ -1406,7 +1421,7 @@ async fn test_add_ddl_request_to_pending() {
 
     scheduler.region_status.insert(
         region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone()),
     );
     scheduler
         .region_status
@@ -1444,7 +1459,7 @@ async fn test_pending_ddl_fences_later_compaction_triggers() {
 
     let (first_manual_tx, mut first_manual_rx) = oneshot::channel();
     let mut status =
-        CompactionStatus::new(region_id, version_control.clone(), env.access_layer.clone());
+        CompactionStatus::for_test(region_id, version_control.clone(), env.access_layer.clone());
     status.start_local_task();
     status.set_pending_request(PendingCompaction {
         options: compact_request::Options::StrictWindow(StrictWindow { window_seconds: 60 }),
@@ -1469,21 +1484,18 @@ async fn test_pending_ddl_fences_later_compaction_triggers() {
     // Automatic regular triggers have no waiter and are ignored by the DDL fence.
     assert!(
         !scheduler
-            .schedule_compaction(
-                region_id,
+            .schedule_automatic_compaction(
                 compact_request::Options::Regular(Default::default()),
                 &version_control,
                 &env.access_layer,
-                OptionOutputTx::none(),
                 &manifest_ctx,
                 schema_metadata_manager.clone(),
-                1,
             )
             .unwrap()
     );
-    let active = scheduler.region_status[&region_id].active.as_ref().unwrap();
+    let active = &scheduler.region_status[&region_id].active;
     assert!(active.waiters.is_empty());
-    assert!(active.regular_followup_waiters.is_none());
+    assert!(!active.automatic_followup_required);
 
     // Explicit regular and strict-window requests both have waiters and are rejected.
     for options in [
@@ -1495,8 +1507,7 @@ async fn test_pending_ddl_fences_later_compaction_triggers() {
         let (later_tx, later_rx) = oneshot::channel();
         assert!(
             !scheduler
-                .schedule_compaction(
-                    region_id,
+                .schedule_manual_compaction(
                     options,
                     &version_control,
                     &env.access_layer,
@@ -1504,6 +1515,7 @@ async fn test_pending_ddl_fences_later_compaction_triggers() {
                     &manifest_ctx,
                     schema_metadata_manager.clone(),
                     1,
+                    None,
                 )
                 .unwrap()
         );
@@ -1533,7 +1545,8 @@ async fn test_request_cancel_state_transitions() {
     let builder = VersionControlBuilder::new();
     let region_id = builder.region_id();
     let version_control = Arc::new(builder.build());
-    let mut status = CompactionStatus::new(region_id, version_control, env.access_layer.clone());
+    let mut status =
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone());
     let state = status.start_local_task();
 
     assert_eq!(status.request_cancel(), RequestCancelResult::CancelIssued);
@@ -1548,9 +1561,6 @@ async fn test_request_cancel_state_transitions() {
         status.request_cancel(),
         RequestCancelResult::AlreadyCancelling
     );
-
-    assert!(status.clear_running_task());
-    assert_eq!(status.request_cancel(), RequestCancelResult::NotRunning);
 }
 
 #[tokio::test]
@@ -1559,7 +1569,8 @@ async fn test_request_cancel_remote_compaction_is_too_late() {
     let builder = VersionControlBuilder::new();
     let region_id = builder.region_id();
     let version_control = Arc::new(builder.build());
-    let mut status = CompactionStatus::new(region_id, version_control, env.access_layer.clone());
+    let mut status =
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone());
 
     status.start_remote_task();
 
@@ -1567,7 +1578,6 @@ async fn test_request_cancel_remote_compaction_is_too_late() {
         status.request_cancel(),
         RequestCancelResult::TooLateToCancel
     );
-    assert!(status.is_busy());
 }
 
 #[tokio::test]
@@ -1604,7 +1614,8 @@ async fn test_try_cancel_and_add_ddl_cancels_and_queues_atomically() {
     let builder = VersionControlBuilder::new();
     let region_id = builder.region_id();
     let version_control = Arc::new(builder.build());
-    let mut status = CompactionStatus::new(region_id, version_control, env.access_layer.clone());
+    let mut status =
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone());
     status.start_picking(7);
     scheduler.region_status.insert(region_id, status);
     let (ddl_tx, _ddl_rx) = oneshot::channel();
@@ -1641,10 +1652,10 @@ async fn test_on_compaction_cancelled_returns_pending_ddl_requests() {
         .await;
     let (_schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
 
-    let (regular_tx, regular_rx) = oneshot::channel();
-    let mut status = CompactionStatus::new(region_id, version_control, env.access_layer.clone());
+    let mut status =
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone());
     status.start_picking(7);
-    status.merge_regular_trigger(OptionOutputTx::from(regular_tx));
+    status.mark_automatic_trigger();
     status.start_local_task();
     scheduler.region_status.insert(region_id, status);
 
@@ -1666,7 +1677,6 @@ async fn test_on_compaction_cancelled_returns_pending_ddl_requests() {
     assert!(!scheduler.has_pending_ddls(region_id));
     assert!(!scheduler.region_status.contains_key(&region_id));
     assert_eq!(job_scheduler.num_jobs(), 0);
-    assert!(regular_rx.await.unwrap().is_err());
 }
 
 #[tokio::test]
@@ -1685,7 +1695,7 @@ async fn test_on_compaction_cancelled_prioritizes_pending_ddls_over_pending_comp
 
     scheduler.region_status.insert(
         region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone()),
     );
     let status = scheduler.region_status.get_mut(&region_id).unwrap();
     status.start_local_task();
@@ -1726,10 +1736,10 @@ async fn test_pending_ddl_request_failed_on_compaction_failed() {
     let version_control = Arc::new(builder.build());
     let region_id = builder.region_id();
 
-    let (regular_tx, regular_rx) = oneshot::channel();
-    let mut status = CompactionStatus::new(region_id, version_control, env.access_layer.clone());
+    let mut status =
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone());
     status.start_picking(7);
-    status.merge_regular_trigger(OptionOutputTx::from(regular_tx));
+    status.mark_automatic_trigger();
     status.start_local_task();
     scheduler.region_status.insert(region_id, status);
 
@@ -1751,7 +1761,6 @@ async fn test_pending_ddl_request_failed_on_compaction_failed() {
     assert!(!scheduler.has_pending_ddls(region_id));
     let result = output_rx.await.unwrap();
     assert_matches!(result, Err(_));
-    assert!(regular_rx.await.unwrap().is_err());
     assert!(rx.try_recv().is_err());
 }
 
@@ -1766,7 +1775,7 @@ async fn test_pending_ddl_request_failed_on_region_closed() {
 
     scheduler.region_status.insert(
         region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone()),
     );
 
     let (output_tx, output_rx) = oneshot::channel();
@@ -1800,7 +1809,7 @@ async fn test_pending_ddl_request_failed_on_region_dropped() {
 
     scheduler.region_status.insert(
         region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone()),
     );
 
     let (output_tx, output_rx) = oneshot::channel();
@@ -1834,7 +1843,7 @@ async fn test_pending_ddl_request_failed_on_region_truncated() {
 
     scheduler.region_status.insert(
         region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone()),
     );
 
     let (output_tx, output_rx) = oneshot::channel();
@@ -1873,7 +1882,7 @@ async fn test_on_compaction_finished_returns_pending_ddl_requests() {
 
     scheduler.region_status.insert(
         region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone()),
     );
     scheduler
         .region_status
@@ -1918,7 +1927,7 @@ async fn test_on_compaction_finished_replays_pending_ddl_after_manual_noop() {
 
     let (manual_tx, manual_rx) = oneshot::channel();
     let mut status =
-        CompactionStatus::new(region_id, version_control.clone(), env.access_layer.clone());
+        CompactionStatus::for_test(region_id, version_control.clone(), env.access_layer.clone());
     status.start_local_task();
     status.set_pending_request(PendingCompaction {
         options: compact_request::Options::Regular(Default::default()),
@@ -1967,14 +1976,13 @@ async fn test_on_compaction_finished_dispatches_pending_ddl_before_chained_regul
         .await;
     let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
 
-    // A regular trigger was retained while picking and the region is now
+    // An automatic trigger was recorded while picking and the region is now
     // executing; a DDL queued behind the task must be dispatched as soon
     // as the task finishes instead of waiting for a whole extra cycle.
-    let (regular_tx, regular_rx) = oneshot::channel();
     let mut status =
-        CompactionStatus::new(region_id, version_control.clone(), env.access_layer.clone());
+        CompactionStatus::for_test(region_id, version_control.clone(), env.access_layer.clone());
     status.start_picking(7);
-    status.merge_regular_trigger(OptionOutputTx::from(regular_tx));
+    status.mark_automatic_trigger();
     status.start_local_task();
     scheduler.region_status.insert(region_id, status);
 
@@ -1995,7 +2003,6 @@ async fn test_on_compaction_finished_dispatches_pending_ddl_before_chained_regul
         .await;
 
     assert_eq!(pending_ddls.len(), 1);
-    assert_eq!(regular_rx.await.unwrap().unwrap(), 0);
     assert!(!scheduler.region_status.contains_key(&region_id));
     assert!(rx.try_recv().is_err());
 }
@@ -2046,7 +2053,7 @@ async fn test_on_compaction_finished_manual_schedule_error_cleans_status() {
 
     let (manual_tx, manual_rx) = oneshot::channel();
     let mut status =
-        CompactionStatus::new(region_id, version_control.clone(), env.access_layer.clone());
+        CompactionStatus::for_test(region_id, version_control.clone(), env.access_layer.clone());
     status.start_local_task();
     status.set_pending_request(PendingCompaction {
         options: compact_request::Options::Regular(Default::default()),
@@ -2081,108 +2088,6 @@ async fn test_on_compaction_finished_manual_schedule_error_cleans_status() {
     assert!(!scheduler.region_status.contains_key(&region_id));
     assert_matches!(manual_rx.await.unwrap(), Err(_));
     assert_matches!(ddl_rx.await.unwrap(), Err(_));
-}
-
-#[tokio::test]
-async fn test_on_compaction_finished_next_schedule_noop_removes_status() {
-    let env = SchedulerEnv::new().await;
-    let (tx, mut rx) = mpsc::channel(4);
-    let mut scheduler = env.mock_compaction_scheduler(tx);
-    let builder = VersionControlBuilder::new();
-    let version_control = Arc::new(builder.build());
-    let region_id = builder.region_id();
-    let manifest_ctx = env
-        .mock_manifest_context(version_control.current().version.metadata.clone())
-        .await;
-    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
-
-    scheduler.region_status.insert(
-        region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
-    );
-    scheduler
-        .region_status
-        .get_mut(&region_id)
-        .unwrap()
-        .start_local_task();
-
-    let pending_ddls = scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager)
-        .await;
-
-    assert!(pending_ddls.is_empty());
-    assert!(scheduler.region_status.contains_key(&region_id));
-
-    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
-    // With no compactable files, next scheduling returns false and removes
-    // the status without creating a background task.
-    let scheduled = scheduler.schedule_next_compaction(
-        region_id,
-        &manifest_ctx,
-        schema_metadata_manager.clone(),
-    );
-    assert!(scheduled);
-    let finished = recv_compaction_pick_finished(&mut rx).await;
-    scheduler
-        .handle_compaction_pick_finished(finished, &manifest_ctx, schema_metadata_manager)
-        .await;
-    assert!(!scheduler.region_status.contains_key(&region_id));
-}
-
-#[tokio::test]
-async fn test_on_compaction_finished_next_schedule_error_cleans_status() {
-    let env = SchedulerEnv::new()
-        .await
-        .scheduler(Arc::new(FailingScheduler));
-    let (tx, mut rx) = mpsc::channel(4);
-    let mut scheduler = env.mock_compaction_scheduler(tx);
-    let mut builder = VersionControlBuilder::new();
-    let end = 1000 * 1000;
-    let version_control = Arc::new(
-        builder
-            .push_l0_file(0, end)
-            .push_l0_file(10, end)
-            .push_l0_file(50, end)
-            .push_l0_file(80, end)
-            .push_l0_file(90, end)
-            .build(),
-    );
-    let region_id = builder.region_id();
-    let manifest_ctx = env
-        .mock_manifest_context(version_control.current().version.metadata.clone())
-        .await;
-    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
-
-    scheduler.region_status.insert(
-        region_id,
-        CompactionStatus::new(region_id, version_control, env.access_layer.clone()),
-    );
-    scheduler
-        .region_status
-        .get_mut(&region_id)
-        .unwrap()
-        .start_local_task();
-
-    let pending_ddls = scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager)
-        .await;
-
-    assert!(pending_ddls.is_empty());
-    assert!(scheduler.region_status.contains_key(&region_id));
-
-    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
-    // The failing scheduler simulates a submit error; callers must see false.
-    let scheduled = scheduler.schedule_next_compaction(
-        region_id,
-        &manifest_ctx,
-        schema_metadata_manager.clone(),
-    );
-    assert!(scheduled);
-    let finished = recv_compaction_pick_finished(&mut rx).await;
-    scheduler
-        .handle_compaction_pick_finished(finished, &manifest_ctx, schema_metadata_manager)
-        .await;
-    assert!(!scheduler.region_status.contains_key(&region_id));
 }
 
 #[tokio::test]

--- a/src/mito2/src/compaction/scheduler_test.rs
+++ b/src/mito2/src/compaction/scheduler_test.rs
@@ -436,6 +436,39 @@ async fn test_schedule_compaction_returns_true_when_task_scheduled() {
 }
 
 #[tokio::test]
+async fn test_planning_followup_reports_automatic_schedule() {
+    let env = SchedulerEnv::new().await;
+    let (tx, _rx) = mpsc::channel(4);
+    let mut scheduler = env.mock_compaction_scheduler(tx);
+    let builder = VersionControlBuilder::new();
+    let region_id = builder.region_id();
+    let version_control = Arc::new(builder.build());
+    let manifest_ctx = env
+        .mock_manifest_context(version_control.current().version.metadata.clone())
+        .await;
+    let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
+    let mut status =
+        CompactionStatus::for_test(region_id, version_control, env.access_layer.clone());
+    status.start_picking(7);
+    status.mark_automatic_trigger();
+    scheduler.region_status.insert(region_id, status);
+
+    let transition = scheduler
+        .handle_compaction_pick_finished(
+            CompactionPickFinished {
+                region_id,
+                plan_id: 7,
+                result: CompactionPlanningResult::NoPlan,
+            },
+            &manifest_ctx,
+            schema_metadata_manager,
+        )
+        .await;
+
+    assert_matches!(transition, CompactionTransition::AutomaticFollowupScheduled);
+}
+
+#[tokio::test]
 async fn test_planning_panic_notifies_and_clears_status() {
     let env = SchedulerEnv::new().await;
     let (tx, mut rx) = mpsc::channel(4);

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -200,7 +200,9 @@ async fn test_append_mode_compaction_with_format(flat_format: bool) {
         .scanner(region_id, ScanRequest::default())
         .await
         .unwrap();
-    assert_eq!(2, scanner.num_files());
+    // The manual compaction waits for the in-flight automatic compaction, then runs its own
+    // cycle and compacts the remaining SSTs into one file.
+    assert_eq!(1, scanner.num_files());
     assert_eq!(1, scanner.num_memtables());
     scanner.set_target_partitions(2);
     let stream = scanner.scan().await.unwrap();

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -38,6 +38,7 @@ use tokio::sync::{Notify, Semaphore};
 
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
+use crate::engine::flush_test::MockTimeProvider;
 use crate::engine::listener::{CompactionListener, EventListener};
 use crate::test_util::{
     CreateRequestBuilder, TestEnv, build_rows_for_key, column_metadata_to_column_schema, put_rows,
@@ -381,6 +382,105 @@ impl EventListener for CompactionPlanningGate {
             self.cancel_requested.notify_one();
         }
     }
+}
+
+#[tokio::test]
+async fn test_planning_followup_updates_schedule_time() {
+    assert_automatic_followup_updates_schedule_time(0).await;
+}
+
+#[tokio::test]
+async fn test_execution_followup_updates_schedule_time() {
+    assert_automatic_followup_updates_schedule_time(4).await;
+}
+
+async fn assert_automatic_followup_updates_schedule_time(preexisting_flushes: usize) {
+    let mut env = TestEnv::new().await;
+    let region_id = RegionId::new(1, 1);
+    let gate = Arc::new(CompactionPlanningGate::new(region_id));
+    let interval = Duration::from_secs(60 * 60);
+    let initial_time = 1_000;
+    let time_provider = Arc::new(MockTimeProvider::new(initial_time));
+    let engine = env
+        .create_engine_with_time(
+            MitoConfig {
+                min_compaction_interval: interval,
+                ..Default::default()
+            },
+            None,
+            Some(gate.clone()),
+            time_provider.clone(),
+        )
+        .await;
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "automatic_followup_interval",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    let create = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .build();
+    let column_schemas = create
+        .column_metadatas
+        .iter()
+        .map(column_metadata_to_column_schema)
+        .collect::<Vec<_>>();
+    engine
+        .handle_request(region_id, RegionRequest::Create(create))
+        .await
+        .unwrap();
+
+    for offset in 0..preexisting_flushes {
+        put_and_flush(
+            &engine,
+            region_id,
+            &column_schemas,
+            offset * 10..offset * 10 + 10,
+        )
+        .await;
+    }
+
+    let first_schedule_time = initial_time + interval.as_millis() as i64;
+    time_provider.set_now(first_schedule_time);
+    let gate_guard = gate.arm();
+    let first_start = preexisting_flushes * 10;
+    put_and_flush(
+        &engine,
+        region_id,
+        &column_schemas,
+        first_start..first_start + 10,
+    )
+    .await;
+    tokio::time::timeout(Duration::from_secs(5), gate.wait_until_entered())
+        .await
+        .expect("initial automatic planning did not reach the gate");
+
+    let trigger_time = first_schedule_time + interval.as_millis() as i64;
+    time_provider.set_now(trigger_time);
+    put_and_flush(
+        &engine,
+        region_id,
+        &column_schemas,
+        first_start + 10..first_start + 20,
+    )
+    .await;
+    let followup_schedule_time = trigger_time + 1;
+    time_provider.set_now(followup_schedule_time);
+    gate_guard.release();
+
+    let region = engine.get_region(region_id).unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while region.last_schedule_compaction_millis() != followup_schedule_time {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("automatic follow-up did not update its schedule time");
 }
 
 #[tokio::test]

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1600,6 +1600,7 @@ impl ErrorExt for Error {
             | UpdateManifest { .. }
             | RegionStopped { .. }
             | RegionBusy { .. }
+            | ManualCompactionAlreadyRunning { .. }
             | FlushableRegionState { .. } => RetryHint::Retryable,
 
             OpenDal { error, .. }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -1157,6 +1157,9 @@ pub enum Error {
     #[snafu(display("Manual compaction is override by following operations."))]
     ManualCompactionOverride {},
 
+    #[snafu(display("Manual compaction is already running for region {region_id}."))]
+    ManualCompactionAlreadyRunning { region_id: RegionId },
+
     #[snafu(display("Compaction is cancelled."))]
     CompactionCancelled {},
 
@@ -1550,6 +1553,11 @@ impl ErrorExt for Error {
             ManualCompactionOverride {} | CompactionCancelled {} | FlushCancelled {} => {
                 StatusCode::Cancelled
             }
+
+            // A concurrent manual compaction fails fast instead of being queued;
+            // the conflict is reported to the caller, which decides whether to
+            // issue a new request after the running one finishes.
+            ManualCompactionAlreadyRunning { .. } => StatusCode::RegionBusy,
 
             CompactionMemoryExhausted { source, .. } => source.status_code(),
 

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 
 use common_telemetry::info;
 use store_api::metadata::RegionMetadataRef;
-use store_api::storage::SequenceNumber;
+use store_api::storage::{RegionId, SequenceNumber};
 
 use crate::error::Result;
 use crate::manifest::action::{RegionEdit, TruncateKind};
@@ -64,6 +64,11 @@ impl VersionControl {
                 is_dropped: false,
             }),
         }
+    }
+
+    /// Returns the id of the region controlled by this instance.
+    pub(crate) fn region_id(&self) -> RegionId {
+        self.data.read().unwrap().version.metadata.region_id
     }
 
     /// Returns current copy of data.

--- a/src/mito2/src/schedule.rs
+++ b/src/mito2/src/schedule.rs
@@ -74,7 +74,6 @@ pub(crate) enum RequestCancelResult {
     CancelIssued,
     AlreadyCancelling,
     TooLateToCancel,
-    NotRunning,
 }
 
 #[cfg(test)]

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -41,6 +41,10 @@ impl<S> RegionWorkerLoop<S> {
         let Some(region) = self.regions.get_region(region_id) else {
             return;
         };
+        // A terminal pick (canceled, no plan, or failed) may remove the
+        // compaction status and release DDLs fenced behind its picking phase.
+        // Such a pick never produces an execution callback, so the worker must
+        // execute the returned DDLs from this notification.
         let mut pending_ddls = self
             .compaction_scheduler
             .handle_compaction_pick_finished(
@@ -50,6 +54,8 @@ impl<S> RegionWorkerLoop<S> {
             )
             .await;
         if !pending_ddls.is_empty() {
+            // Preserve the lifecycle order observed by listeners: compaction
+            // termination is visible before its dependent DDLs are dispatched.
             self.listener.on_compaction_result_notified(region_id).await;
         }
         self.handle_ddl_requests(&mut pending_ddls).await;
@@ -67,26 +73,27 @@ impl<S> RegionWorkerLoop<S> {
         };
         COMPACTION_REQUEST_COUNT.inc();
         let parallelism = req.parallelism.unwrap_or(1) as usize;
-        if let Err(e) = self
-            .compaction_scheduler
-            .schedule_compaction_with_time_range(
-                region.region_id,
-                req.options,
-                &region.version_control,
-                &region.access_layer,
-                sender,
-                &region.manifest_ctx,
-                self.schema_metadata_manager.clone(),
-                parallelism,
-                req.time_range,
-            )
-        {
-            error!(e; "Failed to schedule compaction task for region: {}", region_id);
-        } else {
-            info!(
+        match self.compaction_scheduler.schedule_manual_compaction(
+            req.options,
+            &region.version_control,
+            &region.access_layer,
+            sender,
+            &region.manifest_ctx,
+            self.schema_metadata_manager.clone(),
+            parallelism,
+            req.time_range,
+        ) {
+            // Ok(false) means the request was merged, queued or rejected; the
+            // waiter was already notified or will be completed by the queued
+            // cycle, so only a newly scheduled task is logged as success.
+            Ok(true) => info!(
                 "Successfully scheduled compaction task for region: {}",
                 region_id
-            );
+            ),
+            Ok(false) => {}
+            Err(e) => {
+                error!(e; "Failed to schedule compaction task for region: {}", region_id);
+            }
         }
     }
 
@@ -153,34 +160,6 @@ impl<S> RegionWorkerLoop<S> {
             )
             .await;
         self.handle_ddl_requests(&mut pending_ddls).await;
-
-        if self.compaction_scheduler.is_compacting(region_id) {
-            return;
-        }
-
-        let now = self.time_provider.current_time_millis();
-        if now - region.last_schedule_compaction_millis()
-            >= self.config.min_compaction_interval.as_millis() as i64
-        {
-            debug!(
-                "minimal compaction interval time {:?} has passed, scheduling next compaction",
-                self.config.min_compaction_interval
-            );
-            if self.compaction_scheduler.schedule_next_compaction(
-                region_id,
-                &region.manifest_ctx,
-                self.schema_metadata_manager.clone(),
-            ) {
-                region.update_schedule_compaction_millis();
-            }
-        } else {
-            // The compaction finished within the minimal interval, so the
-            // chained planning is skipped. The finished compaction left an
-            // idle status (no running task) behind; remove it, otherwise it
-            // becomes a zombie that blocks all future compaction scheduling
-            // of the region.
-            self.compaction_scheduler.remove_idle_status(region_id);
-        }
     }
 
     pub(crate) async fn handle_compaction_cancelled(
@@ -251,15 +230,12 @@ impl<S> RegionWorkerLoop<S> {
                 "minimal compaction interval time {:?} has passed, scheduling next compaction",
                 self.config.min_compaction_interval
             );
-            match self.compaction_scheduler.schedule_compaction(
-                region.region_id,
+            match self.compaction_scheduler.schedule_automatic_compaction(
                 compact_request::Options::Regular(Default::default()),
                 &region.version_control,
                 &region.access_layer,
-                OptionOutputTx::none(),
                 &region.manifest_ctx,
                 self.schema_metadata_manager.clone(),
-                1, // Default for automatic compaction
             ) {
                 Ok(true) => region.update_schedule_compaction_millis(),
                 Ok(false) => {}

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -18,7 +18,7 @@ use store_api::logstore::LogStore;
 use store_api::region_request::RegionCompactRequest;
 use store_api::storage::RegionId;
 
-use crate::compaction::CompactionPickFinished;
+use crate::compaction::{CompactionPickFinished, CompactionTransition};
 use crate::config::IndexBuildMode;
 use crate::error::{RegionNotFoundSnafu, StaleCompactionExecutionSnafu};
 use crate::metrics::COMPACTION_REQUEST_COUNT;
@@ -45,7 +45,7 @@ impl<S> RegionWorkerLoop<S> {
         // compaction status and release DDLs fenced behind its picking phase.
         // Such a pick never produces an execution callback, so the worker must
         // execute the returned DDLs from this notification.
-        let mut pending_ddls = self
+        let transition = self
             .compaction_scheduler
             .handle_compaction_pick_finished(
                 request,
@@ -53,12 +53,22 @@ impl<S> RegionWorkerLoop<S> {
                 self.schema_metadata_manager.clone(),
             )
             .await;
-        if !pending_ddls.is_empty() {
-            // Preserve the lifecycle order observed by listeners: compaction
-            // termination is visible before its dependent DDLs are dispatched.
-            self.listener.on_compaction_result_notified(region_id).await;
+        match transition {
+            CompactionTransition::AutomaticFollowupScheduled => {
+                // There will be a followup compaction so we need to update the
+                // last schedule time to avoid frequent compactions.
+                region.update_schedule_compaction_millis();
+            }
+            CompactionTransition::NoAction => {}
+            CompactionTransition::DdlReady(mut pending_ddls) => {
+                if !pending_ddls.is_empty() {
+                    // Preserve the lifecycle order observed by listeners: compaction
+                    // termination is visible before its dependent DDLs are dispatched.
+                    self.listener.on_compaction_result_notified(region_id).await;
+                    self.handle_ddl_requests(&mut pending_ddls).await;
+                }
+            }
         }
-        self.handle_ddl_requests(&mut pending_ddls).await;
     }
 
     /// Handles compaction request submitted to region worker.
@@ -150,7 +160,7 @@ impl<S> RegionWorkerLoop<S> {
         }
 
         // Schedule next compaction if necessary.
-        let mut pending_ddls = self
+        let transition = self
             .compaction_scheduler
             .on_execution_finished(
                 region_id,
@@ -159,7 +169,15 @@ impl<S> RegionWorkerLoop<S> {
                 self.schema_metadata_manager.clone(),
             )
             .await;
-        self.handle_ddl_requests(&mut pending_ddls).await;
+        match transition {
+            CompactionTransition::AutomaticFollowupScheduled => {
+                region.update_schedule_compaction_millis();
+            }
+            CompactionTransition::NoAction => {}
+            CompactionTransition::DdlReady(mut pending_ddls) => {
+                self.handle_ddl_requests(&mut pending_ddls).await;
+            }
+        }
     }
 
     pub(crate) async fn handle_compaction_cancelled(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8698. Bounded compaction continuation is tracked in #8717.

## What's changed and what's your intention?

This PR makes compaction trigger and lifecycle behavior explicit after the scheduler module split in #8698. The goal is to ensure scheduler status always represents active work, distinguish automatic triggers from manual requests, and avoid accidental or unbounded continuation cycles.

- Introduce explicit automatic and manual compaction trigger semantics.
- Represent planning/execution terminal outcomes with `CompactionTransition`, making automatic follow-ups and ready DDLs mutually exclusive.
- Remove transient idle scheduler statuses so map presence always represents an active lifecycle.
- Add scheduler and engine-level regression tests for planning and execution follow-up paths.

## Behavior changes

| Scenario | Before this PR | After this PR |
| --- | --- | --- |
| Automatic trigger while a compaction is active | A trigger received during Picking requested a follow-up, but a trigger received during Local/Remote execution could be absorbed into the current cycle without a fresh pick. | Triggers received during any active phase are coalesced into exactly one unrestricted automatic follow-up planning cycle. |
| Manual request classification | Whether a request used the manual pending slot was inferred from its options: only strict-window or ranged requests were considered manual; an unrestricted regular request followed regular-trigger merge semantics. | Every explicit compact request is classified as manual independently of its options or time range. |
| Manual request during an automatic compaction | Strict-window/ranged requests were queued, while an unrestricted regular request could merge into the current cycle or its regular follow-up. | The manual request is queued and starts after the automatic cycle terminates. A newer queued manual request replaces the older one and the older waiter receives `ManualCompactionOverride`. |
| Manual request during a manual compaction | The request could be merged, queued, or replace an existing pending request depending on its options. | The request fails immediately with `RegionBusy`; concurrent manual compactions are not queued. |
| Automatic backlog draining after a successful round | Subject to `min_compaction_interval`, the worker repeatedly scheduled another regular round after each successful execution until the picker returned `NoPlan`; one automatic trigger could therefore drain all eligible TWCS windows. | The lifecycle stops unless a manual request is queued or another automatic trigger arrived while the round was active. One round picks at most `max_background_compactions` eligible TWCS windows, so excess windows wait for a later flush/edit/manual trigger and may remain after writes stop. Bounded debt-driven continuation is tracked in #8717. |
| Manual or ranged compaction completion | The implicit continuation could keep planning with retained scope after a successful execution. | The requested cycle stops after its execution unless a separate automatic trigger arrived while it was active; that trigger starts an unrestricted follow-up. |
| Automatic follow-up interval accounting | A directly chained follow-up did not record its planning start in `last_schedule_compaction_millis`, allowing later triggers to pass interval gating against an older timestamp. | Dispatching an automatic follow-up records its actual planning start, so subsequent automatic starts continue to respect `min_compaction_interval`. |

DDL fencing, cancellation/failure propagation, stale-notification fencing, persisted formats, wire protocols, schemas, configuration, and public APIs remain unchanged.

### Verification

- `cargo nextest run -p mito2 test_planning_followup_updates_schedule_time`
- `cargo nextest run -p mito2 test_execution_followup_updates_schedule_time`
- `python3 scripts/check-super-imports.py`
- `git diff --check GreptimeTeam/main...HEAD`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.