### PR TITLE
test: stabilize remote dynamic filter left join e2e

### DIFF
--- a/tests-integration/src/tests/remote_dyn_filter_test.rs
+++ b/tests-integration/src/tests/remote_dyn_filter_test.rs
@@ -100,13 +100,9 @@ async fn test_remote_dyn_filter_left_join_e2e() {
 
     assert_contains(&explain, "HashJoinExec: mode=CollectLeft, join_type=Left");
     assert_contains(&explain, "MergeScanExec");
-    assert_seq_scan_dyn_filter_contains(
-        &explain,
-        &[
-            "DynamicFilter [ k@0 >= 2 AND k@0 <= 9",
-            "k@0 IN (SET) ([2, 4, 9])",
-        ],
-    );
+    // RDF is best-effort, so this tiny query may finish before the runtime
+    // predicate is fanned out. Only assert that RDF was planned for the scan.
+    assert_seq_scan_has_dyn_filter(&explain);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

The remote dynamic filter implementation itself is from #8262.

## What's changed and what's your intention?

### Summary

Stabilizes the flaky integration test `tests::remote_dyn_filter_test::test_remote_dyn_filter_left_join_e2e`.

### Background

Remote Dynamic Filters are a **best-effort optimization**, not a correctness mechanism. For a tiny probe scan (this test scans only a handful of rows across 4 regions), the query can legitimately finish and stream EOF **before** the frontend's fanout task pushes the runtime predicate (`[2, 4, 9]`) to the datanodes:

1. `MergeScanExec` registers the initial RDF subscription and issues `do_get` for each region;
2. the datanode registers the subscription and starts producing the tiny scan;
3. only after `do_get` returns does the frontend start the fanout task;
4. a fast tiny scan reaches EOF first, the stream guard removes the registration;
5. the late update hits the expected fail-open `MissingRegistration` path and the scan legitimately shows `DynamicFilter [ true ]`.

So the old assertion that the EXPLAIN must contain the concrete runtime predicate (`k@0 >= 2 AND k@0 <= 9`, `k@0 IN (SET) ([2, 4, 9])`) is inherently timing-dependent and makes the test flaky even though the query results are always correct.

### Change

- Keep the exact LEFT JOIN result assertions (including the unmatched `9 | -1.0` row).
- Keep the distributed-plan assertions (`HashJoinExec: mode=CollectLeft, join_type=Left`, `MergeScanExec`).
- Replace the timing-sensitive concrete-predicate assertion with the existing `assert_seq_scan_has_dyn_filter`, which verifies the region SeqScan planned `dyn_filters` without requiring the runtime predicate to have arrived before EOF.
- Add a comment explaining the best-effort timing so the test does not regress to the old flaky assumption.

### Limitations

No production code, sleeps, test-only hooks, or new dependencies were added; the change is confined to the integration test.

### Compatibility

This PR does not change any API or persisted/wire format. It only modifies an integration test.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
