### PR TITLE
fix(mito2): prioritize newer compaction windows

### DIFF
--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -73,6 +73,7 @@ impl TwcsPicker {
         let mut output = vec![];
         let windows = time_windows
             .values()
+            .rev()
             .filter(|window| {
                 !window.files.is_empty()
                     && self.time_range.as_ref().is_none_or(|time_range| {
@@ -1021,11 +1022,11 @@ mod tests {
             .to_vec(),
             expected_outputs: vec![
                 ExpectedOutput {
-                    input_files: vec![0, 1],
+                    input_files: vec![2, 3],
                     output_level: 1,
                 },
                 ExpectedOutput {
-                    input_files: vec![2, 3],
+                    input_files: vec![0, 1],
                     output_level: 1,
                 },
             ],
@@ -1052,11 +1053,11 @@ mod tests {
             .to_vec(),
             expected_outputs: vec![
                 ExpectedOutput {
-                    input_files: vec![0, 1],
+                    input_files: vec![2, 4],
                     output_level: 1,
                 },
                 ExpectedOutput {
-                    input_files: vec![2, 4],
+                    input_files: vec![0, 1],
                     output_level: 1,
                 },
             ],
@@ -1453,6 +1454,42 @@ mod tests {
 
         assert_eq!(1, output.len());
         assert_eq!(output[0].inputs.len(), 32);
+    }
+
+    #[tokio::test]
+    async fn test_newer_windows_have_priority() {
+        let older_file_ids = [FileId::random(), FileId::random()];
+        let newer_file_ids = [FileId::random(), FileId::random()];
+        let files = [
+            new_file_handle_with_sequence(older_file_ids[0], 1_000, 1_999, 0, 1),
+            new_file_handle_with_sequence(older_file_ids[1], 1_000, 1_999, 0, 2),
+            new_file_handle_with_sequence(newer_file_ids[0], 7_000, 7_999, 0, 3),
+            new_file_handle_with_sequence(newer_file_ids[1], 7_000, 7_999, 0, 4),
+        ];
+        let windows = assign_to_windows(files.iter(), 3);
+        let picker = TwcsPicker {
+            trigger_file_num: 2,
+            time_window_seconds: Some(3),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: Some(1),
+            time_range: None,
+        };
+
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(123), windows, Some(9), None)
+            .await
+            .unwrap();
+
+        assert_eq!(1, output.len());
+        assert_eq!(
+            newer_file_ids.into_iter().collect::<HashSet<_>>(),
+            output[0]
+                .inputs
+                .iter()
+                .map(|file| file.file_id().file_id())
+                .collect::<HashSet<_>>()
+        );
     }
 
     #[test]

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -1456,8 +1456,8 @@ mod tests {
         assert_eq!(output[0].inputs.len(), 32);
     }
 
-    #[tokio::test]
-    async fn test_newer_windows_have_priority() {
+    #[test]
+    fn test_newer_windows_have_priority() {
         let older_file_ids = [FileId::random(), FileId::random()];
         let newer_file_ids = [FileId::random(), FileId::random()];
         let files = [
@@ -1466,7 +1466,7 @@ mod tests {
             new_file_handle_with_sequence(newer_file_ids[0], 7_000, 7_999, 0, 3),
             new_file_handle_with_sequence(newer_file_ids[1], 7_000, 7_999, 0, 4),
         ];
-        let windows = assign_to_windows(files.iter(), 3);
+        let mut windows = assign_to_windows(files.iter(), 3);
         let picker = TwcsPicker {
             trigger_file_num: 2,
             time_window_seconds: Some(3),
@@ -1476,10 +1476,12 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker
-            .build_output_with_time_range(RegionId::from_u64(123), windows, Some(9), None)
-            .await
-            .unwrap();
+        let output = picker.build_output_with_time_range(
+            RegionId::from_u64(123),
+            &mut windows,
+            Some(9),
+            None,
+        );
 
         assert_eq!(1, output.len());
         assert_eq!(

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -1456,8 +1456,8 @@ mod tests {
         assert_eq!(output[0].inputs.len(), 32);
     }
 
-    #[test]
-    fn test_newer_windows_have_priority() {
+    #[tokio::test]
+    async fn test_newer_windows_have_priority() {
         let older_file_ids = [FileId::random(), FileId::random()];
         let newer_file_ids = [FileId::random(), FileId::random()];
         let files = [
@@ -1466,7 +1466,7 @@ mod tests {
             new_file_handle_with_sequence(newer_file_ids[0], 7_000, 7_999, 0, 3),
             new_file_handle_with_sequence(newer_file_ids[1], 7_000, 7_999, 0, 4),
         ];
-        let mut windows = assign_to_windows(files.iter(), 3);
+        let windows = assign_to_windows(files.iter(), 3);
         let picker = TwcsPicker {
             trigger_file_num: 2,
             time_window_seconds: Some(3),
@@ -1476,12 +1476,10 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output_with_time_range(
-            RegionId::from_u64(123),
-            &mut windows,
-            Some(9),
-            None,
-        );
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(123), windows, Some(9), None)
+            .await
+            .unwrap();
 
         assert_eq!(1, output.len());
         assert_eq!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

TWCS currently traverses its `BTreeMap` of time windows in ascending timestamp order. When `max_background_tasks` limits the number of outputs, older windows consume the available slots before recent windows.

This PR traverses eligible windows in reverse order so newer windows are picked first. It also updates existing multi-window output-order expectations and adds a regression test with two eligible windows and `max_background_tasks = 1`, verifying that only the newer window is selected.

This branch is rebased onto GreptimeTeam/main at `81a0dd77c7`. The PR changes only `src/mito2/src/compaction/twcs.rs` and does not depend on the picker thread-limit PR.

This PR does not change persisted data, wire formats, or public APIs.

## Test Plan

- `cargo nextest run -p mito2 --retries 0 'compaction::twcs::tests'` (20 tests)
- `cargo clippy -p mito2 --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check GreptimeTeam/main...HEAD`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.