### PR TITLE
fix(query): validate remote read table metadata against schema race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5991,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=01283641e8776d6896dbd62a2e1ac181b6a4cc33#01283641e8776d6896dbd62a2e1ac181b6a4cc33"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=9f60f9c7d0c57a338c67f77bdc457b5c5c9472c6#9f60f9c7d0c57a338c67f77bdc457b5c5c9472c6"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -6537,7 +6537,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -9017,7 +9017,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11204,7 +11204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -11252,7 +11252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11265,7 +11265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12711,7 +12711,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13623,7 +13623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14617,7 +14617,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11553,6 +11553,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "partition",
  "paste",
+ "pbjson-types",
  "pretty_assertions",
  "prometheus 0.14.0",
  "promql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5991,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=5adb8a1637abe87bcbb455d32136eee5d538cc49#5adb8a1637abe87bcbb455d32136eee5d538cc49"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=01283641e8776d6896dbd62a2e1ac181b6a4cc33#01283641e8776d6896dbd62a2e1ac181b6a4cc33"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -6537,7 +6537,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -9017,7 +9017,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11183,7 +11183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11203,8 +11203,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -11252,7 +11252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11265,7 +11265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12711,7 +12711,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13594,7 +13594,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13623,7 +13623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14617,7 +14617,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "5adb8a1637abe87bcbb455d32136eee5d538cc49" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "01283641e8776d6896dbd62a2e1ac181b6a4cc33" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "01283641e8776d6896dbd62a2e1ac181b6a4cc33" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "9f60f9c7d0c57a338c67f77bdc457b5c5c9472c6" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -37,9 +37,8 @@ use common_telemetry::tracing::Span;
 use common_telemetry::tracing_context::TracingContext;
 use futures_util::Stream;
 use prost::Message;
-use query::query_engine::DefaultSerializer;
+use query::query_engine::remote_plan_codec::encode_remote_plan;
 use snafu::{OptionExt, ResultExt, location};
-use substrait::{DFLogicalSubstraitConvertor, SubstraitPlan};
 use tokio_stream::StreamExt;
 
 use crate::error::{
@@ -75,8 +74,7 @@ impl Datanode for RegionRequester {
     }
 
     async fn handle_query(&self, request: QueryRequest) -> MetaResult<SendableRecordBatchStream> {
-        let plan = DFLogicalSubstraitConvertor
-            .encode(&request.plan, DefaultSerializer)
+        let plan = encode_remote_plan(&request.plan, request.region_id)
             .map_err(BoxedError::new)
             .context(meta_error::ExternalSnafu)?
             .to_vec();

--- a/src/common/meta/src/ddl/alter_logical_tables/update_metadata.rs
+++ b/src/common/meta/src/ddl/alter_logical_tables/update_metadata.rs
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 use common_grpc_expr::alter_expr_to_request;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use table::metadata::TableInfo;
 
 use crate::ddl::alter_logical_tables::AlterLogicalTablesProcedure;
 use crate::ddl::alter_logical_tables::executor::AlterLogicalTablesExecutor;
+use crate::ddl::utils::raw_table_info;
 use crate::ddl::utils::table_info::batch_update_table_info_values;
 use crate::error;
-use crate::error::{ConvertAlterTableRequestSnafu, Result};
+use crate::error::{ConvertAlterTableRequestSnafu, Result, TableInfoNotFoundSnafu};
 use crate::key::DeserializedValueWithBytes;
 use crate::key::table_info::TableInfoValue;
 use crate::rpc::ddl::AlterTableTask;
@@ -49,13 +50,23 @@ impl AlterLogicalTablesProcedure {
     }
 
     pub(crate) async fn update_logical_tables_metadata(&mut self) -> Result<()> {
-        let table_info_values = self.build_update_metadata()?;
+        let physical_table_info = self
+            .context
+            .table_metadata_manager
+            .table_info_manager()
+            .get(self.data.physical_table_id)
+            .await?
+            .with_context(|| TableInfoNotFoundSnafu {
+                table: format!("table id - {}", self.data.physical_table_id),
+            })?;
+        let table_info_values = self.build_update_metadata(&physical_table_info.table_info)?;
         batch_update_table_info_values(&self.context.table_metadata_manager, table_info_values)
             .await
     }
 
     pub(crate) fn build_update_metadata(
         &self,
+        physical_table_info: &TableInfo,
     ) -> Result<Vec<(DeserializedValueWithBytes<TableInfoValue>, TableInfo)>> {
         let mut table_info_values_to_update = Vec::with_capacity(self.data.tasks.len());
         for (task, table) in self
@@ -64,7 +75,11 @@ impl AlterLogicalTablesProcedure {
             .iter()
             .zip(self.data.table_info_values.iter())
         {
-            table_info_values_to_update.push(self.build_new_table_info(task, table)?);
+            table_info_values_to_update.push(self.build_new_table_info(
+                task,
+                table,
+                physical_table_info,
+            )?);
         }
 
         Ok(table_info_values_to_update)
@@ -74,9 +89,13 @@ impl AlterLogicalTablesProcedure {
         &self,
         task: &AlterTableTask,
         table: &DeserializedValueWithBytes<TableInfoValue>,
+        physical_table_info: &TableInfo,
     ) -> Result<(DeserializedValueWithBytes<TableInfoValue>, TableInfo)> {
         // Builds new_meta
-        let table_info = table.table_info.clone();
+        // Validate the persisted mapping before the alter builder or sorting can discard it.
+        // Incomplete legacy mappings are restored; complete conflicts fail closed.
+        let table_info =
+            validate_original_logical_table_mapping(physical_table_info, &table.table_info)?;
         let table_ref = task.table_ref();
         let request = alter_expr_to_request(
             table.table_info.ident.table_id,
@@ -98,7 +117,67 @@ impl AlterLogicalTablesProcedure {
         new_table.ident.version = version;
 
         new_table.sort_columns();
+        raw_table_info::populate_logical_table_column_ids(physical_table_info, &mut new_table)?;
 
         Ok((table.clone(), new_table))
+    }
+}
+
+fn validate_original_logical_table_mapping(
+    physical_table_info: &TableInfo,
+    table_info: &TableInfo,
+) -> Result<TableInfo> {
+    let mut table_info = table_info.clone();
+    raw_table_info::populate_logical_table_column_ids(physical_table_info, &mut table_info)?;
+    Ok(table_info)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datatypes::schema::Schema;
+
+    use super::validate_original_logical_table_mapping;
+    use crate::ddl::test_util::{
+        test_create_logical_table_task, test_create_physical_table_task, test_physical_table_info,
+    };
+    use crate::ddl::utils::raw_table_info::populate_logical_table_column_ids;
+
+    #[test]
+    fn test_populate_logical_column_ids_after_drop() {
+        let physical_table_info =
+            test_physical_table_info(test_create_physical_table_task("phy").table_info);
+        let mut logical_table_info = test_create_logical_table_task("logical").table_info;
+        populate_logical_table_column_ids(&physical_table_info, &mut logical_table_info).unwrap();
+
+        let columns = logical_table_info
+            .meta
+            .schema
+            .column_schemas()
+            .iter()
+            .filter(|column| column.name != "cpu")
+            .cloned()
+            .collect();
+        logical_table_info.meta.schema = Arc::new(Schema::new(columns));
+        logical_table_info.sort_columns();
+        assert!(logical_table_info.meta.column_ids.is_empty());
+
+        populate_logical_table_column_ids(&physical_table_info, &mut logical_table_info).unwrap();
+        assert_eq!(logical_table_info.meta.column_ids, vec![2, 0]);
+    }
+
+    #[test]
+    fn test_original_mapping_conflict_is_rejected_before_alter_builder() {
+        let physical_table_info =
+            test_physical_table_info(test_create_physical_table_task("phy").table_info);
+        let mut logical_table_info = test_create_logical_table_task("logical").table_info;
+        populate_logical_table_column_ids(&physical_table_info, &mut logical_table_info).unwrap();
+        logical_table_info.meta.column_ids[0] += 100;
+
+        assert!(
+            validate_original_logical_table_mapping(&physical_table_info, &logical_table_info,)
+                .is_err()
+        );
     }
 }

--- a/src/common/meta/src/ddl/create_logical_tables.rs
+++ b/src/common/meta/src/ddl/create_logical_tables.rs
@@ -144,6 +144,7 @@ impl CreateLogicalTablesProcedure {
     /// - Failed to create table metadata.
     pub async fn on_create_metadata(&mut self) -> Result<Status> {
         self.update_physical_table_metadata().await?;
+        self.populate_logical_table_column_ids().await?;
         let table_ids = self.create_logical_tables_metadata().await?;
 
         Ok(Status::done_with_output(table_ids))

--- a/src/common/meta/src/ddl/create_logical_tables/update_metadata.rs
+++ b/src/common/meta/src/ddl/create_logical_tables/update_metadata.rs
@@ -81,6 +81,42 @@ impl CreateLogicalTablesProcedure {
         Ok(())
     }
 
+    /// Copies stable column IDs from the physical table to newly created logical tables.
+    pub(crate) async fn populate_logical_table_column_ids(&mut self) -> Result<()> {
+        // Fetch after updating the physical metadata. Datanodes can return either the
+        // complete physical schema or no new columns, so this is the authoritative source
+        // of IDs in both cases.
+        let physical_table_info = self
+            .context
+            .table_metadata_manager
+            .table_info_manager()
+            .get(self.data.physical_table_id)
+            .await?
+            .with_context(|| TableInfoNotFoundSnafu {
+                table: format!("table id - {}", self.data.physical_table_id),
+            })?;
+        let physical_table_info = &physical_table_info.table_info;
+        for (task, already_exists) in self
+            .data
+            .tasks
+            .iter_mut()
+            .zip(&self.data.table_ids_already_exists)
+        {
+            // `create_if_not_exists` tasks refer to persisted metadata and must remain
+            // untouched even when this procedure creates other logical tables.
+            if already_exists.is_some() {
+                continue;
+            }
+
+            raw_table_info::populate_logical_table_column_ids(
+                physical_table_info,
+                &mut task.table_info,
+            )?;
+        }
+
+        Ok(())
+    }
+
     pub(crate) async fn create_logical_tables_metadata(&mut self) -> Result<Vec<TableId>> {
         let remaining_tasks = self.data.remaining_tasks();
         let num_tables = remaining_tasks.len();

--- a/src/common/meta/src/ddl/test_util.rs
+++ b/src/common/meta/src/ddl/test_util.rs
@@ -40,6 +40,7 @@ use crate::ddl::test_util::columns::TestColumnDefBuilder;
 use crate::ddl::test_util::create_table::{
     TestCreateTableExprBuilder, build_raw_table_info_from_expr,
 };
+use crate::ddl::utils::raw_table_info;
 use crate::ddl::{DdlContext, TableMetadata};
 use crate::key::node_address::{NodeAddressKey, NodeAddressValue};
 use crate::key::table_route::TableRouteValue;
@@ -88,14 +89,23 @@ pub async fn create_physical_table(ddl_context: &DdlContext, name: &str) -> Tabl
         .await
         .unwrap();
     create_physical_table_task.set_table_id(table_id);
+    let table_info = test_physical_table_info(create_physical_table_task.table_info.clone());
     create_physical_table_metadata(
         ddl_context,
-        create_physical_table_task.table_info.clone(),
+        table_info,
         TableRouteValue::Physical(table_route),
     )
     .await;
 
     table_id
+}
+
+/// Builds physical metadata after the datanode has added the default logical columns.
+pub fn test_physical_table_info(table_info: TableInfo) -> TableInfo {
+    raw_table_info::build_new_physical_table_info(
+        table_info,
+        &test_column_metadatas(&["host", "cpu"]),
+    )
 }
 
 pub async fn create_logical_table(

--- a/src/common/meta/src/ddl/tests/alter_logical_tables.rs
+++ b/src/common/meta/src/ddl/tests/alter_logical_tables.rs
@@ -37,7 +37,7 @@ use crate::ddl::test_util::datanode_handler::DatanodeWatcher;
 use crate::ddl::test_util::{
     assert_column_name, create_logical_table, create_physical_table,
     create_physical_table_metadata, get_raw_table_info, test_column_metadatas,
-    test_create_physical_table_task,
+    test_create_physical_table_task, test_physical_table_info,
 };
 use crate::error::Error::{AlterLogicalTablesInvalidArguments, TableNotFound};
 use crate::error::Result;
@@ -256,7 +256,7 @@ async fn test_on_prepare() {
 async fn test_on_update_metadata() {
     common_telemetry::init_default_ut_logging();
     let (tx, mut rx) = mpsc::channel(8);
-    let test_column_metadatas = test_column_metadatas(&["new_col", "mew_col"]);
+    let test_column_metadatas = test_column_metadatas(&["host", "cpu", "new_col", "mew_col"]);
     let datanode_handler =
         DatanodeWatcher::new(tx).with_handler(make_alters_request_handler(test_column_metadatas));
     let node_manager = Arc::new(MockDatanodeManager::new(datanode_handler));
@@ -325,7 +325,16 @@ async fn test_on_update_metadata() {
     let table_info = get_raw_table_info(&ddl_context, phy_id).await;
     assert_column_name(
         &table_info,
-        &["ts", "value", "__table_id", "__tsid", "new_col", "mew_col"],
+        &[
+            "ts",
+            "value",
+            "__table_id",
+            "__tsid",
+            "host",
+            "cpu",
+            "new_col",
+            "mew_col",
+        ],
     );
     assert_eq!(
         table_info.meta.column_ids,
@@ -335,8 +344,31 @@ async fn test_on_update_metadata() {
             ReservedColumnId::table_id(),
             ReservedColumnId::tsid(),
             2,
-            3
+            3,
+            4,
+            5
         ]
+    );
+    assert_eq!(
+        get_raw_table_info(&ddl_context, logical_table1_id)
+            .await
+            .meta
+            .column_ids,
+        vec![3, 2, 4, 0]
+    );
+    assert_eq!(
+        get_raw_table_info(&ddl_context, logical_table2_id)
+            .await
+            .meta
+            .column_ids,
+        vec![3, 2, 5, 0]
+    );
+    assert_eq!(
+        get_raw_table_info(&ddl_context, logical_table3_id)
+            .await
+            .meta
+            .column_ids,
+        vec![3, 2, 4, 0]
     );
 }
 
@@ -344,7 +376,7 @@ async fn test_on_update_metadata() {
 async fn test_on_part_duplicate_alter_request() {
     common_telemetry::init_default_ut_logging();
     let (tx, mut rx) = mpsc::channel(8);
-    let column_metadatas = test_column_metadatas(&["col_0"]);
+    let column_metadatas = test_column_metadatas(&["host", "cpu", "col_0"]);
     let handler =
         DatanodeWatcher::new(tx).with_handler(make_alters_request_handler(column_metadatas));
     let node_manager = Arc::new(MockDatanodeManager::new(handler));
@@ -408,7 +440,15 @@ async fn test_on_part_duplicate_alter_request() {
     let table_info = get_raw_table_info(&ddl_context, phy_id).await;
     assert_column_name(
         &table_info,
-        &["ts", "value", "__table_id", "__tsid", "col_0"],
+        &[
+            "ts",
+            "value",
+            "__table_id",
+            "__tsid",
+            "host",
+            "cpu",
+            "col_0",
+        ],
     );
     assert_eq!(
         table_info.meta.column_ids,
@@ -417,12 +457,15 @@ async fn test_on_part_duplicate_alter_request() {
             1,
             ReservedColumnId::table_id(),
             ReservedColumnId::tsid(),
-            2
+            2,
+            3,
+            4
         ]
     );
 
     let (tx, mut rx) = mpsc::channel(8);
-    let column_metadatas = test_column_metadatas(&["col_0", "new_col_1", "new_col_2"]);
+    let column_metadatas =
+        test_column_metadatas(&["host", "cpu", "col_0", "new_col_1", "new_col_2"]);
     let handler =
         DatanodeWatcher::new(tx).with_handler(make_alters_request_handler(column_metadatas));
     let node_manager = Arc::new(MockDatanodeManager::new(handler));
@@ -499,6 +542,8 @@ async fn test_on_part_duplicate_alter_request() {
             "value",
             "__table_id",
             "__tsid",
+            "host",
+            "cpu",
             "col_0",
             "new_col_1",
             "new_col_2",
@@ -514,6 +559,8 @@ async fn test_on_part_duplicate_alter_request() {
             2,
             3,
             4,
+            5,
+            6,
         ]
     );
 
@@ -560,6 +607,7 @@ async fn test_on_part_duplicate_alter_request() {
             "ts".to_string()
         ]
     );
+    assert_eq!(table1.table_info.meta.column_ids, vec![4, 3, 2, 5, 0]);
 
     let table2_cols = table2
         .table_info
@@ -580,6 +628,7 @@ async fn test_on_part_duplicate_alter_request() {
             "ts".to_string()
         ]
     );
+    assert_eq!(table2.table_info.meta.column_ids, vec![4, 3, 2, 5, 6, 0]);
 }
 
 #[tokio::test]
@@ -605,7 +654,7 @@ async fn test_on_submit_alter_region_request() {
     create_physical_table_task.set_table_id(phy_id);
     create_physical_table_metadata(
         &ddl_context,
-        create_physical_table_task.table_info.clone(),
+        test_physical_table_info(create_physical_table_task.table_info.clone()),
         TableRouteValue::Physical(PhysicalTableRouteValue::new(region_routes)),
     )
     .await;

--- a/src/common/meta/src/ddl/tests/create_logical_tables.rs
+++ b/src/common/meta/src/ddl/tests/create_logical_tables.rs
@@ -356,6 +356,22 @@ async fn test_on_create_metadata() {
             3
         ]
     );
+
+    let logical_table_info = get_raw_table_info(&ddl_context, 1025).await;
+    assert_column_name(&logical_table_info, &["cpu", "host", "ts"]);
+    assert_eq!(logical_table_info.meta.column_ids, vec![3, 2, 0]);
+    assert!(
+        !logical_table_info
+            .meta
+            .column_ids
+            .contains(&ReservedColumnId::table_id())
+    );
+    assert!(
+        !logical_table_info
+            .meta
+            .column_ids
+            .contains(&ReservedColumnId::tsid())
+    );
 }
 
 #[tokio::test]
@@ -388,6 +404,7 @@ async fn test_on_create_metadata_part_logical_tables_exist() {
     // Creates the logical table metadata.
     let mut task = test_create_logical_table_task("exists");
     task.set_table_id(8192);
+    let existing_table_info = task.table_info.clone();
     ddl_context
         .table_metadata_manager
         .create_logical_tables_metadata(vec![(
@@ -400,7 +417,13 @@ async fn test_on_create_metadata_part_logical_tables_exist() {
     let physical_table_id = table_id;
     // Sets `create_if_not_exists`
     task.create_table.create_if_not_exists = true;
-    let non_exist_task = test_create_logical_table_task("non_exists");
+    let mut non_exist_task = test_create_logical_table_task("non_exists");
+    non_exist_task.create_table.column_defs[2].semantic_type = api::v1::SemanticType::Tag as i32;
+    non_exist_task
+        .create_table
+        .primary_keys
+        .push("cpu".to_string());
+    non_exist_task.table_info.meta.primary_key_indices.push(2);
     let mut procedure = CreateLogicalTablesProcedure::new(
         vec![task, non_exist_task],
         physical_table_id,
@@ -443,6 +466,15 @@ async fn test_on_create_metadata_part_logical_tables_exist() {
             2,
             3
         ]
+    );
+
+    let logical_table_info = get_raw_table_info(&ddl_context, 1025).await;
+    assert_column_name(&logical_table_info, &["cpu", "host", "ts"]);
+    assert_eq!(logical_table_info.meta.primary_key_indices, vec![0, 1]);
+    assert_eq!(logical_table_info.meta.column_ids, vec![3, 2, 0]);
+    assert_eq!(
+        get_raw_table_info(&ddl_context, 8192).await,
+        existing_table_info
     );
 }
 

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -42,6 +42,7 @@ use crate::ddl::test_util::datanode_handler::{DatanodeWatcher, NaiveDatanodeHand
 use crate::ddl::test_util::{
     create_logical_table, create_physical_table, create_physical_table_metadata,
     put_datanode_address, test_create_logical_table_task, test_create_physical_table_task,
+    test_physical_table_info,
 };
 use crate::ddl::undrop_table::UndropTableProcedure;
 use crate::ddl::{DdlContext, DetectingRegion, RegionFailureDetectorController, TableMetadata};
@@ -2538,7 +2539,7 @@ async fn test_on_rollback() {
     create_physical_table_task.set_table_id(table_id);
     create_physical_table_metadata(
         &ddl_context,
-        create_physical_table_task.table_info.clone(),
+        test_physical_table_info(create_physical_table_task.table_info.clone()),
         TableRouteValue::Physical(table_route),
     )
     .await;

--- a/src/common/meta/src/ddl/utils/raw_table_info.rs
+++ b/src/common/meta/src/ddl/utils/raw_table_info.rs
@@ -18,9 +18,12 @@ use std::sync::Arc;
 use api::v1::SemanticType;
 use common_telemetry::debug;
 use common_telemetry::tracing::warn;
-use datatypes::schema::Schema;
+use datatypes::schema::{ColumnSchema, Schema};
+use snafu::ensure;
 use store_api::metadata::ColumnMetadata;
 use table::metadata::TableInfo;
+
+use crate::error::{MetadataCorruptionSnafu, Result};
 
 /// Generate the new physical table info.
 pub(crate) fn build_new_physical_table_info(
@@ -116,4 +119,258 @@ pub(crate) fn update_table_info_column_ids(
     }
 
     table_info.meta.column_ids = column_ids;
+}
+
+/// Returns the stable IDs for `logical_columns` from the authoritative physical table.
+///
+/// The physical table must have a complete, unambiguous schema-to-ID mapping. Logical
+/// columns may be a subset of physical columns, but every logical column must exist in
+/// the physical table.
+pub(crate) fn logical_column_ids_from_physical_table_info(
+    physical_table_info: &TableInfo,
+    logical_columns: &[ColumnSchema],
+) -> Result<Vec<u32>> {
+    let physical_columns = physical_table_info.meta.schema.column_schemas();
+    let physical_column_ids = &physical_table_info.meta.column_ids;
+    ensure!(
+        physical_columns.len() == physical_column_ids.len(),
+        MetadataCorruptionSnafu {
+            err_msg: format!(
+                "Physical table {} ({}) has {} columns but {} column IDs",
+                physical_table_info.name,
+                physical_table_info.ident.table_id,
+                physical_columns.len(),
+                physical_column_ids.len(),
+            ),
+        }
+    );
+
+    let mut ids_by_name = HashMap::with_capacity(physical_columns.len());
+    let mut seen_ids = HashSet::with_capacity(physical_column_ids.len());
+    for (column, column_id) in physical_columns.iter().zip(physical_column_ids) {
+        ensure!(
+            ids_by_name
+                .insert(column.name.as_str(), *column_id)
+                .is_none(),
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Physical table {} ({}) has duplicate column name {}",
+                    physical_table_info.name, physical_table_info.ident.table_id, column.name,
+                ),
+            }
+        );
+        ensure!(
+            seen_ids.insert(*column_id),
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Physical table {} ({}) has duplicate column ID {}",
+                    physical_table_info.name, physical_table_info.ident.table_id, column_id,
+                ),
+            }
+        );
+    }
+
+    logical_columns
+        .iter()
+        .map(|column| {
+            ids_by_name
+                .get(column.name.as_str())
+                .copied()
+                .ok_or_else(|| {
+                    MetadataCorruptionSnafu {
+                        err_msg: format!(
+                            "Logical column {} is missing from physical table {} ({})",
+                            column.name,
+                            physical_table_info.name,
+                            physical_table_info.ident.table_id,
+                        ),
+                    }
+                    .build()
+                })
+        })
+        .collect()
+}
+
+/// Restores incomplete logical column IDs from the authoritative physical table.
+///
+/// A complete persisted mapping is immutable: it must already match the physical mapping.
+/// This prevents a corrupt complete mapping from being silently overwritten.
+pub(crate) fn populate_logical_table_column_ids(
+    physical_table_info: &TableInfo,
+    logical_table_info: &mut TableInfo,
+) -> Result<()> {
+    let column_ids = logical_column_ids_from_physical_table_info(
+        physical_table_info,
+        logical_table_info.meta.schema.column_schemas(),
+    )?;
+    let existing_column_ids = &logical_table_info.meta.column_ids;
+
+    if existing_column_ids.len() != column_ids.len() {
+        logical_table_info.meta.column_ids = column_ids;
+        return Ok(());
+    }
+    ensure!(
+        *existing_column_ids == column_ids,
+        MetadataCorruptionSnafu {
+            err_msg: format!(
+                "Logical table {} ({}) has a complete column ID mapping that conflicts with physical table {} ({})",
+                logical_table_info.name,
+                logical_table_info.ident.table_id,
+                physical_table_info.name,
+                physical_table_info.ident.table_id,
+            ),
+        }
+    );
+
+    Ok(())
+}
+
+/// Validates that every logical region column uses its physical table's stable ID.
+pub(crate) fn validate_logical_column_metadata_ids(
+    physical_table_info: &TableInfo,
+    column_metadatas: &[ColumnMetadata],
+) -> Result<()> {
+    let logical_columns = column_metadatas
+        .iter()
+        .map(|column_metadata| column_metadata.column_schema.clone())
+        .collect::<Vec<_>>();
+    let expected_column_ids =
+        logical_column_ids_from_physical_table_info(physical_table_info, &logical_columns)?;
+
+    for (column_metadata, expected_column_id) in column_metadatas.iter().zip(expected_column_ids) {
+        ensure!(
+            column_metadata.column_id == expected_column_id,
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Logical region column {} has ID {}, but physical table {} ({}) has ID {}",
+                    column_metadata.column_schema.name,
+                    column_metadata.column_id,
+                    physical_table_info.name,
+                    physical_table_info.ident.table_id,
+                    expected_column_id,
+                ),
+            }
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::Schema;
+
+    use super::*;
+    use crate::ddl::test_util::{
+        test_create_logical_table_task, test_create_physical_table_task, test_physical_table_info,
+    };
+
+    fn table_infos() -> (TableInfo, TableInfo) {
+        let physical =
+            test_physical_table_info(test_create_physical_table_task("physical").table_info);
+        let logical = test_create_logical_table_task("logical").table_info;
+        (physical, logical)
+    }
+
+    #[test]
+    fn test_populate_logical_column_ids_replaces_incomplete_mapping() {
+        let (physical, mut logical) = table_infos();
+        let expected = logical_column_ids_from_physical_table_info(
+            &physical,
+            logical.meta.schema.column_schemas(),
+        )
+        .unwrap();
+        logical.meta.column_ids = vec![999];
+
+        populate_logical_table_column_ids(&physical, &mut logical).unwrap();
+
+        assert_eq!(logical.meta.column_ids, expected);
+    }
+
+    #[test]
+    fn test_populate_logical_column_ids_replaces_overlong_mapping() {
+        let (physical, mut logical) = table_infos();
+        let expected = logical_column_ids_from_physical_table_info(
+            &physical,
+            logical.meta.schema.column_schemas(),
+        )
+        .unwrap();
+        logical.meta.column_ids = expected.iter().copied().chain([999]).collect();
+
+        populate_logical_table_column_ids(&physical, &mut logical).unwrap();
+
+        assert_eq!(logical.meta.column_ids, expected);
+    }
+
+    #[test]
+    fn test_populate_logical_column_ids_keeps_complete_matching_mapping() {
+        let (physical, mut logical) = table_infos();
+        logical.meta.column_ids = logical_column_ids_from_physical_table_info(
+            &physical,
+            logical.meta.schema.column_schemas(),
+        )
+        .unwrap();
+        let expected = logical.clone();
+
+        populate_logical_table_column_ids(&physical, &mut logical).unwrap();
+
+        assert_eq!(logical, expected);
+    }
+
+    #[test]
+    fn test_populate_logical_column_ids_rejects_complete_conflict() {
+        let (physical, mut logical) = table_infos();
+        logical.meta.column_ids = logical_column_ids_from_physical_table_info(
+            &physical,
+            logical.meta.schema.column_schemas(),
+        )
+        .unwrap();
+        logical.meta.column_ids[0] += 100;
+
+        assert!(populate_logical_table_column_ids(&physical, &mut logical).is_err());
+    }
+
+    #[test]
+    fn test_logical_column_ids_reject_incomplete_physical_ids() {
+        let (mut physical, logical) = table_infos();
+        physical.meta.column_ids.pop();
+
+        assert!(
+            logical_column_ids_from_physical_table_info(
+                &physical,
+                logical.meta.schema.column_schemas(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_logical_column_ids_reject_duplicate_physical_id() {
+        let (mut physical, logical) = table_infos();
+        physical.meta.column_ids[1] = physical.meta.column_ids[0];
+        assert!(
+            logical_column_ids_from_physical_table_info(
+                &physical,
+                logical.meta.schema.column_schemas(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_logical_column_ids_reject_missing_logical_column() {
+        let (physical, mut logical) = table_infos();
+        let mut columns = logical.meta.schema.column_schemas().to_vec();
+        columns.push(ColumnSchema::new(
+            "missing",
+            ConcreteDataType::int64_datatype(),
+            true,
+        ));
+        logical.meta.schema = Arc::new(Schema::new(columns));
+
+        assert!(populate_logical_table_column_ids(&physical, &mut logical).is_err());
+    }
 }

--- a/src/common/meta/src/reconciliation/reconcile_logical_tables.rs
+++ b/src/common/meta/src/reconciliation/reconcile_logical_tables.rs
@@ -29,7 +29,7 @@ use common_procedure::{
 };
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
-use store_api::metadata::ColumnMetadata;
+use store_api::metadata::{ColumnMetadata, RegionMetadata};
 use store_api::storage::TableId;
 use table::metadata::TableInfo;
 use table::table_name::TableName;
@@ -103,11 +103,21 @@ pub(crate) struct PersistentContext {
     // The value will be set in `ReconciliationStart` state.
     pub(crate) physical_table_route: Option<PhysicalTableRouteValue>,
     // The table infos to be updated.
+    //
+    // Kept for deserializing procedures persisted before complete region metadata was retained.
+    // Such procedures are re-resolved before an update is attempted.
+    #[serde(default)]
     // The value will be set in `ResolveTableMetadatas` state.
     pub(crate) update_table_infos: Vec<(TableId, Vec<ColumnMetadata>)>,
+    /// Complete authoritative logical region metadata used to update table infos.
+    #[serde(default)]
+    pub(crate) update_region_metadatas: Vec<(TableId, RegionMetadata)>,
     // The table infos to be created.
     // The value will be set in `ResolveTableMetadatas` state.
     pub(crate) create_tables: Vec<(TableId, TableInfo)>,
+    /// Whether the next metadata resolution verifies regions created by this procedure.
+    #[serde(default)]
+    pub(crate) verifying_after_create: bool,
     // Whether the procedure is a subprocedure.
     pub(crate) is_subprocedure: bool,
 }
@@ -129,7 +139,9 @@ impl PersistentContext {
             table_info_value: None,
             physical_table_route: None,
             update_table_infos: vec![],
+            update_region_metadatas: vec![],
             create_tables: vec![],
+            verifying_after_create: false,
             is_subprocedure,
         }
     }

--- a/src/common/meta/src/reconciliation/reconcile_logical_tables/reconcile_regions.rs
+++ b/src/common/meta/src/reconciliation/reconcile_logical_tables/reconcile_regions.rs
@@ -27,6 +27,7 @@ use table::metadata::TableInfo;
 use crate::ddl::utils::{add_peer_context_if_needed, region_storage_path};
 use crate::ddl::{CreateRequestBuilder, build_template_from_raw_table_info};
 use crate::error::Result;
+use crate::reconciliation::reconcile_logical_tables::resolve_table_metadatas::ResolveTableMetadatas;
 use crate::reconciliation::reconcile_logical_tables::update_table_infos::UpdateTableInfos;
 use crate::reconciliation::reconcile_logical_tables::{ReconcileLogicalTablesContext, State};
 use crate::rpc::router::{find_leaders, region_distribution};
@@ -93,7 +94,10 @@ impl State for ReconcileRegions {
             table_name
         );
         ctx.persistent_ctx.create_tables.clear();
-        return Ok((Box::new(UpdateTableInfos), Status::executing(true)));
+        ctx.persistent_ctx.verifying_after_create = true;
+        // Newly created regions must be resolved again before metadata updates. This keeps the
+        // legacy-ID migration gate tied to metadata actually reported by all replicas.
+        Ok((Self::next_state_after_create(), Status::executing(true)))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -102,6 +106,10 @@ impl State for ReconcileRegions {
 }
 
 impl ReconcileRegions {
+    fn next_state_after_create() -> Box<dyn State> {
+        Box::new(ResolveTableMetadatas)
+    }
+
     fn make_request(
         &self,
         region_numbers: &[u32],
@@ -140,6 +148,17 @@ impl ReconcileRegions {
             }),
             body: Some(region_request::Body::Creates(CreateRequests { requests })),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_post_create_transition_re_resolves_table_metadata() {
+        let next_state = ReconcileRegions::next_state_after_create();
+        assert!(next_state.as_any().is::<ResolveTableMetadatas>());
     }
 }
 

--- a/src/common/meta/src/reconciliation/reconcile_logical_tables/resolve_table_metadatas.rs
+++ b/src/common/meta/src/reconciliation/reconcile_logical_tables/resolve_table_metadatas.rs
@@ -15,20 +15,22 @@
 use std::any::Any;
 
 use common_procedure::{Context as ProcedureContext, Status};
-use common_telemetry::{info, warn};
+use common_telemetry::info;
 use serde::{Deserialize, Serialize};
-use snafu::ensure;
+use snafu::{OptionExt, ensure};
 
+use crate::ddl::utils::raw_table_info;
 use crate::ddl::utils::region_metadata_lister::RegionMetadataLister;
 use crate::ddl::utils::table_info::get_all_table_info_values_by_table_ids;
-use crate::error::{self, Result};
+use crate::error::{self, Result, TableInfoNotFoundSnafu};
 use crate::metrics;
 use crate::reconciliation::reconcile_logical_tables::reconcile_regions::ReconcileRegions;
 use crate::reconciliation::reconcile_logical_tables::{
     ReconcileLogicalTablesContext, ReconcileLogicalTablesProcedure, State,
 };
 use crate::reconciliation::utils::{
-    check_column_metadatas_consistent, need_update_logical_table_info,
+    check_region_metadatas_consistent, logical_table_info_matches_region_metadata,
+    validate_logical_region_metadata,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -49,9 +51,18 @@ impl State for ResolveTableMetadatas {
             .map(|t| t.table_ref())
             .collect::<Vec<_>>();
         let table_ids = &ctx.persistent_ctx.logical_table_ids;
+        let physical_table_info = ctx
+            .table_metadata_manager
+            .table_info_manager()
+            .get(ctx.table_id())
+            .await?
+            .with_context(|| TableInfoNotFoundSnafu {
+                table: format!("table id - {}", ctx.table_id()),
+            })?;
+        let physical_table_info = &physical_table_info.table_info;
 
         let mut create_tables = vec![];
-        let mut update_table_infos = vec![];
+        let mut update_region_metadatas = vec![];
 
         let table_info_values = get_all_table_info_values_by_table_ids(
             ctx.table_metadata_manager.table_info_manager(),
@@ -99,6 +110,11 @@ impl State for ResolveTableMetadatas {
             });
 
             if region_metadatas.iter().any(|r| r.is_none()) {
+                Self::ensure_can_create_missing_regions(
+                    ctx.persistent_ctx.verifying_after_create,
+                    &table_info_value.table_info.name,
+                    *table_id,
+                )?;
                 create_tables_count += 1;
                 create_tables.push((*table_id, table_info_value.table_info.clone()));
                 continue;
@@ -109,18 +125,36 @@ impl State for ResolveTableMetadatas {
                 .into_iter()
                 .map(|r| r.unwrap())
                 .collect::<Vec<_>>();
-            if let Some(column_metadatas) = check_column_metadatas_consistent(&region_metadatas) {
+            if let Some(region_metadata) = check_region_metadatas_consistent(&region_metadatas) {
                 metadata_consistent_count += 1;
-                if need_update_logical_table_info(&table_info_value.table_info, &column_metadatas) {
-                    update_table_infos.push((*table_id, column_metadatas));
+                validate_logical_region_metadata(physical_table_info, &region_metadata)?;
+
+                // Always check a complete persisted mapping before scheduling a repair. A
+                // complete conflict is corruption, not a legacy value that may be replaced.
+                let mut table_info_with_restored_ids = table_info_value.table_info.clone();
+                raw_table_info::populate_logical_table_column_ids(
+                    physical_table_info,
+                    &mut table_info_with_restored_ids,
+                )?;
+                let ids_need_update = table_info_with_restored_ids.meta.column_ids
+                    != table_info_value.table_info.meta.column_ids;
+                if !logical_table_info_matches_region_metadata(
+                    &table_info_with_restored_ids,
+                    &region_metadata,
+                ) || ids_need_update
+                {
+                    update_region_metadatas.push((*table_id, region_metadata));
                 }
             } else {
                 metadata_inconsistent_count += 1;
-                // If the logical regions have inconsistent column metadatas, it won't affect read and write.
-                // It's safe to continue if the column metadatas of the logical table are inconsistent.
-                warn!(
-                    "Found inconsistent column metadatas for table: {}, table_id: {}. Remaining the inconsistent column metadatas",
-                    table_info_value.table_info.name, table_id
+                ensure!(
+                    false,
+                    error::UnexpectedSnafu {
+                        err_msg: format!(
+                            "Logical region column metadatas are inconsistent for table: {}, table_id: {}",
+                            table_info_value.table_info.name, table_id
+                        ),
+                    }
                 );
             }
         }
@@ -131,7 +165,7 @@ impl State for ResolveTableMetadatas {
             "Resolving table metadatas for physical table: {}, table_id: {}, updating table infos: {:?}, creating tables: {:?}",
             table_name,
             table_id,
-            update_table_infos
+            update_region_metadatas
                 .iter()
                 .map(|(table_id, _)| *table_id)
                 .collect::<Vec<_>>(),
@@ -140,8 +174,12 @@ impl State for ResolveTableMetadatas {
                 .map(|(table_id, _)| *table_id)
                 .collect::<Vec<_>>(),
         );
-        ctx.persistent_ctx.update_table_infos = update_table_infos;
+        // Replace all transient resolution output atomically so a recovered procedure does not
+        // apply pre-migration column-only authority.
+        ctx.persistent_ctx.update_table_infos.clear();
+        ctx.persistent_ctx.update_region_metadatas = update_region_metadatas;
         ctx.persistent_ctx.create_tables = create_tables;
+        ctx.persistent_ctx.verifying_after_create = false;
         // Update metrics.
         let metrics = ctx.mut_metrics();
         metrics.column_metadata_consistent_count = metadata_consistent_count;
@@ -152,5 +190,39 @@ impl State for ResolveTableMetadatas {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+impl ResolveTableMetadatas {
+    fn ensure_can_create_missing_regions(
+        verifying_after_create: bool,
+        table_name: &str,
+        table_id: u32,
+    ) -> Result<()> {
+        ensure!(
+            !verifying_after_create,
+            error::UnexpectedSnafu {
+                err_msg: format!(
+                    "Logical regions are still absent after create verification for table: {}, table_id: {}",
+                    table_name, table_id
+                ),
+            }
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_post_create_absence_does_not_schedule_another_create() {
+        assert!(
+            ResolveTableMetadatas::ensure_can_create_missing_regions(false, "logical", 1).is_ok()
+        );
+        assert!(
+            ResolveTableMetadatas::ensure_can_create_missing_regions(true, "logical", 1).is_err()
+        );
     }
 }

--- a/src/common/meta/src/reconciliation/reconcile_logical_tables/update_table_infos.rs
+++ b/src/common/meta/src/reconciliation/reconcile_logical_tables/update_table_infos.rs
@@ -18,21 +18,27 @@ use std::collections::HashMap;
 use common_procedure::{Context as ProcedureContext, Status};
 use common_telemetry::info;
 use serde::{Deserialize, Serialize};
-use store_api::metadata::ColumnMetadata;
+use snafu::OptionExt;
+use store_api::metadata::RegionMetadata;
 use store_api::storage::TableId;
 use table::metadata::TableInfo;
 use table::table_name::TableName;
 use table::table_reference::TableReference;
 
 use crate::cache_invalidator::Context as CacheContext;
+use crate::ddl::utils::raw_table_info;
 use crate::ddl::utils::table_info::{
     batch_update_table_info_values, get_all_table_info_values_by_table_ids,
 };
-use crate::error::Result;
+use crate::error::{Result, TableInfoNotFoundSnafu, UnexpectedSnafu};
 use crate::instruction::CacheIdent;
 use crate::reconciliation::reconcile_logical_tables::reconciliation_end::ReconciliationEnd;
+use crate::reconciliation::reconcile_logical_tables::resolve_table_metadatas::ResolveTableMetadatas;
 use crate::reconciliation::reconcile_logical_tables::{ReconcileLogicalTablesContext, State};
-use crate::reconciliation::utils::build_table_meta_from_column_metadatas;
+use crate::reconciliation::utils::{
+    build_table_meta_from_column_metadatas, logical_table_info_matches_region_metadata,
+    validate_logical_region_metadata,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateTableInfos;
@@ -45,8 +51,15 @@ impl State for UpdateTableInfos {
         ctx: &mut ReconcileLogicalTablesContext,
         _procedure_ctx: &ProcedureContext,
     ) -> Result<(Box<dyn State>, Status)> {
-        if ctx.persistent_ctx.update_table_infos.is_empty() {
-            return Ok((Box::new(ReconciliationEnd), Status::executing(false)));
+        if ctx.persistent_ctx.update_region_metadatas.is_empty() {
+            if ctx.persistent_ctx.update_table_infos.is_empty() {
+                return Ok((Box::new(ReconciliationEnd), Status::executing(false)));
+            }
+
+            // A procedure persisted by an older build retained only column metadata. Resolve it
+            // again rather than applying an update without authoritative ordered primary keys.
+            ctx.persistent_ctx.update_table_infos.clear();
+            return Ok((Box::new(ResolveTableMetadatas), Status::executing(true)));
         }
 
         let all_table_names = ctx
@@ -63,7 +76,7 @@ impl State for UpdateTableInfos {
             .collect::<HashMap<_, _>>();
         let table_ids = ctx
             .persistent_ctx
-            .update_table_infos
+            .update_region_metadatas
             .iter()
             .map(|(table_id, _)| *table_id)
             .collect::<Vec<_>>();
@@ -77,33 +90,52 @@ impl State for UpdateTableInfos {
             &table_names,
         )
         .await?;
+        let physical_table_info = ctx
+            .table_metadata_manager
+            .table_info_manager()
+            .get(ctx.table_id())
+            .await?
+            .with_context(|| TableInfoNotFoundSnafu {
+                table: format!("table id - {}", ctx.table_id()),
+            })?;
+        let physical_table_info = &physical_table_info.table_info;
 
         let mut table_info_values_to_update =
-            Vec::with_capacity(ctx.persistent_ctx.update_table_infos.len());
-        for ((table_id, column_metadatas), table_info_value) in ctx
+            Vec::with_capacity(ctx.persistent_ctx.update_region_metadatas.len());
+        let mut updated_table_ids =
+            Vec::with_capacity(ctx.persistent_ctx.update_region_metadatas.len());
+        for ((table_id, region_metadata), table_info_value) in ctx
             .persistent_ctx
-            .update_table_infos
+            .update_region_metadatas
             .iter()
             .zip(table_info_values)
         {
-            let new_table_info = Self::build_new_table_info(
+            if let Some(new_table_info) = Self::build_new_table_info(
                 *table_id,
-                column_metadatas,
+                region_metadata,
                 &table_info_value.table_info,
-            )?;
-            table_info_values_to_update.push((table_info_value, new_table_info));
+                physical_table_info,
+            )? {
+                updated_table_ids.push(*table_id);
+                table_info_values_to_update.push((table_info_value, new_table_info));
+            }
         }
         let table_id = ctx.table_id();
         let table_name = ctx.table_name();
 
         let updated_table_info_num = table_info_values_to_update.len();
+        if updated_table_info_num == 0 {
+            ctx.persistent_ctx.update_table_infos.clear();
+            ctx.persistent_ctx.update_region_metadatas.clear();
+            return Ok((Box::new(ReconciliationEnd), Status::executing(false)));
+        }
         batch_update_table_info_values(&ctx.table_metadata_manager, table_info_values_to_update)
             .await?;
 
         info!(
             "Updated table infos for logical tables: {:?}, physical table: {}, table_id: {}",
             ctx.persistent_ctx
-                .update_table_infos
+                .update_region_metadatas
                 .iter()
                 .map(|(table_id, _)| table_id)
                 .collect::<Vec<_>>(),
@@ -117,12 +149,22 @@ impl State for UpdateTableInfos {
                 table_id
             )),
         };
-        let idents = Self::build_cache_ident_keys(table_id, table_name, &table_ids, &table_names);
+        let updated_table_names = updated_table_ids
+            .iter()
+            .map(|table_id| *all_table_names.get(table_id).unwrap())
+            .collect::<Vec<_>>();
+        let idents = Self::build_cache_ident_keys(
+            table_id,
+            table_name,
+            &updated_table_ids,
+            &updated_table_names,
+        );
         ctx.cache_invalidator
             .invalidate(&cache_ctx, &idents)
             .await?;
 
         ctx.persistent_ctx.update_table_infos.clear();
+        ctx.persistent_ctx.update_region_metadatas.clear();
         // Update metrics.
         let metrics = ctx.mut_metrics();
         metrics.update_table_info_count = updated_table_info_num;
@@ -137,24 +179,127 @@ impl State for UpdateTableInfos {
 impl UpdateTableInfos {
     fn build_new_table_info(
         table_id: TableId,
-        column_metadatas: &[ColumnMetadata],
+        region_metadata: &RegionMetadata,
         table_info: &TableInfo,
-    ) -> Result<TableInfo> {
+        physical_table_info: &TableInfo,
+    ) -> Result<Option<TableInfo>> {
+        validate_logical_region_metadata(physical_table_info, region_metadata)?;
+
+        // Validate or restore the persisted mapping before deciding whether this is a genuine
+        // schema rebuild. This makes complete conflicts fail closed even if metadata changed
+        // between resolution and the CAS update.
+        let mut new_table_info = table_info.clone();
+        raw_table_info::populate_logical_table_column_ids(
+            physical_table_info,
+            &mut new_table_info,
+        )?;
+
+        if logical_table_info_matches_region_metadata(&new_table_info, region_metadata) {
+            if new_table_info.meta.column_ids == table_info.meta.column_ids {
+                return Ok(None);
+            }
+            new_table_info.ident.version = table_info.ident.version + 1;
+            return Ok(Some(new_table_info));
+        }
+
+        let partition_key_names = Self::partition_key_names(table_info)?;
         let table_ref = table_info.table_ref();
         let table_meta = build_table_meta_from_column_metadatas(
             table_id,
             table_ref,
             &table_info.meta,
             None,
-            column_metadatas,
+            &region_metadata.column_metadatas,
         )?;
 
-        let mut new_table_info = table_info.clone();
         new_table_info.meta = table_meta;
-        new_table_info.ident.version = table_info.ident.version + 1;
         new_table_info.sort_columns();
+        Self::remap_sorted_roles(&mut new_table_info, region_metadata, &partition_key_names)?;
+        raw_table_info::populate_logical_table_column_ids(
+            physical_table_info,
+            &mut new_table_info,
+        )?;
+        new_table_info.ident.version = table_info.ident.version + 1;
 
-        Ok(new_table_info)
+        Ok(Some(new_table_info))
+    }
+
+    fn partition_key_names(table_info: &TableInfo) -> Result<Vec<String>> {
+        let columns = table_info.meta.schema.column_schemas();
+        table_info
+            .meta
+            .partition_key_indices
+            .iter()
+            .map(|index| {
+                columns
+                    .get(*index)
+                    .map(|column| column.name.clone())
+                    .with_context(|| UnexpectedSnafu {
+                        err_msg: format!(
+                            "Logical table {} ({}) has invalid partition key index {}",
+                            table_info.name, table_info.ident.table_id, index
+                        ),
+                    })
+            })
+            .collect()
+    }
+
+    fn remap_sorted_roles(
+        table_info: &mut TableInfo,
+        region_metadata: &RegionMetadata,
+        partition_key_names: &[String],
+    ) -> Result<()> {
+        let index_by_name = table_info
+            .meta
+            .schema
+            .column_schemas()
+            .iter()
+            .enumerate()
+            .map(|(index, column)| (column.name.as_str(), index))
+            .collect::<HashMap<_, _>>();
+        let name_by_id = region_metadata
+            .column_metadatas
+            .iter()
+            .map(|column| (column.column_id, column.column_schema.name.as_str()))
+            .collect::<HashMap<_, _>>();
+
+        table_info.meta.primary_key_indices = region_metadata
+            .primary_key
+            .iter()
+            .map(|column_id| {
+                let column_name = name_by_id.get(column_id).with_context(|| UnexpectedSnafu {
+                    err_msg: format!(
+                        "Logical region primary-key ID {} has no column metadata",
+                        column_id
+                    ),
+                })?;
+                index_by_name
+                    .get(*column_name)
+                    .copied()
+                    .with_context(|| UnexpectedSnafu {
+                        err_msg: format!(
+                            "Logical region primary-key column {} is missing after rebuild",
+                            column_name
+                        ),
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        table_info.meta.partition_key_indices = partition_key_names
+            .iter()
+            .map(|column_name| {
+                index_by_name
+                    .get(column_name.as_str())
+                    .copied()
+                    .with_context(|| UnexpectedSnafu {
+                        err_msg: format!(
+                            "Logical partition-key column {} is missing after rebuild",
+                            column_name
+                        ),
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(())
     }
 
     fn build_cache_ident_keys(
@@ -178,5 +323,367 @@ impl UpdateTableInfos {
         );
 
         cache_keys
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api::v1::SemanticType;
+    use datatypes::schema::{ColumnSchema, Schema};
+    use store_api::metadata::{ColumnMetadata, RegionMetadata};
+    use store_api::storage::RegionId;
+
+    use super::*;
+    use crate::ddl::test_util::region_metadata::build_region_metadata;
+    use crate::ddl::test_util::{
+        test_create_logical_table_task, test_create_physical_table_task, test_physical_table_info,
+    };
+
+    fn table_infos() -> (TableInfo, TableInfo) {
+        let physical =
+            test_physical_table_info(test_create_physical_table_task("physical").table_info);
+        let logical = test_create_logical_table_task("logical").table_info;
+        (physical, logical)
+    }
+
+    fn logical_column_metadatas(
+        physical_table_info: &TableInfo,
+        logical_table_info: &TableInfo,
+    ) -> Vec<ColumnMetadata> {
+        let column_ids = raw_table_info::logical_column_ids_from_physical_table_info(
+            physical_table_info,
+            logical_table_info.meta.schema.column_schemas(),
+        )
+        .unwrap();
+        logical_table_info
+            .meta
+            .schema
+            .column_schemas()
+            .iter()
+            .zip(column_ids)
+            .enumerate()
+            .map(|(index, (column_schema, column_id))| ColumnMetadata {
+                column_schema: column_schema.clone(),
+                semantic_type: if logical_table_info.meta.primary_key_indices.contains(&index) {
+                    SemanticType::Tag
+                } else if column_schema.is_time_index() {
+                    SemanticType::Timestamp
+                } else {
+                    SemanticType::Field
+                },
+                column_id,
+            })
+            .collect()
+    }
+
+    fn logical_region_metadata(
+        physical_table_info: &TableInfo,
+        logical_table_info: &TableInfo,
+    ) -> RegionMetadata {
+        let column_metadatas = logical_column_metadatas(physical_table_info, logical_table_info);
+        build_region_metadata(
+            RegionId::new(logical_table_info.ident.table_id, 0),
+            &column_metadatas,
+        )
+    }
+
+    #[test]
+    fn test_id_only_repair_replaces_empty_and_partial_ids() {
+        let (physical, logical) = table_infos();
+        let region_metadata = logical_region_metadata(&physical, &logical);
+        let expected_column_ids = raw_table_info::logical_column_ids_from_physical_table_info(
+            &physical,
+            logical.meta.schema.column_schemas(),
+        )
+        .unwrap();
+
+        for column_ids in [
+            vec![],
+            expected_column_ids[..1].to_vec(),
+            expected_column_ids.iter().copied().chain([999]).collect(),
+        ] {
+            let mut legacy = logical.clone();
+            legacy.meta.column_ids = column_ids;
+            let new_table_info = UpdateTableInfos::build_new_table_info(
+                legacy.ident.table_id,
+                &region_metadata,
+                &legacy,
+                &physical,
+            )
+            .unwrap()
+            .unwrap();
+
+            assert_eq!(new_table_info.meta.schema, legacy.meta.schema);
+            assert_eq!(new_table_info.meta.column_ids, expected_column_ids);
+            assert_eq!(new_table_info.ident.version, legacy.ident.version + 1);
+            let mut expected_meta = legacy.meta.clone();
+            expected_meta.column_ids = expected_column_ids.clone();
+            assert_eq!(new_table_info.meta, expected_meta);
+        }
+    }
+
+    #[test]
+    fn test_id_only_repair_skips_complete_matching_ids() {
+        let (physical, mut logical) = table_infos();
+        logical.meta.column_ids = raw_table_info::logical_column_ids_from_physical_table_info(
+            &physical,
+            logical.meta.schema.column_schemas(),
+        )
+        .unwrap();
+        let region_metadata = logical_region_metadata(&physical, &logical);
+
+        assert!(
+            UpdateTableInfos::build_new_table_info(
+                logical.ident.table_id,
+                &region_metadata,
+                &logical,
+                &physical,
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_reordered_datanode_columns_do_not_rebuild_matching_table() {
+        let (physical, mut logical) = table_infos();
+        raw_table_info::populate_logical_table_column_ids(&physical, &mut logical).unwrap();
+        let mut region_metadata = logical_region_metadata(&physical, &logical);
+        region_metadata.column_metadatas.reverse();
+
+        assert!(
+            UpdateTableInfos::build_new_table_info(
+                logical.ident.table_id,
+                &region_metadata,
+                &logical,
+                &physical,
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_primary_key_membership_and_order_follow_region_authority() {
+        let (physical, mut logical) = table_infos();
+        let cpu_index = logical
+            .meta
+            .schema
+            .column_schemas()
+            .iter()
+            .position(|column| column.name == "cpu")
+            .unwrap();
+        logical.meta.primary_key_indices.push(cpu_index);
+        raw_table_info::populate_logical_table_column_ids(&physical, &mut logical).unwrap();
+        let mut region_metadata = logical_region_metadata(&physical, &logical);
+        region_metadata.primary_key.reverse();
+
+        let new_table_info = UpdateTableInfos::build_new_table_info(
+            logical.ident.table_id,
+            &region_metadata,
+            &logical,
+            &physical,
+        )
+        .unwrap()
+        .unwrap();
+        let primary_key_names = new_table_info
+            .meta
+            .primary_key_indices
+            .iter()
+            .map(|index| {
+                new_table_info.meta.schema.column_schemas()[*index]
+                    .name
+                    .as_str()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(primary_key_names, vec!["cpu", "host"]);
+    }
+
+    #[test]
+    fn test_id_only_repair_rejects_complete_conflicting_ids() {
+        let (physical, mut logical) = table_infos();
+        logical.meta.column_ids = raw_table_info::logical_column_ids_from_physical_table_info(
+            &physical,
+            logical.meta.schema.column_schemas(),
+        )
+        .unwrap();
+        logical.meta.column_ids[0] += 100;
+        let region_metadata = logical_region_metadata(&physical, &logical);
+
+        assert!(
+            UpdateTableInfos::build_new_table_info(
+                logical.ident.table_id,
+                &region_metadata,
+                &logical,
+                &physical,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_id_only_repair_rejects_datanode_and_physical_id_mismatch() {
+        let (physical, logical) = table_infos();
+        let mut region_metadata = logical_region_metadata(&physical, &logical);
+        region_metadata.column_metadatas[0].column_id += 100;
+
+        assert!(
+            UpdateTableInfos::build_new_table_info(
+                logical.ident.table_id,
+                &region_metadata,
+                &logical,
+                &physical,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_schema_mismatch_rebuilds_then_enforces_physical_ids() {
+        let (physical, mut stale_logical) = table_infos();
+        raw_table_info::populate_logical_table_column_ids(&physical, &mut stale_logical).unwrap();
+        let region_metadata = logical_region_metadata(&physical, &stale_logical);
+        let primary_key_names = stale_logical
+            .meta
+            .primary_key_indices
+            .iter()
+            .map(|index| {
+                stale_logical.meta.schema.column_schemas()[*index]
+                    .name
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+        let mut columns = stale_logical.meta.schema.column_schemas().to_vec();
+        let cpu_index = columns
+            .iter()
+            .position(|column| column.name == "cpu")
+            .unwrap();
+        columns.remove(cpu_index);
+        stale_logical.meta.schema = Arc::new(Schema::new(columns));
+        stale_logical.meta.primary_key_indices = stale_logical
+            .meta
+            .schema
+            .column_schemas()
+            .iter()
+            .enumerate()
+            .filter_map(|(index, column)| primary_key_names.contains(&column.name).then_some(index))
+            .collect();
+        stale_logical.meta.column_ids =
+            raw_table_info::logical_column_ids_from_physical_table_info(
+                &physical,
+                stale_logical.meta.schema.column_schemas(),
+            )
+            .unwrap();
+
+        let new_table_info = UpdateTableInfos::build_new_table_info(
+            stale_logical.ident.table_id,
+            &region_metadata,
+            &stale_logical,
+            &physical,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            new_table_info.meta.schema.column_schemas().len(),
+            region_metadata.column_metadatas.len()
+        );
+        assert!(
+            new_table_info
+                .meta
+                .schema
+                .column_schemas()
+                .iter()
+                .any(|column| column.name == "cpu")
+        );
+        assert_eq!(
+            new_table_info.meta.column_ids,
+            raw_table_info::logical_column_ids_from_physical_table_info(
+                &physical,
+                new_table_info.meta.schema.column_schemas(),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_schema_mismatch_rebuilds_type_and_nullability_from_region_authority() {
+        let (physical, mut stale_logical) = table_infos();
+        raw_table_info::populate_logical_table_column_ids(&physical, &mut stale_logical).unwrap();
+        let region_metadata = logical_region_metadata(&physical, &stale_logical);
+        let mut columns = stale_logical.meta.schema.column_schemas().to_vec();
+        let cpu_index = columns
+            .iter()
+            .position(|column| column.name == "cpu")
+            .unwrap();
+        let cpu = columns[cpu_index].clone();
+        columns[cpu_index] =
+            ColumnSchema::new(cpu.name.clone(), cpu.data_type.clone(), !cpu.is_nullable());
+        stale_logical.meta.schema = Arc::new(Schema::new(columns));
+
+        let new_table_info = UpdateTableInfos::build_new_table_info(
+            stale_logical.ident.table_id,
+            &region_metadata,
+            &stale_logical,
+            &physical,
+        )
+        .unwrap()
+        .unwrap();
+
+        let expected_cpu = region_metadata
+            .column_metadatas
+            .iter()
+            .find(|column| column.column_schema.name == "cpu")
+            .unwrap();
+        let rebuilt_cpu = new_table_info
+            .meta
+            .schema
+            .column_schemas()
+            .iter()
+            .find(|column| column.name == "cpu")
+            .unwrap();
+        assert_eq!(rebuilt_cpu, &expected_cpu.column_schema);
+    }
+
+    #[test]
+    fn test_schema_rebuild_preserves_ordered_partition_keys() {
+        let (physical, mut stale_logical) = table_infos();
+        raw_table_info::populate_logical_table_column_ids(&physical, &mut stale_logical).unwrap();
+        let region_metadata = logical_region_metadata(&physical, &stale_logical);
+        let columns = stale_logical.meta.schema.column_schemas();
+        let host_index = columns
+            .iter()
+            .position(|column| column.name == "host")
+            .unwrap();
+        let cpu_index = columns
+            .iter()
+            .position(|column| column.name == "cpu")
+            .unwrap();
+        stale_logical.meta.partition_key_indices = vec![host_index, cpu_index];
+        // Preserve the schema while making the persisted primary-key role stale.
+        stale_logical.meta.primary_key_indices.clear();
+
+        let new_table_info = UpdateTableInfos::build_new_table_info(
+            stale_logical.ident.table_id,
+            &region_metadata,
+            &stale_logical,
+            &physical,
+        )
+        .unwrap()
+        .unwrap();
+
+        let partition_names = new_table_info
+            .meta
+            .partition_key_indices
+            .iter()
+            .map(|index| {
+                new_table_info.meta.schema.column_schemas()[*index]
+                    .name
+                    .as_str()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(partition_names, vec!["host", "cpu"]);
     }
 }

--- a/src/common/meta/src/reconciliation/utils.rs
+++ b/src/common/meta/src/reconciliation/utils.rs
@@ -32,8 +32,9 @@ use table::table_name::TableName;
 use table::table_reference::TableReference;
 
 use crate::cache_invalidator::CacheInvalidatorRef;
+use crate::ddl::utils::raw_table_info;
 use crate::error::{
-    ColumnIdMismatchSnafu, ColumnNotFoundSnafu, MismatchColumnIdSnafu,
+    ColumnIdMismatchSnafu, ColumnNotFoundSnafu, MetadataCorruptionSnafu, MismatchColumnIdSnafu,
     MissingColumnInColumnMetadataSnafu, ProcedureStateReceiverNotFoundSnafu,
     ProcedureStateReceiverSnafu, Result, TimestampMismatchSnafu, UnexpectedSnafu,
     WaitProcedureSnafu,
@@ -83,6 +84,19 @@ pub(crate) fn check_column_metadatas_consistent(
     }
 
     Some(region_metadatas[0].column_metadatas.clone())
+}
+
+/// Returns complete authoritative region metadata when all replicas agree on logical authority.
+///
+/// This retains the ordered primary-key IDs in addition to column metadata.
+pub(crate) fn check_region_metadatas_consistent(
+    region_metadatas: &[RegionMetadata],
+) -> Option<RegionMetadata> {
+    let is_column_metadata_consistent = region_metadatas
+        .windows(2)
+        .all(|w| PartialRegionMetadata::from(&w[0]) == PartialRegionMetadata::from(&w[1]));
+
+    is_column_metadata_consistent.then(|| region_metadatas[0].clone())
 }
 
 /// Resolves column metadata inconsistencies among the given region metadatas
@@ -397,15 +411,161 @@ pub(crate) fn build_table_meta_from_column_metadatas(
     Ok(new_raw_table_meta)
 }
 
-/// Returns true if the logical table info needs to be updated.
-///
-/// The logical table only support to add columns, so we can check the length of column metadatas
-/// to determine whether the logical table info needs to be updated.
-pub(crate) fn need_update_logical_table_info(
-    table_info: &TableInfo,
+/// Validates complete authoritative logical region metadata against the physical table.
+pub(crate) fn validate_logical_region_metadata(
+    physical_table_info: &TableInfo,
+    region_metadata: &RegionMetadata,
+) -> Result<()> {
+    validate_logical_column_metadatas(
+        physical_table_info,
+        &region_metadata.column_metadatas,
+        &region_metadata.primary_key,
+    )
+}
+
+/// Validates logical columns and their ordered primary-key IDs without requiring a constructed
+/// [`RegionMetadata`]. This allows callers to reject malformed authority before attempting a
+/// schema reconstruction.
+pub(crate) fn validate_logical_column_metadatas(
+    physical_table_info: &TableInfo,
     column_metadatas: &[ColumnMetadata],
+    primary_key: &[u32],
+) -> Result<()> {
+    let mut ids_by_name = HashMap::with_capacity(column_metadatas.len());
+    let mut tag_ids = HashSet::with_capacity(column_metadatas.len());
+    let mut seen_ids = HashSet::with_capacity(column_metadatas.len());
+    let mut timestamp_count = 0;
+    for column_metadata in column_metadatas {
+        ensure!(
+            ids_by_name
+                .insert(
+                    column_metadata.column_schema.name.as_str(),
+                    column_metadata.column_id
+                )
+                .is_none(),
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Logical region metadata has duplicate column name {}",
+                    column_metadata.column_schema.name,
+                ),
+            }
+        );
+        ensure!(
+            seen_ids.insert(column_metadata.column_id),
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Logical region metadata has duplicate column ID {}",
+                    column_metadata.column_id,
+                ),
+            }
+        );
+        ensure!(
+            (column_metadata.semantic_type == SemanticType::Timestamp)
+                == column_metadata.column_schema.is_time_index(),
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Logical region column {} has mismatched timestamp semantic and time-index role",
+                    column_metadata.column_schema.name,
+                ),
+            }
+        );
+        if column_metadata.semantic_type == SemanticType::Timestamp {
+            timestamp_count += 1;
+        }
+        if column_metadata.semantic_type == SemanticType::Tag {
+            tag_ids.insert(column_metadata.column_id);
+        }
+    }
+    ensure!(
+        timestamp_count == 1,
+        MetadataCorruptionSnafu {
+            err_msg: format!(
+                "Logical region metadata has {} timestamp columns, expected exactly one",
+                timestamp_count,
+            ),
+        }
+    );
+
+    let mut seen_primary_key_ids = HashSet::with_capacity(primary_key.len());
+    for column_id in primary_key {
+        ensure!(
+            seen_primary_key_ids.insert(*column_id),
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Logical region metadata has duplicate primary-key ID {}",
+                    column_id,
+                ),
+            }
+        );
+        ensure!(
+            tag_ids.contains(column_id),
+            MetadataCorruptionSnafu {
+                err_msg: format!(
+                    "Logical region primary-key ID {} is not a Tag column",
+                    column_id,
+                ),
+            }
+        );
+    }
+    ensure!(
+        seen_primary_key_ids == tag_ids,
+        MetadataCorruptionSnafu {
+            err_msg: "Logical region primary-key IDs do not contain every Tag column exactly once"
+                .to_string(),
+        }
+    );
+
+    raw_table_info::validate_logical_column_metadata_ids(physical_table_info, column_metadatas)
+}
+
+/// Returns whether the logical table schema and roles match authoritative region metadata.
+///
+/// The comparison joins columns by name, so harmless datanode ordering differences do not cause
+/// a rebuild. The caller validates `region_metadata` before calling this function.
+pub(crate) fn logical_table_info_matches_region_metadata(
+    table_info: &TableInfo,
+    region_metadata: &RegionMetadata,
 ) -> bool {
-    table_info.meta.schema.column_schemas().len() != column_metadatas.len()
+    let columns = table_info.meta.schema.column_schemas();
+    if columns.len() != region_metadata.column_metadatas.len()
+        || table_info.meta.column_ids.len() != columns.len()
+    {
+        return false;
+    }
+
+    let region_columns = region_metadata
+        .column_metadatas
+        .iter()
+        .map(|column_metadata| (column_metadata.column_schema.name.as_str(), column_metadata))
+        .collect::<HashMap<_, _>>();
+    if region_columns.len() != region_metadata.column_metadatas.len() {
+        return false;
+    }
+
+    let mut table_primary_key_ids = Vec::with_capacity(table_info.meta.primary_key_indices.len());
+    for index in &table_info.meta.primary_key_indices {
+        let Some(column_id) = table_info.meta.column_ids.get(*index) else {
+            return false;
+        };
+        table_primary_key_ids.push(*column_id);
+    }
+    if table_primary_key_ids != region_metadata.primary_key {
+        return false;
+    }
+
+    columns.iter().enumerate().all(|(index, column)| {
+        let Some(column_metadata) = region_columns.get(column.name.as_str()) else {
+            return false;
+        };
+        let semantic_type = if table_info.meta.primary_key_indices.contains(&index) {
+            SemanticType::Tag
+        } else if column.is_time_index() {
+            SemanticType::Timestamp
+        } else {
+            SemanticType::Field
+        };
+        column == &column_metadata.column_schema && semantic_type == column_metadata.semantic_type
+    })
 }
 
 /// The result of waiting for inflight subprocedures.
@@ -963,6 +1123,9 @@ mod tests {
 
     use super::*;
     use crate::ddl::test_util::region_metadata::build_region_metadata;
+    use crate::ddl::test_util::{
+        test_column_metadatas, test_create_physical_table_task, test_physical_table_info,
+    };
     use crate::error::Error;
     use crate::reconciliation::utils::check_column_metadatas_consistent;
 
@@ -1193,6 +1356,91 @@ mod tests {
         let region_metadata2 = build_region_metadata(RegionId::new(1024, 1), &column_metadatas);
         let result = check_column_metadatas_consistent(&[region_metadata1, region_metadata2]);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_validate_logical_column_metadatas_rejects_duplicate_name_and_id() {
+        let physical_table_info =
+            test_physical_table_info(test_create_physical_table_task("physical").table_info);
+        let column_metadatas = test_column_metadatas(&["host", "cpu"]);
+        let primary_key = column_metadatas
+            .iter()
+            .filter(|column| column.semantic_type == SemanticType::Tag)
+            .map(|column| column.column_id)
+            .collect::<Vec<_>>();
+
+        let mut duplicate_name = column_metadatas.clone();
+        duplicate_name.push(column_metadatas[0].clone());
+        assert!(
+            validate_logical_column_metadatas(&physical_table_info, &duplicate_name, &primary_key,)
+                .is_err()
+        );
+
+        let mut duplicate_id = column_metadatas.clone();
+        duplicate_id[1].column_id = duplicate_id[0].column_id;
+        assert!(
+            validate_logical_column_metadatas(&physical_table_info, &duplicate_id, &primary_key,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_logical_column_metadatas_rejects_timestamp_and_primary_key_violations() {
+        let physical_table_info =
+            test_physical_table_info(test_create_physical_table_task("physical").table_info);
+        let column_metadatas = test_column_metadatas(&["host", "cpu"]);
+        let primary_key = column_metadatas
+            .iter()
+            .filter(|column| column.semantic_type == SemanticType::Tag)
+            .map(|column| column.column_id)
+            .collect::<Vec<_>>();
+
+        let mut missing_timestamp = column_metadatas.clone();
+        missing_timestamp.retain(|column| column.semantic_type != SemanticType::Timestamp);
+        assert!(
+            validate_logical_column_metadatas(
+                &physical_table_info,
+                &missing_timestamp,
+                &primary_key,
+            )
+            .is_err()
+        );
+
+        let mut multiple_timestamps = column_metadatas.clone();
+        let mut extra_timestamp = column_metadatas[0].clone();
+        extra_timestamp.column_schema.name = "another_ts".to_string();
+        extra_timestamp.column_id = 999;
+        multiple_timestamps.push(extra_timestamp);
+        assert!(
+            validate_logical_column_metadatas(
+                &physical_table_info,
+                &multiple_timestamps,
+                &primary_key,
+            )
+            .is_err()
+        );
+
+        let mut misflagged_timestamp = column_metadatas.clone();
+        misflagged_timestamp[1].semantic_type = SemanticType::Timestamp;
+        assert!(
+            validate_logical_column_metadatas(
+                &physical_table_info,
+                &misflagged_timestamp,
+                &primary_key,
+            )
+            .is_err()
+        );
+
+        let mut invalid_primary_key = primary_key.clone();
+        invalid_primary_key.push(column_metadatas[0].column_id);
+        assert!(
+            validate_logical_column_metadatas(
+                &physical_table_info,
+                &column_metadatas,
+                &invalid_primary_key,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 
 use arrow::error::ArrowError;
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use datafusion_common::DataFusionError;
@@ -256,6 +256,16 @@ impl ErrorExt for Error {
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::DecodePlan { source, .. }
+            | Error::Execute { source, .. }
+            | Error::ProcedureService { source, .. }
+            | Error::TableMutation { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }
 

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -61,6 +61,7 @@ pub use query::dummy_catalog::{
     DummyCatalogList, DummyTableProviderFactory, TableProviderFactoryRef,
 };
 use query::options::should_collect_region_watermark_from_extensions;
+use query::query_engine::remote_plan_codec::decode_remote_plan;
 use serde_json;
 use servers::error::{
     self as servers_error, ExecuteGrpcRequestSnafu, Result as ServerResult, SuspendedSnafu,
@@ -310,8 +311,7 @@ impl RegionServer {
             .new_plan_decoder()
             .context(NewPlanDecoderSnafu)?;
 
-        let plan = decoder
-            .decode(Bytes::from(request.plan), catalog_list, false)
+        let plan = decode_remote_plan(&*decoder, Bytes::from(request.plan), catalog_list)
             .await
             .context(DecodeLogicalPlanSnafu)?;
 

--- a/src/datanode/src/region_server/catalog.rs
+++ b/src/datanode/src/region_server/catalog.rs
@@ -25,6 +25,7 @@ use datafusion_common::DataFusionError;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion, TreeNodeRewriter};
 use datafusion_expr::{LogicalPlan, TableSource};
 use futures::TryStreamExt;
+use query::query_engine::remote_plan_codec::is_reserved_internal_table_name;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
 use store_api::region_info::RegionInfoEntry;
@@ -48,6 +49,9 @@ enum InternalTableKind {
 impl InternalTableKind {
     /// Determine if the name is a reserved internal table (case-insensitive).
     pub fn from_table_name(name: &str) -> Option<Self> {
+        if !is_reserved_internal_table_name(name) {
+            return None;
+        }
         if name.eq_ignore_ascii_case(ManifestSstEntry::reserved_table_name_for_inspection()) {
             return Some(Self::InspectSstManifest);
         }
@@ -60,7 +64,7 @@ impl InternalTableKind {
         if name.eq_ignore_ascii_case(RegionInfoEntry::reserved_table_name_for_inspection()) {
             return Some(Self::InspectRegionInfo);
         }
-        None
+        unreachable!("shared reserved inspection-name predicate must match an internal table kind")
     }
 
     /// Return the `TableProvider` for the internal table.

--- a/src/datanode/src/region_server/catalog.rs
+++ b/src/datanode/src/region_server/catalog.rs
@@ -35,47 +35,28 @@ use store_api::storage::RegionId;
 use crate::error::{DataFusionSnafu, ListStorageSstsSnafu, Result, UnexpectedSnafu};
 use crate::region_server::RegionServer;
 
-/// Reserved internal table kinds used.
-/// These are recognized by reserved table names and mapped to providers.
-#[allow(clippy::enum_variant_names)]
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
-enum InternalTableKind {
-    InspectSstManifest,
-    InspectSstStorage,
-    InspectSstIndexMeta,
-    InspectRegionInfo,
-}
-
-impl InternalTableKind {
-    /// Determine if the name is a reserved internal table (case-insensitive).
-    pub fn from_table_name(name: &str) -> Option<Self> {
-        if !is_reserved_internal_table_name(name) {
-            return None;
-        }
-        if name.eq_ignore_ascii_case(ManifestSstEntry::reserved_table_name_for_inspection()) {
-            return Some(Self::InspectSstManifest);
-        }
-        if name.eq_ignore_ascii_case(StorageSstEntry::reserved_table_name_for_inspection()) {
-            return Some(Self::InspectSstStorage);
-        }
-        if name.eq_ignore_ascii_case(PuffinIndexMetaEntry::reserved_table_name_for_inspection()) {
-            return Some(Self::InspectSstIndexMeta);
-        }
-        if name.eq_ignore_ascii_case(RegionInfoEntry::reserved_table_name_for_inspection()) {
-            return Some(Self::InspectRegionInfo);
-        }
-        unreachable!("shared reserved inspection-name predicate must match an internal table kind")
+/// Builds the inspection `TableProvider` for a reserved internal table name.
+///
+/// Returns `None` for any name that is not one of the four reserved inspection
+/// tables; reserved-name classification itself is the shared
+/// [`is_reserved_internal_table_name`] predicate.
+async fn reserved_inspection_provider(
+    name: &str,
+    server: &RegionServer,
+) -> Result<Option<Arc<dyn TableProvider>>> {
+    if name.eq_ignore_ascii_case(ManifestSstEntry::reserved_table_name_for_inspection()) {
+        return server.inspect_sst_manifest_provider().await.map(Some);
     }
-
-    /// Return the `TableProvider` for the internal table.
-    pub async fn table_provider(&self, server: &RegionServer) -> Result<Arc<dyn TableProvider>> {
-        match self {
-            Self::InspectSstManifest => server.inspect_sst_manifest_provider().await,
-            Self::InspectSstStorage => server.inspect_sst_storage_provider().await,
-            Self::InspectSstIndexMeta => server.inspect_sst_index_meta_provider().await,
-            Self::InspectRegionInfo => server.inspect_region_info_provider().await,
-        }
+    if name.eq_ignore_ascii_case(StorageSstEntry::reserved_table_name_for_inspection()) {
+        return server.inspect_sst_storage_provider().await.map(Some);
     }
+    if name.eq_ignore_ascii_case(PuffinIndexMetaEntry::reserved_table_name_for_inspection()) {
+        return server.inspect_sst_index_meta_provider().await.map(Some);
+    }
+    if name.eq_ignore_ascii_case(RegionInfoEntry::reserved_table_name_for_inspection()) {
+        return server.inspect_region_info_provider().await.map(Some);
+    }
+    Ok(None)
 }
 
 impl RegionServer {
@@ -241,13 +222,13 @@ impl SchemaProvider for NameAwareSchemaProvider {
     }
 
     async fn table(&self, name: &str) -> DfResult<Option<Arc<dyn TableProvider>>> {
-        // Resolve inspect providers by reserved names.
-        if let Some(kind) = InternalTableKind::from_table_name(name) {
-            return kind
-                .table_provider(&self.server)
-                .await
-                .map(Some)
-                .map_err(|e| df_error::DataFusionError::External(Box::new(e)));
+        // Resolve reserved inspection tables by name; everything else falls back
+        // to the Region provider.
+        if let Some(provider) = reserved_inspection_provider(name, &self.server)
+            .await
+            .map_err(|e| df_error::DataFusionError::External(Box::new(e)))?
+        {
+            return Ok(Some(provider));
         }
 
         // Fallback to region provider for any other table name.
@@ -267,26 +248,26 @@ impl SchemaProvider for NameAwareSchemaProvider {
 ///
 /// It scans the plan to determine:
 /// - whether a Region `TableSource` is required, and
-/// - which internal inspection sources are referenced.
+/// - which reserved internal inspection sources are referenced.
 pub(crate) struct NameAwareDataSourceInjectorBuilder {
     /// Whether the plan requires a Region `TableSource`.
     need_region_provider: bool,
-    /// Internal table kinds referenced by the plan.
-    reserved_table_needed: Vec<InternalTableKind>,
+    /// Names of reserved internal inspection tables referenced by the plan.
+    reserved_table_needed: Vec<String>,
 }
 
 impl NameAwareDataSourceInjectorBuilder {
     /// Walk the `LogicalPlan` to determine whether a Region source is needed,
-    /// and collect the kinds of internal sources required.
+    /// and collect the names of internal inspection sources required.
     pub fn from_plan(plan: &LogicalPlan) -> DfResult<Self> {
         let mut need_region_provider = false;
         let mut reserved_table_needed = Vec::new();
         plan.apply(|node| {
             if let LogicalPlan::TableScan(ts) = node {
                 let name = ts.table_name.to_string();
-                if let Some(kind) = InternalTableKind::from_table_name(&name) {
-                    if !reserved_table_needed.contains(&kind) {
-                        reserved_table_needed.push(kind);
+                if is_reserved_internal_table_name(&name) {
+                    if !reserved_table_needed.contains(&name) {
+                        reserved_table_needed.push(name);
                     }
                 } else {
                     // Any normal table scan implies a Region source is needed.
@@ -316,9 +297,10 @@ impl NameAwareDataSourceInjectorBuilder {
         };
 
         let mut reserved_sources = HashMap::new();
-        for kind in &self.reserved_table_needed {
-            let provider = kind.table_provider(server).await?;
-            reserved_sources.insert(*kind, provider_as_source(provider));
+        for name in &self.reserved_table_needed {
+            if let Some(provider) = reserved_inspection_provider(name, server).await? {
+                reserved_sources.insert(name.clone(), provider_as_source(provider));
+            }
         }
 
         Ok(NameAwareDataSourceInjector {
@@ -331,8 +313,8 @@ impl NameAwareDataSourceInjectorBuilder {
 /// Rewrites `LogicalPlan` to inject proper data sources for `TableScan`.
 /// Uses internal sources for reserved tables; otherwise uses the Region source.
 pub(crate) struct NameAwareDataSourceInjector {
-    /// Sources for reserved internal tables, keyed by kind.
-    reserved_sources: HashMap<InternalTableKind, Arc<dyn TableSource>>,
+    /// Sources for reserved internal tables, keyed by table name.
+    reserved_sources: HashMap<String, Arc<dyn TableSource>>,
     /// Optional Region-level source used for normal tables.
     region_source: Option<Arc<dyn TableSource>>,
 }
@@ -344,9 +326,7 @@ impl TreeNodeRewriter for NameAwareDataSourceInjector {
         Ok(match node {
             LogicalPlan::TableScan(mut scan) => {
                 let name = scan.table_name.to_string();
-                if let Some(kind) = InternalTableKind::from_table_name(&name)
-                    && let Some(source) = self.reserved_sources.get(&kind)
-                {
+                if let Some(source) = self.reserved_sources.get(&name) {
                     // Matched a reserved internal table: rewrite to its dedicated source.
                     scan.source = source.clone();
                 } else {
@@ -405,10 +385,7 @@ mod tests {
             .unwrap();
         let b1 = NameAwareDataSourceInjectorBuilder::from_plan(&plan1).unwrap();
         assert!(!b1.need_region_provider);
-        assert_eq!(
-            b1.reserved_table_needed,
-            vec![InternalTableKind::InspectSstManifest]
-        );
+        assert_eq!(b1.reserved_table_needed, vec![reserved.to_string()]);
 
         // plan2: normal table scan only
         let plan2 = table_scan(Some("normal_table"), &schema, None)
@@ -435,10 +412,7 @@ mod tests {
             .unwrap();
         let b3 = NameAwareDataSourceInjectorBuilder::from_plan(&plan3).unwrap();
         assert!(b3.need_region_provider);
-        assert_eq!(
-            b3.reserved_table_needed,
-            vec![InternalTableKind::InspectSstManifest]
-        );
+        assert_eq!(b3.reserved_table_needed, vec![reserved.to_string()]);
 
         let region_info = RegionInfoEntry::reserved_table_name_for_inspection();
         let plan4 = table_scan(Some(region_info), &schema, None)
@@ -447,10 +421,7 @@ mod tests {
             .unwrap();
         let b4 = NameAwareDataSourceInjectorBuilder::from_plan(&plan4).unwrap();
         assert!(!b4.need_region_provider);
-        assert_eq!(
-            b4.reserved_table_needed,
-            vec![InternalTableKind::InspectRegionInfo]
-        );
+        assert_eq!(b4.reserved_table_needed, vec![region_info.to_string()]);
     }
 
     #[test]
@@ -468,7 +439,7 @@ mod tests {
         let mut injector = NameAwareDataSourceInjector {
             reserved_sources: {
                 let mut m = HashMap::new();
-                m.insert(InternalTableKind::InspectSstManifest, source.clone());
+                m.insert(table_name.to_string(), source.clone());
                 m
             },
             region_source: None,
@@ -502,7 +473,7 @@ mod tests {
         let mut injector = NameAwareDataSourceInjector {
             reserved_sources: {
                 let mut m = HashMap::new();
-                m.insert(InternalTableKind::InspectRegionInfo, source.clone());
+                m.insert(table_name.to_string(), source.clone());
                 m
             },
             region_source: None,

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use api::region::RegionResponse;
+#[cfg(test)]
+use api::v1::SemanticType;
 use async_trait::async_trait;
 use common_error::ext::BoxedError;
 use common_function::function_factory::ScalarFunctionFactory;
@@ -25,17 +27,43 @@ use common_runtime::Runtime;
 use common_runtime::runtime::{BuilderBuild, RuntimeTrait};
 use datafusion::catalog::TableFunction;
 use datafusion::dataframe::DataFrame;
+#[cfg(test)]
+use datafusion::datasource::TableProvider;
+#[cfg(test)]
+use datafusion::execution::SessionStateBuilder;
 use datafusion_expr::{AggregateUDF, LogicalPlan, WindowUDF};
+#[cfg(test)]
+use datatypes::prelude::ConcreteDataType;
+#[cfg(test)]
+use datatypes::schema::ColumnSchema;
+#[cfg(test)]
+use metric_engine::config::EngineConfig as MetricEngineConfig;
+#[cfg(test)]
+use metric_engine::engine::MetricEngine;
+#[cfg(test)]
+use mito2::config::MitoConfig;
+#[cfg(test)]
+use mito2::test_util::TestEnv as MitoTestEnv;
 use query::planner::LogicalPlanner;
 use query::query_engine::{DescribeResult, QueryEngineState};
 use query::{QueryEngine, QueryEngineContext};
 use servers::grpc::FlightCompression;
 use session::context::QueryContextRef;
+#[cfg(test)]
+use store_api::metadata::ColumnMetadata;
 use store_api::metadata::RegionMetadataRef;
+#[cfg(test)]
+use store_api::metric_engine_consts::{
+    LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME, PHYSICAL_TABLE_METADATA_KEY,
+};
 use store_api::region_engine::{
     RegionEngine, RegionRole, RegionScannerRef, RegionStatistic, RemapManifestsRequest,
     RemapManifestsResponse, SetRegionRoleStateResponse, SettableRegionRoleState,
     SyncRegionFromRequest, SyncRegionFromResponse,
+};
+#[cfg(test)]
+use store_api::region_request::{
+    AddColumn, AlterKind, PathType, RegionAlterRequest, RegionCreateRequest,
 };
 use store_api::region_request::{AffectedRows, RegionRequest};
 use store_api::storage::{RegionId, ScanRequest, SequenceNumber};
@@ -45,6 +73,132 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use crate::error::{Error, NotYetImplementedSnafu};
 use crate::event_listener::NoopRegionServerEventListener;
 use crate::region_server::RegionServer;
+
+#[cfg(test)]
+#[tokio::test]
+async fn test_metric_logical_region_scan_revalidates_current_metadata() {
+    let mut mito_env = MitoTestEnv::with_prefix("dummy_catalog_metric_metadata").await;
+    let mito = mito_env.create_engine(MitoConfig::default()).await;
+    let metric = MetricEngine::try_new(mito, MetricEngineConfig::default()).unwrap();
+    let physical_region_id = RegionId::new(1, 2);
+    let logical_region_id = RegionId::new(3, 2);
+
+    metric
+        .handle_request(
+            physical_region_id,
+            RegionRequest::Create(RegionCreateRequest {
+                engine: METRIC_ENGINE_NAME.to_string(),
+                column_metadatas: vec![
+                    metric_column(0, "ts", SemanticType::Timestamp, true),
+                    metric_column(1, "val", SemanticType::Field, false),
+                ],
+                primary_key: vec![],
+                options: [(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new())]
+                    .into_iter()
+                    .collect(),
+                table_dir: "dummy_catalog_metric_metadata".to_string(),
+                path_type: PathType::Bare,
+                partition_expr_json: Some(String::new()),
+                requirements: Default::default(),
+            }),
+        )
+        .await
+        .unwrap();
+    metric
+        .handle_request(
+            logical_region_id,
+            RegionRequest::Create(RegionCreateRequest {
+                engine: METRIC_ENGINE_NAME.to_string(),
+                column_metadatas: vec![
+                    metric_column(0, "ts", SemanticType::Timestamp, true),
+                    metric_column(1, "val", SemanticType::Field, false),
+                    metric_column(2, "job", SemanticType::Tag, false),
+                ],
+                primary_key: vec![],
+                options: [(
+                    LOGICAL_TABLE_METADATA_KEY.to_string(),
+                    physical_region_id.as_u64().to_string(),
+                )]
+                .into_iter()
+                .collect(),
+                table_dir: "dummy_catalog_metric_metadata".to_string(),
+                path_type: PathType::Bare,
+                partition_expr_json: Some(String::new()),
+                requirements: Default::default(),
+            }),
+        )
+        .await
+        .unwrap();
+
+    let scanner = metric
+        .handle_query(logical_region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    assert!(scanner.properties().is_logical_region());
+    assert_ne!(scanner.metadata().region_id, logical_region_id);
+
+    let provider = query::dummy_catalog::DummyTableProviderFactory
+        .create_table_provider(logical_region_id, Arc::new(metric.clone()), None)
+        .await
+        .unwrap();
+    let state = SessionStateBuilder::new().build();
+    TableProvider::scan(&provider, &state, None, &[], None)
+        .await
+        .unwrap();
+
+    metric
+        .handle_request(
+            logical_region_id,
+            RegionRequest::Alter(RegionAlterRequest {
+                kind: AlterKind::AddColumns {
+                    columns: vec![AddColumn {
+                        column_metadata: metric_column(3, "instance", SemanticType::Tag, false),
+                        location: None,
+                    }],
+                },
+            }),
+        )
+        .await
+        .unwrap();
+
+    let err = TableProvider::scan(&provider, &state, None, &[], None)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("logical region metadata mismatch"));
+
+    let current_provider = query::dummy_catalog::DummyTableProviderFactory
+        .create_table_provider(logical_region_id, Arc::new(metric), None)
+        .await
+        .unwrap();
+    TableProvider::scan(&current_provider, &state, None, &[], None)
+        .await
+        .unwrap();
+}
+
+#[cfg(test)]
+fn metric_column(
+    column_id: u32,
+    name: &str,
+    semantic_type: SemanticType,
+    is_timestamp: bool,
+) -> ColumnMetadata {
+    let data_type = if is_timestamp {
+        ConcreteDataType::timestamp_millisecond_datatype()
+    } else if semantic_type == SemanticType::Field {
+        ConcreteDataType::float64_datatype()
+    } else {
+        ConcreteDataType::string_datatype()
+    };
+    let mut column_schema = ColumnSchema::new(name, data_type, false);
+    if is_timestamp {
+        column_schema = column_schema.with_time_index(true);
+    }
+    ColumnMetadata {
+        column_schema,
+        semantic_type,
+        column_id,
+    }
+}
 
 pub struct MockQueryEngine;
 

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -61,6 +61,7 @@ object-store.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 partition.workspace = true
+pbjson-types = "0.8"
 prometheus.workspace = true
 promql.workspace = true
 promql-parser.workspace = true

--- a/src/query/src/dist_plan/analyzer/test.rs
+++ b/src/query/src/dist_plan/analyzer/test.rs
@@ -12,29 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::collections::{BTreeSet, HashSet};
+use std::fmt;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use arrow::datatypes::{DataType, IntervalDayTime, TimeUnit};
+use arrow::array::Int64Array;
+use arrow::datatypes::{DataType, Field, IntervalDayTime, Schema as ArrowSchema, TimeUnit};
+use arrow::record_batch::RecordBatch as ArrowRecordBatch;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, MITO_ENGINE};
 use common_error::ext::BoxedError;
 use common_function::aggrs::aggr_wrapper::{StateMergeHelper, StateWrapper};
 use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::error::Result as RecordBatchResult;
-use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, SendableRecordBatchStream};
+use common_recordbatch::{
+    OrderOption, RecordBatch, RecordBatchStream, SendableRecordBatchStream, util,
+};
 use common_telemetry::init_default_ut_logging;
-use datafusion::datasource::DefaultTableSource;
+use datafusion::catalog::{CatalogProvider, CatalogProviderList, SchemaProvider, TableProvider};
+use datafusion::datasource::{DefaultTableSource, MemTable, provider_as_source};
 use datafusion::execution::SessionState;
 use datafusion::functions_aggregate::expr_fn::avg;
 use datafusion::functions_aggregate::min_max::{max, min};
 use datafusion::prelude::SessionContext;
-use datafusion_common::tree_node::TreeNodeRecursion;
+use datafusion_common::tree_node::{TreeNode as _, TreeNodeRecursion};
 use datafusion_common::{ExprSchema, JoinType, ScalarValue};
 use datafusion_expr::expr::{Exists, ScalarFunction};
 use datafusion_expr::{
-    AggregateUDF, Expr, ExprSchemable as _, LogicalPlanBuilder, Operator, Subquery, binary_expr,
-    col, lit,
+    AggregateUDF, Expr, ExprSchemable as _, LogicalPlan, LogicalPlanBuilder, Operator, Subquery,
+    binary_expr, col, lit,
 };
 use datafusion_functions::datetime::date_bin;
 use datafusion_functions::datetime::expr_fn::now;
@@ -46,7 +53,8 @@ use futures::task::{Context, Poll};
 use pretty_assertions::assert_eq;
 use regex::Regex;
 use store_api::data_source::DataSource;
-use store_api::storage::ScanRequest;
+use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
+use store_api::storage::{RegionId, ScanRequest};
 use table::metadata::{
     FilterPushDownType, TableId, TableInfoBuilder, TableInfoRef, TableMeta, TableType,
 };
@@ -55,6 +63,11 @@ use table::table::numbers::NumbersTable;
 use table::{Table, TableRef};
 
 use super::*;
+use crate::dummy_catalog::{DummyCatalogList, DummyTableProvider};
+use crate::optimizer::test_util::MetaRegionEngine;
+use crate::options::QueryOptions;
+use crate::query_engine::QueryEngineFactory;
+use crate::query_engine::remote_plan_codec::{decode_remote_plan, encode_remote_plan};
 
 fn collect_merge_scan_remote_dyn_filter_producer_ids(
     plan: &LogicalPlan,
@@ -2821,5 +2834,472 @@ fn scheduled_none_falls_back_to_wall_clock() {
     assert!(
         remote_section.contains("TimestampNanosecond("),
         "Remote should contain TimestampNanosecond:\n{result_str}"
+    );
+}
+
+const QX_046_TABLE: &str = "qx_046_schema_race";
+
+/// Catalog resolver used by QX-046. The table slot is deliberately mutable so every
+/// decode observes the provider currently registered under the same table name.
+#[derive(Clone)]
+struct SchemaRaceCatalogList {
+    schema: SchemaRaceSchemaProvider,
+}
+
+impl SchemaRaceCatalogList {
+    fn new(table: Arc<dyn TableProvider>) -> Self {
+        Self {
+            schema: SchemaRaceSchemaProvider {
+                table: Arc::new(Mutex::new(Some(table))),
+            },
+        }
+    }
+
+    fn replace(&self, table: Arc<dyn TableProvider>) {
+        *self.schema.table.lock().unwrap() = Some(table);
+    }
+
+    fn drop_table(&self) {
+        *self.schema.table.lock().unwrap() = None;
+    }
+}
+
+impl fmt::Debug for SchemaRaceCatalogList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SchemaRaceCatalogList").finish()
+    }
+}
+
+impl CatalogProviderList for SchemaRaceCatalogList {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn register_catalog(
+        &self,
+        _name: String,
+        _catalog: Arc<dyn CatalogProvider>,
+    ) -> Option<Arc<dyn CatalogProvider>> {
+        None
+    }
+
+    fn catalog_names(&self) -> Vec<String> {
+        vec![DEFAULT_CATALOG_NAME.to_string()]
+    }
+
+    fn catalog(&self, _name: &str) -> Option<Arc<dyn CatalogProvider>> {
+        Some(Arc::new(SchemaRaceCatalogProvider {
+            schema: self.schema.clone(),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct SchemaRaceCatalogProvider {
+    schema: SchemaRaceSchemaProvider,
+}
+
+impl fmt::Debug for SchemaRaceCatalogProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SchemaRaceCatalogProvider").finish()
+    }
+}
+
+impl CatalogProvider for SchemaRaceCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        vec![DEFAULT_SCHEMA_NAME.to_string()]
+    }
+
+    fn schema(&self, _name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        Some(Arc::new(self.schema.clone()))
+    }
+}
+
+#[derive(Clone)]
+struct SchemaRaceSchemaProvider {
+    table: Arc<Mutex<Option<Arc<dyn TableProvider>>>>,
+}
+
+impl fmt::Debug for SchemaRaceSchemaProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SchemaRaceSchemaProvider").finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl SchemaProvider for SchemaRaceSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.table
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|_| vec![QX_046_TABLE.to_string()])
+            .unwrap_or_default()
+    }
+
+    async fn table(&self, name: &str) -> datafusion::error::Result<Option<Arc<dyn TableProvider>>> {
+        Ok((name == QX_046_TABLE)
+            .then(|| self.table.lock().unwrap().clone())
+            .flatten())
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        name == QX_046_TABLE && self.table.lock().unwrap().is_some()
+    }
+}
+
+fn qx_046_provider(
+    nullable: bool,
+    values: Vec<Option<i64>>,
+    prefix: Option<(String, Vec<Option<String>>)>,
+) -> Arc<dyn TableProvider> {
+    let mut fields = Vec::new();
+    let mut columns: Vec<Arc<dyn arrow::array::Array>> = Vec::new();
+    if let Some((name, values)) = prefix {
+        fields.push(Field::new(name, DataType::Utf8, true));
+        columns.push(Arc::new(arrow::array::StringArray::from(values)));
+    }
+    fields.push(Field::new("x", DataType::Int64, nullable));
+    columns.push(Arc::new(Int64Array::from(values)));
+
+    let schema = Arc::new(ArrowSchema::new(fields));
+    let batch = ArrowRecordBatch::try_new(schema.clone(), columns).unwrap();
+    Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap())
+}
+
+fn qx_046_incompatible_provider() -> Arc<dyn TableProvider> {
+    let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        "x",
+        DataType::Utf8,
+        true,
+    )]));
+    let batch = ArrowRecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(arrow::array::StringArray::from(vec![Some(
+            "not-an-i64",
+        )]))],
+    )
+    .unwrap();
+    Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap())
+}
+
+fn qx_046_plan(table: Arc<dyn TableProvider>) -> LogicalPlan {
+    LogicalPlanBuilder::scan(QX_046_TABLE, provider_as_source(table), None)
+        .unwrap()
+        .filter(col("x").is_not_null())
+        .unwrap()
+        .project(vec![col("x")])
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+/// This is the exact expression simplification and pre-MergeScan optimizer chain
+/// used by `DistPlannerAnalyzer::analyze` before distributed splitting.
+fn qx_046_simplify_before_distributed_split(plan: LogicalPlan) -> LogicalPlan {
+    let config = Arc::new(ConfigOptions::default());
+    let optimizer_context = PatchOptimizerContext {
+        inner: datafusion_optimizer::OptimizerContext::new(),
+        config: config.clone(),
+        scheduled_time: None,
+    };
+    let plan = plan
+        .rewrite_with_subqueries(&mut PlanTreeExpressionSimplifier::new(optimizer_context))
+        .unwrap()
+        .data;
+
+    let optimizer_context = PatchOptimizerContext {
+        inner: datafusion_optimizer::OptimizerContext::new(),
+        config,
+        scheduled_time: None,
+    };
+    pre_merge_scan_optimizer()
+        .optimize(plan, &optimizer_context, |_, _| {})
+        .unwrap()
+}
+
+fn qx_046_contains_is_not_null(plan: &LogicalPlan) -> bool {
+    let mut found = false;
+    plan.apply(|node| {
+        for expr in node.expressions_consider_join() {
+            expr.apply(|expr| {
+                if matches!(expr, Expr::IsNotNull(_)) {
+                    found = true;
+                    Ok(TreeNodeRecursion::Stop)
+                } else {
+                    Ok(TreeNodeRecursion::Continue)
+                }
+            })?;
+        }
+        Ok(if found {
+            TreeNodeRecursion::Stop
+        } else {
+            TreeNodeRecursion::Continue
+        })
+    })
+    .unwrap();
+    found
+}
+
+fn qx_046_table_info(nullable: bool, x_column_id: u32, version: u64) -> TableInfoRef {
+    let schema = Arc::new(
+        SchemaBuilder::try_from_columns(vec![ColumnSchema::new(
+            "x",
+            ConcreteDataType::int64_datatype(),
+            nullable,
+        )])
+        .unwrap()
+        .build()
+        .unwrap(),
+    );
+    let meta = TableMeta {
+        schema,
+        primary_key_indices: vec![],
+        value_indices: vec![0],
+        engine: "mito".to_string(),
+        next_column_id: x_column_id + 1,
+        options: Default::default(),
+        created_on: Default::default(),
+        updated_on: Default::default(),
+        partition_key_indices: vec![],
+        column_ids: vec![x_column_id],
+    };
+    Arc::new(
+        TableInfoBuilder::default()
+            .table_id(46)
+            .table_version(version)
+            .name(QX_046_TABLE)
+            .catalog_name(DEFAULT_CATALOG_NAME)
+            .schema_name(DEFAULT_SCHEMA_NAME)
+            .table_type(TableType::Base)
+            .meta(meta)
+            .build()
+            .unwrap(),
+    )
+}
+
+async fn qx_046_execute_x(engine: &crate::QueryEngineRef, plan: LogicalPlan) -> Vec<Option<i64>> {
+    let output = engine
+        .execute(plan, session::context::QueryContext::arc())
+        .await
+        .unwrap();
+    let common_query::OutputData::Stream(stream) = output.data else {
+        panic!("QX-046 expected a record-batch stream");
+    };
+    let batches = util::collect(stream).await.unwrap();
+    let mut values = Vec::new();
+    for batch in batches {
+        let values_array = batch
+            .df_record_batch()
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        values.extend(values_array.iter());
+    }
+    values
+}
+
+#[tokio::test]
+async fn qx_046_default_decoder_nullable_reincarnation_wrong_result() {
+    let old_metadata = qx_046_table_info(false, 7, 1);
+    let new_metadata = qx_046_table_info(true, 8, 2);
+    assert!(old_metadata.meta.primary_key_indices.is_empty());
+    assert!(old_metadata.meta.partition_key_indices.is_empty());
+    assert_eq!(old_metadata.meta.value_indices, vec![0]);
+    assert!(!old_metadata.meta.schema.column_schemas()[0].is_time_index());
+    assert_eq!(old_metadata.name_to_ids().unwrap()["x"], 7);
+    assert_eq!(new_metadata.name_to_ids().unwrap()["x"], 8);
+    assert_eq!(old_metadata.ident.version, 1);
+    assert_eq!(new_metadata.ident.version, 2);
+
+    let old_provider = qx_046_provider(false, vec![Some(7)], None);
+    let old_plan = qx_046_simplify_before_distributed_split(qx_046_plan(old_provider.clone()));
+    assert!(
+        !qx_046_contains_is_not_null(&old_plan),
+        "the old non-null schema must simplify x IS NOT NULL before distributed splitting"
+    );
+    let stale_bytes = substrait::DFLogicalSubstraitConvertor
+        .encode(&old_plan, crate::query_engine::DefaultSerializer)
+        .unwrap();
+
+    let factory = QueryEngineFactory::new(
+        catalog::memory::new_memory_catalog_manager().unwrap(),
+        None,
+        None,
+        None,
+        None,
+        false,
+        QueryOptions::default(),
+    );
+    let engine = factory.query_engine();
+    let decoder = engine
+        .engine_context(session::context::QueryContext::arc())
+        .new_plan_decoder()
+        .unwrap();
+    let catalog = Arc::new(SchemaRaceCatalogList::new(old_provider));
+
+    // Old encode -> old decode is the control for the real serializer/decoder path.
+    let old_decoded = decoder
+        .decode(stale_bytes.clone(), catalog.clone(), false)
+        .await
+        .unwrap();
+    assert_eq!(qx_046_execute_x(&engine, old_decoded).await, vec![Some(7)]);
+
+    // DROP x; ADD x BIGINT: the name remains, but its TableMeta identity, version,
+    // nullability, and provider data change. MemTable is only the DataFusion provider;
+    // the TableInfo fixtures above prove the closest real ordinary-column DDL metadata.
+    let new_provider = qx_046_provider(true, vec![None, Some(9)], None);
+    catalog.replace(new_provider.clone());
+    // Frozen red evidence: the generic decoder remains intentionally unchanged
+    // for persisted views and flow plans, and therefore exposes the original
+    // wrong-result behavior. Remote reads use the dedicated guarded codec.
+    let stale_decoded = decoder
+        .decode(stale_bytes.clone(), catalog.clone(), false)
+        .await
+        .unwrap();
+    assert_eq!(
+        qx_046_execute_x(&engine, stale_decoded).await,
+        vec![None, Some(9)],
+        "the frozen generic decoder oracle must retain the pre-fix wrong result"
+    );
+
+    let fresh_plan = qx_046_simplify_before_distributed_split(qx_046_plan(new_provider));
+    assert!(
+        qx_046_contains_is_not_null(&fresh_plan),
+        "the nullable reincarnated x must retain x IS NOT NULL structurally"
+    );
+    let fresh_bytes = substrait::DFLogicalSubstraitConvertor
+        .encode(&fresh_plan, crate::query_engine::DefaultSerializer)
+        .unwrap();
+    let fresh_decoded = decoder
+        .decode(fresh_bytes, catalog.clone(), false)
+        .await
+        .unwrap();
+    assert_eq!(
+        qx_046_execute_x(&engine, fresh_decoded).await,
+        vec![Some(9)]
+    );
+
+    // A direct drop is still rejected by the real DefaultPlanDecoder catalog path.
+    catalog.drop_table();
+    assert!(
+        decoder
+            .decode(stale_bytes.clone(), catalog.clone(), false)
+            .await
+            .is_err()
+    );
+
+    // Arrow-incompatible replacements are rejected before execution.
+    catalog.replace(qx_046_incompatible_provider());
+    assert!(
+        decoder
+            .decode(stale_bytes.clone(), catalog.clone(), false)
+            .await
+            .is_err()
+    );
+
+    // Reordering x while adding an unrelated field remains compatible because the
+    // decoder resolves the serialized field by name and projects it from the provider.
+    catalog.replace(qx_046_provider(
+        false,
+        vec![Some(11)],
+        Some(("unrelated".to_string(), vec![Some("safe".to_string())])),
+    ));
+    let reordered_decoded = decoder.decode(stale_bytes, catalog, false).await.unwrap();
+    assert_eq!(
+        qx_046_execute_x(&engine, reordered_decoded).await,
+        vec![Some(11)]
+    );
+}
+
+fn qx_046_adapter_plan(table_info: TableInfoRef) -> LogicalPlan {
+    let table = Arc::new(Table::new(
+        table_info.clone(),
+        FilterPushDownType::Unsupported,
+        Arc::new(TestDataSource::new(table_info.meta.schema.clone())),
+    ));
+    LogicalPlanBuilder::scan(
+        QX_046_TABLE,
+        Arc::new(DefaultTableSource::new(Arc::new(
+            DfTableProviderAdapter::new(table),
+        ))),
+        None,
+    )
+    .unwrap()
+    .filter(col("x").is_not_null())
+    .unwrap()
+    .project(vec![col("x")])
+    .unwrap()
+    .build()
+    .unwrap()
+}
+
+fn qx_046_dummy_provider(nullable: bool, column_id: u32) -> DummyTableProvider {
+    let region_id = RegionId::new(46, 1);
+    let mut metadata = RegionMetadataBuilder::new(region_id);
+    metadata.push_column_metadata(ColumnMetadata {
+        column_schema: ColumnSchema::new("x", ConcreteDataType::int64_datatype(), nullable),
+        semantic_type: api::v1::SemanticType::Field,
+        column_id,
+    });
+    metadata.push_column_metadata(ColumnMetadata {
+        column_schema: ColumnSchema::new(
+            "ts",
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            false,
+        ),
+        semantic_type: api::v1::SemanticType::Timestamp,
+        column_id: column_id + 1,
+    });
+    let metadata = Arc::new(metadata.build().unwrap());
+    let engine = Arc::new(MetaRegionEngine::with_metadata(metadata.clone()));
+    DummyTableProvider::new(region_id, engine, metadata)
+}
+
+#[tokio::test]
+async fn qx_046_remote_codec_rejects_simplified_nullable_reincarnation() {
+    let old_plan = qx_046_simplify_before_distributed_split(qx_046_adapter_plan(
+        qx_046_table_info(false, 7, 1),
+    ));
+    assert!(
+        !qx_046_contains_is_not_null(&old_plan),
+        "the real pre-split simplifier must erase x IS NOT NULL on the old required schema"
+    );
+
+    let region_id = RegionId::new(46, 1);
+    let encoded = encode_remote_plan(&old_plan, region_id).unwrap();
+    let factory = QueryEngineFactory::new(
+        catalog::memory::new_memory_catalog_manager().unwrap(),
+        None,
+        None,
+        None,
+        None,
+        false,
+        QueryOptions::default(),
+    );
+    let decoder = factory
+        .query_engine()
+        .engine_context(session::context::QueryContext::arc())
+        .new_plan_decoder()
+        .unwrap();
+    let catalog: Arc<dyn CatalogProviderList> = Arc::new(DummyCatalogList::with_table_provider(
+        Arc::new(qx_046_dummy_provider(true, 8)),
+    ));
+
+    // This is deliberately only a decode assertion: validation must reject the
+    // stale nullable/current-column-ID provider before the plan can execute.
+    assert!(
+        decode_remote_plan(decoder.as_ref(), encoded, catalog)
+            .await
+            .is_err()
     );
 }

--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -245,6 +245,7 @@ impl DistExtensionPlanner {
             })?;
 
         let table_info = table.table_info();
+        ensure_planned_table_routing_coherence(logical_plan, &table_info)?;
         let (physical_table_id, physical_table_route) = self
             .partition_rule_manager
             .find_physical_table_route_with_id(table_info.table_id())
@@ -436,6 +437,81 @@ fn partition_column_types(table_info: &TableInfo) -> Vec<(String, ConcreteDataTy
         .collect()
 }
 
+/// Reject a stale analysis result before it is used to choose regions.  This is
+/// intentionally limited to the table identity and partition columns that the
+/// FE uses for routing; DN schema validation cannot prove route completeness.
+fn ensure_planned_table_routing_coherence(
+    plan: &LogicalPlan,
+    current: &table::metadata::TableInfo,
+) -> Result<()> {
+    let mut planned = None;
+    plan.apply(|node| {
+        if let LogicalPlan::TableScan(scan) = node
+            && let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>()
+            && let Some(provider) = source
+                .table_provider
+                .as_any()
+                .downcast_ref::<DfTableProviderAdapter>()
+            && provider.table().table_type() == TableType::Base
+        {
+            planned = Some(provider.table().table_info());
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    let Some(planned) = planned else {
+        return Err(DataFusionError::Plan(
+            "distributed routing requires a planned Greptime base-table provider".to_string(),
+        ));
+    };
+    if planned.table_id() != current.table_id()
+        || partition_signature(&planned)? != partition_signature(current)?
+    {
+        return Err(DataFusionError::Plan(format!(
+            "planned table {} partition metadata no longer matches current table {}",
+            planned.table_id(),
+            current.table_id()
+        )));
+    }
+    Ok(())
+}
+
+/// The FE uses this ordered signature while extracting partition predicates and
+/// pruning regions. A missing stable ID is unsafe: names alone could describe a
+/// dropped-and-recreated partition column.
+fn partition_signature(
+    table: &table::metadata::TableInfo,
+) -> Result<Vec<(String, u32, datatypes::prelude::ConcreteDataType)>> {
+    let ids = table.name_to_ids().ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "table {} has incomplete column IDs for distributed routing",
+            table.table_id()
+        ))
+    })?;
+    if ids.len() != table.meta.schema.num_columns()
+        || ids.values().collect::<std::collections::HashSet<_>>().len() != ids.len()
+    {
+        return Err(DataFusionError::Plan(format!(
+            "table {} has partial or duplicate column IDs for distributed routing",
+            table.table_id()
+        )));
+    }
+    table
+        .meta
+        .partition_columns()
+        .map(|column| {
+            let id = ids.get(&column.name).copied().ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "partition column {} has no stable ID for distributed routing",
+                    column.name
+                ))
+            })?;
+            Ok((column.name.clone(), id, column.data_type.clone()))
+        })
+        .collect()
+}
+
 /// Visitor to extract table name from logical plan (TableScan node)
 #[derive(Default)]
 struct TableNameExtractor {
@@ -521,7 +597,7 @@ mod tests {
     use datafusion::datasource::DefaultTableSource;
     use datafusion_expr::{LogicalPlan, LogicalPlanBuilder, col as df_col, lit};
     use datatypes::prelude::ConcreteDataType;
-    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::schema::{ColumnSchema, SchemaBuilder};
     use datatypes::value::Value;
     use moka::future::CacheBuilder;
     use partition::cache::new_partition_info_cache;
@@ -571,41 +647,61 @@ mod tests {
         }
     }
 
+    use super::*;
+
+    fn base_columns() -> Vec<ColumnSchema> {
+        vec![
+            ColumnSchema::new("partition_a", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("partition_b", ConcreteDataType::int32_datatype(), false),
+            ColumnSchema::new("value", ConcreteDataType::float64_datatype(), true),
+        ]
+    }
+
     fn table_info(
         table_id: u32,
+        table_version: u64,
         name: &str,
-        columns: &[&str],
-        partition_keys: Vec<usize>,
+        columns: Vec<ColumnSchema>,
+        partition_key_indices: Vec<usize>,
+        column_ids: Vec<u32>,
     ) -> TableInfo {
-        let schema = Arc::new(Schema::new(
-            columns
-                .iter()
-                .map(|name| ColumnSchema::new(*name, ConcreteDataType::string_datatype(), true))
-                .collect(),
-        ));
+        let schema = Arc::new(
+            SchemaBuilder::try_from_columns(columns)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let primary_key_indices = partition_key_indices.clone();
+        let value_indices = (0..schema.column_schemas().len())
+            .filter(|idx| !primary_key_indices.contains(idx))
+            .collect();
         let meta = TableMeta {
             schema,
-            primary_key_indices: vec![],
-            value_indices: vec![],
-            engine: "metric".to_string(),
-            next_column_id: columns.len() as u32,
+            primary_key_indices,
+            value_indices,
+            engine: "test".to_string(),
+            next_column_id: column_ids.iter().max().copied().unwrap() + 1,
             options: Default::default(),
             created_on: Default::default(),
             updated_on: Default::default(),
-            partition_key_indices: partition_keys,
-            column_ids: (0..columns.len() as u32).collect(),
+            partition_key_indices,
+            column_ids,
         };
         TableInfoBuilder::default()
             .table_id(table_id)
-            .table_version(0)
-            .name(name.to_string())
-            .catalog_name(DEFAULT_CATALOG_NAME.to_string())
-            .schema_name(DEFAULT_SCHEMA_NAME.to_string())
-            .desc(None)
-            .table_type(TableType::Base)
+            .table_version(table_version)
+            .name(name)
             .meta(meta)
+            .table_type(TableType::Base)
             .build()
             .unwrap()
+    }
+
+    fn string_columns(names: &[&str]) -> Vec<ColumnSchema> {
+        names
+            .iter()
+            .map(|name| ColumnSchema::new(*name, ConcreteDataType::string_datatype(), true))
+            .collect()
     }
 
     fn region_route(region_number: u32, expression: Option<PartitionExpr>) -> RegionRoute {
@@ -625,12 +721,21 @@ mod tests {
         physical_partition_keys: Vec<usize>,
         expressions: Vec<Option<PartitionExpr>>,
     ) -> (DistExtensionPlanner, LogicalPlan, TableName) {
-        let logical_info = table_info(LOGICAL_TABLE_ID, "logical", &["host"], vec![0]);
+        let logical_info = table_info(
+            LOGICAL_TABLE_ID,
+            0,
+            "logical",
+            string_columns(&["host"]),
+            vec![0],
+            vec![0],
+        );
         let physical_info = table_info(
             PHYSICAL_TABLE_ID,
+            0,
             "physical",
-            &["host", "rack"],
+            string_columns(&["host", "rack"]),
             physical_partition_keys,
+            vec![0, 1],
         );
         let logical_table = EmptyTable::from_table_info(&logical_info);
         let physical_table = EmptyTable::from_table_info(&physical_info);
@@ -774,6 +879,116 @@ mod tests {
                 RegionId::new(LOGICAL_TABLE_ID, 3),
             ],
             regions
+        );
+    }
+
+    fn planned_table_scan(planned: &TableInfo) -> LogicalPlan {
+        let provider = Arc::new(DfTableProviderAdapter::new(EmptyTable::from_table_info(
+            planned,
+        )));
+        let source = Arc::new(DefaultTableSource::new(provider));
+        LogicalPlanBuilder::scan("test", source, None)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn planned_routing_coherence_accepts_matching_partition_signature() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let current = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current).is_ok()
+        );
+    }
+
+    #[test]
+    fn planned_routing_coherence_rejects_different_table_id() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let current = table_info(2, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn planned_routing_coherence_rejects_changed_partition_column_id() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let current = table_info(1, 2, "test", base_columns(), vec![0, 1], vec![20, 11, 12]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn planned_routing_coherence_rejects_renamed_partition_column() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let mut columns = base_columns();
+        columns[0] = ColumnSchema::new(
+            "partition_a_renamed",
+            ConcreteDataType::string_datatype(),
+            false,
+        );
+        let current = table_info(1, 2, "test", columns, vec![0, 1], vec![10, 11, 12]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn planned_routing_coherence_rejects_reordered_partition_columns() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let current = table_info(1, 2, "test", base_columns(), vec![1, 0], vec![10, 11, 12]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn planned_routing_coherence_rejects_changed_partition_column_type() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let mut columns = base_columns();
+        columns[1] = ColumnSchema::new("partition_b", ConcreteDataType::int64_datatype(), false);
+        let current = table_info(1, 2, "test", columns, vec![0, 1], vec![10, 11, 12]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn planned_routing_coherence_accepts_unrelated_column_addition() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let mut columns = base_columns();
+        columns.push(ColumnSchema::new(
+            "unrelated",
+            ConcreteDataType::boolean_datatype(),
+            true,
+        ));
+        let current = table_info(1, 2, "test", columns, vec![0, 1], vec![10, 11, 12, 13]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current).is_ok()
+        );
+    }
+
+    #[test]
+    fn planned_routing_coherence_accepts_table_version_change() {
+        let planned = table_info(1, 1, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+        let current = table_info(1, 2, "test", base_columns(), vec![0, 1], vec![10, 11, 12]);
+
+        assert!(
+            ensure_planned_table_routing_coherence(&planned_table_scan(&planned), &current).is_ok()
         );
     }
 }

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -203,6 +203,34 @@ impl TableProvider for DummyTableProvider {
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
+        if scanner.properties().is_logical_region() {
+            let current_metadata = self.engine.get_metadata(self.region_id).await.map_err(|error| {
+                DataFusionError::Plan(format!(
+                    "failed to re-fetch logical region metadata after opening scanner: expected {:#?}; current metadata unavailable: {error}",
+                    self.metadata,
+                ))
+            })?;
+            if current_metadata.as_ref() != self.metadata.as_ref() {
+                return Err(DataFusionError::Plan(format!(
+                    "logical region metadata mismatch: expected {:#?}; current {:#?}",
+                    self.metadata, current_metadata,
+                )));
+            }
+        } else {
+            let scanner_metadata = scanner.metadata();
+            if scanner_metadata.region_id != self.metadata.region_id
+                || scanner_metadata.schema_version != self.metadata.schema_version
+            {
+                return Err(DataFusionError::Plan(format!(
+                    "region scanner metadata mismatch: expected region_id={}, schema_version={}; current region_id={}, schema_version={}",
+                    self.metadata.region_id,
+                    self.metadata.schema_version,
+                    scanner_metadata.region_id,
+                    scanner_metadata.schema_version,
+                )));
+            }
+        }
+
         if request.snapshot_on_scan
             && let Some(query_ctx) = &self.query_ctx
             && let Some(snapshot_sequence) = scanner.snapshot_sequence()
@@ -641,11 +669,24 @@ impl CatalogManager for DummyCatalogManager {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::{Arc, RwLock};
+    use std::sync::{Arc, Mutex, RwLock};
 
-    use common_error::ext::ErrorExt;
+    use api::region::RegionResponse;
+    use async_trait::async_trait;
+    use common_error::ext::{BoxedError, ErrorExt};
     use common_error::status_code::StatusCode;
+    use common_recordbatch::{EmptyRecordBatchStream, SendableRecordBatchStream};
+    use datafusion::execution::SessionStateBuilder;
     use session::context::QueryContextBuilder;
+    use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
+    use store_api::region_engine::{
+        RegionEngine, RegionRole, RegionScanner, RegionScannerRef, RegionStatistic,
+        RemapManifestsRequest, RemapManifestsResponse, SetRegionRoleStateResponse,
+        SettableRegionRoleState, SinglePartitionScanner, SyncRegionFromRequest,
+        SyncRegionFromResponse,
+    };
+    use store_api::region_request::RegionRequest;
+    use store_api::storage::{ConcreteDataType, SequenceNumber};
 
     use super::*;
     use crate::error::Error;
@@ -656,6 +697,237 @@ mod tests {
 
     fn test_region_id() -> RegionId {
         RegionId::new(1024, 1)
+    }
+
+    #[derive(Debug)]
+    struct MutableScannerMetadataEngine {
+        provider_metadata: Mutex<RegionMetadataRef>,
+        scanner_metadata: Mutex<RegionMetadataRef>,
+        scanner_is_logical_region: Mutex<bool>,
+    }
+
+    impl MutableScannerMetadataEngine {
+        fn new(metadata: RegionMetadataRef) -> Self {
+            Self {
+                provider_metadata: Mutex::new(metadata.clone()),
+                scanner_metadata: Mutex::new(metadata),
+                scanner_is_logical_region: Mutex::new(false),
+            }
+        }
+
+        fn set_scanner_metadata(&self, metadata: RegionMetadataRef) {
+            *self.scanner_metadata.lock().unwrap() = metadata;
+        }
+
+        fn set_scanner_is_logical_region(&self, is_logical_region: bool) {
+            *self.scanner_is_logical_region.lock().unwrap() = is_logical_region;
+        }
+
+        fn set_provider_metadata(&self, metadata: RegionMetadataRef) {
+            *self.provider_metadata.lock().unwrap() = metadata;
+        }
+    }
+
+    #[async_trait]
+    impl RegionEngine for MutableScannerMetadataEngine {
+        fn name(&self) -> &str {
+            "MutableScannerMetadataEngine"
+        }
+
+        async fn handle_request(
+            &self,
+            _region_id: RegionId,
+            _request: RegionRequest,
+        ) -> std::result::Result<RegionResponse, BoxedError> {
+            unimplemented!()
+        }
+
+        async fn get_committed_sequence(
+            &self,
+            _region_id: RegionId,
+        ) -> std::result::Result<SequenceNumber, BoxedError> {
+            Ok(SequenceNumber::default())
+        }
+
+        async fn handle_query(
+            &self,
+            _region_id: RegionId,
+            _request: ScanRequest,
+        ) -> std::result::Result<RegionScannerRef, BoxedError> {
+            let metadata = self.scanner_metadata.lock().unwrap().clone();
+            let stream: SendableRecordBatchStream =
+                Box::pin(EmptyRecordBatchStream::new(metadata.schema.clone()));
+            let mut scanner = SinglePartitionScanner::new(stream, false, metadata, None);
+            scanner.set_logical_region(*self.scanner_is_logical_region.lock().unwrap());
+            Ok(Box::new(scanner))
+        }
+
+        async fn get_metadata(
+            &self,
+            _region_id: RegionId,
+        ) -> std::result::Result<RegionMetadataRef, BoxedError> {
+            Ok(self.provider_metadata.lock().unwrap().clone())
+        }
+
+        fn region_statistic(&self, _region_id: RegionId) -> Option<RegionStatistic> {
+            None
+        }
+
+        async fn stop(&self) -> std::result::Result<(), BoxedError> {
+            Ok(())
+        }
+
+        fn set_region_role(
+            &self,
+            _region_id: RegionId,
+            _role: RegionRole,
+        ) -> std::result::Result<(), BoxedError> {
+            unimplemented!()
+        }
+
+        async fn sync_region(
+            &self,
+            _region_id: RegionId,
+            _request: SyncRegionFromRequest,
+        ) -> std::result::Result<SyncRegionFromResponse, BoxedError> {
+            unimplemented!()
+        }
+
+        async fn remap_manifests(
+            &self,
+            _request: RemapManifestsRequest,
+        ) -> std::result::Result<RemapManifestsResponse, BoxedError> {
+            unimplemented!()
+        }
+
+        async fn set_region_role_state_gracefully(
+            &self,
+            _region_id: RegionId,
+            _region_role_state: SettableRegionRoleState,
+        ) -> std::result::Result<SetRegionRoleStateResponse, BoxedError> {
+            unimplemented!()
+        }
+
+        fn role(&self, _region_id: RegionId) -> Option<RegionRole> {
+            None
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    fn test_region_metadata(region_id: RegionId, schema_version: u64) -> RegionMetadataRef {
+        let mut builder = RegionMetadataBuilder::new(region_id);
+        builder.push_column_metadata(ColumnMetadata {
+            column_schema: datatypes::schema::ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+            semantic_type: SemanticType::Timestamp,
+            column_id: 1,
+        });
+        for _ in 0..schema_version {
+            builder.bump_version();
+        }
+        Arc::new(builder.build().unwrap())
+    }
+
+    async fn provider_with_snapshot(
+        metadata: RegionMetadataRef,
+    ) -> (DummyTableProvider, Arc<MutableScannerMetadataEngine>) {
+        let engine = Arc::new(MutableScannerMetadataEngine::new(metadata));
+        let provider = DummyTableProviderFactory
+            .create_table_provider(test_region_id(), engine.clone(), None)
+            .await
+            .unwrap();
+        (provider, engine)
+    }
+
+    #[tokio::test]
+    async fn test_scan_rejects_scanner_schema_version_changed_after_provider_snapshot() {
+        let region_id = test_region_id();
+        let (provider, engine) = provider_with_snapshot(test_region_metadata(region_id, 7)).await;
+
+        // Simulate compatible DDL after remote-plan decode captured the provider snapshot.
+        engine.set_scanner_metadata(test_region_metadata(region_id, 8));
+
+        let state = SessionStateBuilder::new().build();
+        let err = TableProvider::scan(&provider, &state, None, &[], None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains(&format!(
+            "expected region_id={region_id}, schema_version=7; current region_id={region_id}, schema_version=8"
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_scan_rejects_scanner_region_id_mismatch() {
+        let region_id = test_region_id();
+        let (provider, engine) = provider_with_snapshot(test_region_metadata(region_id, 7)).await;
+        let current_region_id = RegionId::new(1024, 2);
+        engine.set_scanner_metadata(test_region_metadata(current_region_id, 7));
+
+        let state = SessionStateBuilder::new().build();
+        let err = TableProvider::scan(&provider, &state, None, &[], None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains(&format!(
+            "expected region_id={region_id}, schema_version=7; current region_id={current_region_id}, schema_version=7"
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_scan_accepts_matching_scanner_metadata() {
+        let metadata = test_region_metadata(test_region_id(), 7);
+        let (provider, _engine) = provider_with_snapshot(metadata).await;
+        let state = SessionStateBuilder::new().build();
+
+        let plan = TableProvider::scan(&provider, &state, None, &[], None)
+            .await
+            .unwrap();
+
+        assert_eq!(plan.schema(), provider.schema());
+    }
+
+    #[tokio::test]
+    async fn test_scan_accepts_logical_scanner_with_physical_metadata() {
+        let logical_region_id = test_region_id();
+        let (provider, engine) =
+            provider_with_snapshot(test_region_metadata(logical_region_id, 7)).await;
+        let physical_region_id = RegionId::new(2048, 3);
+        engine.set_scanner_metadata(test_region_metadata(physical_region_id, 2));
+        engine.set_scanner_is_logical_region(true);
+
+        let state = SessionStateBuilder::new().build();
+        let plan = TableProvider::scan(&provider, &state, None, &[], None)
+            .await
+            .unwrap();
+
+        assert_eq!(plan.schema(), provider.schema());
+    }
+
+    #[tokio::test]
+    async fn test_scan_rejects_logical_metadata_changed_after_provider_snapshot() {
+        let logical_region_id = test_region_id();
+        let (provider, engine) =
+            provider_with_snapshot(test_region_metadata(logical_region_id, 7)).await;
+        engine.set_scanner_metadata(test_region_metadata(RegionId::new(2048, 3), 2));
+        engine.set_scanner_is_logical_region(true);
+        engine.set_provider_metadata(test_region_metadata(logical_region_id, 8));
+
+        let state = SessionStateBuilder::new().build();
+        let err = TableProvider::scan(&provider, &state, None, &[], None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("logical region metadata mismatch"));
+        assert!(err.to_string().contains("schema_version: 7"));
+        assert!(err.to_string().contains("schema_version: 8"));
     }
 
     #[test]

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -15,6 +15,7 @@
 mod context;
 mod default_serializer;
 pub mod options;
+pub mod remote_plan_codec;
 pub mod runtime;
 mod state;
 use std::any::Any;

--- a/src/query/src/query_engine/remote_plan_codec.rs
+++ b/src/query/src/query_engine/remote_plan_codec.rs
@@ -1,0 +1,2386 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fail-closed codec used only for region remote reads.
+//!
+//! The ordinary Substrait serializer intentionally remains reusable by views,
+//! flows, and internal RPCs.  Remote reads instead carry this root envelope so
+//! their target table identity and semantic metadata can be checked before the
+//! decoded plan is executed against the region's current provider.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use api::v1::SemanticType;
+use bytes::Bytes;
+use common_error::ext::{BoxedError, PlainError};
+use common_error::status_code::StatusCode;
+use common_query::logical_plan::SubstraitPlanDecoder;
+use datafusion::catalog::{CatalogProviderList, MemTable};
+use datafusion::datasource::DefaultTableSource;
+use datafusion_common::DataFusionError;
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion_expr::{Expr, LogicalPlan};
+use datatypes::arrow::datatypes::{DataType as ArrowDataType, Field};
+use datatypes::data_type::DataType;
+use greptime_proto::substrait_extension::{
+    RemoteReadColumnV1, RemoteReadInternalV1, RemoteReadSemanticTypeV1, RemoteReadTableV1,
+};
+use pbjson_types::Any;
+use prost::Message;
+use store_api::metadata::RegionMetadata;
+use store_api::region_info::RegionInfoEntry;
+use store_api::sst_entry::{ManifestSstEntry, PuffinIndexMetaEntry, StorageSstEntry};
+use store_api::storage::RegionId;
+use substrait::substrait_proto_df::proto;
+use substrait::{DFLogicalSubstraitConvertor, SubstraitPlan};
+use table::metadata::TableInfo;
+use table::table::adapter::DfTableProviderAdapter;
+
+use crate::dummy_catalog::DummyTableProvider;
+use crate::plan::ExtractExpr;
+use crate::query_engine::DefaultSerializer;
+
+/// Mandatory contract for production region reads.
+pub const REMOTE_READ_TABLE_V1_TYPE_URL: &str =
+    "type.googleapis.com/substrait_extension.RemoteReadTableV1";
+/// Envelope for an inspection-only remote plan. It has no payload and must not
+/// resolve a [`DummyTableProvider`].
+pub const REMOTE_READ_INTERNAL_V1_TYPE_URL: &str =
+    "type.googleapis.com/substrait_extension.RemoteReadInternalV1";
+
+/// Returns whether `name` is one of the inspection-only table names supported
+/// by a region remote-read catalog.
+///
+/// This is deliberately the single source of truth shared with datanode's
+/// name-aware catalog: any other source at this boundary is rejected.
+pub fn is_reserved_internal_table_name(name: &str) -> bool {
+    name.eq_ignore_ascii_case(ManifestSstEntry::reserved_table_name_for_inspection())
+        || name.eq_ignore_ascii_case(StorageSstEntry::reserved_table_name_for_inspection())
+        || name.eq_ignore_ascii_case(PuffinIndexMetaEntry::reserved_table_name_for_inspection())
+        || name.eq_ignore_ascii_case(RegionInfoEntry::reserved_table_name_for_inspection())
+}
+
+#[derive(Debug)]
+enum Envelope {
+    Target(RemoteReadTableV1),
+    Internal,
+}
+
+#[derive(Debug)]
+struct ReadSchema {
+    table_name: String,
+    table_reference: Vec<String>,
+    names: Vec<String>,
+    types: Vec<proto::Type>,
+}
+
+/// Encodes a plan for `RegionRequester::handle_query`.
+///
+/// A base Greptime table must be represented by exactly one table identity and
+/// that identity must agree with the destination region. Plans containing only
+/// recognized synthetic sources use the explicit internal envelope instead.
+pub fn encode_remote_plan(
+    plan: &LogicalPlan,
+    region_id: RegionId,
+) -> std::result::Result<Bytes, BoxedError> {
+    reject_logical_subqueries(plan)?;
+    let target = extract_target_table(plan)?;
+    let mut encoded = DFLogicalSubstraitConvertor
+        .encode(plan, DefaultSerializer)
+        .map_err(|error| remote_error(error.to_string()))?;
+    let mut substrait_plan =
+        proto::Plan::decode(encoded.as_ref()).map_err(|error| remote_error(error.to_string()))?;
+
+    let envelope = match target {
+        Some(table) => {
+            if table.table_id() != region_id.table_id() {
+                return Err(remote_error(format!(
+                    "planned table {} does not match remote region table {}",
+                    table.table_id(),
+                    region_id.table_id()
+                )));
+            }
+            Any {
+                type_url: REMOTE_READ_TABLE_V1_TYPE_URL.to_string(),
+                value: table_contract(&table)?.encode_to_vec().into(),
+            }
+        }
+        None => Any {
+            type_url: REMOTE_READ_INTERNAL_V1_TYPE_URL.to_string(),
+            value: RemoteReadInternalV1 {}.encode_to_vec().into(),
+        },
+    };
+
+    wrap_root(&mut substrait_plan, envelope)?;
+    encoded = Bytes::from(substrait_plan.encode_to_vec());
+    Ok(encoded)
+}
+
+/// Decodes a region remote-read envelope and validates its current provider.
+///
+/// This is deliberately not used by persisted-view, flow, or generic logical
+/// plan decode paths. The stock decoder still performs its normal logical-type
+/// compatibility check after this function restores the standard root relation.
+pub async fn decode_remote_plan(
+    decoder: &(dyn SubstraitPlanDecoder + Send + Sync),
+    message: Bytes,
+    catalog_list: Arc<dyn CatalogProviderList>,
+) -> common_query::error::Result<LogicalPlan> {
+    let mut plan =
+        proto::Plan::decode(message.as_ref()).map_err(|error| decode_error(error.to_string()))?;
+    let envelope = unwrap_root(&mut plan)?;
+    let read_schemas = collect_read_schemas(root_input(&plan).map_err(decode_error)?)?;
+    reject_raw_subqueries(root_input(&plan).map_err(decode_error)?)?;
+
+    let plan = decoder
+        // A remote plan is always decoded unoptimized. Validation must observe
+        // every resolved scan before any optimizer can remove or rewrite it.
+        .decode(Bytes::from(plan.encode_to_vec()), catalog_list, false)
+        .await?;
+    validate_decoded_sources(&plan, &envelope, &read_schemas)?;
+    Ok(plan)
+}
+
+fn extract_target_table(
+    plan: &LogicalPlan,
+) -> std::result::Result<Option<Arc<TableInfo>>, BoxedError> {
+    let mut target: Option<Arc<TableInfo>> = None;
+    let mut classification_error = None;
+    plan.apply(|node| {
+        let LogicalPlan::TableScan(scan) = node else {
+            return Ok(TreeNodeRecursion::Continue);
+        };
+        if is_reserved_internal_table_name(scan.table_name.table()) {
+            return Ok(TreeNodeRecursion::Continue);
+        }
+        let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>() else {
+            classification_error = Some(format!(
+                "remote read table {} has an unknown table source",
+                scan.table_name
+            ));
+            return Ok(TreeNodeRecursion::Stop);
+        };
+        let Some(provider) = source
+            .table_provider
+            .as_any()
+            .downcast_ref::<DfTableProviderAdapter>()
+        else {
+            classification_error = Some(format!(
+                "remote read table {} has an unrecognized table provider",
+                scan.table_name
+            ));
+            return Ok(TreeNodeRecursion::Stop);
+        };
+        let table = provider.table();
+        if table.table_type() != table::metadata::TableType::Base {
+            classification_error = Some(format!(
+                "remote read table {} is not a base table provider",
+                scan.table_name
+            ));
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        let info = table.table_info();
+        if let Some(existing) = &target
+            && existing.table_id() != info.table_id()
+        {
+            return Err(DataFusionError::Plan(format!(
+                "remote read has multiple protected table IDs: {} and {}",
+                existing.table_id(),
+                info.table_id()
+            )));
+        }
+        target = Some(info);
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .map_err(|error| remote_error(error.to_string()))?;
+    if let Some(error) = classification_error {
+        return Err(remote_error(error));
+    }
+    Ok(target)
+}
+
+fn reject_logical_subqueries(plan: &LogicalPlan) -> std::result::Result<(), BoxedError> {
+    let mut subquery = None;
+    plan.apply(|node| {
+        for expression in node.expressions_consider_join() {
+            expression.apply(|expression| {
+                if matches!(
+                    expression,
+                    Expr::ScalarSubquery(_)
+                        | Expr::Exists(_)
+                        | Expr::InSubquery(_)
+                        | Expr::SetComparison(_)
+                ) {
+                    subquery = Some("logical subquery".to_string());
+                    Ok(TreeNodeRecursion::Stop)
+                } else {
+                    Ok(TreeNodeRecursion::Continue)
+                }
+            })?;
+            if subquery.is_some() {
+                return Ok(TreeNodeRecursion::Stop);
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .map_err(|error| remote_error(error.to_string()))?;
+    subquery.map_or(Ok(()), |expression| {
+        Err(remote_error(format!(
+            "remote reads do not support logical subqueries ({expression})"
+        )))
+    })
+}
+
+fn table_contract(table: &TableInfo) -> std::result::Result<RemoteReadTableV1, BoxedError> {
+    let schema = table.meta.schema.column_schemas();
+    let ids = table.name_to_ids().ok_or_else(|| {
+        remote_error(format!(
+            "remote read table {} has incomplete column ID metadata",
+            table.table_id()
+        ))
+    })?;
+    if ids.len() != schema.len() {
+        return Err(remote_error(
+            "remote read table has incomplete column ID metadata",
+        ));
+    }
+    let primary_key_indices =
+        if table.meta.engine == store_api::metric_engine_consts::METRIC_ENGINE_NAME {
+            // MetricEngine synthesizes logical RegionMetadata by sorting logical
+            // columns by name before deriving primary-key IDs. Match that order;
+            // `schema` is TableInfo's logical schema, so physical reserved columns
+            // are intentionally not considered here.
+            let mut indexed_names = table
+                .meta
+                .primary_key_indices
+                .iter()
+                .map(|index| {
+                    schema
+                        .get(*index)
+                        .map(|column| (*index, column.name.as_str()))
+                        .ok_or_else(|| {
+                            remote_error("remote read table has an invalid primary key index")
+                        })
+                })
+                .collect::<std::result::Result<Vec<_>, BoxedError>>()?;
+            indexed_names.sort_by(|left, right| left.1.cmp(right.1));
+            indexed_names.into_iter().map(|(index, _)| index).collect()
+        } else {
+            table.meta.primary_key_indices.clone()
+        };
+
+    let mut seen_ids = HashSet::with_capacity(ids.len());
+    let columns = schema
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            let column_id = *ids.get(&column.name).ok_or_else(|| {
+                remote_error(format!("missing stable ID for column {}", column.name))
+            })?;
+            if !seen_ids.insert(column_id) {
+                return Err(remote_error(format!(
+                    "duplicate stable ID {column_id} in remote read table"
+                )));
+            }
+            let primary_key_ordinal = primary_key_indices
+                .iter()
+                .position(|primary_key_index| *primary_key_index == index)
+                .map(|ordinal| ordinal as u32);
+            let semantic_type = if column.is_time_index() {
+                SemanticType::Timestamp
+            } else if primary_key_ordinal.is_some() {
+                SemanticType::Tag
+            } else {
+                SemanticType::Field
+            };
+            Ok(RemoteReadColumnV1 {
+                name: column.name.clone(),
+                column_id,
+                semantic_type: Some(api_semantic_to_remote(semantic_type)? as i32),
+                is_time_index: Some(column.is_time_index()),
+                primary_key_ordinal,
+            })
+        })
+        .collect::<std::result::Result<Vec<_>, BoxedError>>()?;
+
+    Ok(RemoteReadTableV1 {
+        table_id: table.table_id(),
+        // This is diagnostic only. It is intentionally never compared at decode.
+        table_version: Some(table.ident.version),
+        columns,
+    })
+}
+
+fn wrap_root(plan: &mut proto::Plan, detail: Any) -> std::result::Result<(), BoxedError> {
+    let input = root_input_mut(plan)
+        .map_err(remote_error)?
+        .take()
+        .ok_or_else(|| remote_error("remote plan root has no input"))?;
+    *root_input_mut(plan).map_err(remote_error)? = Some(proto::Rel {
+        rel_type: Some(proto::rel::RelType::ExtensionSingle(Box::new(
+            proto::ExtensionSingleRel {
+                common: None,
+                detail: Some(detail),
+                input: Some(Box::new(input)),
+            },
+        ))),
+    });
+    Ok(())
+}
+
+fn unwrap_root(plan: &mut proto::Plan) -> common_query::error::Result<Envelope> {
+    let input = root_input_mut(plan)
+        .map_err(decode_error)?
+        .take()
+        .ok_or_else(|| decode_error("remote plan root has no input"))?;
+    let Some(proto::rel::RelType::ExtensionSingle(extension)) = input.rel_type else {
+        return Err(decode_error("remote read requires a v1 root envelope"));
+    };
+    let detail = extension
+        .detail
+        .ok_or_else(|| decode_error("remote read envelope is missing detail"))?;
+    let inner = extension
+        .input
+        .ok_or_else(|| decode_error("remote read envelope is missing input"))?;
+    let envelope = match detail.type_url.as_str() {
+        REMOTE_READ_TABLE_V1_TYPE_URL => {
+            if detail.value.is_empty() {
+                return Err(decode_error("remote read target contract is empty"));
+            }
+            let contract = RemoteReadTableV1::decode(detail.value.as_ref())
+                .map_err(|error| decode_error(error.to_string()))?;
+            if contract.table_id == 0 || contract.columns.is_empty() {
+                return Err(decode_error("remote read target contract is incomplete"));
+            }
+            Envelope::Target(contract)
+        }
+        REMOTE_READ_INTERNAL_V1_TYPE_URL => {
+            RemoteReadInternalV1::decode(detail.value.as_ref())
+                .map_err(|error| decode_error(error.to_string()))?;
+            Envelope::Internal
+        }
+        _ => return Err(decode_error("unknown remote read envelope URL or version")),
+    };
+    *root_input_mut(plan).map_err(decode_error)? = Some(*inner);
+    Ok(envelope)
+}
+
+fn root_input(plan: &proto::Plan) -> std::result::Result<&proto::Rel, String> {
+    if plan.relations.len() != 1 {
+        return Err("remote plan must contain exactly one relation tree".to_string());
+    }
+    match plan.relations[0].rel_type.as_ref() {
+        Some(proto::plan_rel::RelType::Root(root)) => root
+            .input
+            .as_ref()
+            .ok_or_else(|| "remote plan root has no input".to_string()),
+        _ => Err("remote plan must use a root relation".to_string()),
+    }
+}
+
+fn root_input_mut(plan: &mut proto::Plan) -> std::result::Result<&mut Option<proto::Rel>, String> {
+    if plan.relations.len() != 1 {
+        return Err("remote plan must contain exactly one relation tree".to_string());
+    }
+    match plan.relations[0].rel_type.as_mut() {
+        Some(proto::plan_rel::RelType::Root(root)) => Ok(&mut root.input),
+        _ => Err("remote plan must use a root relation".to_string()),
+    }
+}
+
+fn collect_read_schemas(root: &proto::Rel) -> common_query::error::Result<Vec<ReadSchema>> {
+    let mut reads = Vec::new();
+    collect_read_schemas_inner(root, &mut reads)?;
+    Ok(reads)
+}
+
+fn collect_read_schemas_inner(
+    rel: &proto::Rel,
+    reads: &mut Vec<ReadSchema>,
+) -> common_query::error::Result<()> {
+    use proto::rel::RelType;
+
+    let Some(rel_type) = rel.rel_type.as_ref() else {
+        return Err(decode_error("remote plan contains an empty relation"));
+    };
+    match rel_type {
+        RelType::Read(read) => {
+            let Some(proto::read_rel::ReadType::NamedTable(named_table)) = read.read_type.as_ref()
+            else {
+                return Err(decode_error(
+                    "remote read supports only named-table ReadRel providers",
+                ));
+            };
+            let Some(table_name) = named_table.names.last().filter(|name| !name.is_empty()) else {
+                return Err(decode_error("remote read named table has no name"));
+            };
+            let schema = read
+                .base_schema
+                .as_ref()
+                .ok_or_else(|| decode_error("protected read has no base schema"))?;
+            let struct_type = schema
+                .r#struct
+                .as_ref()
+                .ok_or_else(|| decode_error("protected read has no type struct"))?;
+            let (names, types) = extract_top_level_named_struct(schema, struct_type)?;
+            reads.push(ReadSchema {
+                table_name: table_name.clone(),
+                table_reference: named_table.names.clone(),
+                names,
+                types,
+            });
+        }
+        RelType::Filter(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Fetch(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Aggregate(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Sort(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Project(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::ExtensionSingle(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Exchange(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Expand(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Window(rel) => collect_optional_input(rel.input.as_ref(), reads)?,
+        RelType::Join(rel) => {
+            collect_optional_input(rel.left.as_ref(), reads)?;
+            collect_optional_input(rel.right.as_ref(), reads)?;
+        }
+        RelType::Cross(rel) => {
+            collect_optional_input(rel.left.as_ref(), reads)?;
+            collect_optional_input(rel.right.as_ref(), reads)?;
+        }
+        RelType::Set(rel) => {
+            for input in &rel.inputs {
+                collect_read_schemas_inner(input, reads)?;
+            }
+        }
+        RelType::ExtensionMulti(rel) => {
+            for input in &rel.inputs {
+                collect_read_schemas_inner(input, reads)?;
+            }
+        }
+        RelType::HashJoin(rel) => {
+            collect_optional_input(rel.left.as_ref(), reads)?;
+            collect_optional_input(rel.right.as_ref(), reads)?;
+        }
+        RelType::MergeJoin(rel) => {
+            collect_optional_input(rel.left.as_ref(), reads)?;
+            collect_optional_input(rel.right.as_ref(), reads)?;
+        }
+        RelType::NestedLoopJoin(rel) => {
+            collect_optional_input(rel.left.as_ref(), reads)?;
+            collect_optional_input(rel.right.as_ref(), reads)?;
+        }
+        RelType::Write(_)
+        | RelType::Ddl(_)
+        | RelType::ExtensionLeaf(_)
+        | RelType::Reference(_)
+        | RelType::Update(_) => {
+            return Err(decode_error(
+                "unsupported relation shape at the remote-read boundary",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Rebuild just the top-level field association from Substrait's flattened
+/// `NamedStruct.names` representation. This mirrors DataFusion 53's name
+/// consumption rules while retaining the original top-level type for remote
+/// nullability validation.
+fn extract_top_level_named_struct(
+    schema: &proto::NamedStruct,
+    struct_type: &proto::r#type::Struct,
+) -> common_query::error::Result<(Vec<String>, Vec<proto::Type>)> {
+    let mut name_index = 0;
+    let mut names = Vec::with_capacity(struct_type.types.len());
+    for type_ in &struct_type.types {
+        let name = consume_flattened_type_name(type_, &schema.names, &mut name_index, true)?;
+        names.push(name);
+    }
+    if name_index != schema.names.len()
+        || names.iter().any(|name| name.is_empty())
+        || names.iter().collect::<HashSet<_>>().len() != names.len()
+    {
+        return Err(decode_error(
+            "protected read base schema is incomplete or ambiguous",
+        ));
+    }
+    Ok((names, struct_type.types.clone()))
+}
+
+fn consume_flattened_type_name(
+    type_: &proto::Type,
+    names: &[String],
+    name_index: &mut usize,
+    consume_self: bool,
+) -> common_query::error::Result<String> {
+    let own_name = if consume_self {
+        let name = names
+            .get(*name_index)
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| decode_error("protected read base schema has too few names"))?
+            .clone();
+        *name_index += 1;
+        name
+    } else {
+        String::new()
+    };
+    let kind = type_
+        .kind
+        .as_ref()
+        .ok_or_else(|| decode_error("protected read type is unspecified"))?;
+    match kind {
+        proto::r#type::Kind::Struct(struct_type) => {
+            for child in &struct_type.types {
+                consume_flattened_type_name(child, names, name_index, true)?;
+            }
+        }
+        proto::r#type::Kind::List(list) => {
+            consume_flattened_type_name(
+                list.r#type
+                    .as_deref()
+                    .ok_or_else(|| decode_error("protected list has no child type"))?,
+                names,
+                name_index,
+                false,
+            )?;
+        }
+        proto::r#type::Kind::Map(map) => {
+            consume_flattened_type_name(
+                map.key
+                    .as_deref()
+                    .ok_or_else(|| decode_error("protected map has no key type"))?,
+                names,
+                name_index,
+                false,
+            )?;
+            consume_flattened_type_name(
+                map.value
+                    .as_deref()
+                    .ok_or_else(|| decode_error("protected map has no value type"))?,
+                names,
+                name_index,
+                false,
+            )?;
+        }
+        _ => {}
+    }
+    Ok(own_name)
+}
+
+fn reject_raw_subqueries(root: &proto::Rel) -> common_query::error::Result<()> {
+    reject_raw_subqueries_in_rel(root)
+}
+
+fn reject_raw_subqueries_in_rel(rel: &proto::Rel) -> common_query::error::Result<()> {
+    use proto::rel::RelType;
+
+    let Some(rel_type) = rel.rel_type.as_ref() else {
+        return Ok(());
+    };
+    match rel_type {
+        RelType::Read(read) => {
+            reject_raw_subqueries_in_exprs([
+                read.filter.as_deref(),
+                read.best_effort_filter.as_deref(),
+            ])?;
+            if let Some(proto::read_rel::ReadType::VirtualTable(table)) = read.read_type.as_ref() {
+                for expression in &table.expressions {
+                    reject_raw_subqueries_in_exprs(expression.fields.iter().map(Some))?;
+                }
+            }
+        }
+        RelType::Filter(filter) => {
+            reject_raw_subqueries_in_rel_child(filter.input.as_deref())?;
+            reject_raw_subqueries_in_exprs([filter.condition.as_deref()])?;
+        }
+        RelType::Fetch(fetch) => {
+            reject_raw_subqueries_in_rel_child(fetch.input.as_deref())?;
+            if let Some(proto::fetch_rel::OffsetMode::OffsetExpr(expression)) = &fetch.offset_mode {
+                reject_raw_subqueries_in_expr(expression)?;
+            }
+            if let Some(proto::fetch_rel::CountMode::CountExpr(expression)) = &fetch.count_mode {
+                reject_raw_subqueries_in_expr(expression)?;
+            }
+        }
+        RelType::Aggregate(aggregate) => {
+            reject_raw_subqueries_in_rel_child(aggregate.input.as_deref())?;
+            reject_raw_subqueries_in_exprs(aggregate.grouping_expressions.iter().map(Some))?;
+            #[allow(deprecated)]
+            for grouping in &aggregate.groupings {
+                reject_raw_subqueries_in_exprs(grouping.grouping_expressions.iter().map(Some))?;
+            }
+            for measure in &aggregate.measures {
+                if let Some(measure) = measure.measure.as_ref() {
+                    reject_raw_subqueries_in_aggregate_function(measure)?;
+                }
+                reject_raw_subqueries_in_exprs([measure.filter.as_ref()])?;
+            }
+        }
+        RelType::Sort(sort) => {
+            reject_raw_subqueries_in_rel_child(sort.input.as_deref())?;
+            reject_raw_subqueries_in_sort_fields(&sort.sorts)?;
+        }
+        RelType::Join(join) => {
+            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
+            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
+            reject_raw_subqueries_in_exprs([
+                join.expression.as_deref(),
+                join.post_join_filter.as_deref(),
+            ])?;
+        }
+        RelType::Project(project) => {
+            reject_raw_subqueries_in_rel_child(project.input.as_deref())?;
+            reject_raw_subqueries_in_exprs(project.expressions.iter().map(Some))?;
+        }
+        RelType::Set(set) => {
+            for input in &set.inputs {
+                reject_raw_subqueries_in_rel(input)?;
+            }
+        }
+        RelType::ExtensionMulti(extension) => {
+            for input in &extension.inputs {
+                reject_raw_subqueries_in_rel(input)?;
+            }
+        }
+        RelType::ExtensionSingle(extension) => {
+            reject_raw_subqueries_in_rel_child(extension.input.as_deref())?;
+        }
+        RelType::ExtensionLeaf(_) | RelType::Reference(_) => {}
+        RelType::Cross(cross) => {
+            reject_raw_subqueries_in_rel_child(cross.left.as_deref())?;
+            reject_raw_subqueries_in_rel_child(cross.right.as_deref())?;
+        }
+        RelType::Write(write) => reject_raw_subqueries_in_rel_child(write.input.as_deref())?,
+        RelType::Ddl(ddl) => reject_raw_subqueries_in_rel_child(ddl.view_definition.as_deref())?,
+        RelType::Update(update) => {
+            reject_raw_subqueries_in_exprs([update.condition.as_deref()])?;
+            for transformation in &update.transformations {
+                reject_raw_subqueries_in_exprs([transformation.transformation.as_ref()])?;
+            }
+        }
+        #[allow(deprecated)]
+        RelType::HashJoin(join) => {
+            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
+            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
+            reject_raw_subqueries_in_field_refs(&join.left_keys)?;
+            reject_raw_subqueries_in_field_refs(&join.right_keys)?;
+            for key in &join.keys {
+                reject_raw_subqueries_in_optional_field_refs([
+                    key.left.as_ref(),
+                    key.right.as_ref(),
+                ])?;
+            }
+            reject_raw_subqueries_in_exprs([join.post_join_filter.as_deref()])?;
+        }
+        #[allow(deprecated)]
+        RelType::MergeJoin(join) => {
+            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
+            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
+            reject_raw_subqueries_in_field_refs(&join.left_keys)?;
+            reject_raw_subqueries_in_field_refs(&join.right_keys)?;
+            for key in &join.keys {
+                reject_raw_subqueries_in_optional_field_refs([
+                    key.left.as_ref(),
+                    key.right.as_ref(),
+                ])?;
+            }
+            reject_raw_subqueries_in_exprs([join.post_join_filter.as_deref()])?;
+        }
+        RelType::NestedLoopJoin(join) => {
+            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
+            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
+            reject_raw_subqueries_in_exprs([join.expression.as_deref()])?;
+        }
+        RelType::Window(window) => {
+            reject_raw_subqueries_in_rel_child(window.input.as_deref())?;
+            reject_raw_subqueries_in_exprs(window.partition_expressions.iter().map(Some))?;
+            reject_raw_subqueries_in_sort_fields(&window.sorts)?;
+            for function in &window.window_functions {
+                reject_raw_subqueries_in_function_args(&function.arguments)?;
+            }
+        }
+        RelType::Exchange(exchange) => {
+            reject_raw_subqueries_in_rel_child(exchange.input.as_deref())?;
+            match exchange.exchange_kind.as_ref() {
+                Some(proto::exchange_rel::ExchangeKind::ScatterByFields(fields)) => {
+                    reject_raw_subqueries_in_field_refs(&fields.fields)?;
+                }
+                Some(proto::exchange_rel::ExchangeKind::SingleTarget(expression)) => {
+                    reject_raw_subqueries_in_exprs([expression.expression.as_deref()])?;
+                }
+                Some(proto::exchange_rel::ExchangeKind::MultiTarget(expression)) => {
+                    reject_raw_subqueries_in_exprs([expression.expression.as_deref()])?;
+                }
+                _ => {}
+            }
+        }
+        RelType::Expand(expand) => {
+            reject_raw_subqueries_in_rel_child(expand.input.as_deref())?;
+            for field in &expand.fields {
+                match field.field_type.as_ref() {
+                    Some(proto::expand_rel::expand_field::FieldType::SwitchingField(field)) => {
+                        reject_raw_subqueries_in_exprs(field.duplicates.iter().map(Some))?;
+                    }
+                    Some(proto::expand_rel::expand_field::FieldType::ConsistentField(
+                        expression,
+                    )) => {
+                        reject_raw_subqueries_in_expr(expression)?;
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reject_raw_subqueries_in_rel_child(rel: Option<&proto::Rel>) -> common_query::error::Result<()> {
+    rel.map_or(Ok(()), reject_raw_subqueries_in_rel)
+}
+
+fn reject_raw_subqueries_in_exprs<'a>(
+    expressions: impl IntoIterator<Item = Option<&'a proto::Expression>>,
+) -> common_query::error::Result<()> {
+    for expression in expressions.into_iter().flatten() {
+        reject_raw_subqueries_in_expr(expression)?;
+    }
+    Ok(())
+}
+
+fn reject_raw_subqueries_in_expr(
+    expression: &proto::Expression,
+) -> common_query::error::Result<()> {
+    use proto::expression::RexType;
+
+    match expression.rex_type.as_ref() {
+        Some(RexType::Subquery(_)) => Err(decode_error(
+            "remote reads do not support raw Substrait subqueries",
+        )),
+        Some(RexType::Selection(reference)) => {
+            reject_raw_subqueries_in_field_refs(std::slice::from_ref(reference))
+        }
+        Some(RexType::ScalarFunction(function)) => {
+            reject_raw_subqueries_in_function_args(&function.arguments)?;
+            #[allow(deprecated)]
+            reject_raw_subqueries_in_exprs(function.args.iter().map(Some))
+        }
+        Some(RexType::WindowFunction(function)) => {
+            reject_raw_subqueries_in_function_args(&function.arguments)?;
+            reject_raw_subqueries_in_exprs(function.partitions.iter().map(Some))?;
+            reject_raw_subqueries_in_sort_fields(&function.sorts)?;
+            #[allow(deprecated)]
+            reject_raw_subqueries_in_exprs(function.args.iter().map(Some))
+        }
+        Some(RexType::IfThen(if_then)) => {
+            for clause in &if_then.ifs {
+                reject_raw_subqueries_in_exprs([clause.r#if.as_ref(), clause.then.as_ref()])?;
+            }
+            reject_raw_subqueries_in_exprs([if_then.r#else.as_deref()])
+        }
+        Some(RexType::SwitchExpression(switch)) => {
+            reject_raw_subqueries_in_exprs([switch.r#match.as_deref(), switch.r#else.as_deref()])?;
+            reject_raw_subqueries_in_exprs(switch.ifs.iter().map(|clause| clause.then.as_ref()))
+        }
+        Some(RexType::SingularOrList(list)) => {
+            reject_raw_subqueries_in_exprs([list.value.as_deref()])?;
+            reject_raw_subqueries_in_exprs(list.options.iter().map(Some))
+        }
+        Some(RexType::MultiOrList(list)) => {
+            reject_raw_subqueries_in_exprs(list.value.iter().map(Some))?;
+            for record in &list.options {
+                reject_raw_subqueries_in_exprs(record.fields.iter().map(Some))?;
+            }
+            Ok(())
+        }
+        Some(RexType::Cast(cast)) => reject_raw_subqueries_in_exprs([cast.input.as_deref()]),
+        Some(RexType::Nested(nested)) => match nested.nested_type.as_ref() {
+            Some(proto::expression::nested::NestedType::Struct(struct_)) => {
+                reject_raw_subqueries_in_exprs(struct_.fields.iter().map(Some))
+            }
+            Some(proto::expression::nested::NestedType::List(list)) => {
+                reject_raw_subqueries_in_exprs(list.values.iter().map(Some))
+            }
+            Some(proto::expression::nested::NestedType::Map(map)) => {
+                for entry in &map.key_values {
+                    reject_raw_subqueries_in_exprs([entry.key.as_ref(), entry.value.as_ref()])?;
+                }
+                Ok(())
+            }
+            None => Ok(()),
+        },
+        Some(RexType::Literal(_))
+        | Some(RexType::DynamicParameter(_))
+        | Some(RexType::Enum(_))
+        | None => Ok(()),
+    }
+}
+
+fn reject_raw_subqueries_in_function_args(
+    arguments: &[proto::FunctionArgument],
+) -> common_query::error::Result<()> {
+    for argument in arguments {
+        if let Some(proto::function_argument::ArgType::Value(expression)) =
+            argument.arg_type.as_ref()
+        {
+            reject_raw_subqueries_in_expr(expression)?;
+        }
+    }
+    Ok(())
+}
+
+fn reject_raw_subqueries_in_aggregate_function(
+    function: &proto::AggregateFunction,
+) -> common_query::error::Result<()> {
+    reject_raw_subqueries_in_function_args(&function.arguments)?;
+    reject_raw_subqueries_in_sort_fields(&function.sorts)?;
+    #[allow(deprecated)]
+    reject_raw_subqueries_in_exprs(function.args.iter().map(Some))
+}
+
+fn reject_raw_subqueries_in_sort_fields(
+    fields: &[proto::SortField],
+) -> common_query::error::Result<()> {
+    reject_raw_subqueries_in_exprs(fields.iter().map(|field| field.expr.as_ref()))
+}
+
+fn reject_raw_subqueries_in_field_refs(
+    references: &[proto::expression::FieldReference],
+) -> common_query::error::Result<()> {
+    for reference in references {
+        if let Some(proto::expression::field_reference::RootType::Expression(expression)) =
+            reference.root_type.as_ref()
+        {
+            reject_raw_subqueries_in_expr(expression)?;
+        }
+    }
+    Ok(())
+}
+
+fn reject_raw_subqueries_in_optional_field_refs<'a>(
+    references: impl IntoIterator<Item = Option<&'a proto::expression::FieldReference>>,
+) -> common_query::error::Result<()> {
+    for reference in references.into_iter().flatten() {
+        reject_raw_subqueries_in_field_refs(std::slice::from_ref(reference))?;
+    }
+    Ok(())
+}
+
+fn collect_optional_input(
+    input: Option<&Box<proto::Rel>>,
+    reads: &mut Vec<ReadSchema>,
+) -> common_query::error::Result<()> {
+    let input = input.ok_or_else(|| decode_error("remote plan relation has no input"))?;
+    collect_read_schemas_inner(input.as_ref(), reads)
+}
+
+fn validate_decoded_sources(
+    plan: &LogicalPlan,
+    envelope: &Envelope,
+    read_schemas: &[ReadSchema],
+) -> common_query::error::Result<()> {
+    let mut protected = 0;
+    let mut validation_error = None;
+    let mut reads_by_table = HashMap::<&str, Vec<&ReadSchema>>::new();
+    for read in read_schemas {
+        if let Some(existing) = reads_by_table.get(read.table_name.as_str())
+            && existing
+                .iter()
+                .any(|existing| existing.table_reference != read.table_reference)
+        {
+            return Err(decode_error(format!(
+                "remote read has ambiguous qualified references for table {}",
+                read.table_name
+            )));
+        }
+        reads_by_table
+            .entry(read.table_name.as_str())
+            .or_default()
+            .push(read);
+    }
+    plan.apply(|node| {
+        let LogicalPlan::TableScan(scan) = node else {
+            return Ok(TreeNodeRecursion::Continue);
+        };
+        let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>() else {
+            validation_error = Some("remote read resolved an unknown table source".to_string());
+            return Ok(TreeNodeRecursion::Stop);
+        };
+        let table_name = scan.table_name.table();
+        let Some(reads) = reads_by_table.get_mut(table_name) else {
+            validation_error = Some(format!(
+                "decoded remote table scan {table_name} has no matching ReadRel"
+            ));
+            return Ok(TreeNodeRecursion::Stop);
+        };
+        let Some(read) = reads.pop() else {
+            validation_error = Some(format!(
+                "decoded remote table scan {table_name} has no remaining ReadRel"
+            ));
+            return Ok(TreeNodeRecursion::Stop);
+        };
+        let provider = &source.table_provider;
+        if let Some(dummy) = provider.as_any().downcast_ref::<DummyTableProvider>() {
+            protected += 1;
+            match envelope {
+                Envelope::Target(contract) => {
+                    if let Err(error) = validate_target(dummy.region_metadata().as_ref(), contract)
+                        .and_then(|_| {
+                            validate_read_schema(dummy.region_metadata().as_ref(), contract, read)
+                        })
+                    {
+                        validation_error = Some(error);
+                        return Ok(TreeNodeRecursion::Stop);
+                    }
+                }
+                Envelope::Internal => {
+                    validation_error = Some(
+                        "internal remote plan resolved a protected region provider".to_string(),
+                    );
+                    return Ok(TreeNodeRecursion::Stop);
+                }
+            }
+        } else if provider.as_any().downcast_ref::<MemTable>().is_some() {
+            if !is_reserved_internal_table_name(table_name) {
+                validation_error = Some(format!(
+                    "remote read MemTable source {table_name} is not a reserved inspection source"
+                ));
+                return Ok(TreeNodeRecursion::Stop);
+            }
+            if let Err(error) = validate_internal_read_schema(provider.schema().as_ref(), read) {
+                validation_error = Some(error);
+                return Ok(TreeNodeRecursion::Stop);
+            }
+        } else {
+            validation_error =
+                Some("remote read resolved an unrecognized table provider".to_string());
+            return Ok(TreeNodeRecursion::Stop);
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .map_err(|error| decode_error(error.to_string()))?;
+
+    if let Some(error) = validation_error {
+        return Err(decode_error(error));
+    }
+    if reads_by_table.values().any(|reads| !reads.is_empty()) {
+        return Err(decode_error(
+            "remote read contains ReadRel entries not resolved by the decoded plan",
+        ));
+    }
+    match envelope {
+        Envelope::Target(_) if protected == 0 => Err(decode_error(
+            "remote target contract consumed no protected read",
+        )),
+        Envelope::Internal if protected != 0 => Err(decode_error(
+            "internal remote plan consumed a protected read",
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn validate_target(
+    metadata: &RegionMetadata,
+    contract: &RemoteReadTableV1,
+) -> std::result::Result<(), String> {
+    // TableInfo and RegionMetadata versions are deliberately diagnostic only.
+    if metadata.region_id.table_id() != contract.table_id {
+        return Err(format!(
+            "remote table ID {} does not match region table ID {}",
+            contract.table_id,
+            metadata.region_id.table_id()
+        ));
+    }
+    let mut contract_columns = HashMap::with_capacity(contract.columns.len());
+    for column in &contract.columns {
+        if column.name.is_empty()
+            || column.semantic_type.is_none()
+            || column.is_time_index.is_none()
+            || contract_columns
+                .insert(column.name.as_str(), column)
+                .is_some()
+        {
+            return Err("remote target contract has incomplete or duplicate columns".to_string());
+        }
+    }
+    for expected in contract_columns.values() {
+        let Some(current) = metadata.column_by_name(&expected.name) else {
+            return Err(format!("remote target column {} is missing", expected.name));
+        };
+        let expected_semantic = remote_semantic_to_api(expected.semantic_type.unwrap())?;
+        if expected.column_id != current.column_id
+            || expected_semantic != current.semantic_type
+            || expected.is_time_index != Some(current.semantic_type == SemanticType::Timestamp)
+            || expected.primary_key_ordinal
+                != metadata
+                    .primary_key_index(current.column_id)
+                    .map(|index| index as u32)
+        {
+            return Err(format!(
+                "remote target column {} changed identity or semantic role",
+                expected.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_read_schema(
+    metadata: &RegionMetadata,
+    contract: &RemoteReadTableV1,
+    read_schema: &ReadSchema,
+) -> std::result::Result<(), String> {
+    let contract_columns = contract
+        .columns
+        .iter()
+        .map(|column| (column.name.as_str(), column))
+        .collect::<HashMap<_, _>>();
+    if read_schema.names.len() != contract_columns.len()
+        || read_schema.names.iter().collect::<HashSet<_>>().len() != read_schema.names.len()
+        || read_schema
+            .names
+            .iter()
+            .any(|name| !contract_columns.contains_key(name.as_str()))
+    {
+        return Err("protected read schema does not exactly cover the target contract".to_string());
+    }
+    for (name, expected_type) in read_schema.names.iter().zip(&read_schema.types) {
+        let current = metadata
+            .column_by_name(name)
+            .ok_or_else(|| format!("protected read column {name} is missing"))?;
+        let current_field = Field::new(
+            &current.column_schema.name,
+            current.column_schema.data_type.as_arrow_type(),
+            current.column_schema.is_nullable(),
+        );
+        validate_nullability(expected_type, &current_field)?;
+    }
+    Ok(())
+}
+
+fn validate_internal_read_schema(
+    schema: &datatypes::arrow::datatypes::Schema,
+    read_schema: &ReadSchema,
+) -> std::result::Result<(), String> {
+    for (name, expected_type) in read_schema.names.iter().zip(&read_schema.types) {
+        let actual = schema
+            .field_with_name(name)
+            .map_err(|_| format!("internal inspection column {name} is missing"))?;
+        validate_nullability(expected_type, actual)?;
+    }
+    Ok(())
+}
+
+fn remote_semantic_to_api(value: i32) -> std::result::Result<SemanticType, String> {
+    match RemoteReadSemanticTypeV1::try_from(value) {
+        Ok(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeTag) => Ok(SemanticType::Tag),
+        Ok(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeField) => Ok(SemanticType::Field),
+        Ok(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeTimestamp) => {
+            Ok(SemanticType::Timestamp)
+        }
+        Ok(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeUnspecified) | Err(_) => {
+            Err("remote target contract has an unspecified or invalid semantic type".to_string())
+        }
+    }
+}
+
+fn api_semantic_to_remote(
+    value: SemanticType,
+) -> std::result::Result<RemoteReadSemanticTypeV1, BoxedError> {
+    match value {
+        SemanticType::Tag => Ok(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeTag),
+        SemanticType::Field => Ok(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeField),
+        SemanticType::Timestamp => Ok(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeTimestamp),
+    }
+}
+
+fn validate_nullability(expected: &proto::Type, actual: &Field) -> std::result::Result<(), String> {
+    let kind = expected
+        .kind
+        .as_ref()
+        .ok_or_else(|| "protected read type is unspecified".to_string())?;
+    let nullability = type_nullability(kind).ok_or_else(|| {
+        "protected read type has unsupported or unspecified nullability".to_string()
+    })?;
+    if nullability == proto::r#type::Nullability::Required && actual.is_nullable() {
+        return Err(format!(
+            "protected read field {} changed from required to nullable",
+            actual.name()
+        ));
+    }
+    match kind {
+        proto::r#type::Kind::Struct(expected) => match actual.data_type() {
+            ArrowDataType::Struct(fields) if fields.len() == expected.types.len() => {
+                for (expected, actual) in expected.types.iter().zip(fields) {
+                    validate_nullability(expected, actual)?;
+                }
+            }
+            _ => {
+                return Err(format!(
+                    "protected read struct field {} changed shape",
+                    actual.name()
+                ));
+            }
+        },
+        proto::r#type::Kind::List(expected) => match actual.data_type() {
+            ArrowDataType::List(field)
+            | ArrowDataType::LargeList(field)
+            | ArrowDataType::FixedSizeList(field, _) => {
+                validate_nullability(
+                    expected
+                        .r#type
+                        .as_ref()
+                        .ok_or_else(|| "protected list has no child type".to_string())?,
+                    field,
+                )?;
+            }
+            _ => {
+                return Err(format!(
+                    "protected read list field {} changed shape",
+                    actual.name()
+                ));
+            }
+        },
+        proto::r#type::Kind::Map(expected) => match actual.data_type() {
+            ArrowDataType::Map(entries, _) => match entries.data_type() {
+                ArrowDataType::Struct(fields) if fields.len() == 2 => {
+                    validate_nullability(
+                        expected
+                            .key
+                            .as_ref()
+                            .ok_or_else(|| "protected map has no key type".to_string())?,
+                        &fields[0],
+                    )?;
+                    validate_nullability(
+                        expected
+                            .value
+                            .as_ref()
+                            .ok_or_else(|| "protected map has no value type".to_string())?,
+                        &fields[1],
+                    )?;
+                }
+                _ => {
+                    return Err(format!(
+                        "protected read map field {} changed shape",
+                        actual.name()
+                    ));
+                }
+            },
+            _ => {
+                return Err(format!(
+                    "protected read map field {} changed shape",
+                    actual.name()
+                ));
+            }
+        },
+        _ => {}
+    }
+    Ok(())
+}
+
+fn type_nullability(kind: &proto::r#type::Kind) -> Option<proto::r#type::Nullability> {
+    use proto::r#type::Kind;
+    let nullability = match kind {
+        Kind::Bool(value) => value.nullability,
+        Kind::I8(value) => value.nullability,
+        Kind::I16(value) => value.nullability,
+        Kind::I32(value) => value.nullability,
+        Kind::I64(value) => value.nullability,
+        Kind::Fp32(value) => value.nullability,
+        Kind::Fp64(value) => value.nullability,
+        Kind::String(value) => value.nullability,
+        Kind::Binary(value) => value.nullability,
+        Kind::Timestamp(value) => value.nullability,
+        Kind::Date(value) => value.nullability,
+        Kind::Time(value) => value.nullability,
+        Kind::IntervalYear(value) => value.nullability,
+        Kind::IntervalDay(value) => value.nullability,
+        Kind::IntervalCompound(value) => value.nullability,
+        Kind::TimestampTz(value) => value.nullability,
+        Kind::Uuid(value) => value.nullability,
+        Kind::FixedChar(value) => value.nullability,
+        Kind::Varchar(value) => value.nullability,
+        Kind::FixedBinary(value) => value.nullability,
+        Kind::Decimal(value) => value.nullability,
+        Kind::PrecisionTime(value) => value.nullability,
+        Kind::PrecisionTimestamp(value) => value.nullability,
+        Kind::PrecisionTimestampTz(value) => value.nullability,
+        Kind::Struct(value) => value.nullability,
+        Kind::List(value) => value.nullability,
+        Kind::Map(value) => value.nullability,
+        Kind::UserDefined(value) => value.nullability,
+        Kind::UserDefinedTypeReference(_) | Kind::Alias(_) => return None,
+    };
+    match proto::r#type::Nullability::try_from(nullability).ok()? {
+        proto::r#type::Nullability::Nullable => Some(proto::r#type::Nullability::Nullable),
+        proto::r#type::Nullability::Required => Some(proto::r#type::Nullability::Required),
+        _ => None,
+    }
+}
+
+fn remote_error(message: impl Into<String>) -> BoxedError {
+    BoxedError::new(PlainError::new(
+        message.into(),
+        StatusCode::InvalidArguments,
+    ))
+}
+
+fn decode_error(message: impl Into<String>) -> common_query::error::Error {
+    common_query::error::Error::DecodePlan {
+        source: remote_error(message),
+        location: snafu::location!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::catalog::CatalogProviderList;
+    use datafusion_expr::LogicalPlanBuilder;
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::{ColumnSchema, SchemaBuilder};
+    use session::context::QueryContext;
+    use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
+    use table::metadata::{TableInfoBuilder, TableMeta, TableType};
+    use table::table::adapter::DfTableProviderAdapter;
+    use table::test_util::EmptyTable;
+
+    use super::*;
+    use crate::QueryEngineFactory;
+    use crate::dummy_catalog::DummyCatalogList;
+    use crate::optimizer::test_util::{MetaRegionEngine, mock_table_provider};
+    use crate::options::QueryOptions;
+
+    fn contract_from_current(metadata: &RegionMetadata) -> RemoteReadTableV1 {
+        RemoteReadTableV1 {
+            table_id: metadata.region_id.table_id(),
+            table_version: Some(1),
+            columns: metadata
+                .column_metadatas
+                .iter()
+                .map(|column| RemoteReadColumnV1 {
+                    name: column.column_schema.name.clone(),
+                    column_id: column.column_id,
+                    semantic_type: Some(match column.semantic_type {
+                        SemanticType::Tag => RemoteReadSemanticTypeV1::RemoteReadSemanticTypeTag,
+                        SemanticType::Field => {
+                            RemoteReadSemanticTypeV1::RemoteReadSemanticTypeField
+                        }
+                        SemanticType::Timestamp => {
+                            RemoteReadSemanticTypeV1::RemoteReadSemanticTypeTimestamp
+                        }
+                    } as i32),
+                    is_time_index: Some(column.semantic_type == SemanticType::Timestamp),
+                    primary_key_ordinal: metadata
+                        .primary_key_index(column.column_id)
+                        .map(|index| index as u32),
+                })
+                .collect(),
+        }
+    }
+
+    fn encoder_table_info(table_id: u32, version: u64) -> TableInfo {
+        let schema = Arc::new(
+            SchemaBuilder::try_from_columns(vec![
+                ColumnSchema::new("k0", ConcreteDataType::string_datatype(), true),
+                ColumnSchema::new(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                )
+                .with_time_index(true),
+                ColumnSchema::new("v0", ConcreteDataType::float64_datatype(), false),
+            ])
+            .unwrap()
+            .build()
+            .unwrap(),
+        );
+        TableInfoBuilder::default()
+            .table_id(table_id)
+            .table_version(version)
+            .name("remote_codec")
+            .meta(TableMeta {
+                schema,
+                primary_key_indices: vec![0],
+                value_indices: vec![1, 2],
+                engine: "mito".to_string(),
+                next_column_id: 4,
+                options: Default::default(),
+                created_on: Default::default(),
+                updated_on: Default::default(),
+                partition_key_indices: vec![],
+                column_ids: vec![1, 2, 3],
+            })
+            .table_type(TableType::Base)
+            .build()
+            .unwrap()
+    }
+
+    fn primary_key_order_table_info(engine: &str) -> TableInfo {
+        let schema = Arc::new(
+            SchemaBuilder::try_from_columns(vec![
+                ColumnSchema::new("z", ConcreteDataType::string_datatype(), false),
+                ColumnSchema::new("a", ConcreteDataType::string_datatype(), false),
+                ColumnSchema::new(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                )
+                .with_time_index(true),
+                ColumnSchema::new("value", ConcreteDataType::float64_datatype(), true),
+            ])
+            .unwrap()
+            .build()
+            .unwrap(),
+        );
+        TableInfoBuilder::default()
+            .table_id(88)
+            .table_version(1)
+            .name("metric_primary_key_order")
+            .meta(TableMeta {
+                schema,
+                // Deliberately declared as (z, a), not alphabetical.
+                primary_key_indices: vec![0, 1],
+                value_indices: vec![2, 3],
+                engine: engine.to_string(),
+                next_column_id: 100,
+                options: Default::default(),
+                created_on: Default::default(),
+                updated_on: Default::default(),
+                partition_key_indices: vec![],
+                // These are stable IDs sourced from the physical metric table.
+                column_ids: vec![71, 41, 2, 99],
+            })
+            .table_type(TableType::Base)
+            .build()
+            .unwrap()
+    }
+
+    fn adapter_plan(table_id: u32) -> LogicalPlan {
+        let info = encoder_table_info(table_id, 7);
+        let table = EmptyTable::from_table_info(&info);
+        let source = Arc::new(DefaultTableSource::new(Arc::new(
+            DfTableProviderAdapter::new(table),
+        )));
+        LogicalPlanBuilder::scan("remote_codec", source, None)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    fn dn_column(
+        name: &str,
+        data_type: ConcreteDataType,
+        nullable: bool,
+        semantic_type: SemanticType,
+        column_id: u32,
+    ) -> ColumnMetadata {
+        ColumnMetadata {
+            column_schema: ColumnSchema::new(name, data_type, nullable),
+            semantic_type,
+            column_id,
+        }
+    }
+
+    fn dn_metadata(
+        region_id: RegionId,
+        columns: Vec<ColumnMetadata>,
+        primary_key: Vec<u32>,
+    ) -> RegionMetadata {
+        let mut builder = RegionMetadataBuilder::new(region_id);
+        for column in columns {
+            builder.push_column_metadata(column);
+        }
+        builder.primary_key(primary_key);
+        builder.build().unwrap()
+    }
+
+    fn standard_dn_metadata(region_id: RegionId) -> RegionMetadata {
+        dn_metadata(
+            region_id,
+            vec![
+                dn_column(
+                    "k0",
+                    ConcreteDataType::string_datatype(),
+                    true,
+                    SemanticType::Tag,
+                    1,
+                ),
+                dn_column(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                    SemanticType::Timestamp,
+                    2,
+                ),
+                dn_column(
+                    "v0",
+                    ConcreteDataType::float64_datatype(),
+                    false,
+                    SemanticType::Field,
+                    3,
+                ),
+            ],
+            vec![1],
+        )
+    }
+
+    fn provider_with_metadata(metadata: RegionMetadata) -> DummyTableProvider {
+        let region_id = metadata.region_id;
+        let metadata = Arc::new(metadata);
+        let engine = Arc::new(MetaRegionEngine::with_metadata(metadata.clone()));
+        DummyTableProvider::new(region_id, engine, metadata)
+    }
+
+    fn remote_decoder() -> common_query::logical_plan::SubstraitPlanDecoderRef {
+        let catalog_manager = catalog::memory::new_memory_catalog_manager().unwrap();
+        let factory = QueryEngineFactory::new(
+            catalog_manager,
+            None,
+            None,
+            None,
+            None,
+            false,
+            QueryOptions::default(),
+        );
+        factory
+            .query_engine()
+            .engine_context(QueryContext::arc())
+            .new_plan_decoder()
+            .unwrap()
+    }
+
+    async fn decode_with_provider(
+        message: Bytes,
+        provider: DummyTableProvider,
+    ) -> common_query::error::Result<LogicalPlan> {
+        let decoder = remote_decoder();
+        let catalog_list: Arc<dyn CatalogProviderList> =
+            Arc::new(DummyCatalogList::with_table_provider(Arc::new(provider)));
+        decode_remote_plan(decoder.as_ref(), message, catalog_list).await
+    }
+
+    fn encoded_remote_plan(region_id: RegionId) -> Bytes {
+        encode_remote_plan(&adapter_plan(region_id.table_id()), region_id).unwrap()
+    }
+
+    fn inspection_memtable_plan(name: &str) -> LogicalPlan {
+        let schema = Arc::new(datatypes::arrow::datatypes::Schema::empty());
+        let provider = Arc::new(MemTable::try_new(schema, vec![vec![]]).unwrap());
+        LogicalPlanBuilder::scan(name, Arc::new(DefaultTableSource::new(provider)), None)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_accepts_matching_fe_and_dn_schema() {
+        let region_id = RegionId::new(42, 1);
+        let plan = decode_with_provider(
+            encoded_remote_plan(region_id),
+            mock_table_provider(region_id),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_rejects_required_to_nullable_drift() {
+        let region_id = RegionId::new(42, 1);
+        let mut metadata = standard_dn_metadata(region_id);
+        metadata.column_metadatas[2].column_schema =
+            ColumnSchema::new("v0", ConcreteDataType::float64_datatype(), true);
+        let metadata = RegionMetadataBuilder::from_existing(metadata)
+            .build()
+            .unwrap();
+
+        assert!(
+            decode_with_provider(
+                encoded_remote_plan(region_id),
+                provider_with_metadata(metadata)
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_accepts_nullable_to_required_drift() {
+        let region_id = RegionId::new(42, 1);
+        let mut metadata = standard_dn_metadata(region_id);
+        metadata.column_metadatas[0].column_schema =
+            ColumnSchema::new("k0", ConcreteDataType::string_datatype(), false);
+        let metadata = RegionMetadataBuilder::from_existing(metadata)
+            .build()
+            .unwrap();
+
+        assert!(
+            decode_with_provider(
+                encoded_remote_plan(region_id),
+                provider_with_metadata(metadata),
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_rejects_changed_stable_column_id() {
+        let region_id = RegionId::new(42, 1);
+        let metadata = dn_metadata(
+            region_id,
+            vec![
+                dn_column(
+                    "k0",
+                    ConcreteDataType::string_datatype(),
+                    true,
+                    SemanticType::Tag,
+                    11,
+                ),
+                dn_column(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                    SemanticType::Timestamp,
+                    2,
+                ),
+                dn_column(
+                    "v0",
+                    ConcreteDataType::float64_datatype(),
+                    false,
+                    SemanticType::Field,
+                    3,
+                ),
+            ],
+            vec![11],
+        );
+
+        assert!(
+            decode_with_provider(
+                encoded_remote_plan(region_id),
+                provider_with_metadata(metadata)
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_accepts_reordered_schema_with_added_column() {
+        let region_id = RegionId::new(42, 1);
+        let metadata = dn_metadata(
+            region_id,
+            vec![
+                dn_column(
+                    "v0",
+                    ConcreteDataType::float64_datatype(),
+                    false,
+                    SemanticType::Field,
+                    3,
+                ),
+                dn_column(
+                    "extra",
+                    ConcreteDataType::int64_datatype(),
+                    true,
+                    SemanticType::Field,
+                    4,
+                ),
+                dn_column(
+                    "k0",
+                    ConcreteDataType::string_datatype(),
+                    true,
+                    SemanticType::Tag,
+                    1,
+                ),
+                dn_column(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                    SemanticType::Timestamp,
+                    2,
+                ),
+            ],
+            vec![1],
+        );
+
+        assert!(
+            decode_with_provider(
+                encoded_remote_plan(region_id),
+                provider_with_metadata(metadata)
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_rejects_missing_or_type_changed_column() {
+        let region_id = RegionId::new(42, 1);
+        let mut missing = standard_dn_metadata(region_id);
+        missing.column_metadatas.pop();
+        let missing = RegionMetadataBuilder::from_existing(missing)
+            .build()
+            .unwrap();
+        assert!(
+            decode_with_provider(
+                encoded_remote_plan(region_id),
+                provider_with_metadata(missing)
+            )
+            .await
+            .is_err()
+        );
+
+        let mut changed_type = standard_dn_metadata(region_id);
+        changed_type.column_metadatas[2].column_schema =
+            ColumnSchema::new("v0", ConcreteDataType::int64_datatype(), false);
+        let changed_type = RegionMetadataBuilder::from_existing(changed_type)
+            .build()
+            .unwrap();
+        assert!(
+            decode_with_provider(
+                encoded_remote_plan(region_id),
+                provider_with_metadata(changed_type),
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_decoder_rejects_wrapped_remote_plan() {
+        let region_id = RegionId::new(42, 1);
+        let decoder = remote_decoder();
+        let catalog_list: Arc<dyn CatalogProviderList> =
+            Arc::new(DummyCatalogList::with_table_provider(Arc::new(
+                provider_with_metadata(standard_dn_metadata(region_id)),
+            )));
+
+        assert!(
+            decoder
+                .decode(encoded_remote_plan(region_id), catalog_list, false)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_rejects_missing_or_unknown_envelope() {
+        let region_id = RegionId::new(42, 1);
+        assert!(
+            decode_with_provider(
+                Bytes::from(rooted_plan().encode_to_vec()),
+                mock_table_provider(region_id),
+            )
+            .await
+            .is_err()
+        );
+
+        let input = Some(Box::new(proto::Rel {
+            rel_type: Some(proto::rel::RelType::Read(Box::default())),
+        }));
+        let plan = plan_with_envelope(
+            Some(Any {
+                type_url: "type.googleapis.com/substrait_extension.RemoteReadTableV2".to_string(),
+                value: vec![].into(),
+            }),
+            input,
+        );
+        assert!(
+            decode_with_provider(
+                Bytes::from(plan.encode_to_vec()),
+                mock_table_provider(region_id),
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_rejects_internal_envelope_with_region_provider() {
+        let region_id = RegionId::new(42, 1);
+        let mut plan = proto::Plan::decode(encoded_remote_plan(region_id).as_ref()).unwrap();
+        unwrap_root(&mut plan).unwrap();
+        wrap_root(
+            &mut plan,
+            Any {
+                type_url: REMOTE_READ_INTERNAL_V1_TYPE_URL.to_string(),
+                value: RemoteReadInternalV1 {}.encode_to_vec().into(),
+            },
+        )
+        .unwrap();
+        assert!(
+            decode_with_provider(
+                Bytes::from(plan.encode_to_vec()),
+                mock_table_provider(region_id),
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_encode_real_adapter_contract_and_request_identity() {
+        let plan = adapter_plan(42);
+        let bytes = encode_remote_plan(&plan, RegionId::new(42, 1)).unwrap();
+        let mut plan = proto::Plan::decode(bytes.as_ref()).unwrap();
+        let Envelope::Target(contract) = unwrap_root(&mut plan).unwrap() else {
+            panic!("expected target envelope");
+        };
+        assert_eq!(42, contract.table_id);
+        assert_eq!(Some(7), contract.table_version);
+        assert_eq!(
+            vec![1, 2, 3],
+            contract
+                .columns
+                .iter()
+                .map(|column| column.column_id)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(Some(0), contract.columns[0].primary_key_ordinal);
+        assert_eq!(Some(true), contract.columns[1].is_time_index);
+        assert!(encode_remote_plan(&plan_from_adapter(42), RegionId::new(43, 1)).is_err());
+    }
+
+    #[test]
+    fn test_encode_rejects_multiple_real_protected_table_ids() {
+        let left = adapter_plan(42);
+        let right = adapter_plan(43);
+        let plan = LogicalPlanBuilder::from(left)
+            .union(right)
+            .unwrap()
+            .build()
+            .unwrap();
+        assert!(encode_remote_plan(&plan, RegionId::new(42, 1)).is_err());
+    }
+
+    #[test]
+    fn test_encode_classifies_only_reserved_memtables_as_internal() {
+        let internal =
+            inspection_memtable_plan(ManifestSstEntry::reserved_table_name_for_inspection());
+        let bytes = encode_remote_plan(&internal, RegionId::new(42, 1)).unwrap();
+        let mut plan = proto::Plan::decode(bytes.as_ref()).unwrap();
+        assert!(matches!(unwrap_root(&mut plan), Ok(Envelope::Internal)));
+
+        assert!(
+            encode_remote_plan(
+                &inspection_memtable_plan("unrecognized_memtable"),
+                RegionId::new(42, 1),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_encode_allows_target_with_reserved_inspection_source() {
+        let target = adapter_plan(42);
+        let inspection =
+            inspection_memtable_plan(ManifestSstEntry::reserved_table_name_for_inspection());
+        let plan = LogicalPlanBuilder::from(target)
+            .cross_join(inspection)
+            .unwrap()
+            .build()
+            .unwrap();
+        let bytes = encode_remote_plan(&plan, RegionId::new(42, 1)).unwrap();
+        let mut plan = proto::Plan::decode(bytes.as_ref()).unwrap();
+        assert!(matches!(unwrap_root(&mut plan), Ok(Envelope::Target(_))));
+    }
+
+    #[test]
+    fn test_read_schema_rejects_distinct_qualified_references_with_same_bare_name() {
+        let read = |reference: &[&str]| ReadSchema {
+            table_name: "same".to_string(),
+            table_reference: reference.iter().map(|part| (*part).to_string()).collect(),
+            names: vec![],
+            types: vec![],
+        };
+        assert!(
+            validate_decoded_sources(
+                &adapter_plan(42),
+                &Envelope::Internal,
+                &[
+                    read(&["catalog_a", "public", "same"]),
+                    read(&["catalog_b", "public", "same"])
+                ]
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_same_table_duplicate_scans_remain_unambiguous() {
+        let left = adapter_plan(42);
+        let plan = LogicalPlanBuilder::from(left.clone())
+            .union(left)
+            .unwrap()
+            .build()
+            .unwrap();
+        assert!(encode_remote_plan(&plan, RegionId::new(42, 1)).is_ok());
+    }
+
+    fn plan_from_adapter(table_id: u32) -> LogicalPlan {
+        adapter_plan(table_id)
+    }
+
+    #[test]
+    fn test_target_allows_added_unrelated_current_column() {
+        let provider = mock_table_provider(RegionId::new(1024, 1));
+        let metadata = provider.region_metadata();
+        let mut contract = contract_from_current(&metadata);
+        contract.columns.pop();
+
+        assert!(validate_target(&metadata, &contract).is_ok());
+    }
+
+    #[test]
+    fn test_target_rejects_changed_column_id_and_unspecified_semantic_type() {
+        let provider = mock_table_provider(RegionId::new(1024, 1));
+        let metadata = provider.region_metadata();
+        let mut contract = contract_from_current(&metadata);
+        contract.columns[0].column_id += 100;
+        assert!(validate_target(&metadata, &contract).is_err());
+
+        let mut contract = contract_from_current(&metadata);
+        contract.columns[0].semantic_type =
+            Some(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeUnspecified as i32);
+        assert!(validate_target(&metadata, &contract).is_err());
+    }
+
+    #[test]
+    fn test_target_contract_compatibility_matrix() {
+        let provider = mock_table_provider(RegionId::new(1024, 1));
+        let metadata = provider.region_metadata();
+
+        let contract = contract_from_current(&metadata);
+        assert!(validate_target(&metadata, &contract).is_ok());
+
+        let mut changed = contract.clone();
+        changed.table_id += 1;
+        assert!(validate_target(&metadata, &changed).is_err());
+
+        let mut changed = contract.clone();
+        changed.columns[0].name = "missing".to_string();
+        assert!(validate_target(&metadata, &changed).is_err());
+
+        let mut changed = contract.clone();
+        changed.columns[0].semantic_type =
+            Some(RemoteReadSemanticTypeV1::RemoteReadSemanticTypeField as i32);
+        assert!(validate_target(&metadata, &changed).is_err());
+
+        let time_index = contract
+            .columns
+            .iter()
+            .position(|column| column.is_time_index == Some(true))
+            .expect("mock metadata has a time index");
+        let mut changed = contract.clone();
+        changed.columns[time_index].is_time_index = Some(false);
+        assert!(validate_target(&metadata, &changed).is_err());
+
+        let mut changed = contract.clone();
+        changed.columns[0].primary_key_ordinal = None;
+        assert!(validate_target(&metadata, &changed).is_err());
+
+        let mut changed = contract.clone();
+        changed.columns[0].semantic_type = None;
+        assert!(validate_target(&metadata, &changed).is_err());
+
+        let mut changed = contract.clone();
+        changed.columns[0].is_time_index = None;
+        assert!(validate_target(&metadata, &changed).is_err());
+
+        let mut compatible = contract.clone();
+        compatible.columns.reverse();
+        compatible.table_version = Some(999);
+        assert!(validate_target(&metadata, &compatible).is_ok());
+    }
+
+    #[test]
+    fn test_metric_engine_primary_key_ordinal_matches_logical_region_metadata() {
+        let table =
+            primary_key_order_table_info(store_api::metric_engine_consts::METRIC_ENGINE_NAME);
+        let contract = table_contract(&table).unwrap();
+        let ordinal = |name: &str| {
+            contract
+                .columns
+                .iter()
+                .find(|column| column.name == name)
+                .unwrap()
+                .primary_key_ordinal
+        };
+        // MetricEngineInner::load_logical_columns sorts logical columns by name
+        // before RegionMetadata derives primary_key IDs (read.rs:239-268).
+        assert_eq!(Some(0), ordinal("a"));
+        assert_eq!(Some(1), ordinal("z"));
+
+        let metadata = dn_metadata(
+            RegionId::new(88, 1),
+            vec![
+                dn_column(
+                    "a",
+                    ConcreteDataType::string_datatype(),
+                    false,
+                    SemanticType::Tag,
+                    41,
+                ),
+                dn_column(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                    SemanticType::Timestamp,
+                    2,
+                ),
+                dn_column(
+                    "value",
+                    ConcreteDataType::float64_datatype(),
+                    true,
+                    SemanticType::Field,
+                    99,
+                ),
+                dn_column(
+                    "z",
+                    ConcreteDataType::string_datatype(),
+                    false,
+                    SemanticType::Tag,
+                    71,
+                ),
+            ],
+            // This mirrors the logical metadata synthesized from alphabetically
+            // ordered logical columns, with no physical reserved columns.
+            vec![41, 71],
+        );
+        assert!(validate_target(&metadata, &contract).is_ok());
+    }
+
+    #[test]
+    fn test_ordinary_engine_primary_key_ordinal_preserves_declared_order() {
+        let table = primary_key_order_table_info("mito");
+        let contract = table_contract(&table).unwrap();
+        let ordinal = |name: &str| {
+            contract
+                .columns
+                .iter()
+                .find(|column| column.name == name)
+                .unwrap()
+                .primary_key_ordinal
+        };
+        assert_eq!(Some(0), ordinal("z"));
+        assert_eq!(Some(1), ordinal("a"));
+    }
+
+    fn scalar_type(nullability: i32) -> proto::Type {
+        proto::Type {
+            kind: Some(proto::r#type::Kind::I64(proto::r#type::I64 {
+                type_variation_reference: 0,
+                nullability,
+            })),
+        }
+    }
+
+    #[test]
+    fn test_raw_nullability_direction_is_fail_closed() {
+        let nullable = Field::new("x", ArrowDataType::Int64, true);
+        let required = Field::new("x", ArrowDataType::Int64, false);
+        assert!(
+            validate_nullability(
+                &scalar_type(proto::r#type::Nullability::Required as i32),
+                &nullable
+            )
+            .is_err()
+        );
+        assert!(
+            validate_nullability(
+                &scalar_type(proto::r#type::Nullability::Nullable as i32),
+                &required
+            )
+            .is_ok()
+        );
+        assert!(validate_nullability(&scalar_type(0), &required).is_err());
+    }
+
+    #[test]
+    fn test_raw_nested_nullability_direction_is_fail_closed() {
+        let required_child = scalar_type(proto::r#type::Nullability::Required as i32);
+        let struct_type = proto::Type {
+            kind: Some(proto::r#type::Kind::Struct(proto::r#type::Struct {
+                types: vec![required_child.clone()],
+                type_variation_reference: 0,
+                nullability: proto::r#type::Nullability::Nullable as i32,
+            })),
+        };
+        let struct_field = Field::new(
+            "s",
+            ArrowDataType::Struct(
+                vec![std::sync::Arc::new(Field::new(
+                    "child",
+                    ArrowDataType::Int64,
+                    true,
+                ))]
+                .into(),
+            ),
+            false,
+        );
+        assert!(validate_nullability(&struct_type, &struct_field).is_err());
+
+        let list_type = proto::Type {
+            kind: Some(proto::r#type::Kind::List(Box::new(proto::r#type::List {
+                r#type: Some(Box::new(required_child.clone())),
+                type_variation_reference: 0,
+                nullability: proto::r#type::Nullability::Nullable as i32,
+            }))),
+        };
+        let list_field = Field::new(
+            "l",
+            ArrowDataType::List(std::sync::Arc::new(Field::new(
+                "item",
+                ArrowDataType::Int64,
+                true,
+            ))),
+            false,
+        );
+        assert!(validate_nullability(&list_type, &list_field).is_err());
+
+        let map_type = proto::Type {
+            kind: Some(proto::r#type::Kind::Map(Box::new(proto::r#type::Map {
+                key: Some(Box::new(scalar_type(
+                    proto::r#type::Nullability::Nullable as i32,
+                ))),
+                value: Some(Box::new(required_child)),
+                type_variation_reference: 0,
+                nullability: proto::r#type::Nullability::Nullable as i32,
+            }))),
+        };
+        let entries = Field::new(
+            "entries",
+            ArrowDataType::Struct(
+                vec![
+                    std::sync::Arc::new(Field::new("key", ArrowDataType::Int64, false)),
+                    std::sync::Arc::new(Field::new("value", ArrowDataType::Int64, true)),
+                ]
+                .into(),
+            ),
+            false,
+        );
+        let map_field = Field::new(
+            "m",
+            ArrowDataType::Map(std::sync::Arc::new(entries), false),
+            false,
+        );
+        assert!(validate_nullability(&map_type, &map_field).is_err());
+    }
+
+    #[test]
+    fn test_named_struct_extracts_top_level_names_after_nested_flattening() {
+        use proto::r#type::{List, Map, Struct};
+
+        let required = || scalar_type(proto::r#type::Nullability::Required as i32);
+        let nested_struct = proto::Type {
+            kind: Some(proto::r#type::Kind::Struct(Struct {
+                types: vec![required()],
+                type_variation_reference: 0,
+                nullability: proto::r#type::Nullability::Nullable as i32,
+            })),
+        };
+        let list_of_struct = proto::Type {
+            kind: Some(proto::r#type::Kind::List(Box::new(List {
+                r#type: Some(Box::new(nested_struct.clone())),
+                type_variation_reference: 0,
+                nullability: proto::r#type::Nullability::Nullable as i32,
+            }))),
+        };
+        let map_of_struct = proto::Type {
+            kind: Some(proto::r#type::Kind::Map(Box::new(Map {
+                key: Some(Box::new(required())),
+                value: Some(Box::new(nested_struct.clone())),
+                type_variation_reference: 0,
+                nullability: proto::r#type::Nullability::Nullable as i32,
+            }))),
+        };
+        let named = proto::NamedStruct {
+            // This is the exact flattening order emitted by DataFusion 53.
+            names: vec!["s", "s_child", "l", "l_child", "m", "m_value_child"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            r#struct: Some(Struct {
+                types: vec![nested_struct, list_of_struct, map_of_struct],
+                type_variation_reference: 0,
+                nullability: proto::r#type::Nullability::Required as i32,
+            }),
+        };
+        let (names, types) =
+            extract_top_level_named_struct(&named, named.r#struct.as_ref().unwrap()).unwrap();
+        assert_eq!(names, vec!["s", "l", "m"]);
+        assert_eq!(types.len(), 3);
+    }
+
+    #[derive(Clone, Copy)]
+    enum RawSubqueryForm {
+        Scalar,
+        InPredicate,
+        SetPredicate,
+        SetComparison,
+    }
+
+    fn raw_subquery(form: RawSubqueryForm) -> proto::Expression {
+        use proto::expression::subquery::{
+            InPredicate, Scalar, SetComparison, SetPredicate, SubqueryType,
+        };
+
+        let subquery_type = match form {
+            RawSubqueryForm::Scalar => SubqueryType::Scalar(Box::new(Scalar { input: None })),
+            RawSubqueryForm::InPredicate => SubqueryType::InPredicate(Box::new(InPredicate {
+                needles: vec![],
+                haystack: None,
+            })),
+            RawSubqueryForm::SetPredicate => SubqueryType::SetPredicate(Box::new(SetPredicate {
+                predicate_op: 0,
+                tuples: None,
+            })),
+            RawSubqueryForm::SetComparison => {
+                SubqueryType::SetComparison(Box::new(SetComparison {
+                    reduction_op: 0,
+                    comparison_op: 0,
+                    left: None,
+                    right: None,
+                }))
+            }
+        };
+        proto::Expression {
+            rex_type: Some(proto::expression::RexType::Subquery(Box::new(
+                proto::expression::Subquery {
+                    subquery_type: Some(subquery_type),
+                },
+            ))),
+        }
+    }
+
+    fn rel_with_filter(expression: proto::Expression) -> proto::Rel {
+        proto::Rel {
+            rel_type: Some(proto::rel::RelType::Filter(Box::new(proto::FilterRel {
+                common: None,
+                input: None,
+                condition: Some(Box::new(expression)),
+                advanced_extension: None,
+            }))),
+        }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_raw_substrait_subquery_forms_and_placements_are_rejected() {
+        let forms = [
+            RawSubqueryForm::Scalar,
+            RawSubqueryForm::InPredicate,
+            RawSubqueryForm::SetPredicate,
+            RawSubqueryForm::SetComparison,
+        ];
+        for form in forms {
+            assert!(reject_raw_subqueries(&rel_with_filter(raw_subquery(form))).is_err());
+        }
+
+        let nested = proto::Expression {
+            rex_type: Some(proto::expression::RexType::Nested(
+                proto::expression::Nested {
+                    nullable: false,
+                    type_variation_reference: 0,
+                    nested_type: Some(proto::expression::nested::NestedType::Struct(
+                        proto::expression::nested::Struct {
+                            fields: vec![raw_subquery(RawSubqueryForm::Scalar)],
+                        },
+                    )),
+                },
+            )),
+        };
+        let field_reference = proto::expression::FieldReference {
+            reference_type: None,
+            root_type: Some(proto::expression::field_reference::RootType::Expression(
+                Box::new(raw_subquery(RawSubqueryForm::InPredicate)),
+            )),
+        };
+        let virtual_table = proto::Rel {
+            rel_type: Some(proto::rel::RelType::Read(Box::new(proto::ReadRel {
+                common: None,
+                base_schema: None,
+                filter: None,
+                best_effort_filter: None,
+                projection: None,
+                advanced_extension: None,
+                read_type: Some(proto::read_rel::ReadType::VirtualTable(
+                    proto::read_rel::VirtualTable {
+                        values: vec![],
+                        expressions: vec![proto::expression::nested::Struct {
+                            fields: vec![raw_subquery(RawSubqueryForm::SetPredicate)],
+                        }],
+                    },
+                )),
+            }))),
+        };
+        let exchange = proto::Rel {
+            rel_type: Some(proto::rel::RelType::Exchange(Box::new(
+                proto::ExchangeRel {
+                    common: None,
+                    input: None,
+                    partition_count: 0,
+                    targets: vec![],
+                    advanced_extension: None,
+                    exchange_kind: Some(proto::exchange_rel::ExchangeKind::ScatterByFields(
+                        proto::exchange_rel::ScatterFields {
+                            fields: vec![field_reference],
+                        },
+                    )),
+                },
+            ))),
+        };
+
+        assert!(reject_raw_subqueries(&rel_with_filter(nested)).is_err());
+        assert!(reject_raw_subqueries(&virtual_table).is_err());
+        assert!(reject_raw_subqueries(&exchange).is_err());
+    }
+
+    #[test]
+    fn test_raw_substrait_literal_containing_subquery_is_accepted() {
+        let literal = proto::Expression {
+            rex_type: Some(proto::expression::RexType::Literal(
+                proto::expression::Literal {
+                    nullable: false,
+                    type_variation_reference: 0,
+                    literal_type: Some(proto::expression::literal::LiteralType::String(
+                        "Subquery(".to_string(),
+                    )),
+                },
+            )),
+        };
+
+        assert!(reject_raw_subqueries(&rel_with_filter(literal)).is_ok());
+    }
+
+    #[test]
+    fn test_internal_envelope_uses_generated_marker() {
+        let detail = Any {
+            type_url: REMOTE_READ_INTERNAL_V1_TYPE_URL.to_string(),
+            value: RemoteReadInternalV1 {}.encode_to_vec().into(),
+        };
+        assert!(RemoteReadInternalV1::decode(detail.value.as_ref()).is_ok());
+        assert_eq!(detail.type_url, REMOTE_READ_INTERNAL_V1_TYPE_URL);
+    }
+
+    fn rooted_plan() -> proto::Plan {
+        proto::Plan {
+            relations: vec![proto::PlanRel {
+                rel_type: Some(proto::plan_rel::RelType::Root(proto::RelRoot {
+                    input: Some(proto::Rel {
+                        rel_type: Some(proto::rel::RelType::Read(Box::default())),
+                    }),
+                    names: vec![],
+                })),
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn plan_with_envelope(detail: Option<Any>, input: Option<Box<proto::Rel>>) -> proto::Plan {
+        proto::Plan {
+            relations: vec![proto::PlanRel {
+                rel_type: Some(proto::plan_rel::RelType::Root(proto::RelRoot {
+                    input: Some(proto::Rel {
+                        rel_type: Some(proto::rel::RelType::ExtensionSingle(Box::new(
+                            proto::ExtensionSingleRel {
+                                common: None,
+                                detail,
+                                input,
+                            },
+                        ))),
+                    }),
+                    names: vec![],
+                })),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_root_envelope_roundtrip_and_rejection_matrix() {
+        let provider = mock_table_provider(RegionId::new(1024, 1));
+        let contract = contract_from_current(&provider.region_metadata());
+        let mut plan = rooted_plan();
+        wrap_root(
+            &mut plan,
+            Any {
+                type_url: REMOTE_READ_TABLE_V1_TYPE_URL.to_string(),
+                value: contract.encode_to_vec().into(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(unwrap_root(&mut plan), Ok(Envelope::Target(_))));
+
+        let mut plan = rooted_plan();
+        wrap_root(
+            &mut plan,
+            Any {
+                type_url: REMOTE_READ_INTERNAL_V1_TYPE_URL.to_string(),
+                value: RemoteReadInternalV1 {}.encode_to_vec().into(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(unwrap_root(&mut plan), Ok(Envelope::Internal)));
+
+        assert!(unwrap_root(&mut rooted_plan()).is_err());
+
+        let input = Some(Box::new(proto::Rel {
+            rel_type: Some(proto::rel::RelType::Read(Box::default())),
+        }));
+        assert!(unwrap_root(&mut plan_with_envelope(None, input.clone())).is_err());
+        assert!(
+            unwrap_root(&mut plan_with_envelope(
+                Some(Any {
+                    type_url: REMOTE_READ_TABLE_V1_TYPE_URL.to_string(),
+                    value: vec![0xff].into(),
+                }),
+                input.clone(),
+            ))
+            .is_err()
+        );
+        assert!(
+            unwrap_root(&mut plan_with_envelope(
+                Some(Any {
+                    type_url: REMOTE_READ_INTERNAL_V1_TYPE_URL.to_string(),
+                    value: vec![0xff].into(),
+                }),
+                input.clone(),
+            ))
+            .is_err()
+        );
+        assert!(
+            unwrap_root(&mut plan_with_envelope(
+                Some(Any {
+                    type_url: "type.googleapis.com/substrait_extension.RemoteReadTableV2"
+                        .to_string(),
+                    value: vec![].into(),
+                }),
+                input.clone(),
+            ))
+            .is_err()
+        );
+        assert!(
+            unwrap_root(&mut plan_with_envelope(
+                Some(Any {
+                    type_url: REMOTE_READ_INTERNAL_V1_TYPE_URL.to_string(),
+                    value: RemoteReadInternalV1 {}.encode_to_vec().into(),
+                }),
+                None,
+            ))
+            .is_err()
+        );
+    }
+}

--- a/src/query/src/query_engine/remote_plan_codec.rs
+++ b/src/query/src/query_engine/remote_plan_codec.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use api::v1::SemanticType;
 use bytes::Bytes;
-use common_error::ext::{BoxedError, PlainError};
+use common_error::ext::{BoxedError, PlainError, RetryHint};
 use common_error::status_code::StatusCode;
 use common_query::logical_plan::SubstraitPlanDecoder;
 use datafusion::catalog::{CatalogProviderList, MemTable};
@@ -140,9 +140,19 @@ pub async fn decode_remote_plan(
 ) -> common_query::error::Result<LogicalPlan> {
     let mut plan =
         proto::Plan::decode(message.as_ref()).map_err(|error| decode_error(error.to_string()))?;
+
+    // Plans without the v1 root envelope were produced by an older frontend.
+    // During rolling upgrades a mixed FE/DN cluster must keep working, so decode
+    // them with the base semantics: the DataFusion fork's schema-compatibility
+    // check still fails safely on column drop/rename/type-change.
+    if is_legacy_unwrapped_root(&plan) {
+        return decoder
+            .decode(Bytes::from(plan.encode_to_vec()), catalog_list, false)
+            .await;
+    }
+
     let envelope = unwrap_root(&mut plan)?;
     let read_schemas = collect_read_schemas(root_input(&plan).map_err(decode_error)?)?;
-    reject_raw_subqueries(root_input(&plan).map_err(decode_error)?)?;
 
     let plan = decoder
         // A remote plan is always decoded unoptimized. Validation must observe
@@ -151,6 +161,15 @@ pub async fn decode_remote_plan(
         .await?;
     validate_decoded_sources(&plan, &envelope, &read_schemas)?;
     Ok(plan)
+}
+
+/// Returns whether `plan` is a legacy remote-read plan encoded without the v1
+/// root envelope, i.e. its root relation is not an [`proto::ExtensionSingleRel`].
+fn is_legacy_unwrapped_root(plan: &proto::Plan) -> bool {
+    match root_input(plan) {
+        Ok(root) => !matches!(root.rel_type, Some(proto::rel::RelType::ExtensionSingle(_))),
+        Err(_) => false,
+    }
 }
 
 fn extract_target_table(
@@ -481,15 +500,13 @@ fn collect_read_schemas_inner(
             collect_optional_input(rel.left.as_ref(), reads)?;
             collect_optional_input(rel.right.as_ref(), reads)?;
         }
-        RelType::Write(_)
-        | RelType::Ddl(_)
-        | RelType::ExtensionLeaf(_)
-        | RelType::Reference(_)
-        | RelType::Update(_) => {
-            return Err(decode_error(
-                "unsupported relation shape at the remote-read boundary",
-            ));
-        }
+        // The walk only collects ReadRels; it does not fail-closed on relation
+        // shapes. Every decoded scan is still matched against the collected
+        // ReadRels by `validate_decoded_sources`, so a scan that was never
+        // collected still fails validation.
+        RelType::Write(write) => collect_optional_input(write.input.as_ref(), reads)?,
+        RelType::Ddl(ddl) => collect_optional_input(ddl.view_definition.as_ref(), reads)?,
+        RelType::Update(_) | RelType::ExtensionLeaf(_) | RelType::Reference(_) => {}
     }
     Ok(())
 }
@@ -577,304 +594,6 @@ fn consume_flattened_type_name(
         _ => {}
     }
     Ok(own_name)
-}
-
-fn reject_raw_subqueries(root: &proto::Rel) -> common_query::error::Result<()> {
-    reject_raw_subqueries_in_rel(root)
-}
-
-fn reject_raw_subqueries_in_rel(rel: &proto::Rel) -> common_query::error::Result<()> {
-    use proto::rel::RelType;
-
-    let Some(rel_type) = rel.rel_type.as_ref() else {
-        return Ok(());
-    };
-    match rel_type {
-        RelType::Read(read) => {
-            reject_raw_subqueries_in_exprs([
-                read.filter.as_deref(),
-                read.best_effort_filter.as_deref(),
-            ])?;
-            if let Some(proto::read_rel::ReadType::VirtualTable(table)) = read.read_type.as_ref() {
-                for expression in &table.expressions {
-                    reject_raw_subqueries_in_exprs(expression.fields.iter().map(Some))?;
-                }
-            }
-        }
-        RelType::Filter(filter) => {
-            reject_raw_subqueries_in_rel_child(filter.input.as_deref())?;
-            reject_raw_subqueries_in_exprs([filter.condition.as_deref()])?;
-        }
-        RelType::Fetch(fetch) => {
-            reject_raw_subqueries_in_rel_child(fetch.input.as_deref())?;
-            if let Some(proto::fetch_rel::OffsetMode::OffsetExpr(expression)) = &fetch.offset_mode {
-                reject_raw_subqueries_in_expr(expression)?;
-            }
-            if let Some(proto::fetch_rel::CountMode::CountExpr(expression)) = &fetch.count_mode {
-                reject_raw_subqueries_in_expr(expression)?;
-            }
-        }
-        RelType::Aggregate(aggregate) => {
-            reject_raw_subqueries_in_rel_child(aggregate.input.as_deref())?;
-            reject_raw_subqueries_in_exprs(aggregate.grouping_expressions.iter().map(Some))?;
-            #[allow(deprecated)]
-            for grouping in &aggregate.groupings {
-                reject_raw_subqueries_in_exprs(grouping.grouping_expressions.iter().map(Some))?;
-            }
-            for measure in &aggregate.measures {
-                if let Some(measure) = measure.measure.as_ref() {
-                    reject_raw_subqueries_in_aggregate_function(measure)?;
-                }
-                reject_raw_subqueries_in_exprs([measure.filter.as_ref()])?;
-            }
-        }
-        RelType::Sort(sort) => {
-            reject_raw_subqueries_in_rel_child(sort.input.as_deref())?;
-            reject_raw_subqueries_in_sort_fields(&sort.sorts)?;
-        }
-        RelType::Join(join) => {
-            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
-            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
-            reject_raw_subqueries_in_exprs([
-                join.expression.as_deref(),
-                join.post_join_filter.as_deref(),
-            ])?;
-        }
-        RelType::Project(project) => {
-            reject_raw_subqueries_in_rel_child(project.input.as_deref())?;
-            reject_raw_subqueries_in_exprs(project.expressions.iter().map(Some))?;
-        }
-        RelType::Set(set) => {
-            for input in &set.inputs {
-                reject_raw_subqueries_in_rel(input)?;
-            }
-        }
-        RelType::ExtensionMulti(extension) => {
-            for input in &extension.inputs {
-                reject_raw_subqueries_in_rel(input)?;
-            }
-        }
-        RelType::ExtensionSingle(extension) => {
-            reject_raw_subqueries_in_rel_child(extension.input.as_deref())?;
-        }
-        RelType::ExtensionLeaf(_) | RelType::Reference(_) => {}
-        RelType::Cross(cross) => {
-            reject_raw_subqueries_in_rel_child(cross.left.as_deref())?;
-            reject_raw_subqueries_in_rel_child(cross.right.as_deref())?;
-        }
-        RelType::Write(write) => reject_raw_subqueries_in_rel_child(write.input.as_deref())?,
-        RelType::Ddl(ddl) => reject_raw_subqueries_in_rel_child(ddl.view_definition.as_deref())?,
-        RelType::Update(update) => {
-            reject_raw_subqueries_in_exprs([update.condition.as_deref()])?;
-            for transformation in &update.transformations {
-                reject_raw_subqueries_in_exprs([transformation.transformation.as_ref()])?;
-            }
-        }
-        #[allow(deprecated)]
-        RelType::HashJoin(join) => {
-            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
-            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
-            reject_raw_subqueries_in_field_refs(&join.left_keys)?;
-            reject_raw_subqueries_in_field_refs(&join.right_keys)?;
-            for key in &join.keys {
-                reject_raw_subqueries_in_optional_field_refs([
-                    key.left.as_ref(),
-                    key.right.as_ref(),
-                ])?;
-            }
-            reject_raw_subqueries_in_exprs([join.post_join_filter.as_deref()])?;
-        }
-        #[allow(deprecated)]
-        RelType::MergeJoin(join) => {
-            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
-            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
-            reject_raw_subqueries_in_field_refs(&join.left_keys)?;
-            reject_raw_subqueries_in_field_refs(&join.right_keys)?;
-            for key in &join.keys {
-                reject_raw_subqueries_in_optional_field_refs([
-                    key.left.as_ref(),
-                    key.right.as_ref(),
-                ])?;
-            }
-            reject_raw_subqueries_in_exprs([join.post_join_filter.as_deref()])?;
-        }
-        RelType::NestedLoopJoin(join) => {
-            reject_raw_subqueries_in_rel_child(join.left.as_deref())?;
-            reject_raw_subqueries_in_rel_child(join.right.as_deref())?;
-            reject_raw_subqueries_in_exprs([join.expression.as_deref()])?;
-        }
-        RelType::Window(window) => {
-            reject_raw_subqueries_in_rel_child(window.input.as_deref())?;
-            reject_raw_subqueries_in_exprs(window.partition_expressions.iter().map(Some))?;
-            reject_raw_subqueries_in_sort_fields(&window.sorts)?;
-            for function in &window.window_functions {
-                reject_raw_subqueries_in_function_args(&function.arguments)?;
-            }
-        }
-        RelType::Exchange(exchange) => {
-            reject_raw_subqueries_in_rel_child(exchange.input.as_deref())?;
-            match exchange.exchange_kind.as_ref() {
-                Some(proto::exchange_rel::ExchangeKind::ScatterByFields(fields)) => {
-                    reject_raw_subqueries_in_field_refs(&fields.fields)?;
-                }
-                Some(proto::exchange_rel::ExchangeKind::SingleTarget(expression)) => {
-                    reject_raw_subqueries_in_exprs([expression.expression.as_deref()])?;
-                }
-                Some(proto::exchange_rel::ExchangeKind::MultiTarget(expression)) => {
-                    reject_raw_subqueries_in_exprs([expression.expression.as_deref()])?;
-                }
-                _ => {}
-            }
-        }
-        RelType::Expand(expand) => {
-            reject_raw_subqueries_in_rel_child(expand.input.as_deref())?;
-            for field in &expand.fields {
-                match field.field_type.as_ref() {
-                    Some(proto::expand_rel::expand_field::FieldType::SwitchingField(field)) => {
-                        reject_raw_subqueries_in_exprs(field.duplicates.iter().map(Some))?;
-                    }
-                    Some(proto::expand_rel::expand_field::FieldType::ConsistentField(
-                        expression,
-                    )) => {
-                        reject_raw_subqueries_in_expr(expression)?;
-                    }
-                    None => {}
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn reject_raw_subqueries_in_rel_child(rel: Option<&proto::Rel>) -> common_query::error::Result<()> {
-    rel.map_or(Ok(()), reject_raw_subqueries_in_rel)
-}
-
-fn reject_raw_subqueries_in_exprs<'a>(
-    expressions: impl IntoIterator<Item = Option<&'a proto::Expression>>,
-) -> common_query::error::Result<()> {
-    for expression in expressions.into_iter().flatten() {
-        reject_raw_subqueries_in_expr(expression)?;
-    }
-    Ok(())
-}
-
-fn reject_raw_subqueries_in_expr(
-    expression: &proto::Expression,
-) -> common_query::error::Result<()> {
-    use proto::expression::RexType;
-
-    match expression.rex_type.as_ref() {
-        Some(RexType::Subquery(_)) => Err(decode_error(
-            "remote reads do not support raw Substrait subqueries",
-        )),
-        Some(RexType::Selection(reference)) => {
-            reject_raw_subqueries_in_field_refs(std::slice::from_ref(reference))
-        }
-        Some(RexType::ScalarFunction(function)) => {
-            reject_raw_subqueries_in_function_args(&function.arguments)?;
-            #[allow(deprecated)]
-            reject_raw_subqueries_in_exprs(function.args.iter().map(Some))
-        }
-        Some(RexType::WindowFunction(function)) => {
-            reject_raw_subqueries_in_function_args(&function.arguments)?;
-            reject_raw_subqueries_in_exprs(function.partitions.iter().map(Some))?;
-            reject_raw_subqueries_in_sort_fields(&function.sorts)?;
-            #[allow(deprecated)]
-            reject_raw_subqueries_in_exprs(function.args.iter().map(Some))
-        }
-        Some(RexType::IfThen(if_then)) => {
-            for clause in &if_then.ifs {
-                reject_raw_subqueries_in_exprs([clause.r#if.as_ref(), clause.then.as_ref()])?;
-            }
-            reject_raw_subqueries_in_exprs([if_then.r#else.as_deref()])
-        }
-        Some(RexType::SwitchExpression(switch)) => {
-            reject_raw_subqueries_in_exprs([switch.r#match.as_deref(), switch.r#else.as_deref()])?;
-            reject_raw_subqueries_in_exprs(switch.ifs.iter().map(|clause| clause.then.as_ref()))
-        }
-        Some(RexType::SingularOrList(list)) => {
-            reject_raw_subqueries_in_exprs([list.value.as_deref()])?;
-            reject_raw_subqueries_in_exprs(list.options.iter().map(Some))
-        }
-        Some(RexType::MultiOrList(list)) => {
-            reject_raw_subqueries_in_exprs(list.value.iter().map(Some))?;
-            for record in &list.options {
-                reject_raw_subqueries_in_exprs(record.fields.iter().map(Some))?;
-            }
-            Ok(())
-        }
-        Some(RexType::Cast(cast)) => reject_raw_subqueries_in_exprs([cast.input.as_deref()]),
-        Some(RexType::Nested(nested)) => match nested.nested_type.as_ref() {
-            Some(proto::expression::nested::NestedType::Struct(struct_)) => {
-                reject_raw_subqueries_in_exprs(struct_.fields.iter().map(Some))
-            }
-            Some(proto::expression::nested::NestedType::List(list)) => {
-                reject_raw_subqueries_in_exprs(list.values.iter().map(Some))
-            }
-            Some(proto::expression::nested::NestedType::Map(map)) => {
-                for entry in &map.key_values {
-                    reject_raw_subqueries_in_exprs([entry.key.as_ref(), entry.value.as_ref()])?;
-                }
-                Ok(())
-            }
-            None => Ok(()),
-        },
-        Some(RexType::Literal(_))
-        | Some(RexType::DynamicParameter(_))
-        | Some(RexType::Enum(_))
-        | None => Ok(()),
-    }
-}
-
-fn reject_raw_subqueries_in_function_args(
-    arguments: &[proto::FunctionArgument],
-) -> common_query::error::Result<()> {
-    for argument in arguments {
-        if let Some(proto::function_argument::ArgType::Value(expression)) =
-            argument.arg_type.as_ref()
-        {
-            reject_raw_subqueries_in_expr(expression)?;
-        }
-    }
-    Ok(())
-}
-
-fn reject_raw_subqueries_in_aggregate_function(
-    function: &proto::AggregateFunction,
-) -> common_query::error::Result<()> {
-    reject_raw_subqueries_in_function_args(&function.arguments)?;
-    reject_raw_subqueries_in_sort_fields(&function.sorts)?;
-    #[allow(deprecated)]
-    reject_raw_subqueries_in_exprs(function.args.iter().map(Some))
-}
-
-fn reject_raw_subqueries_in_sort_fields(
-    fields: &[proto::SortField],
-) -> common_query::error::Result<()> {
-    reject_raw_subqueries_in_exprs(fields.iter().map(|field| field.expr.as_ref()))
-}
-
-fn reject_raw_subqueries_in_field_refs(
-    references: &[proto::expression::FieldReference],
-) -> common_query::error::Result<()> {
-    for reference in references {
-        if let Some(proto::expression::field_reference::RootType::Expression(expression)) =
-            reference.root_type.as_ref()
-        {
-            reject_raw_subqueries_in_expr(expression)?;
-        }
-    }
-    Ok(())
-}
-
-fn reject_raw_subqueries_in_optional_field_refs<'a>(
-    references: impl IntoIterator<Item = Option<&'a proto::expression::FieldReference>>,
-) -> common_query::error::Result<()> {
-    for reference in references.into_iter().flatten() {
-        reject_raw_subqueries_in_field_refs(std::slice::from_ref(reference))?;
-    }
-    Ok(())
 }
 
 fn collect_optional_input(
@@ -1230,15 +949,63 @@ fn type_nullability(kind: &proto::r#type::Kind) -> Option<proto::r#type::Nullabi
 }
 
 fn remote_error(message: impl Into<String>) -> BoxedError {
+    // Encode-side errors are local frontend errors, not schema races, so they
+    // keep the non-retryable InvalidArguments status.
     BoxedError::new(PlainError::new(
         message.into(),
         StatusCode::InvalidArguments,
     ))
 }
 
+/// A remote-read contract violation detected at decode time.
+///
+/// These are transient: the frontend planned against a schema the region has
+/// since changed (a schema race). They are marked retryable so the caller can
+/// retry against fresh metadata.
+#[derive(Debug)]
+struct ContractViolation {
+    message: String,
+}
+
+impl std::fmt::Display for ContractViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ContractViolation {}
+
+impl common_error::ext::ErrorExt for ContractViolation {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::Internal
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        RetryHint::Retryable
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl common_error::ext::StackError for ContractViolation {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        buf.push(format!("{}: {}", layer, self.message))
+    }
+
+    fn next(&self) -> Option<&dyn common_error::ext::StackError> {
+        None
+    }
+}
+
 fn decode_error(message: impl Into<String>) -> common_query::error::Error {
+    // Decode-side contract violations are transient schema races and must be
+    // retryable.
     common_query::error::Error::DecodePlan {
-        source: remote_error(message),
+        source: BoxedError::new(ContractViolation {
+            message: message.into(),
+        }),
         location: snafu::location!(),
     }
 }
@@ -1494,6 +1261,36 @@ mod tests {
         .unwrap();
 
         assert!(matches!(plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn test_decode_remote_plan_tolerates_legacy_unwrapped_plan() {
+        let region_id = RegionId::new(42, 1);
+        // An older frontend encodes the plan without the v1 root envelope.
+        let mut legacy = proto::Plan::decode(encoded_remote_plan(region_id).as_ref()).unwrap();
+        unwrap_root(&mut legacy).unwrap();
+        let legacy_bytes = Bytes::from(legacy.encode_to_vec());
+
+        // The new datanode accepts the legacy plan and decodes it with base
+        // semantics.
+        let decoded = decode_with_provider(legacy_bytes.clone(), mock_table_provider(region_id))
+            .await
+            .unwrap();
+        assert!(matches!(decoded, LogicalPlan::TableScan(_)));
+
+        // It is still safe: the base decoder's schema-compatibility check
+        // rejects a column whose type changed between planning and execution.
+        let mut metadata = standard_dn_metadata(region_id);
+        metadata.column_metadatas[2].column_schema =
+            ColumnSchema::new("v0", ConcreteDataType::int64_datatype(), false);
+        let metadata = RegionMetadataBuilder::from_existing(metadata)
+            .build()
+            .unwrap();
+        assert!(
+            decode_with_provider(legacy_bytes, provider_with_metadata(metadata))
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -2122,147 +1919,6 @@ mod tests {
             extract_top_level_named_struct(&named, named.r#struct.as_ref().unwrap()).unwrap();
         assert_eq!(names, vec!["s", "l", "m"]);
         assert_eq!(types.len(), 3);
-    }
-
-    #[derive(Clone, Copy)]
-    enum RawSubqueryForm {
-        Scalar,
-        InPredicate,
-        SetPredicate,
-        SetComparison,
-    }
-
-    fn raw_subquery(form: RawSubqueryForm) -> proto::Expression {
-        use proto::expression::subquery::{
-            InPredicate, Scalar, SetComparison, SetPredicate, SubqueryType,
-        };
-
-        let subquery_type = match form {
-            RawSubqueryForm::Scalar => SubqueryType::Scalar(Box::new(Scalar { input: None })),
-            RawSubqueryForm::InPredicate => SubqueryType::InPredicate(Box::new(InPredicate {
-                needles: vec![],
-                haystack: None,
-            })),
-            RawSubqueryForm::SetPredicate => SubqueryType::SetPredicate(Box::new(SetPredicate {
-                predicate_op: 0,
-                tuples: None,
-            })),
-            RawSubqueryForm::SetComparison => {
-                SubqueryType::SetComparison(Box::new(SetComparison {
-                    reduction_op: 0,
-                    comparison_op: 0,
-                    left: None,
-                    right: None,
-                }))
-            }
-        };
-        proto::Expression {
-            rex_type: Some(proto::expression::RexType::Subquery(Box::new(
-                proto::expression::Subquery {
-                    subquery_type: Some(subquery_type),
-                },
-            ))),
-        }
-    }
-
-    fn rel_with_filter(expression: proto::Expression) -> proto::Rel {
-        proto::Rel {
-            rel_type: Some(proto::rel::RelType::Filter(Box::new(proto::FilterRel {
-                common: None,
-                input: None,
-                condition: Some(Box::new(expression)),
-                advanced_extension: None,
-            }))),
-        }
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_raw_substrait_subquery_forms_and_placements_are_rejected() {
-        let forms = [
-            RawSubqueryForm::Scalar,
-            RawSubqueryForm::InPredicate,
-            RawSubqueryForm::SetPredicate,
-            RawSubqueryForm::SetComparison,
-        ];
-        for form in forms {
-            assert!(reject_raw_subqueries(&rel_with_filter(raw_subquery(form))).is_err());
-        }
-
-        let nested = proto::Expression {
-            rex_type: Some(proto::expression::RexType::Nested(
-                proto::expression::Nested {
-                    nullable: false,
-                    type_variation_reference: 0,
-                    nested_type: Some(proto::expression::nested::NestedType::Struct(
-                        proto::expression::nested::Struct {
-                            fields: vec![raw_subquery(RawSubqueryForm::Scalar)],
-                        },
-                    )),
-                },
-            )),
-        };
-        let field_reference = proto::expression::FieldReference {
-            reference_type: None,
-            root_type: Some(proto::expression::field_reference::RootType::Expression(
-                Box::new(raw_subquery(RawSubqueryForm::InPredicate)),
-            )),
-        };
-        let virtual_table = proto::Rel {
-            rel_type: Some(proto::rel::RelType::Read(Box::new(proto::ReadRel {
-                common: None,
-                base_schema: None,
-                filter: None,
-                best_effort_filter: None,
-                projection: None,
-                advanced_extension: None,
-                read_type: Some(proto::read_rel::ReadType::VirtualTable(
-                    proto::read_rel::VirtualTable {
-                        values: vec![],
-                        expressions: vec![proto::expression::nested::Struct {
-                            fields: vec![raw_subquery(RawSubqueryForm::SetPredicate)],
-                        }],
-                    },
-                )),
-            }))),
-        };
-        let exchange = proto::Rel {
-            rel_type: Some(proto::rel::RelType::Exchange(Box::new(
-                proto::ExchangeRel {
-                    common: None,
-                    input: None,
-                    partition_count: 0,
-                    targets: vec![],
-                    advanced_extension: None,
-                    exchange_kind: Some(proto::exchange_rel::ExchangeKind::ScatterByFields(
-                        proto::exchange_rel::ScatterFields {
-                            fields: vec![field_reference],
-                        },
-                    )),
-                },
-            ))),
-        };
-
-        assert!(reject_raw_subqueries(&rel_with_filter(nested)).is_err());
-        assert!(reject_raw_subqueries(&virtual_table).is_err());
-        assert!(reject_raw_subqueries(&exchange).is_err());
-    }
-
-    #[test]
-    fn test_raw_substrait_literal_containing_subquery_is_accepted() {
-        let literal = proto::Expression {
-            rex_type: Some(proto::expression::RexType::Literal(
-                proto::expression::Literal {
-                    nullable: false,
-                    type_variation_reference: 0,
-                    literal_type: Some(proto::expression::literal::LiteralType::String(
-                        "Subquery(".to_string(),
-                    )),
-                },
-            )),
-        };
-
-        assert!(reject_raw_subqueries(&rel_with_filter(literal)).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

Fixes QX-046: a schema race between FE serialization and DN decode of remote read plans. The FE serializes a remote read plan (substrait) that the DN decodes and executes; if the table was altered or reincarnated between FE plan creation and DN execution, the DN could execute a stale plan against a changed schema and return wrong results.

This change makes the race fail closed:

- **FE routing coherence** (`src/query/src/dist_plan/planner.rs`): before region pruning, compares the analyze-time `TableInfo` captured in the plan against the route-time table (`table_id` + ordered partition-column signature). Catches FE partition-column changes between analyze and route.
- **DN decode-time contract** (new `src/query/src/query_engine/remote_plan_codec.rs`): the FE wraps the substrait plan root in an `ExtensionSingleRel` carrying `RemoteReadTableV1 { table_id, table_version (diagnostic), columns: [{name, column_id, semantic_type, is_time_index, primary_key_ordinal}] }` (greptime-proto #331). The DN validates table_id equality and per-column identity/roles against current `RegionMetadata`, plus raw-substrait nullability/shape (catches required→nullable reincarnation, which the base decoder normalizes away).
- **DN scan-window check** (`src/query/src/dummy_catalog.rs`): after the scanner opens, compares provider metadata vs scanner metadata, catching alters between decode and scan.

Right-sizing per senior review: the orthogonal boundary hardening (raw-substrait subquery rejection, relation-shape whitelist, internal-table classification) is removed. Two operational issues fixed:

- **Rolling-upgrade compatibility**: a legacy (unwrapped) remote-read plan is now decoded with previous semantics (which already fail safely on column drop/rename/type change) instead of being hard-rejected, so mixed FE/DN clusters keep working in both upgrade directions.
- **Retryable contract errors**: contract violations surface as a retryable error (`StatusCode::Internal` + `RetryHint::Retryable` via `ContractViolation`), so a transient schema race can be re-planned and retried.

Depends on greptime-proto #331 (rebase to 9f60f9c). Core tests: `qx_046_remote_codec_rejects_simplified_nullable_reincarnation`, `qx_046_default_decoder_nullable_reincarnation_wrong_result`, plus 156 dist_plan tests.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
