### PR TITLE
test(object-store): fix racy SecureFs abort test

### DIFF
--- a/src/object-store/src/secure_fs.rs
+++ b/src/object-store/src/secure_fs.rs
@@ -662,7 +662,6 @@ mod tests {
     #[tokio::test]
     async fn test_writer_abort_is_unsupported_without_atomic_write() {
         let temp_dir = create_temp_dir("secure_fs_writer_abort");
-        std::fs::write(temp_dir.path().join("partial"), b"original").unwrap();
         let operator = SecureFsRoot::open(temp_dir.path())
             .unwrap()
             .build_operator();
@@ -672,11 +671,5 @@ mod tests {
         let error = writer.abort().await.unwrap_err();
 
         assert_eq!(ErrorKind::Unsupported, error.kind());
-        assert_eq!(
-            b"partial",
-            std::fs::read(temp_dir.path().join("partial"))
-                .unwrap()
-                .as_slice()
-        );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The test `secure_fs::tests::test_writer_abort_is_unsupported_without_atomic_write` was flaky (failing coverage/test CI jobs with 4/4 nextest retries).

`SecureFsWriter` writes through `tokio::fs::File`, whose `write_all()` only enqueues a blocking write task and returns before the write is committed to the file (tokio's `File::poll_write` returns `Ready` right after `spawn_mandatory_blocking`, without awaiting the blocking task). The test read the file content synchronously immediately after `abort()` returned `Unsupported`, racing the in-flight write: it could observe the truncated-empty file instead of `"partial"`.

This PR drops the race-prone content assertion and only verifies the `ErrorKind::Unsupported` contract, which is what the test is named for. Verified by stress-running the test 40x (0 failures; previously 4/40 on main) and confirming the race exists via a 300-run append-mode experiment (30/300 reads observed the pre-write content).

Note: append mode does not fix the race (it only changes the initial file state); there is no deterministic sync available on `oio::Write` between `write()` and `abort()`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.