### PR TITLE
feat(logging): add enable_file_logging option to disable file logging

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -217,6 +217,7 @@
 | `logging.enable_otlp_tracing` | Bool | `false` | Enable OTLP tracing. |
 | `logging.otlp_endpoint` | String | `http://localhost:4318/v1/traces` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
+| `logging.enable_file_logging` | Bool | `true` | Whether to write logs to files in `dir`. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
 | `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.enable_per_region_metrics` | Bool | `false` | Whether to enable per-region metrics.<br/>Default to false. |
@@ -351,6 +352,7 @@
 | `logging.enable_otlp_tracing` | Bool | `false` | Enable OTLP tracing. |
 | `logging.otlp_endpoint` | String | `http://localhost:4318/v1/traces` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
+| `logging.enable_file_logging` | Bool | `true` | Whether to write logs to files in `dir`. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
 | `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.enable_per_region_metrics` | Bool | `false` | Whether to enable per-region metrics.<br/>Default to false. |
@@ -464,6 +466,7 @@
 | `logging.enable_otlp_tracing` | Bool | `false` | Enable OTLP tracing. |
 | `logging.otlp_endpoint` | String | `http://localhost:4318/v1/traces` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
+| `logging.enable_file_logging` | Bool | `true` | Whether to write logs to files in `dir`. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
 | `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.otlp_export_protocol` | String | `http` | The OTLP tracing export protocol. Can be `grpc`/`http`. |
@@ -641,6 +644,7 @@
 | `logging.enable_otlp_tracing` | Bool | `false` | Enable OTLP tracing. |
 | `logging.otlp_endpoint` | String | `http://localhost:4318/v1/traces` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
+| `logging.enable_file_logging` | Bool | `true` | Whether to write logs to files in `dir`. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
 | `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.otlp_export_protocol` | String | `http` | The OTLP tracing export protocol. Can be `grpc`/`http`. |
@@ -701,6 +705,7 @@
 | `logging.enable_otlp_tracing` | Bool | `false` | Enable OTLP tracing. |
 | `logging.otlp_endpoint` | String | `http://localhost:4318/v1/traces` | The OTLP tracing endpoint. |
 | `logging.append_stdout` | Bool | `true` | Whether to append logs to stdout. |
+| `logging.enable_file_logging` | Bool | `true` | Whether to write logs to files in `dir`. |
 | `logging.log_format` | String | `text` | The log format. Can be `text`/`json`. |
 | `logging.max_log_files` | Integer | `720` | The maximum amount of log files. |
 | `logging.otlp_export_protocol` | String | `http` | The OTLP tracing export protocol. Can be `grpc`/`http`. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -723,6 +723,9 @@ otlp_endpoint = "http://localhost:4318/v1/traces"
 ## Whether to append logs to stdout.
 append_stdout = true
 
+## Whether to write logs to files in `dir`.
+enable_file_logging = true
+
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -114,6 +114,9 @@ otlp_endpoint = "http://localhost:4318/v1/traces"
 ## Whether to append logs to stdout.
 append_stdout = true
 
+## Whether to write logs to files in `dir`.
+enable_file_logging = true
+
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -339,6 +339,9 @@ otlp_endpoint = "http://localhost:4318/v1/traces"
 ## Whether to append logs to stdout.
 append_stdout = true
 
+## Whether to write logs to files in `dir`.
+enable_file_logging = true
+
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -368,6 +368,9 @@ otlp_endpoint = "http://localhost:4318/v1/traces"
 ## Whether to append logs to stdout.
 append_stdout = true
 
+## Whether to write logs to files in `dir`.
+enable_file_logging = true
+
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -862,6 +862,9 @@ otlp_endpoint = "http://localhost:4318/v1/traces"
 ## Whether to append logs to stdout.
 append_stdout = true
 
+## Whether to write logs to files in `dir`.
+enable_file_logging = true
+
 ## The log format. Can be `text`/`json`.
 log_format = "text"
 

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -256,6 +256,9 @@ pub struct LoggingOptions {
     /// Whether to append logs to stdout. Default is true.
     pub append_stdout: bool,
 
+    /// Whether to write logs to files in `dir`. Default is true.
+    pub enable_file_logging: bool,
+
     /// Whether to enable tracing with OTLP. Default is false.
     pub enable_otlp_tracing: bool,
 
@@ -359,6 +362,7 @@ impl Default for LoggingOptions {
             otlp_endpoint: None,
             tracing_sample_ratio: None,
             append_stdout: true,
+            enable_file_logging: true,
             // Rotation hourly, 24 files per day, keeps info log files of 30 days
             max_log_files: 720,
             otlp_export_protocol: None,
@@ -455,8 +459,10 @@ pub fn init_global_logging(
             None
         };
 
+        let file_logging_enabled = opts.enable_file_logging && !opts.dir.is_empty();
+
         // Configure the file logging layer with rolling policy.
-        let file_logging_layer = if !opts.dir.is_empty() {
+        let file_logging_layer = if file_logging_enabled {
             let rolling_appender = RollingFileAppender::builder()
                 .rotation(Rotation::HOURLY)
                 .filename_prefix("greptimedb")
@@ -487,7 +493,7 @@ pub fn init_global_logging(
         };
 
         // Configure the error file logging layer with rolling policy.
-        let err_file_logging_layer = if !opts.dir.is_empty() {
+        let err_file_logging_layer = if file_logging_enabled {
             let rolling_appender = RollingFileAppender::builder()
                 .rotation(Rotation::HOURLY)
                 .filename_prefix("greptimedb-err")
@@ -712,7 +718,8 @@ where
         + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
     if let Some(slow_query_opts) = slow_query_opts {
-        if !opts.dir.is_empty()
+        if opts.enable_file_logging
+            && !opts.dir.is_empty()
             && slow_query_opts.enable
             && slow_query_opts.record_type == SlowQueriesRecordType::Log
         {
@@ -777,6 +784,15 @@ mod tests {
         assert_eq!(opts.dir, "");
         assert_eq!(opts.level, None);
         assert!(opts.append_stdout);
+        assert!(opts.enable_file_logging);
+    }
+
+    #[test]
+    fn test_logging_options_deserialization_enable_file_logging() {
+        let json = r#"{"enable_file_logging": false}"#;
+        let opts: LoggingOptions = serde_json::from_str(json).unwrap();
+
+        assert!(!opts.enable_file_logging);
     }
 
     #[test]

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2190,6 +2190,7 @@ read_preference = "Leader"
 [logging]
 max_log_files = 720
 append_stdout = true
+enable_file_logging = true
 enable_otlp_tracing = false
 enable_per_region_metrics = false
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
issue #1572

## What's changed and what's your intention?
Add a `logging.enable_file_logging` option (default: `true`) to allow disabling
file logging when running with an external log collector. Existing configs are unaffected.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
