### PR TITLE
fix: add public constructor for compactor

### DIFF
--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -562,6 +562,19 @@ impl<M: SstMerger> DefaultCompactor<M> {
 }
 
 impl DefaultCompactor {
+    /// Creates a new `DefaultCompactor` with the given cancel handle and no
+    /// uncommitted SSTs tracking.
+    ///
+    /// This is the public entry point for external crates that want a
+    /// cancellable compactor without opting into uncommitted-SST tracking.
+    pub fn new_with_cancel_handle(cancel_handle: Arc<CancellationHandle>) -> Self {
+        Self {
+            merger: DefaultSstMerger,
+            cancel_handle,
+            uncommitted: None,
+        }
+    }
+
     pub(crate) fn with_cancel_handle(
         cancel_handle: Arc<CancellationHandle>,
         uncommitted: UncommittedSsts,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add a public constructor for compactor. Addressing changes from #8685 

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
