### PR TITLE
feat: make frontend heartbeat extensible and lifecycle-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6041,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=5adb8a1637abe87bcbb455d32136eee5d538cc49#5adb8a1637abe87bcbb455d32136eee5d538cc49"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=28b52f8d02b9f8fc5f036338c4e5ca46cdd57184#28b52f8d02b9f8fc5f036338c4e5ca46cdd57184"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -11263,7 +11263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11283,7 +11283,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.11.0",
  "log",
  "multimap",
@@ -13683,7 +13683,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6041,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=28b52f8d02b9f8fc5f036338c4e5ca46cdd57184#28b52f8d02b9f8fc5f036338c4e5ca46cdd57184"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=032510ded061277b7d1bbb29d4046abb5b1cbf4b#032510ded061277b7d1bbb29d4046abb5b1cbf4b"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "5adb8a1637abe87bcbb455d32136eee5d538cc49" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "28b52f8d02b9f8fc5f036338c4e5ca46cdd57184" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "28b52f8d02b9f8fc5f036338c4e5ca46cdd57184" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "032510ded061277b7d1bbb29d4046abb5b1cbf4b" }
 hex = "0.4"
 http = "1"
 humantime = "2.1"

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -40,7 +40,7 @@ use common_time::timezone::set_default_timezone;
 use common_version::{short_version, verbose_version};
 use frontend::frontend::Frontend;
 use frontend::heartbeat::{
-    HeartbeatExtensions, HeartbeatTask, heartbeat_response_handler_executor,
+    FrontendHeartbeatExtensions, HeartbeatTask, heartbeat_response_handler_executor,
 };
 use frontend::instance::builder::FrontendBuilder;
 use frontend::server::Services;
@@ -500,7 +500,9 @@ impl StartCommand {
         plugins::setup_frontend_heartbeat_extensions(&mut plugins, &plugin_opts, &instance)
             .await
             .context(error::StartFrontendSnafu)?;
-        let heartbeat_extensions = plugins.get::<HeartbeatExtensions>().unwrap_or_default();
+        let heartbeat_extensions = plugins
+            .get::<FrontendHeartbeatExtensions>()
+            .unwrap_or_default();
         let heartbeat_task = Some(create_heartbeat_task_with_extensions(
             &opts,
             meta_client,
@@ -534,7 +536,7 @@ fn create_heartbeat_task_with_extensions(
     options: &frontend::frontend::FrontendOptions,
     meta_client: MetaClientRef,
     instance: &frontend::instance::Instance,
-    extensions: HeartbeatExtensions,
+    extensions: FrontendHeartbeatExtensions,
 ) -> HeartbeatTask {
     let executor = heartbeat_response_handler_executor(
         &extensions,

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -32,10 +32,6 @@ use common_base::Plugins;
 use common_config::{Configurable, DEFAULT_DATA_HOME};
 use common_error::ext::BoxedError;
 use common_meta::cache::{CacheRegistryBuilder, LayeredCacheRegistryBuilder};
-use common_meta::heartbeat::handler::HandlerGroupExecutor;
-use common_meta::heartbeat::handler::invalidate_table_cache::InvalidateCacheHandler;
-use common_meta::heartbeat::handler::parse_mailbox_message::ParseMailboxMessageHandler;
-use common_meta::heartbeat::handler::suspend::SuspendHandler;
 use common_query::prelude::set_default_prefix;
 use common_stat::ResourceStatImpl;
 use common_telemetry::info;
@@ -43,7 +39,9 @@ use common_telemetry::logging::{DEFAULT_LOGGING_DIR, TracingOptions};
 use common_time::timezone::set_default_timezone;
 use common_version::{short_version, verbose_version};
 use frontend::frontend::Frontend;
-use frontend::heartbeat::HeartbeatTask;
+use frontend::heartbeat::{
+    HeartbeatExtensions, HeartbeatTask, heartbeat_response_handler_executor,
+};
 use frontend::instance::builder::FrontendBuilder;
 use frontend::server::Services;
 use meta_client::{MetaClientOptions, MetaClientRef, MetaClientType};
@@ -497,9 +495,18 @@ impl StartCommand {
             .await
             .context(error::StartFrontendSnafu)?;
 
-        let heartbeat_task = Some(create_heartbeat_task(&opts, meta_client, &instance));
-
         let instance = Arc::new(instance);
+
+        plugins::setup_frontend_heartbeat_extensions(&mut plugins, &plugin_opts, &instance)
+            .await
+            .context(error::StartFrontendSnafu)?;
+        let heartbeat_extensions = plugins.get::<HeartbeatExtensions>().unwrap_or_default();
+        let heartbeat_task = Some(create_heartbeat_task_with_extensions(
+            &opts,
+            meta_client,
+            &instance,
+            heartbeat_extensions,
+        ));
 
         let servers = Services::new(opts, instance.clone(), plugins)
             .build()
@@ -520,13 +527,20 @@ pub fn create_heartbeat_task(
     meta_client: MetaClientRef,
     instance: &frontend::instance::Instance,
 ) -> HeartbeatTask {
-    let executor = Arc::new(HandlerGroupExecutor::new(vec![
-        Arc::new(ParseMailboxMessageHandler),
-        Arc::new(SuspendHandler::new(instance.suspend_state())),
-        Arc::new(InvalidateCacheHandler::new(
-            instance.cache_invalidator().clone(),
-        )),
-    ]));
+    create_heartbeat_task_with_extensions(options, meta_client, instance, Default::default())
+}
+
+fn create_heartbeat_task_with_extensions(
+    options: &frontend::frontend::FrontendOptions,
+    meta_client: MetaClientRef,
+    instance: &frontend::instance::Instance,
+    extensions: HeartbeatExtensions,
+) -> HeartbeatTask {
+    let executor = heartbeat_response_handler_executor(
+        &extensions,
+        instance.suspend_state(),
+        instance.cache_invalidator().clone(),
+    );
 
     let stat = {
         let mut stat = ResourceStatImpl::default();
@@ -541,6 +555,7 @@ pub fn create_heartbeat_task(
         executor,
         stat,
     )
+    .with_extensions(extensions)
 }
 
 #[cfg(test)]

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -200,7 +200,9 @@ mod tests {
     use tonic::{Request, Response, Status, Streaming};
 
     use super::*;
-    use crate::heartbeat::{HeartbeatExtension, HeartbeatExtensionResult, HeartbeatExtensions};
+    use crate::heartbeat::{
+        FrontendHeartbeatExtension, FrontendHeartbeatExtensionResult, FrontendHeartbeatExtensions,
+    };
     use crate::instance::builder::FrontendBuilder;
     use crate::server::Services;
 
@@ -232,12 +234,12 @@ mod tests {
     }
 
     #[async_trait]
-    impl HeartbeatExtension for ShutdownTrackingExtension {
+    impl FrontendHeartbeatExtension for ShutdownTrackingExtension {
         fn name(&self) -> &str {
             "shutdown-tracking"
         }
 
-        async fn shutdown(&self) -> HeartbeatExtensionResult<()> {
+        async fn shutdown(&self) -> FrontendHeartbeatExtensionResult<()> {
             self.shutdown_calls.fetch_add(1, Ordering::AcqRel);
             Ok(())
         }
@@ -480,7 +482,7 @@ mod tests {
         let extension = Arc::new(ShutdownTrackingExtension {
             shutdown_calls: AtomicUsize::new(0),
         });
-        let extensions = HeartbeatExtensions::default();
+        let extensions = FrontendHeartbeatExtensions::default();
         assert!(extensions.register(extension.clone()));
         let heartbeat_task = HeartbeatTask::new(
             instance.frontend_peer_addr().to_string(),

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -130,8 +130,11 @@ pub struct Frontend {
 
 impl Frontend {
     pub async fn start(&mut self) -> Result<()> {
-        if let Some(t) = &self.heartbeat_task {
-            t.start().await?;
+        if let Some(t) = &self.heartbeat_task
+            && let Err(error) = t.start().await
+        {
+            t.shutdown().await;
+            return Err(error);
         }
 
         if let Err(source) = self.servers.start_all().await {
@@ -162,7 +165,7 @@ impl Frontend {
 mod tests {
     use std::any::Any;
     use std::net::SocketAddr;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Duration;
 
     use api::v1::meta::heartbeat_server::HeartbeatServer;
@@ -197,6 +200,7 @@ mod tests {
     use tonic::{Request, Response, Status, Streaming};
 
     use super::*;
+    use crate::heartbeat::{HeartbeatExtension, HeartbeatExtensionResult, HeartbeatExtensions};
     use crate::instance::builder::FrontendBuilder;
     use crate::server::Services;
 
@@ -218,9 +222,26 @@ mod tests {
 
     struct SuspendableHeartbeatServer {
         suspend: Arc<AtomicBool>,
+        fail_heartbeat: bool,
     }
 
     struct FailingServer;
+
+    struct ShutdownTrackingExtension {
+        shutdown_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl HeartbeatExtension for ShutdownTrackingExtension {
+        fn name(&self) -> &str {
+            "shutdown-tracking"
+        }
+
+        async fn shutdown(&self) -> HeartbeatExtensionResult<()> {
+            self.shutdown_calls.fetch_add(1, Ordering::AcqRel);
+            Ok(())
+        }
+    }
 
     #[async_trait]
     impl Server for FailingServer {
@@ -251,6 +272,10 @@ mod tests {
             &self,
             request: Request<Streaming<HeartbeatRequest>>,
         ) -> std::result::Result<Response<Self::HeartbeatStream>, Status> {
+            if self.fail_heartbeat {
+                return Err(Status::unavailable("mock initial heartbeat failure"));
+            }
+
             let (tx, rx) = mpsc::channel(4);
 
             common_runtime::spawn_global({
@@ -402,6 +427,7 @@ mod tests {
         };
         let heartbeat_server = Arc::new(SuspendableHeartbeatServer {
             suspend: Arc::new(AtomicBool::new(false)),
+            fail_heartbeat: false,
         });
         let meta_client = create_meta_client(&meta_client_options, heartbeat_server).await;
         let instance = Arc::new(
@@ -428,6 +454,52 @@ mod tests {
 
         assert!(frontend.start().await.is_err());
         assert!(heartbeat_probe.is_shutdown());
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_start_failure_shuts_down_extensions() {
+        let meta_client_options = MetaClientOptions {
+            metasrv_addrs: vec!["localhost:0".to_string()],
+            ..Default::default()
+        };
+        let options = FrontendOptions {
+            meta_client: Some(meta_client_options.clone()),
+            ..Default::default()
+        };
+        let heartbeat_server = Arc::new(SuspendableHeartbeatServer {
+            suspend: Arc::new(AtomicBool::new(false)),
+            fail_heartbeat: true,
+        });
+        let meta_client = create_meta_client(&meta_client_options, heartbeat_server).await;
+        let instance = Arc::new(
+            FrontendBuilder::new_test(&options, meta_client.clone())
+                .try_build()
+                .await
+                .unwrap(),
+        );
+        let extension = Arc::new(ShutdownTrackingExtension {
+            shutdown_calls: AtomicUsize::new(0),
+        });
+        let extensions = HeartbeatExtensions::default();
+        assert!(extensions.register(extension.clone()));
+        let heartbeat_task = HeartbeatTask::new(
+            instance.frontend_peer_addr().to_string(),
+            &options,
+            meta_client,
+            Arc::new(HandlerGroupExecutor::new(vec![])),
+            Arc::new(ResourceStatImpl::default()),
+        )
+        .with_extensions(extensions);
+        let heartbeat_probe = heartbeat_task.clone();
+        let mut frontend = Frontend {
+            instance,
+            servers: ServerHandlers::default(),
+            heartbeat_task: Some(heartbeat_task),
+        };
+
+        assert!(frontend.start().await.is_err());
+        assert!(heartbeat_probe.is_shutdown());
+        assert_eq!(extension.shutdown_calls.load(Ordering::Acquire), 1);
     }
 
     async fn verify_suspend_state_by_http(
@@ -526,6 +598,7 @@ mod tests {
 
         let server = Arc::new(SuspendableHeartbeatServer {
             suspend: Arc::new(AtomicBool::new(false)),
+            fail_heartbeat: false,
         });
         let meta_client = create_meta_client(&meta_client_options, server.clone()).await;
         let frontend = create_frontend(&options, meta_client).await?;

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -134,13 +134,19 @@ impl Frontend {
             t.start().await?;
         }
 
-        self.servers
-            .start_all()
-            .await
-            .context(error::StartServerSnafu)
+        if let Err(source) = self.servers.start_all().await {
+            if let Some(t) = &self.heartbeat_task {
+                t.shutdown().await;
+            }
+            return Err(source).context(error::StartServerSnafu);
+        }
+        Ok(())
     }
 
     pub async fn shutdown(&mut self) -> Result<()> {
+        if let Some(t) = &self.heartbeat_task {
+            t.shutdown().await;
+        }
         self.servers
             .shutdown_all()
             .await
@@ -154,6 +160,8 @@ impl Frontend {
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+    use std::net::SocketAddr;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
@@ -181,6 +189,7 @@ mod tests {
     use servers::grpc::{FlightCompression, GRPC_SERVER};
     use servers::http::HTTP_SERVER;
     use servers::http::result::greptime_result_v1::GreptimedbV1Response;
+    use servers::server::Server;
     use tokio::sync::mpsc;
     use tonic::codec::CompressionEncoding;
     use tonic::codegen::tokio_stream::StreamExt;
@@ -209,6 +218,29 @@ mod tests {
 
     struct SuspendableHeartbeatServer {
         suspend: Arc<AtomicBool>,
+    }
+
+    struct FailingServer;
+
+    #[async_trait]
+    impl Server for FailingServer {
+        async fn shutdown(&self) -> servers::error::Result<()> {
+            Ok(())
+        }
+
+        async fn start(&mut self, _listening: SocketAddr) -> servers::error::Result<()> {
+            Err(servers::error::Error::Internal {
+                err_msg: "mock server start failure".to_string(),
+            })
+        }
+
+        fn name(&self) -> &str {
+            "FAILING_SERVER"
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
     }
 
     #[async_trait]
@@ -356,6 +388,46 @@ mod tests {
         };
         frontend.start().await?;
         Ok(frontend)
+    }
+
+    #[tokio::test]
+    async fn test_server_start_failure_shuts_down_heartbeat() {
+        let meta_client_options = MetaClientOptions {
+            metasrv_addrs: vec!["localhost:0".to_string()],
+            ..Default::default()
+        };
+        let options = FrontendOptions {
+            meta_client: Some(meta_client_options.clone()),
+            ..Default::default()
+        };
+        let heartbeat_server = Arc::new(SuspendableHeartbeatServer {
+            suspend: Arc::new(AtomicBool::new(false)),
+        });
+        let meta_client = create_meta_client(&meta_client_options, heartbeat_server).await;
+        let instance = Arc::new(
+            FrontendBuilder::new_test(&options, meta_client.clone())
+                .try_build()
+                .await
+                .unwrap(),
+        );
+        let heartbeat_task = HeartbeatTask::new(
+            instance.frontend_peer_addr().to_string(),
+            &options,
+            meta_client,
+            Arc::new(HandlerGroupExecutor::new(vec![])),
+            Arc::new(ResourceStatImpl::default()),
+        );
+        let heartbeat_probe = heartbeat_task.clone();
+        let servers = ServerHandlers::default();
+        servers.insert((Box::new(FailingServer), "127.0.0.1:0".parse().unwrap()));
+        let mut frontend = Frontend {
+            instance,
+            servers,
+            heartbeat_task: Some(heartbeat_task),
+        };
+
+        assert!(frontend.start().await.is_err());
+        assert!(heartbeat_probe.is_shutdown());
     }
 
     async fn verify_suspend_state_by_http(

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -50,23 +50,26 @@ use crate::error::Result;
 use crate::frontend::FrontendOptions;
 use crate::metrics::{HEARTBEAT_RECV_COUNT, HEARTBEAT_SENT_COUNT};
 
-/// The result type returned by a [`HeartbeatExtension`].
-pub type HeartbeatExtensionResult<T> = std::result::Result<T, BoxedError>;
+/// The result type returned by a [`FrontendHeartbeatExtension`].
+pub type FrontendHeartbeatExtensionResult<T> = std::result::Result<T, BoxedError>;
 
 /// An extension to frontend heartbeat requests, responses, and lifecycle events.
 ///
-/// [`HeartbeatExtension::request_extensions`] is called for every heartbeat. A failed call is
-/// isolated from the base heartbeat and from other extensions. [`HeartbeatExtension::connected`]
-/// is called once for every successfully established connection generation, including reconnects;
-/// implementations must therefore be idempotent. [`HeartbeatExtension::shutdown`] is called once
-/// during task shutdown after heartbeat I/O has stopped.
+/// [`FrontendHeartbeatExtension::request_extensions`] is called for every heartbeat. A failed call
+/// is isolated from the base heartbeat and from other extensions.
+/// [`FrontendHeartbeatExtension::connected`] is called once for every successfully established
+/// connection generation, including reconnects; implementations must therefore be idempotent.
+/// [`FrontendHeartbeatExtension::shutdown`] is called once during task shutdown after heartbeat
+/// I/O has stopped.
 #[async_trait]
-pub trait HeartbeatExtension: Send + Sync {
+pub trait FrontendHeartbeatExtension: Send + Sync {
     /// Returns the stable name used to make registration idempotent.
     fn name(&self) -> &str;
 
     /// Generates request extensions for one heartbeat.
-    async fn request_extensions(&self) -> HeartbeatExtensionResult<HashMap<String, Vec<u8>>> {
+    async fn request_extensions(
+        &self,
+    ) -> FrontendHeartbeatExtensionResult<HashMap<String, Vec<u8>>> {
         Ok(HashMap::new())
     }
 
@@ -79,33 +82,33 @@ pub trait HeartbeatExtension: Send + Sync {
     }
 
     /// Notifies the extension that a heartbeat connection generation is ready.
-    async fn connected(&self, _generation: u64) -> HeartbeatExtensionResult<()> {
+    async fn connected(&self, _generation: u64) -> FrontendHeartbeatExtensionResult<()> {
         Ok(())
     }
 
     /// Stops and joins background work owned by the extension.
-    async fn shutdown(&self) -> HeartbeatExtensionResult<()> {
+    async fn shutdown(&self) -> FrontendHeartbeatExtensionResult<()> {
         Ok(())
     }
 }
 
 /// A shareable, ordered registry of frontend heartbeat extensions.
 #[derive(Clone, Default)]
-pub struct HeartbeatExtensions {
-    inner: Arc<StdMutex<HeartbeatExtensionsInner>>,
+pub struct FrontendHeartbeatExtensions {
+    inner: Arc<StdMutex<FrontendHeartbeatExtensionsInner>>,
 }
 
 #[derive(Default)]
-struct HeartbeatExtensionsInner {
+struct FrontendHeartbeatExtensionsInner {
     names: HashSet<String>,
-    extensions: Vec<Arc<dyn HeartbeatExtension>>,
+    extensions: Vec<Arc<dyn FrontendHeartbeatExtension>>,
 }
 
-impl HeartbeatExtensions {
+impl FrontendHeartbeatExtensions {
     /// Registers an extension without replacing an existing extension of the same name.
     ///
     /// Returns `true` for a new registration and `false` for an idempotent duplicate.
-    pub fn register(&self, extension: Arc<dyn HeartbeatExtension>) -> bool {
+    pub fn register(&self, extension: Arc<dyn FrontendHeartbeatExtension>) -> bool {
         let mut inner = self.inner.lock().unwrap();
         let name = extension.name().to_string();
         if !inner.names.insert(name) {
@@ -116,7 +119,7 @@ impl HeartbeatExtensions {
     }
 
     /// Returns the registered extensions in registration order.
-    pub fn extensions(&self) -> Vec<Arc<dyn HeartbeatExtension>> {
+    pub fn extensions(&self) -> Vec<Arc<dyn FrontendHeartbeatExtension>> {
         self.inner.lock().unwrap().extensions.clone()
     }
 
@@ -144,7 +147,7 @@ impl HeartbeatExtensions {
 /// Mailbox parsing always runs first, followed by extension handlers, suspension state handling,
 /// and cache invalidation.
 pub fn heartbeat_response_handler_executor(
-    extensions: &HeartbeatExtensions,
+    extensions: &FrontendHeartbeatExtensions,
     suspend_state: Arc<AtomicBool>,
     cache_invalidator: CacheInvalidatorRef,
 ) -> HeartbeatResponseHandlerExecutorRef {
@@ -191,12 +194,12 @@ trait HeartbeatConnector: Send + Sync {
 
 #[async_trait]
 trait HeartbeatRequestSender: Send + Sync {
-    async fn send(&self, request: HeartbeatRequest) -> HeartbeatExtensionResult<()>;
+    async fn send(&self, request: HeartbeatRequest) -> FrontendHeartbeatExtensionResult<()>;
 }
 
 #[async_trait]
 trait HeartbeatResponseStream: Send {
-    async fn message(&mut self) -> HeartbeatExtensionResult<Option<HeartbeatResponse>>;
+    async fn message(&mut self) -> FrontendHeartbeatExtensionResult<Option<HeartbeatResponse>>;
 }
 
 struct HeartbeatConnection {
@@ -229,7 +232,7 @@ struct MetaHeartbeatSender(HeartbeatSender);
 
 #[async_trait]
 impl HeartbeatRequestSender for MetaHeartbeatSender {
-    async fn send(&self, request: HeartbeatRequest) -> HeartbeatExtensionResult<()> {
+    async fn send(&self, request: HeartbeatRequest) -> FrontendHeartbeatExtensionResult<()> {
         self.0.send(request).await.map_err(BoxedError::new)
     }
 }
@@ -238,7 +241,7 @@ struct MetaHeartbeatStream(HeartbeatStream);
 
 #[async_trait]
 impl HeartbeatResponseStream for MetaHeartbeatStream {
-    async fn message(&mut self) -> HeartbeatExtensionResult<Option<HeartbeatResponse>> {
+    async fn message(&mut self) -> FrontendHeartbeatExtensionResult<Option<HeartbeatResponse>> {
         self.0.message().await.map_err(BoxedError::new)
     }
 }
@@ -251,7 +254,7 @@ struct HeartbeatRunner {
     start_time_ms: u64,
     resource_stat: ResourceStatRef,
     env_vars: EnvVars,
-    extensions: HeartbeatExtensions,
+    extensions: FrontendHeartbeatExtensions,
     cancellation: CancellationToken,
     generation: Arc<AtomicU64>,
 }
@@ -397,7 +400,7 @@ impl HeartbeatRunner {
         let total_cpu_millicores = self.resource_stat.get_total_cpu_millicores();
         let total_memory_bytes = self.resource_stat.get_total_memory_bytes();
         let mut extensions = HashMap::new();
-        self.env_vars.clone().into_extensions(&mut extensions);
+        self.env_vars.into_extensions(&mut extensions);
         let heartbeat_request = HeartbeatRequest {
             peer: Some(Peer {
                 // Metasrv calculates the frontend id by hashing this reachable address.
@@ -442,19 +445,19 @@ impl HeartbeatRunner {
                 if !self.add_request_extensions(&mut request).await {
                     return ConnectionEnd::Shutdown;
                 }
+                debug!(
+                    "Sending a heartbeat request to metasrv, content: {:?}",
+                    request
+                );
                 let result = tokio::select! {
                     _ = self.cancellation.cancelled() => return ConnectionEnd::Shutdown,
-                    result = sender.send(request.clone()) => result,
+                    result = sender.send(request) => result,
                 };
                 if let Err(error) = result {
                     error!(error; "Failed to send heartbeat to metasrv");
                     return ConnectionEnd::Reconnect;
                 }
                 HEARTBEAT_SENT_COUNT.inc();
-                debug!(
-                    "Send a heartbeat request to metasrv, content: {:?}",
-                    request
-                );
             }
         }
     }
@@ -597,7 +600,7 @@ impl HeartbeatTask {
                 start_time_ms: common_time::util::current_time_millis() as u64,
                 resource_stat,
                 env_vars: EnvVars::from_config(&opts.heartbeat_env_vars),
-                extensions: HeartbeatExtensions::default(),
+                extensions: FrontendHeartbeatExtensions::default(),
                 cancellation: CancellationToken::new(),
                 generation: Arc::new(AtomicU64::new(0)),
             },
@@ -608,7 +611,7 @@ impl HeartbeatTask {
     }
 
     /// Installs the extensions registered before heartbeat startup.
-    pub fn with_extensions(mut self, extensions: HeartbeatExtensions) -> Self {
+    pub fn with_extensions(mut self, extensions: FrontendHeartbeatExtensions) -> Self {
         self.runner.extensions = extensions;
         self
     }

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -71,6 +71,9 @@ pub trait HeartbeatExtension: Send + Sync {
     }
 
     /// Returns a handler to insert into the heartbeat response handler chain.
+    ///
+    /// Errors and [`common_meta::heartbeat::handler::HandleControl::Done`] are isolated to this
+    /// extension so they cannot skip later extensions or mandatory OSS handlers.
     fn response_handler(&self) -> Option<HeartbeatResponseHandlerRef> {
         None
     }
@@ -146,12 +149,39 @@ pub fn heartbeat_response_handler_executor(
     cache_invalidator: CacheInvalidatorRef,
 ) -> HeartbeatResponseHandlerExecutorRef {
     let mut handlers: Vec<HeartbeatResponseHandlerRef> = vec![Arc::new(ParseMailboxMessageHandler)];
-    handlers.extend(extensions.response_handlers());
+    handlers.extend(extensions.response_handlers().into_iter().map(|handler| {
+        Arc::new(IsolatedHeartbeatResponseHandler(handler)) as HeartbeatResponseHandlerRef
+    }));
     handlers.extend([
         Arc::new(SuspendHandler::new(suspend_state)) as HeartbeatResponseHandlerRef,
         Arc::new(InvalidateCacheHandler::new(cache_invalidator)),
     ]);
     Arc::new(HandlerGroupExecutor::new(handlers))
+}
+
+struct IsolatedHeartbeatResponseHandler(HeartbeatResponseHandlerRef);
+
+#[async_trait]
+impl common_meta::heartbeat::handler::HeartbeatResponseHandler
+    for IsolatedHeartbeatResponseHandler
+{
+    fn is_acceptable(&self, _ctx: &HeartbeatResponseHandlerContext) -> bool {
+        true
+    }
+
+    async fn handle(
+        &self,
+        ctx: &mut HeartbeatResponseHandlerContext,
+    ) -> common_meta::error::Result<common_meta::heartbeat::handler::HandleControl> {
+        use common_meta::heartbeat::handler::HandleControl;
+
+        if self.0.is_acceptable(ctx)
+            && let Err(error) = self.0.handle(ctx).await
+        {
+            error!(error; "Heartbeat extension response handler failed");
+        }
+        Ok(HandleControl::Continue)
+    }
 }
 
 #[async_trait]

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -362,7 +362,11 @@ impl HeartbeatRunner {
                         info!("Received mailbox message: {message:?}");
                     }
                     let context = HeartbeatResponseHandlerContext::new(mailbox.clone(), response);
-                    if let Err(error) = self.handle_response(context).await {
+                    let result = tokio::select! {
+                        _ = self.cancellation.cancelled() => return ConnectionEnd::Shutdown,
+                        result = self.handle_response(context) => result,
+                    };
+                    if let Err(error) = result {
                         error!(error; "Error while handling heartbeat response");
                         HEARTBEAT_RECV_COUNT
                             .with_label_values(&["processing_error"])

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -15,119 +15,444 @@
 #[cfg(test)]
 mod tests;
 
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 
 use api::v1::meta::heartbeat_request::NodeWorkloads;
-use api::v1::meta::{FrontendWorkloads, HeartbeatRequest, NodeInfo, Peer};
+use api::v1::meta::{FrontendWorkloads, HeartbeatRequest, HeartbeatResponse, NodeInfo, Peer};
+use async_trait::async_trait;
+use common_error::ext::BoxedError;
+use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::datanode::EnvVars;
+use common_meta::heartbeat::handler::invalidate_table_cache::InvalidateCacheHandler;
+use common_meta::heartbeat::handler::parse_mailbox_message::ParseMailboxMessageHandler;
+use common_meta::heartbeat::handler::suspend::SuspendHandler;
 use common_meta::heartbeat::handler::{
-    HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutorRef,
+    HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutorRef,
+    HeartbeatResponseHandlerRef,
 };
 use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MailboxRef, OutgoingMessage};
 use common_meta::heartbeat::utils::outgoing_message_to_mailbox_message;
 use common_stat::ResourceStatRef;
 use common_telemetry::{debug, error, info, warn};
+use meta_client::client::heartbeat::HeartbeatConfig;
 use meta_client::client::{HeartbeatSender, HeartbeatStream, MetaClient};
 use servers::addrs;
 use snafu::ResultExt;
-use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
+use tokio::sync::{Mutex, mpsc};
 use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
 
 use crate::error;
 use crate::error::Result;
 use crate::frontend::FrontendOptions;
 use crate::metrics::{HEARTBEAT_RECV_COUNT, HEARTBEAT_SENT_COUNT};
 
-/// The frontend heartbeat task which sending `[HeartbeatRequest]` to Metasrv periodically in background.
+/// The result type returned by a [`HeartbeatExtension`].
+pub type HeartbeatExtensionResult<T> = std::result::Result<T, BoxedError>;
+
+/// An extension to frontend heartbeat requests, responses, and lifecycle events.
+///
+/// [`HeartbeatExtension::request_extensions`] is called for every heartbeat. A failed call is
+/// isolated from the base heartbeat and from other extensions. [`HeartbeatExtension::connected`]
+/// is called once for every successfully established connection generation, including reconnects;
+/// implementations must therefore be idempotent. [`HeartbeatExtension::shutdown`] is called once
+/// during task shutdown after heartbeat I/O has stopped.
+#[async_trait]
+pub trait HeartbeatExtension: Send + Sync {
+    /// Returns the stable name used to make registration idempotent.
+    fn name(&self) -> &str;
+
+    /// Generates request extensions for one heartbeat.
+    async fn request_extensions(&self) -> HeartbeatExtensionResult<HashMap<String, Vec<u8>>> {
+        Ok(HashMap::new())
+    }
+
+    /// Returns a handler to insert into the heartbeat response handler chain.
+    fn response_handler(&self) -> Option<HeartbeatResponseHandlerRef> {
+        None
+    }
+
+    /// Notifies the extension that a heartbeat connection generation is ready.
+    async fn connected(&self, _generation: u64) -> HeartbeatExtensionResult<()> {
+        Ok(())
+    }
+
+    /// Stops and joins background work owned by the extension.
+    async fn shutdown(&self) -> HeartbeatExtensionResult<()> {
+        Ok(())
+    }
+}
+
+/// A shareable, ordered registry of frontend heartbeat extensions.
+#[derive(Clone, Default)]
+pub struct HeartbeatExtensions {
+    inner: Arc<StdMutex<HeartbeatExtensionsInner>>,
+}
+
+#[derive(Default)]
+struct HeartbeatExtensionsInner {
+    names: HashSet<String>,
+    extensions: Vec<Arc<dyn HeartbeatExtension>>,
+}
+
+impl HeartbeatExtensions {
+    /// Registers an extension without replacing an existing extension of the same name.
+    ///
+    /// Returns `true` for a new registration and `false` for an idempotent duplicate.
+    pub fn register(&self, extension: Arc<dyn HeartbeatExtension>) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        let name = extension.name().to_string();
+        if !inner.names.insert(name) {
+            return false;
+        }
+        inner.extensions.push(extension);
+        true
+    }
+
+    /// Returns the registered extensions in registration order.
+    pub fn extensions(&self) -> Vec<Arc<dyn HeartbeatExtension>> {
+        self.inner.lock().unwrap().extensions.clone()
+    }
+
+    /// Returns response handlers in extension registration order.
+    pub fn response_handlers(&self) -> Vec<HeartbeatResponseHandlerRef> {
+        self.extensions()
+            .into_iter()
+            .filter_map(|extension| extension.response_handler())
+            .collect()
+    }
+
+    /// Returns the number of registered extensions.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().extensions.len()
+    }
+
+    /// Returns whether no extension is registered.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Builds the frontend heartbeat response handler chain.
+///
+/// Mailbox parsing always runs first, followed by extension handlers, suspension state handling,
+/// and cache invalidation.
+pub fn heartbeat_response_handler_executor(
+    extensions: &HeartbeatExtensions,
+    suspend_state: Arc<AtomicBool>,
+    cache_invalidator: CacheInvalidatorRef,
+) -> HeartbeatResponseHandlerExecutorRef {
+    let mut handlers: Vec<HeartbeatResponseHandlerRef> = vec![Arc::new(ParseMailboxMessageHandler)];
+    handlers.extend(extensions.response_handlers());
+    handlers.extend([
+        Arc::new(SuspendHandler::new(suspend_state)) as HeartbeatResponseHandlerRef,
+        Arc::new(InvalidateCacheHandler::new(cache_invalidator)),
+    ]);
+    Arc::new(HandlerGroupExecutor::new(handlers))
+}
+
+#[async_trait]
+trait HeartbeatConnector: Send + Sync {
+    async fn connect(&self) -> Result<HeartbeatConnection>;
+}
+
+#[async_trait]
+trait HeartbeatRequestSender: Send + Sync {
+    async fn send(&self, request: HeartbeatRequest) -> HeartbeatExtensionResult<()>;
+}
+
+#[async_trait]
+trait HeartbeatResponseStream: Send {
+    async fn message(&mut self) -> HeartbeatExtensionResult<Option<HeartbeatResponse>>;
+}
+
+struct HeartbeatConnection {
+    sender: Arc<dyn HeartbeatRequestSender>,
+    stream: Box<dyn HeartbeatResponseStream>,
+    config: HeartbeatConfig,
+}
+
+struct MetaHeartbeatConnector {
+    client: Arc<MetaClient>,
+}
+
+#[async_trait]
+impl HeartbeatConnector for MetaHeartbeatConnector {
+    async fn connect(&self) -> Result<HeartbeatConnection> {
+        let (sender, stream, config) = self
+            .client
+            .heartbeat()
+            .await
+            .context(error::CreateMetaHeartbeatStreamSnafu)?;
+        Ok(HeartbeatConnection {
+            sender: Arc::new(MetaHeartbeatSender(sender)),
+            stream: Box::new(MetaHeartbeatStream(stream)),
+            config,
+        })
+    }
+}
+
+struct MetaHeartbeatSender(HeartbeatSender);
+
+#[async_trait]
+impl HeartbeatRequestSender for MetaHeartbeatSender {
+    async fn send(&self, request: HeartbeatRequest) -> HeartbeatExtensionResult<()> {
+        self.0.send(request).await.map_err(BoxedError::new)
+    }
+}
+
+struct MetaHeartbeatStream(HeartbeatStream);
+
+#[async_trait]
+impl HeartbeatResponseStream for MetaHeartbeatStream {
+    async fn message(&mut self) -> HeartbeatExtensionResult<Option<HeartbeatResponse>> {
+        self.0.message().await.map_err(BoxedError::new)
+    }
+}
+
 #[derive(Clone)]
-pub struct HeartbeatTask {
+struct HeartbeatRunner {
     peer_addr: String,
-    meta_client: Arc<MetaClient>,
+    connector: Arc<dyn HeartbeatConnector>,
     resp_handler_executor: HeartbeatResponseHandlerExecutorRef,
     start_time_ms: u64,
     resource_stat: ResourceStatRef,
     env_vars: EnvVars,
+    extensions: HeartbeatExtensions,
+    cancellation: CancellationToken,
+    generation: Arc<AtomicU64>,
 }
 
-impl HeartbeatTask {
-    pub fn new(
-        peer_addr: String,
-        opts: &FrontendOptions,
-        meta_client: Arc<MetaClient>,
-        resp_handler_executor: HeartbeatResponseHandlerExecutorRef,
-        resource_stat: ResourceStatRef,
-    ) -> Self {
-        HeartbeatTask {
-            peer_addr,
-            meta_client,
-            resp_handler_executor,
-            start_time_ms: common_time::util::current_time_millis() as u64,
-            resource_stat,
-            env_vars: EnvVars::from_config(&opts.heartbeat_env_vars),
+impl HeartbeatRunner {
+    async fn connect(&self) -> Result<Option<HeartbeatConnection>> {
+        tokio::select! {
+            _ = self.cancellation.cancelled() => Ok(None),
+            connection = self.connector.connect() => connection.map(Some),
         }
     }
 
-    pub async fn start(&self) -> Result<()> {
-        let (req_sender, resp_stream, config) = self
-            .meta_client
-            .heartbeat()
-            .await
-            .context(error::CreateMetaHeartbeatStreamSnafu)?;
-
-        info!("Heartbeat started with Metasrv config: {}", config);
-
-        let (outgoing_tx, outgoing_rx) = mpsc::channel(16);
-        let mailbox = Arc::new(HeartbeatMailbox::new(outgoing_tx));
-
-        self.start_handle_resp_stream(resp_stream, mailbox, config.retry_interval);
-
-        self.start_heartbeat_report(req_sender, outgoing_rx, config.interval);
-
-        Ok(())
+    fn next_generation(&self) -> u64 {
+        self.generation
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1)
     }
 
-    fn start_handle_resp_stream(
-        &self,
-        mut resp_stream: HeartbeatStream,
-        mailbox: MailboxRef,
-        retry_interval: Duration,
-    ) {
-        let capture_self = self.clone();
+    async fn notify_connected(&self, generation: u64) -> bool {
+        for extension in self.extensions.extensions() {
+            let result = tokio::select! {
+                _ = self.cancellation.cancelled() => return false,
+                result = extension.connected(generation) => result,
+            };
+            if let Err(error) = result {
+                error!(error; "Heartbeat extension '{}' failed its connected callback", extension.name());
+            }
+        }
+        true
+    }
 
-        let _handle = common_runtime::spawn_hb(async move {
+    async fn shutdown_extensions(&self) {
+        for extension in self.extensions.extensions() {
+            if let Err(error) = extension.shutdown().await {
+                error!(error; "Failed to shut down heartbeat extension '{}'", extension.name());
+            }
+        }
+    }
+
+    async fn run(self, mut connection: HeartbeatConnection) {
+        loop {
+            let retry_interval = connection.config.retry_interval;
+            if self.run_connection(connection).await == ConnectionEnd::Shutdown {
+                return;
+            }
+
             loop {
-                match resp_stream.message().await {
-                    Ok(Some(resp)) => {
-                        debug!("Receiving heartbeat response: {:?}", resp);
-                        if let Some(message) = &resp.mailbox_message {
-                            info!("Received mailbox message: {message:?}");
-                        }
-                        let ctx = HeartbeatResponseHandlerContext::new(mailbox.clone(), resp);
-                        if let Err(e) = capture_self.handle_response(ctx).await {
-                            error!(e; "Error while handling heartbeat response");
-                            HEARTBEAT_RECV_COUNT
-                                .with_label_values(&["processing_error"])
-                                .inc();
-                        } else {
-                            HEARTBEAT_RECV_COUNT.with_label_values(&["success"]).inc();
-                        }
-                    }
-                    Ok(None) => {
-                        warn!("Heartbeat response stream closed");
-                        capture_self.start_with_retry(retry_interval).await;
-                        break;
-                    }
-                    Err(e) => {
-                        HEARTBEAT_RECV_COUNT.with_label_values(&["error"]).inc();
-                        error!(e; "Occur error while reading heartbeat response");
-                        capture_self.start_with_retry(retry_interval).await;
+                if !self.wait_retry(retry_interval).await {
+                    return;
+                }
+                info!("Try to re-establish the heartbeat connection to metasrv.");
 
+                match self.connect().await {
+                    Ok(Some(next)) => {
+                        let generation = self.next_generation();
+                        if !self.notify_connected(generation).await {
+                            return;
+                        }
+                        connection = next;
                         break;
+                    }
+                    Ok(None) => return,
+                    Err(error) => {
+                        error!(error; "Failed to re-establish heartbeat connection to metasrv");
                     }
                 }
             }
-        });
+        }
+    }
+
+    async fn wait_retry(&self, retry_interval: Duration) -> bool {
+        tokio::select! {
+            _ = self.cancellation.cancelled() => false,
+            _ = tokio::time::sleep(retry_interval) => true,
+        }
+    }
+
+    async fn run_connection(&self, connection: HeartbeatConnection) -> ConnectionEnd {
+        let (outgoing_tx, outgoing_rx) = mpsc::channel(16);
+        let mailbox = Arc::new(HeartbeatMailbox::new(outgoing_tx));
+        let report =
+            self.report_heartbeats(connection.sender, outgoing_rx, connection.config.interval);
+        let responses = self.handle_responses(connection.stream, mailbox);
+        tokio::pin!(report);
+        tokio::pin!(responses);
+
+        tokio::select! {
+            _ = self.cancellation.cancelled() => ConnectionEnd::Shutdown,
+            end = &mut report => end,
+            end = &mut responses => end,
+        }
+    }
+
+    async fn handle_responses(
+        &self,
+        mut stream: Box<dyn HeartbeatResponseStream>,
+        mailbox: MailboxRef,
+    ) -> ConnectionEnd {
+        loop {
+            let response = tokio::select! {
+                _ = self.cancellation.cancelled() => return ConnectionEnd::Shutdown,
+                response = stream.message() => response,
+            };
+            match response {
+                Ok(Some(response)) => {
+                    debug!("Receiving heartbeat response: {:?}", response);
+                    if let Some(message) = &response.mailbox_message {
+                        info!("Received mailbox message: {message:?}");
+                    }
+                    let context = HeartbeatResponseHandlerContext::new(mailbox.clone(), response);
+                    if let Err(error) = self.handle_response(context).await {
+                        error!(error; "Error while handling heartbeat response");
+                        HEARTBEAT_RECV_COUNT
+                            .with_label_values(&["processing_error"])
+                            .inc();
+                    } else {
+                        HEARTBEAT_RECV_COUNT.with_label_values(&["success"]).inc();
+                    }
+                }
+                Ok(None) => {
+                    warn!("Heartbeat response stream closed");
+                    return ConnectionEnd::Reconnect;
+                }
+                Err(error) => {
+                    HEARTBEAT_RECV_COUNT.with_label_values(&["error"]).inc();
+                    error!(error; "Occur error while reading heartbeat response");
+                    return ConnectionEnd::Reconnect;
+                }
+            }
+        }
+    }
+
+    async fn report_heartbeats(
+        &self,
+        sender: Arc<dyn HeartbeatRequestSender>,
+        mut outgoing_rx: Receiver<OutgoingMessage>,
+        report_interval: Duration,
+    ) -> ConnectionEnd {
+        let total_cpu_millicores = self.resource_stat.get_total_cpu_millicores();
+        let total_memory_bytes = self.resource_stat.get_total_memory_bytes();
+        let mut extensions = HashMap::new();
+        self.env_vars.clone().into_extensions(&mut extensions);
+        let heartbeat_request = HeartbeatRequest {
+            peer: Some(Peer {
+                // Metasrv calculates the frontend id by hashing this reachable address.
+                id: 0,
+                addr: self.peer_addr.clone(),
+            }),
+            info: Self::build_node_info(
+                self.start_time_ms,
+                total_cpu_millicores,
+                total_memory_bytes,
+            ),
+            node_workloads: Some(NodeWorkloads::Frontend(FrontendWorkloads { types: vec![] })),
+            extensions,
+            ..Default::default()
+        };
+        let sleep = tokio::time::sleep(Duration::ZERO);
+        tokio::pin!(sleep);
+
+        loop {
+            let request = tokio::select! {
+                _ = self.cancellation.cancelled() => return ConnectionEnd::Shutdown,
+                message = outgoing_rx.recv() => {
+                    if let Some(message) = message {
+                        Self::new_heartbeat_request(&heartbeat_request, Some(message), 0, 0)
+                    } else {
+                        warn!("Sender has been dropped, exiting the heartbeat loop");
+                        return ConnectionEnd::Reconnect;
+                    }
+                }
+                _ = &mut sleep => {
+                    sleep.as_mut().reset(Instant::now() + report_interval);
+                    Self::new_heartbeat_request(
+                        &heartbeat_request,
+                        None,
+                        self.resource_stat.get_cpu_usage_millicores(),
+                        self.resource_stat.get_memory_usage_bytes(),
+                    )
+                }
+            };
+
+            if let Some(mut request) = request {
+                if !self.add_request_extensions(&mut request).await {
+                    return ConnectionEnd::Shutdown;
+                }
+                let result = tokio::select! {
+                    _ = self.cancellation.cancelled() => return ConnectionEnd::Shutdown,
+                    result = sender.send(request.clone()) => result,
+                };
+                if let Err(error) = result {
+                    error!(error; "Failed to send heartbeat to metasrv");
+                    return ConnectionEnd::Reconnect;
+                }
+                HEARTBEAT_SENT_COUNT.inc();
+                debug!(
+                    "Send a heartbeat request to metasrv, content: {:?}",
+                    request
+                );
+            }
+        }
+    }
+
+    async fn add_request_extensions(&self, request: &mut HeartbeatRequest) -> bool {
+        for extension in self.extensions.extensions() {
+            let generated = tokio::select! {
+                _ = self.cancellation.cancelled() => return false,
+                generated = extension.request_extensions() => generated,
+            };
+            let generated = match generated {
+                Ok(generated) => generated,
+                Err(error) => {
+                    error!(error; "Heartbeat extension '{}' failed to generate request extensions", extension.name());
+                    continue;
+                }
+            };
+
+            if let Some(key) = generated
+                .keys()
+                .find(|key| request.extensions.contains_key(*key))
+            {
+                warn!(
+                    "Heartbeat extension '{}' produced conflicting key '{}'; discarding its output",
+                    extension.name(),
+                    key
+                );
+                continue;
+            }
+            request.extensions.extend(generated);
+        }
+        true
     }
 
     fn new_heartbeat_request(
@@ -138,8 +463,8 @@ impl HeartbeatTask {
     ) -> Option<HeartbeatRequest> {
         let mailbox_message = match message.map(outgoing_message_to_mailbox_message) {
             Some(Ok(message)) => Some(message),
-            Some(Err(e)) => {
-                error!(e; "Failed to encode mailbox messages");
+            Some(Err(error)) => {
+                error!(error; "Failed to encode mailbox messages");
                 return None;
             }
             None => None,
@@ -149,12 +474,10 @@ impl HeartbeatTask {
             mailbox_message,
             ..heartbeat_request.clone()
         };
-
         if let Some(info) = heartbeat_request.info.as_mut() {
             info.memory_usage_bytes = memory_usage;
             info.cpu_usage_millicores = cpu_usage;
         }
-
         Some(heartbeat_request)
     }
 
@@ -165,7 +488,6 @@ impl HeartbeatTask {
         total_memory_bytes: i64,
     ) -> Option<NodeInfo> {
         let build_info = common_version::build_info();
-
         Some(NodeInfo {
             version: build_info.version.to_string(),
             git_commit: build_info.commit_short.to_string(),
@@ -184,89 +506,155 @@ impl HeartbeatTask {
         })
     }
 
-    fn start_heartbeat_report(
-        &self,
-        req_sender: HeartbeatSender,
-        mut outgoing_rx: Receiver<OutgoingMessage>,
-        report_interval: Duration,
-    ) {
-        let start_time_ms = self.start_time_ms;
-        let self_peer = Some(Peer {
-            // The node id will be actually calculated from its address (by hashing the address
-            // string) in the metasrv. So it can be set to 0 here, as a placeholder.
-            id: 0,
-            addr: self.peer_addr.clone(),
-        });
-        let total_cpu_millicores = self.resource_stat.get_total_cpu_millicores();
-        let total_memory_bytes = self.resource_stat.get_total_memory_bytes();
-        let resource_stat = self.resource_stat.clone();
-        let env_vars = self.env_vars.clone();
-        common_runtime::spawn_hb(async move {
-            let sleep = tokio::time::sleep(Duration::from_millis(0));
-            tokio::pin!(sleep);
-
-            let mut extensions = std::collections::HashMap::new();
-            env_vars.into_extensions(&mut extensions);
-
-            let heartbeat_request = HeartbeatRequest {
-                peer: self_peer,
-                info: Self::build_node_info(
-                    start_time_ms,
-                    total_cpu_millicores,
-                    total_memory_bytes,
-                ),
-                node_workloads: Some(NodeWorkloads::Frontend(FrontendWorkloads { types: vec![] })),
-                extensions,
-                ..Default::default()
-            };
-
-            loop {
-                let req = tokio::select! {
-                    message = outgoing_rx.recv() => {
-                        if let Some(message) = message {
-                            Self::new_heartbeat_request(&heartbeat_request, Some(message), 0, 0)
-                        } else {
-                            warn!("Sender has been dropped, exiting the heartbeat loop");
-                            // Receives None that means Sender was dropped, we need to break the current loop
-                            break
-                        }
-                    }
-                    _ = &mut sleep => {
-                       sleep.as_mut().reset(Instant::now() + report_interval);
-                       Self::new_heartbeat_request(&heartbeat_request, None, resource_stat.get_cpu_usage_millicores(), resource_stat.get_memory_usage_bytes())
-                    }
-                };
-
-                if let Some(req) = req {
-                    if let Err(e) = req_sender.send(req.clone()).await {
-                        error!(e; "Failed to send heartbeat to metasrv");
-                        break;
-                    } else {
-                        HEARTBEAT_SENT_COUNT.inc();
-                        debug!("Send a heartbeat request to metasrv, content: {:?}", req);
-                    }
-                }
-            }
-        });
-    }
-
-    async fn handle_response(&self, ctx: HeartbeatResponseHandlerContext) -> Result<()> {
+    async fn handle_response(&self, context: HeartbeatResponseHandlerContext) -> Result<()> {
         self.resp_handler_executor
-            .handle(ctx)
+            .handle(context)
             .await
             .context(error::HandleHeartbeatResponseSnafu)
     }
+}
 
-    async fn start_with_retry(&self, retry_interval: Duration) {
-        loop {
-            tokio::time::sleep(retry_interval).await;
+#[derive(Debug, PartialEq, Eq)]
+enum ConnectionEnd {
+    Reconnect,
+    Shutdown,
+}
 
-            info!("Try to re-establish the heartbeat connection to metasrv.");
+/// The frontend task that sends [`HeartbeatRequest`] values to metasrv in the background.
+#[derive(Clone)]
+pub struct HeartbeatTask {
+    runner: HeartbeatRunner,
+    start_lock: Arc<Mutex<()>>,
+    shutdown_lock: Arc<Mutex<()>>,
+    supervisor: Arc<Mutex<Option<common_runtime::JoinHandle<()>>>>,
+}
 
-            if self.start().await.is_ok() {
-                break;
-            }
+impl HeartbeatTask {
+    pub fn new(
+        peer_addr: String,
+        opts: &FrontendOptions,
+        meta_client: Arc<MetaClient>,
+        resp_handler_executor: HeartbeatResponseHandlerExecutorRef,
+        resource_stat: ResourceStatRef,
+    ) -> Self {
+        Self::new_with_connector(
+            peer_addr,
+            opts,
+            Arc::new(MetaHeartbeatConnector {
+                client: meta_client,
+            }),
+            resp_handler_executor,
+            resource_stat,
+        )
+    }
+
+    fn new_with_connector(
+        peer_addr: String,
+        opts: &FrontendOptions,
+        connector: Arc<dyn HeartbeatConnector>,
+        resp_handler_executor: HeartbeatResponseHandlerExecutorRef,
+        resource_stat: ResourceStatRef,
+    ) -> Self {
+        Self {
+            runner: HeartbeatRunner {
+                peer_addr,
+                connector,
+                resp_handler_executor,
+                start_time_ms: common_time::util::current_time_millis() as u64,
+                resource_stat,
+                env_vars: EnvVars::from_config(&opts.heartbeat_env_vars),
+                extensions: HeartbeatExtensions::default(),
+                cancellation: CancellationToken::new(),
+                generation: Arc::new(AtomicU64::new(0)),
+            },
+            start_lock: Arc::new(Mutex::new(())),
+            shutdown_lock: Arc::new(Mutex::new(())),
+            supervisor: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Installs the extensions registered before heartbeat startup.
+    pub fn with_extensions(mut self, extensions: HeartbeatExtensions) -> Self {
+        self.runner.extensions = extensions;
+        self
+    }
+
+    /// Establishes the initial heartbeat connection and starts its background supervisor.
+    pub async fn start(&self) -> Result<()> {
+        let _start_guard = self.start_lock.lock().await;
+        if self.runner.cancellation.is_cancelled() {
+            return Ok(());
+        }
+
+        let finished = {
+            let mut supervisor = self.supervisor.lock().await;
+            match supervisor.as_ref() {
+                Some(handle) if !handle.is_finished() => return Ok(()),
+                Some(_) => supervisor.take(),
+                None => None,
+            }
+        };
+        if let Some(handle) = finished
+            && let Err(error) = handle.await
+            && !error.is_cancelled()
+        {
+            error!(error; "Heartbeat supervisor join failed");
+        }
+
+        let Some(connection) = self.runner.connect().await? else {
+            return Ok(());
+        };
+        info!(
+            "Heartbeat started with Metasrv config: {}",
+            connection.config
+        );
+
+        let generation = self.runner.next_generation();
+        if !self.runner.notify_connected(generation).await {
+            return Ok(());
+        }
+
+        let runner = self.runner.clone();
+        let handle = common_runtime::spawn_hb(async move {
+            runner.run(connection).await;
+        });
+        *self.supervisor.lock().await = Some(handle);
+        Ok(())
+    }
+
+    /// Cancels and joins heartbeat I/O and all registered extension lifecycles.
+    pub async fn shutdown(&self) {
+        let _shutdown_guard = self.shutdown_lock.lock().await;
+        if self.runner.cancellation.is_cancelled() {
+            return;
+        }
+        self.runner.cancellation.cancel();
+
+        // Wait for a concurrently running handshake or connected callback to observe cancellation.
+        let _start_guard = self.start_lock.lock().await;
+        let handle = self.supervisor.lock().await.take();
+        if let Some(handle) = handle
+            && let Err(error) = handle.await
+            && !error.is_cancelled()
+        {
+            error!(error; "Heartbeat supervisor join failed");
+        }
+        self.runner.shutdown_extensions().await;
+    }
+
+    #[cfg(test)]
+    fn generation(&self) -> u64 {
+        self.runner.generation.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    async fn has_supervisor(&self) -> bool {
+        self.supervisor.lock().await.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.runner.cancellation.is_cancelled()
     }
 }
 

--- a/src/frontend/src/heartbeat/tests.rs
+++ b/src/frontend/src/heartbeat/tests.rs
@@ -324,7 +324,7 @@ struct MockSender {
 
 #[async_trait]
 impl HeartbeatRequestSender for MockSender {
-    async fn send(&self, request: HeartbeatRequest) -> HeartbeatExtensionResult<()> {
+    async fn send(&self, request: HeartbeatRequest) -> FrontendHeartbeatExtensionResult<()> {
         if self.fail_send.load(Ordering::Acquire) {
             return Err(test_error("mock heartbeat send failure"));
         }
@@ -346,7 +346,7 @@ struct MockStream {
 
 #[async_trait]
 impl HeartbeatResponseStream for MockStream {
-    async fn message(&mut self) -> HeartbeatExtensionResult<Option<HeartbeatResponse>> {
+    async fn message(&mut self) -> FrontendHeartbeatExtensionResult<Option<HeartbeatResponse>> {
         match self.receiver.recv().await {
             Some(MockStreamEvent::Response(response)) => Ok(Some(response)),
             Some(MockStreamEvent::Close) | None => Ok(None),
@@ -460,12 +460,14 @@ impl TestExtension {
 }
 
 #[async_trait]
-impl HeartbeatExtension for TestExtension {
+impl FrontendHeartbeatExtension for TestExtension {
     fn name(&self) -> &str {
         &self.name
     }
 
-    async fn request_extensions(&self) -> HeartbeatExtensionResult<HashMap<String, Vec<u8>>> {
+    async fn request_extensions(
+        &self,
+    ) -> FrontendHeartbeatExtensionResult<HashMap<String, Vec<u8>>> {
         let call = self.request_calls.fetch_add(1, Ordering::AcqRel) + 1;
         if self.fail_request.load(Ordering::Acquire) {
             return Err(test_error("mock extension failure"));
@@ -481,12 +483,12 @@ impl HeartbeatExtension for TestExtension {
         self.response_handler.clone()
     }
 
-    async fn connected(&self, generation: u64) -> HeartbeatExtensionResult<()> {
+    async fn connected(&self, generation: u64) -> FrontendHeartbeatExtensionResult<()> {
         self.connected_generations.lock().unwrap().push(generation);
         Ok(())
     }
 
-    async fn shutdown(&self) -> HeartbeatExtensionResult<()> {
+    async fn shutdown(&self) -> FrontendHeartbeatExtensionResult<()> {
         self.shutdown_calls.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
@@ -494,7 +496,7 @@ impl HeartbeatExtension for TestExtension {
 
 fn test_task(
     connector: Arc<dyn HeartbeatConnector>,
-    extensions: HeartbeatExtensions,
+    extensions: FrontendHeartbeatExtensions,
     options: FrontendOptions,
 ) -> HeartbeatTask {
     let executor = heartbeat_response_handler_executor(
@@ -518,7 +520,7 @@ async fn test_heartbeat_without_extensions_preserves_base_behavior() {
     let connector = MockConnector::new([ConnectPlan::Ready(plan)]);
     let task = test_task(
         connector,
-        HeartbeatExtensions::default(),
+        FrontendHeartbeatExtensions::default(),
         FrontendOptions::default(),
     );
 
@@ -539,7 +541,7 @@ async fn test_heartbeat_without_extensions_preserves_base_behavior() {
 #[tokio::test]
 async fn test_initial_connection_failure_does_not_start_extension_lifecycle() {
     let extension = TestExtension::new("lifecycle");
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     assert!(extensions.register(extension.clone()));
     let connector = MockConnector::new([ConnectPlan::Fail]);
     let task = test_task(connector, extensions, FrontendOptions::default());
@@ -553,7 +555,7 @@ async fn test_initial_connection_failure_does_not_start_extension_lifecycle() {
 #[tokio::test]
 async fn test_request_extensions_are_regenerated_for_every_heartbeat() {
     let extension = TestExtension::dynamic("dynamic", "dynamic-key");
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(extension.clone());
     let (plan, handle) = mock_connection(Duration::from_millis(10), Duration::from_millis(10));
     let task = test_task(
@@ -577,7 +579,7 @@ async fn test_failed_provider_preserves_base_and_other_extensions() {
         "successful",
         HashMap::from([("other".to_string(), b"value".to_vec())]),
     );
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(failing);
     extensions.register(successful);
     let task = test_task(
@@ -608,7 +610,7 @@ async fn test_conflicting_provider_output_is_discarded_atomically() {
         "successful",
         HashMap::from([("other".to_string(), b"value".to_vec())]),
     );
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     assert!(extensions.register(conflicting.clone()));
     assert!(!extensions.register(conflicting));
     assert!(extensions.register(successful));
@@ -726,7 +728,7 @@ async fn test_response_extension_handler_order() {
         cache: cache.clone(),
         table_key: table_key.clone(),
     });
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(TestExtension::with_handler("response", handler));
     let executor =
         heartbeat_response_handler_executor(&extensions, suspend_state.clone(), cache.clone());
@@ -780,7 +782,7 @@ async fn test_heartbeat_response_wire_compatibility_preserves_handlers() {
     });
     let suspend_state = Arc::new(AtomicBool::new(false));
     let executor = heartbeat_response_handler_executor(
-        &HeartbeatExtensions::default(),
+        &FrontendHeartbeatExtensions::default(),
         suspend_state.clone(),
         cache.clone(),
     );
@@ -876,7 +878,7 @@ async fn assert_extension_short_circuit_is_isolated(result: ShortCircuitResult) 
     let suspend_state = Arc::new(AtomicBool::new(true));
     let short_circuit_calls = Arc::new(AtomicUsize::new(0));
     let observations = Arc::new(Mutex::new(Vec::new()));
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(TestExtension::with_handler(
         "short-circuit",
         Arc::new(ShortCircuitHandler {
@@ -946,7 +948,7 @@ async fn test_response_extension_error_does_not_skip_remaining_handlers() {
 #[tokio::test]
 async fn test_closed_response_stream_reconnects_once() {
     let extension = TestExtension::new("lifecycle");
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(extension.clone());
     let (first_plan, first) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
     let (second_plan, second) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
@@ -970,6 +972,56 @@ async fn test_closed_response_stream_reconnects_once() {
 }
 
 #[tokio::test]
+async fn test_response_stream_error_reconnects() {
+    let (first_plan, first) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let (second_plan, second) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([
+        ConnectPlan::Ready(first_plan),
+        ConnectPlan::Ready(second_plan),
+    ]);
+    let task = test_task(
+        connector.clone(),
+        FrontendHeartbeatExtensions::default(),
+        FrontendOptions::default(),
+    );
+
+    task.start().await.unwrap();
+    first.wait_for_requests(1).await;
+    first.fail_responses();
+    connector.wait_for_calls(2).await;
+    second.wait_for_requests(1).await;
+    assert_eq!(task.generation(), 2);
+    task.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_failed_reconnect_is_retried() {
+    let extension = TestExtension::new("lifecycle");
+    let extensions = FrontendHeartbeatExtensions::default();
+    extensions.register(extension.clone());
+    let (first_plan, first) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let (second_plan, second) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([
+        ConnectPlan::Ready(first_plan),
+        ConnectPlan::Fail,
+        ConnectPlan::Ready(second_plan),
+    ]);
+    let task = test_task(connector.clone(), extensions, FrontendOptions::default());
+
+    task.start().await.unwrap();
+    first.wait_for_requests(1).await;
+    first.close_responses();
+    connector.wait_for_calls(3).await;
+    second.wait_for_requests(1).await;
+    assert_eq!(task.generation(), 2);
+    assert_eq!(
+        extension.connected_generations.lock().unwrap().as_slice(),
+        &[1, 2]
+    );
+    task.shutdown().await;
+}
+
+#[tokio::test]
 async fn test_send_failure_reconnects() {
     let (first_plan, first) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
     first.fail_send.store(true, Ordering::Release);
@@ -980,7 +1032,7 @@ async fn test_send_failure_reconnects() {
     ]);
     let task = test_task(
         connector.clone(),
-        HeartbeatExtensions::default(),
+        FrontendHeartbeatExtensions::default(),
         FrontendOptions::default(),
     );
 
@@ -1003,7 +1055,7 @@ async fn test_concurrent_send_receive_failure_creates_one_generation() {
     ]);
     let task = test_task(
         connector.clone(),
-        HeartbeatExtensions::default(),
+        FrontendHeartbeatExtensions::default(),
         FrontendOptions::default(),
     );
 
@@ -1019,7 +1071,7 @@ async fn test_concurrent_send_receive_failure_creates_one_generation() {
 #[tokio::test]
 async fn test_shutdown_cancels_stuck_handshake() {
     let extension = TestExtension::new("lifecycle");
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(extension.clone());
     let connector = MockConnector::new([ConnectPlan::Pending]);
     let task = test_task(connector.clone(), extensions, FrontendOptions::default());
@@ -1041,7 +1093,7 @@ async fn test_shutdown_cancels_retry_sleep_and_joins_supervisor() {
     let connector = MockConnector::new([ConnectPlan::Ready(plan)]);
     let task = test_task(
         connector.clone(),
-        HeartbeatExtensions::default(),
+        FrontendHeartbeatExtensions::default(),
         FrontendOptions::default(),
     );
     task.start().await.unwrap();
@@ -1065,7 +1117,7 @@ async fn test_shutdown_cancels_inflight_response_handler() {
             started: started.clone(),
         }),
     );
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(extension.clone());
     let (plan, handle) = mock_connection(Duration::from_secs(60), Duration::from_secs(60));
     let task = test_task(
@@ -1095,7 +1147,7 @@ async fn test_concurrent_start_has_one_active_generation() {
     let connector = MockConnector::new([ConnectPlan::Ready(plan)]);
     let task = test_task(
         connector.clone(),
-        HeartbeatExtensions::default(),
+        FrontendHeartbeatExtensions::default(),
         FrontendOptions::default(),
     );
     let starts = (0..8).map(|_| {
@@ -1115,7 +1167,7 @@ async fn test_concurrent_start_has_one_active_generation() {
 #[tokio::test]
 async fn test_shutdown_prevents_restart_and_extension_callbacks() {
     let extension = TestExtension::dynamic("lifecycle", "dynamic");
-    let extensions = HeartbeatExtensions::default();
+    let extensions = FrontendHeartbeatExtensions::default();
     extensions.register(extension.clone());
     let (plan, handle) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
     let connector = MockConnector::new([ConnectPlan::Ready(plan)]);

--- a/src/frontend/src/heartbeat/tests.rs
+++ b/src/frontend/src/heartbeat/tests.rs
@@ -20,7 +20,10 @@ use std::time::Duration;
 
 use api::v1::meta::heartbeat_request::NodeWorkloads;
 use api::v1::meta::mailbox_message::Payload;
-use api::v1::meta::{HeartbeatRequest, HeartbeatResponse, MailboxMessage, Role};
+use api::v1::meta::{
+    HeartbeatConfig as ApiHeartbeatConfig, HeartbeatRequest, HeartbeatResponse, MailboxMessage,
+    RegionLease, ResponseHeader, Role,
+};
 use async_trait::async_trait;
 use common_error::ext::{BoxedError, PlainError};
 use common_error::status_code::StatusCode;
@@ -38,6 +41,7 @@ use common_meta::key::table_info::TableInfoKey;
 use common_stat::ResourceStatImpl;
 use common_telemetry::tracing_context::TracingContext;
 use meta_client::client::MetaClient;
+use prost::Message;
 use tokio::sync::{Notify, mpsc};
 
 use super::*;
@@ -46,6 +50,18 @@ use crate::frontend::FrontendOptions;
 #[derive(Default)]
 pub struct MockKvCacheInvalidator {
     inner: Mutex<HashMap<Vec<u8>, i32>>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct LegacyHeartbeatResponse {
+    #[prost(message, optional, tag = "1")]
+    header: Option<ResponseHeader>,
+    #[prost(message, optional, tag = "2")]
+    mailbox_message: Option<MailboxMessage>,
+    #[prost(message, optional, tag = "3")]
+    region_lease: Option<RegionLease>,
+    #[prost(message, optional, tag = "4")]
+    heartbeat_config: Option<ApiHeartbeatConfig>,
 }
 
 #[async_trait::async_trait]
@@ -752,6 +768,102 @@ async fn test_response_extension_handler_order() {
         &[(false, true, true, true), (true, false, true, true)]
     );
     assert!(!suspend_state.load(Ordering::Acquire));
+    assert!(!cache.inner.lock().unwrap().contains_key(&table_key));
+}
+
+#[tokio::test]
+async fn test_heartbeat_response_wire_compatibility_preserves_handlers() {
+    let table_id = 42;
+    let table_key = TableInfoKey::new(table_id).to_bytes();
+    let cache = Arc::new(MockKvCacheInvalidator {
+        inner: Mutex::new(HashMap::from([(table_key.clone(), 1)])),
+    });
+    let suspend_state = Arc::new(AtomicBool::new(false));
+    let executor = heartbeat_response_handler_executor(
+        &HeartbeatExtensions::default(),
+        suspend_state.clone(),
+        cache.clone(),
+    );
+    let (mailbox_tx, _) = mpsc::channel(1);
+    let mailbox = Arc::new(HeartbeatMailbox::new(mailbox_tx));
+    let heartbeat_config = ApiHeartbeatConfig {
+        heartbeat_interval_ms: 3_000,
+        retry_interval_ms: 500,
+        gc_enabled: true,
+    };
+
+    let new_response = HeartbeatResponse {
+        header: Some(ResponseHeader::success()),
+        mailbox_message: Some(MailboxMessage {
+            payload: Some(Payload::Json(
+                serde_json::to_string(&Instruction::Suspend).unwrap(),
+            )),
+            ..Default::default()
+        }),
+        region_lease: Some(RegionLease::default()),
+        heartbeat_config: Some(heartbeat_config),
+        extensions: HashMap::from([("response-extension".to_string(), b"value".to_vec())]),
+    };
+    let legacy_decoded =
+        LegacyHeartbeatResponse::decode(new_response.encode_to_vec().as_slice()).unwrap();
+    assert_eq!(new_response.header, legacy_decoded.header);
+    assert_eq!(new_response.mailbox_message, legacy_decoded.mailbox_message);
+    assert_eq!(new_response.region_lease, legacy_decoded.region_lease);
+    assert_eq!(
+        new_response.heartbeat_config,
+        legacy_decoded.heartbeat_config
+    );
+
+    executor
+        .handle(HeartbeatResponseHandlerContext::new(
+            mailbox.clone(),
+            HeartbeatResponse {
+                header: legacy_decoded.header,
+                mailbox_message: legacy_decoded.mailbox_message,
+                region_lease: legacy_decoded.region_lease,
+                heartbeat_config: legacy_decoded.heartbeat_config,
+                extensions: HashMap::new(),
+            },
+        ))
+        .await
+        .unwrap();
+    assert!(suspend_state.load(Ordering::Acquire));
+
+    let legacy_response = LegacyHeartbeatResponse {
+        header: Some(ResponseHeader::success()),
+        mailbox_message: Some(MailboxMessage {
+            payload: Some(Payload::Json(
+                serde_json::to_string(&Instruction::InvalidateCaches(vec![CacheIdent::TableId(
+                    table_id,
+                )]))
+                .unwrap(),
+            )),
+            ..Default::default()
+        }),
+        region_lease: Some(RegionLease::default()),
+        heartbeat_config: Some(heartbeat_config),
+    };
+    let current_decoded =
+        HeartbeatResponse::decode(legacy_response.encode_to_vec().as_slice()).unwrap();
+    assert_eq!(legacy_response.header, current_decoded.header);
+    assert_eq!(
+        legacy_response.mailbox_message,
+        current_decoded.mailbox_message
+    );
+    assert_eq!(legacy_response.region_lease, current_decoded.region_lease);
+    assert_eq!(
+        legacy_response.heartbeat_config,
+        current_decoded.heartbeat_config
+    );
+    assert!(current_decoded.extensions.is_empty());
+
+    executor
+        .handle(HeartbeatResponseHandlerContext::new(
+            mailbox,
+            current_decoded,
+        ))
+        .await
+        .unwrap();
     assert!(!cache.inner.lock().unwrap().contains_key(&table_key));
 }
 

--- a/src/frontend/src/heartbeat/tests.rs
+++ b/src/frontend/src/heartbeat/tests.rs
@@ -12,14 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::future::pending;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use api::v1::meta::{HeartbeatResponse, Role};
+use api::v1::meta::heartbeat_request::NodeWorkloads;
+use api::v1::meta::mailbox_message::Payload;
+use api::v1::meta::{HeartbeatRequest, HeartbeatResponse, MailboxMessage, Role};
+use async_trait::async_trait;
+use common_error::ext::{BoxedError, PlainError};
+use common_error::status_code::StatusCode;
 use common_meta::cache_invalidator::KvCacheInvalidator;
 use common_meta::heartbeat::handler::invalidate_table_cache::InvalidateCacheHandler;
 use common_meta::heartbeat::handler::{
-    HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutor,
+    HandleControl, HandlerGroupExecutor, HeartbeatResponseHandler, HeartbeatResponseHandlerContext,
+    HeartbeatResponseHandlerExecutor, HeartbeatResponseHandlerRef,
 };
 use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MessageMeta};
 use common_meta::instruction::{CacheIdent, Instruction};
@@ -29,9 +38,9 @@ use common_meta::key::table_info::TableInfoKey;
 use common_stat::ResourceStatImpl;
 use common_telemetry::tracing_context::TracingContext;
 use meta_client::client::MetaClient;
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 
-use super::HeartbeatTask;
+use super::*;
 use crate::frontend::FrontendOptions;
 
 #[derive(Default)]
@@ -172,5 +181,675 @@ fn test_heartbeat_task_uses_resolved_peer_addr() {
         stat,
     );
 
-    assert_eq!(task.peer_addr, "10.0.0.1:4001");
+    assert_eq!(task.runner.peer_addr, "10.0.0.1:4001");
+}
+
+enum ConnectPlan {
+    Ready(MockConnectionPlan),
+    Fail,
+    Pending,
+}
+
+struct MockConnector {
+    plans: Mutex<VecDeque<ConnectPlan>>,
+    calls: AtomicUsize,
+    called: Notify,
+}
+
+impl MockConnector {
+    fn new(plans: impl IntoIterator<Item = ConnectPlan>) -> Arc<Self> {
+        Arc::new(Self {
+            plans: Mutex::new(plans.into_iter().collect()),
+            calls: AtomicUsize::new(0),
+            called: Notify::new(),
+        })
+    }
+
+    async fn wait_for_calls(&self, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if self.calls.load(Ordering::Acquire) >= expected {
+                    return;
+                }
+                let notified = self.called.notified();
+                if self.calls.load(Ordering::Acquire) >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+}
+
+#[async_trait]
+impl HeartbeatConnector for MockConnector {
+    async fn connect(&self) -> Result<HeartbeatConnection> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        self.called.notify_waiters();
+        let plan = self.plans.lock().unwrap().pop_front();
+        match plan {
+            Some(ConnectPlan::Ready(plan)) => Ok(plan.into_connection()),
+            Some(ConnectPlan::Fail) => Err(crate::error::Error::NotSupported {
+                feat: "mock heartbeat connection".to_string(),
+            }),
+            Some(ConnectPlan::Pending) | None => pending().await,
+        }
+    }
+}
+
+struct MockConnectionPlan {
+    sender: MockSender,
+    response_rx: mpsc::UnboundedReceiver<MockStreamEvent>,
+    config: HeartbeatConfig,
+}
+
+impl MockConnectionPlan {
+    fn into_connection(self) -> HeartbeatConnection {
+        HeartbeatConnection {
+            sender: Arc::new(self.sender),
+            stream: Box::new(MockStream {
+                receiver: self.response_rx,
+            }),
+            config: self.config,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct MockConnectionHandle {
+    requests: Arc<Mutex<Vec<HeartbeatRequest>>>,
+    request_added: Arc<Notify>,
+    response_tx: mpsc::UnboundedSender<MockStreamEvent>,
+    fail_send: Arc<AtomicBool>,
+}
+
+impl MockConnectionHandle {
+    async fn wait_for_requests(&self, expected: usize) -> Vec<HeartbeatRequest> {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let requests = self.requests.lock().unwrap().clone();
+                if requests.len() >= expected {
+                    return requests;
+                }
+                let notified = self.request_added.notified();
+                if self.requests.lock().unwrap().len() >= expected {
+                    continue;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .unwrap()
+    }
+
+    fn close_responses(&self) {
+        self.response_tx.send(MockStreamEvent::Close).unwrap();
+    }
+
+    fn fail_responses(&self) {
+        self.response_tx.send(MockStreamEvent::Error).unwrap();
+    }
+}
+
+#[derive(Clone)]
+struct MockSender {
+    requests: Arc<Mutex<Vec<HeartbeatRequest>>>,
+    request_added: Arc<Notify>,
+    fail_send: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl HeartbeatRequestSender for MockSender {
+    async fn send(&self, request: HeartbeatRequest) -> HeartbeatExtensionResult<()> {
+        if self.fail_send.load(Ordering::Acquire) {
+            return Err(test_error("mock heartbeat send failure"));
+        }
+        self.requests.lock().unwrap().push(request);
+        self.request_added.notify_waiters();
+        Ok(())
+    }
+}
+
+enum MockStreamEvent {
+    Close,
+    Error,
+}
+
+struct MockStream {
+    receiver: mpsc::UnboundedReceiver<MockStreamEvent>,
+}
+
+#[async_trait]
+impl HeartbeatResponseStream for MockStream {
+    async fn message(&mut self) -> HeartbeatExtensionResult<Option<HeartbeatResponse>> {
+        match self.receiver.recv().await {
+            Some(MockStreamEvent::Close) | None => Ok(None),
+            Some(MockStreamEvent::Error) => Err(test_error("mock heartbeat receive failure")),
+        }
+    }
+}
+
+fn mock_connection(
+    interval: Duration,
+    retry_interval: Duration,
+) -> (MockConnectionPlan, MockConnectionHandle) {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let request_added = Arc::new(Notify::new());
+    let fail_send = Arc::new(AtomicBool::new(false));
+    let (response_tx, response_rx) = mpsc::unbounded_channel();
+    let sender = MockSender {
+        requests: requests.clone(),
+        request_added: request_added.clone(),
+        fail_send: fail_send.clone(),
+    };
+    let handle = MockConnectionHandle {
+        requests,
+        request_added,
+        response_tx,
+        fail_send,
+    };
+    (
+        MockConnectionPlan {
+            sender,
+            response_rx,
+            config: HeartbeatConfig {
+                interval,
+                retry_interval,
+                gc_enabled: false,
+            },
+        },
+        handle,
+    )
+}
+
+fn test_error(message: &str) -> BoxedError {
+    BoxedError::new(PlainError::new(message.to_string(), StatusCode::Unexpected))
+}
+
+struct TestExtension {
+    name: String,
+    static_extensions: HashMap<String, Vec<u8>>,
+    dynamic_key: Option<String>,
+    fail_request: AtomicBool,
+    request_calls: AtomicUsize,
+    connected_generations: Mutex<Vec<u64>>,
+    shutdown_calls: AtomicUsize,
+    response_handler: Option<HeartbeatResponseHandlerRef>,
+}
+
+impl TestExtension {
+    fn new(name: &str) -> Arc<Self> {
+        Arc::new(Self {
+            name: name.to_string(),
+            static_extensions: HashMap::new(),
+            dynamic_key: None,
+            fail_request: AtomicBool::new(false),
+            request_calls: AtomicUsize::new(0),
+            connected_generations: Mutex::new(Vec::new()),
+            shutdown_calls: AtomicUsize::new(0),
+            response_handler: None,
+        })
+    }
+
+    fn with_static(name: &str, static_extensions: HashMap<String, Vec<u8>>) -> Arc<Self> {
+        Arc::new(Self {
+            static_extensions,
+            ..Self::new_fields(name)
+        })
+    }
+
+    fn dynamic(name: &str, key: &str) -> Arc<Self> {
+        Arc::new(Self {
+            dynamic_key: Some(key.to_string()),
+            ..Self::new_fields(name)
+        })
+    }
+
+    fn failing(name: &str) -> Arc<Self> {
+        Arc::new(Self {
+            fail_request: AtomicBool::new(true),
+            ..Self::new_fields(name)
+        })
+    }
+
+    fn with_handler(name: &str, response_handler: HeartbeatResponseHandlerRef) -> Arc<Self> {
+        Arc::new(Self {
+            response_handler: Some(response_handler),
+            ..Self::new_fields(name)
+        })
+    }
+
+    fn new_fields(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            static_extensions: HashMap::new(),
+            dynamic_key: None,
+            fail_request: AtomicBool::new(false),
+            request_calls: AtomicUsize::new(0),
+            connected_generations: Mutex::new(Vec::new()),
+            shutdown_calls: AtomicUsize::new(0),
+            response_handler: None,
+        }
+    }
+}
+
+#[async_trait]
+impl HeartbeatExtension for TestExtension {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn request_extensions(&self) -> HeartbeatExtensionResult<HashMap<String, Vec<u8>>> {
+        let call = self.request_calls.fetch_add(1, Ordering::AcqRel) + 1;
+        if self.fail_request.load(Ordering::Acquire) {
+            return Err(test_error("mock extension failure"));
+        }
+        let mut extensions = self.static_extensions.clone();
+        if let Some(key) = &self.dynamic_key {
+            extensions.insert(key.clone(), call.to_string().into_bytes());
+        }
+        Ok(extensions)
+    }
+
+    fn response_handler(&self) -> Option<HeartbeatResponseHandlerRef> {
+        self.response_handler.clone()
+    }
+
+    async fn connected(&self, generation: u64) -> HeartbeatExtensionResult<()> {
+        self.connected_generations.lock().unwrap().push(generation);
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> HeartbeatExtensionResult<()> {
+        self.shutdown_calls.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
+fn test_task(
+    connector: Arc<dyn HeartbeatConnector>,
+    extensions: HeartbeatExtensions,
+    options: FrontendOptions,
+) -> HeartbeatTask {
+    HeartbeatTask::new_with_connector(
+        "127.0.0.1:4001".to_string(),
+        &options,
+        connector,
+        Arc::new(HandlerGroupExecutor::new(vec![])),
+        Arc::new(ResourceStatImpl::default()),
+    )
+    .with_extensions(extensions)
+}
+
+#[tokio::test]
+async fn test_heartbeat_without_extensions_preserves_base_behavior() {
+    let (plan, handle) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([ConnectPlan::Ready(plan)]);
+    let task = test_task(
+        connector,
+        HeartbeatExtensions::default(),
+        FrontendOptions::default(),
+    );
+
+    task.start().await.unwrap();
+    let requests = handle.wait_for_requests(1).await;
+    let request = &requests[0];
+    assert_eq!(request.peer.as_ref().unwrap().addr, "127.0.0.1:4001");
+    assert!(request.extensions.is_empty());
+    assert!(matches!(
+        request.node_workloads,
+        Some(NodeWorkloads::Frontend(_))
+    ));
+
+    task.shutdown().await;
+    assert!(!task.has_supervisor().await);
+}
+
+#[tokio::test]
+async fn test_initial_connection_failure_does_not_start_extension_lifecycle() {
+    let extension = TestExtension::new("lifecycle");
+    let extensions = HeartbeatExtensions::default();
+    assert!(extensions.register(extension.clone()));
+    let connector = MockConnector::new([ConnectPlan::Fail]);
+    let task = test_task(connector, extensions, FrontendOptions::default());
+
+    assert!(task.start().await.is_err());
+    assert!(extension.connected_generations.lock().unwrap().is_empty());
+    assert!(!task.has_supervisor().await);
+    task.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_request_extensions_are_regenerated_for_every_heartbeat() {
+    let extension = TestExtension::dynamic("dynamic", "dynamic-key");
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(extension.clone());
+    let (plan, handle) = mock_connection(Duration::from_millis(10), Duration::from_millis(10));
+    let task = test_task(
+        MockConnector::new([ConnectPlan::Ready(plan)]),
+        extensions,
+        FrontendOptions::default(),
+    );
+
+    task.start().await.unwrap();
+    let requests = handle.wait_for_requests(2).await;
+    assert_eq!(requests[0].extensions["dynamic-key"], b"1");
+    assert_eq!(requests[1].extensions["dynamic-key"], b"2");
+    assert_eq!(extension.request_calls.load(Ordering::Acquire), 2);
+    task.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_failed_provider_preserves_base_and_other_extensions() {
+    let failing = TestExtension::failing("failing");
+    let successful = TestExtension::with_static(
+        "successful",
+        HashMap::from([("other".to_string(), b"value".to_vec())]),
+    );
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(failing);
+    extensions.register(successful);
+    let task = test_task(
+        MockConnector::new([ConnectPlan::Pending]),
+        extensions,
+        FrontendOptions::default(),
+    );
+    let mut request = HeartbeatRequest {
+        extensions: HashMap::from([("base".to_string(), b"keep".to_vec())]),
+        ..Default::default()
+    };
+
+    assert!(task.runner.add_request_extensions(&mut request).await);
+    assert_eq!(request.extensions["base"], b"keep");
+    assert_eq!(request.extensions["other"], b"value");
+}
+
+#[tokio::test]
+async fn test_conflicting_provider_output_is_discarded_atomically() {
+    let conflicting = TestExtension::with_static(
+        "conflicting",
+        HashMap::from([
+            ("base".to_string(), b"replace".to_vec()),
+            ("partial".to_string(), b"discard".to_vec()),
+        ]),
+    );
+    let successful = TestExtension::with_static(
+        "successful",
+        HashMap::from([("other".to_string(), b"value".to_vec())]),
+    );
+    let extensions = HeartbeatExtensions::default();
+    assert!(extensions.register(conflicting.clone()));
+    assert!(!extensions.register(conflicting));
+    assert!(extensions.register(successful));
+    let task = test_task(
+        MockConnector::new([ConnectPlan::Pending]),
+        extensions,
+        FrontendOptions::default(),
+    );
+    let mut request = HeartbeatRequest {
+        extensions: HashMap::from([("base".to_string(), b"keep".to_vec())]),
+        ..Default::default()
+    };
+
+    assert!(task.runner.add_request_extensions(&mut request).await);
+    assert_eq!(request.extensions["base"], b"keep");
+    assert!(!request.extensions.contains_key("partial"));
+    assert_eq!(request.extensions["other"], b"value");
+}
+
+type HandlerObservations = Arc<Mutex<Vec<(bool, bool, bool, bool)>>>;
+
+struct OrderingHandler {
+    observations: HandlerObservations,
+    suspend_state: Arc<AtomicBool>,
+    cache: Arc<MockKvCacheInvalidator>,
+    table_key: Vec<u8>,
+}
+
+#[async_trait]
+impl HeartbeatResponseHandler for OrderingHandler {
+    fn is_acceptable(&self, _ctx: &HeartbeatResponseHandlerContext) -> bool {
+        true
+    }
+
+    async fn handle(
+        &self,
+        ctx: &mut HeartbeatResponseHandlerContext,
+    ) -> common_meta::error::Result<HandleControl> {
+        self.observations.lock().unwrap().push((
+            ctx.incoming_message.is_some(),
+            self.suspend_state.load(Ordering::Acquire),
+            self.cache
+                .inner
+                .lock()
+                .unwrap()
+                .contains_key(&self.table_key),
+            ctx.response.extensions.contains_key("response-extension"),
+        ));
+        Ok(HandleControl::Continue)
+    }
+}
+
+#[tokio::test]
+async fn test_response_extension_handler_order() {
+    let table_id = 42;
+    let table_key = TableInfoKey::new(table_id).to_bytes();
+    let cache = Arc::new(MockKvCacheInvalidator {
+        inner: Mutex::new(HashMap::from([(table_key.clone(), 1)])),
+    });
+    let suspend_state = Arc::new(AtomicBool::new(true));
+    let observations = Arc::new(Mutex::new(Vec::new()));
+    let handler = Arc::new(OrderingHandler {
+        observations: observations.clone(),
+        suspend_state: suspend_state.clone(),
+        cache: cache.clone(),
+        table_key: table_key.clone(),
+    });
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(TestExtension::with_handler("response", handler));
+    let executor =
+        heartbeat_response_handler_executor(&extensions, suspend_state.clone(), cache.clone());
+    let (mailbox_tx, _) = mpsc::channel(1);
+    let mailbox = Arc::new(HeartbeatMailbox::new(mailbox_tx));
+
+    executor
+        .handle(HeartbeatResponseHandlerContext::new(
+            mailbox.clone(),
+            HeartbeatResponse {
+                extensions: HashMap::from([("response-extension".to_string(), b"value".to_vec())]),
+                ..Default::default()
+            },
+        ))
+        .await
+        .unwrap();
+    assert!(!suspend_state.load(Ordering::Acquire));
+
+    let response = HeartbeatResponse {
+        mailbox_message: Some(MailboxMessage {
+            payload: Some(Payload::Json(
+                serde_json::to_string(&Instruction::InvalidateCaches(vec![CacheIdent::TableId(
+                    table_id,
+                )]))
+                .unwrap(),
+            )),
+            ..Default::default()
+        }),
+        extensions: HashMap::from([("response-extension".to_string(), b"value".to_vec())]),
+        ..Default::default()
+    };
+    executor
+        .handle(HeartbeatResponseHandlerContext::new(mailbox, response))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        observations.lock().unwrap().as_slice(),
+        &[(false, true, true, true), (true, false, true, true)]
+    );
+    assert!(!suspend_state.load(Ordering::Acquire));
+    assert!(!cache.inner.lock().unwrap().contains_key(&table_key));
+}
+
+#[tokio::test]
+async fn test_closed_response_stream_reconnects_once() {
+    let extension = TestExtension::new("lifecycle");
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(extension.clone());
+    let (first_plan, first) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let (second_plan, second) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([
+        ConnectPlan::Ready(first_plan),
+        ConnectPlan::Ready(second_plan),
+    ]);
+    let task = test_task(connector.clone(), extensions, FrontendOptions::default());
+
+    task.start().await.unwrap();
+    first.wait_for_requests(1).await;
+    first.close_responses();
+    connector.wait_for_calls(2).await;
+    second.wait_for_requests(1).await;
+    assert_eq!(task.generation(), 2);
+    assert_eq!(
+        extension.connected_generations.lock().unwrap().as_slice(),
+        &[1, 2]
+    );
+    task.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_send_failure_reconnects() {
+    let (first_plan, first) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    first.fail_send.store(true, Ordering::Release);
+    let (second_plan, second) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([
+        ConnectPlan::Ready(first_plan),
+        ConnectPlan::Ready(second_plan),
+    ]);
+    let task = test_task(
+        connector.clone(),
+        HeartbeatExtensions::default(),
+        FrontendOptions::default(),
+    );
+
+    task.start().await.unwrap();
+    connector.wait_for_calls(2).await;
+    second.wait_for_requests(1).await;
+    assert_eq!(task.generation(), 2);
+    task.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_concurrent_send_receive_failure_creates_one_generation() {
+    let (first_plan, first) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    first.fail_send.store(true, Ordering::Release);
+    first.fail_responses();
+    let (second_plan, second) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([
+        ConnectPlan::Ready(first_plan),
+        ConnectPlan::Ready(second_plan),
+    ]);
+    let task = test_task(
+        connector.clone(),
+        HeartbeatExtensions::default(),
+        FrontendOptions::default(),
+    );
+
+    task.start().await.unwrap();
+    connector.wait_for_calls(2).await;
+    second.wait_for_requests(1).await;
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(connector.calls.load(Ordering::Acquire), 2);
+    assert_eq!(task.generation(), 2);
+    task.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_shutdown_cancels_stuck_handshake() {
+    let extension = TestExtension::new("lifecycle");
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(extension.clone());
+    let connector = MockConnector::new([ConnectPlan::Pending]);
+    let task = test_task(connector.clone(), extensions, FrontendOptions::default());
+    let start_task = task.clone();
+    let start = tokio::spawn(async move { start_task.start().await });
+    connector.wait_for_calls(1).await;
+
+    tokio::time::timeout(Duration::from_secs(1), task.shutdown())
+        .await
+        .unwrap();
+    start.await.unwrap().unwrap();
+    assert!(extension.connected_generations.lock().unwrap().is_empty());
+    assert!(!task.has_supervisor().await);
+}
+
+#[tokio::test]
+async fn test_shutdown_cancels_retry_sleep_and_joins_supervisor() {
+    let (plan, handle) = mock_connection(Duration::from_secs(60), Duration::from_secs(60));
+    let connector = MockConnector::new([ConnectPlan::Ready(plan)]);
+    let task = test_task(
+        connector.clone(),
+        HeartbeatExtensions::default(),
+        FrontendOptions::default(),
+    );
+    task.start().await.unwrap();
+    handle.wait_for_requests(1).await;
+    handle.close_responses();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    tokio::time::timeout(Duration::from_secs(1), task.shutdown())
+        .await
+        .unwrap();
+    assert_eq!(connector.calls.load(Ordering::Acquire), 1);
+    assert!(!task.has_supervisor().await);
+}
+
+#[tokio::test]
+async fn test_concurrent_start_has_one_active_generation() {
+    let (plan, handle) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([ConnectPlan::Ready(plan)]);
+    let task = test_task(
+        connector.clone(),
+        HeartbeatExtensions::default(),
+        FrontendOptions::default(),
+    );
+    let starts = (0..8).map(|_| {
+        let task = task.clone();
+        tokio::spawn(async move { task.start().await })
+    });
+    for start in starts {
+        start.await.unwrap().unwrap();
+    }
+    handle.wait_for_requests(1).await;
+
+    assert_eq!(connector.calls.load(Ordering::Acquire), 1);
+    assert_eq!(task.generation(), 1);
+    task.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_shutdown_prevents_restart_and_extension_callbacks() {
+    let extension = TestExtension::dynamic("lifecycle", "dynamic");
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(extension.clone());
+    let (plan, handle) = mock_connection(Duration::from_secs(60), Duration::from_millis(10));
+    let connector = MockConnector::new([ConnectPlan::Ready(plan)]);
+    let task = test_task(connector.clone(), extensions, FrontendOptions::default());
+    task.start().await.unwrap();
+    handle.wait_for_requests(1).await;
+    task.shutdown().await;
+    task.shutdown().await;
+
+    let request_calls = extension.request_calls.load(Ordering::Acquire);
+    let connected = extension.connected_generations.lock().unwrap().clone();
+    task.start().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(connector.calls.load(Ordering::Acquire), 1);
+    assert_eq!(
+        extension.request_calls.load(Ordering::Acquire),
+        request_calls
+    );
+    assert_eq!(*extension.connected_generations.lock().unwrap(), connected);
+    assert_eq!(extension.shutdown_calls.load(Ordering::Acquire), 1);
 }

--- a/src/frontend/src/heartbeat/tests.rs
+++ b/src/frontend/src/heartbeat/tests.rs
@@ -291,6 +291,12 @@ impl MockConnectionHandle {
     fn fail_responses(&self) {
         self.response_tx.send(MockStreamEvent::Error).unwrap();
     }
+
+    fn send_response(&self, response: HeartbeatResponse) {
+        self.response_tx
+            .send(MockStreamEvent::Response(response))
+            .unwrap();
+    }
 }
 
 #[derive(Clone)]
@@ -313,6 +319,7 @@ impl HeartbeatRequestSender for MockSender {
 }
 
 enum MockStreamEvent {
+    Response(HeartbeatResponse),
     Close,
     Error,
 }
@@ -325,6 +332,7 @@ struct MockStream {
 impl HeartbeatResponseStream for MockStream {
     async fn message(&mut self) -> HeartbeatExtensionResult<Option<HeartbeatResponse>> {
         match self.receiver.recv().await {
+            Some(MockStreamEvent::Response(response)) => Ok(Some(response)),
             Some(MockStreamEvent::Close) | None => Ok(None),
             Some(MockStreamEvent::Error) => Err(test_error("mock heartbeat receive failure")),
         }
@@ -473,11 +481,16 @@ fn test_task(
     extensions: HeartbeatExtensions,
     options: FrontendOptions,
 ) -> HeartbeatTask {
+    let executor = heartbeat_response_handler_executor(
+        &extensions,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(MockKvCacheInvalidator::default()),
+    );
     HeartbeatTask::new_with_connector(
         "127.0.0.1:4001".to_string(),
         &options,
         connector,
-        Arc::new(HandlerGroupExecutor::new(vec![])),
+        executor,
         Arc::new(ResourceStatImpl::default()),
     )
     .with_extensions(extensions)
@@ -616,6 +629,25 @@ enum ShortCircuitResult {
 struct ShortCircuitHandler {
     result: ShortCircuitResult,
     calls: Arc<AtomicUsize>,
+}
+
+struct PendingHandler {
+    started: Arc<Notify>,
+}
+
+#[async_trait]
+impl HeartbeatResponseHandler for PendingHandler {
+    fn is_acceptable(&self, _ctx: &HeartbeatResponseHandlerContext) -> bool {
+        true
+    }
+
+    async fn handle(
+        &self,
+        _ctx: &mut HeartbeatResponseHandlerContext,
+    ) -> common_meta::error::Result<HandleControl> {
+        self.started.notify_waiters();
+        pending().await
+    }
 }
 
 #[async_trait]
@@ -910,6 +942,39 @@ async fn test_shutdown_cancels_retry_sleep_and_joins_supervisor() {
         .unwrap();
     assert_eq!(connector.calls.load(Ordering::Acquire), 1);
     assert!(!task.has_supervisor().await);
+}
+
+#[tokio::test]
+async fn test_shutdown_cancels_inflight_response_handler() {
+    let started = Arc::new(Notify::new());
+    let extension = TestExtension::with_handler(
+        "pending-response",
+        Arc::new(PendingHandler {
+            started: started.clone(),
+        }),
+    );
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(extension.clone());
+    let (plan, handle) = mock_connection(Duration::from_secs(60), Duration::from_secs(60));
+    let task = test_task(
+        MockConnector::new([ConnectPlan::Ready(plan)]),
+        extensions,
+        FrontendOptions::default(),
+    );
+    task.start().await.unwrap();
+    handle.wait_for_requests(1).await;
+
+    let handler_started = started.notified();
+    handle.send_response(HeartbeatResponse::default());
+    tokio::time::timeout(Duration::from_secs(1), handler_started)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), task.shutdown())
+        .await
+        .unwrap();
+    assert!(!task.has_supervisor().await);
+    assert_eq!(extension.shutdown_calls.load(Ordering::Acquire), 1);
 }
 
 #[tokio::test]

--- a/src/frontend/src/heartbeat/tests.rs
+++ b/src/frontend/src/heartbeat/tests.rs
@@ -608,6 +608,37 @@ struct OrderingHandler {
     table_key: Vec<u8>,
 }
 
+enum ShortCircuitResult {
+    Done,
+    Error,
+}
+
+struct ShortCircuitHandler {
+    result: ShortCircuitResult,
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl HeartbeatResponseHandler for ShortCircuitHandler {
+    fn is_acceptable(&self, _ctx: &HeartbeatResponseHandlerContext) -> bool {
+        true
+    }
+
+    async fn handle(
+        &self,
+        _ctx: &mut HeartbeatResponseHandlerContext,
+    ) -> common_meta::error::Result<HandleControl> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        match self.result {
+            ShortCircuitResult::Done => Ok(HandleControl::Done),
+            ShortCircuitResult::Error => common_meta::error::UnsupportedSnafu {
+                operation: "mock extension response handler",
+            }
+            .fail(),
+        }
+    }
+}
+
 #[async_trait]
 impl HeartbeatResponseHandler for OrderingHandler {
     fn is_acceptable(&self, _ctx: &HeartbeatResponseHandlerContext) -> bool {
@@ -690,6 +721,82 @@ async fn test_response_extension_handler_order() {
     );
     assert!(!suspend_state.load(Ordering::Acquire));
     assert!(!cache.inner.lock().unwrap().contains_key(&table_key));
+}
+
+async fn assert_extension_short_circuit_is_isolated(result: ShortCircuitResult) {
+    let table_id = 42;
+    let table_key = TableInfoKey::new(table_id).to_bytes();
+    let cache = Arc::new(MockKvCacheInvalidator {
+        inner: Mutex::new(HashMap::from([(table_key.clone(), 1)])),
+    });
+    let suspend_state = Arc::new(AtomicBool::new(true));
+    let short_circuit_calls = Arc::new(AtomicUsize::new(0));
+    let observations = Arc::new(Mutex::new(Vec::new()));
+    let extensions = HeartbeatExtensions::default();
+    extensions.register(TestExtension::with_handler(
+        "short-circuit",
+        Arc::new(ShortCircuitHandler {
+            result,
+            calls: short_circuit_calls.clone(),
+        }),
+    ));
+    extensions.register(TestExtension::with_handler(
+        "remaining",
+        Arc::new(OrderingHandler {
+            observations: observations.clone(),
+            suspend_state: suspend_state.clone(),
+            cache: cache.clone(),
+            table_key: table_key.clone(),
+        }),
+    ));
+    let executor =
+        heartbeat_response_handler_executor(&extensions, suspend_state.clone(), cache.clone());
+    let (mailbox_tx, _) = mpsc::channel(1);
+    let mailbox = Arc::new(HeartbeatMailbox::new(mailbox_tx));
+
+    executor
+        .handle(HeartbeatResponseHandlerContext::new(
+            mailbox.clone(),
+            HeartbeatResponse::default(),
+        ))
+        .await
+        .unwrap();
+
+    let invalidate_response = HeartbeatResponse {
+        mailbox_message: Some(MailboxMessage {
+            payload: Some(Payload::Json(
+                serde_json::to_string(&Instruction::InvalidateCaches(vec![CacheIdent::TableId(
+                    table_id,
+                )]))
+                .unwrap(),
+            )),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    executor
+        .handle(HeartbeatResponseHandlerContext::new(
+            mailbox,
+            invalidate_response,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(short_circuit_calls.load(Ordering::Acquire), 2);
+    assert_eq!(observations.lock().unwrap().len(), 2);
+    assert!(!suspend_state.load(Ordering::Acquire));
+    assert!(!cache.inner.lock().unwrap().contains_key(&table_key));
+}
+
+#[tokio::test]
+async fn test_response_extension_done_does_not_skip_remaining_handlers() {
+    assert_extension_short_circuit_is_isolated(ShortCircuitResult::Done).await;
+}
+
+#[tokio::test]
+async fn test_response_extension_error_does_not_skip_remaining_handlers() {
+    assert_extension_short_circuit_is_isolated(ShortCircuitResult::Error).await;
 }
 
 #[tokio::test]

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -405,6 +405,7 @@ impl HeartbeatHandlerGroup {
             region_lease: acc.region_lease,
             mailbox_message,
             heartbeat_config,
+            extensions: Default::default(),
         };
         Ok(res)
     }

--- a/src/plugins/src/frontend.rs
+++ b/src/plugins/src/frontend.rs
@@ -19,7 +19,7 @@ use common_base::Plugins;
 use common_meta::cache::CacheRegistryBuilder;
 use frontend::error::{IllegalAuthConfigSnafu, Result};
 use frontend::frontend::FrontendOptions;
-use frontend::heartbeat::HeartbeatExtensions;
+use frontend::heartbeat::FrontendHeartbeatExtensions;
 use frontend::instance::Instance;
 use frontend::instance::builder::FrontendBuilder;
 use snafu::ResultExt;
@@ -70,14 +70,14 @@ pub async fn setup_frontend_plugins_post_build(
 /// Sets up heartbeat extensions after the frontend [`Instance`] is available.
 ///
 /// Implementations may use the instance to construct extensions and register them in the
-/// [`HeartbeatExtensions`] stored in `plugins`. Registrations must be idempotent because plugin
-/// setup can be invoked more than once.
+/// [`FrontendHeartbeatExtensions`] stored in `plugins`. Registrations must be idempotent because
+/// plugin setup can be invoked more than once.
 pub async fn setup_frontend_heartbeat_extensions(
     plugins: &mut Plugins,
     _plugin_options: &[PluginOptions],
     _instance: &Arc<Instance>,
 ) -> Result<()> {
-    plugins.get_or_insert(HeartbeatExtensions::default);
+    plugins.get_or_insert(FrontendHeartbeatExtensions::default);
     Ok(())
 }
 

--- a/src/plugins/src/frontend.rs
+++ b/src/plugins/src/frontend.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use auth::{DefaultPermissionChecker, PermissionCheckerRef, UserProviderRef};
 use common_base::Plugins;
 use common_meta::cache::CacheRegistryBuilder;
 use frontend::error::{IllegalAuthConfigSnafu, Result};
 use frontend::frontend::FrontendOptions;
+use frontend::heartbeat::HeartbeatExtensions;
 use frontend::instance::Instance;
 use frontend::instance::builder::FrontendBuilder;
 use snafu::ResultExt;
@@ -61,6 +64,20 @@ pub async fn setup_frontend_plugins_post_build(
     _plugin_options: &[PluginOptions],
     _builder: &FrontendBuilder,
 ) -> Result<()> {
+    Ok(())
+}
+
+/// Sets up heartbeat extensions after the frontend [`Instance`] is available.
+///
+/// Implementations may use the instance to construct extensions and register them in the
+/// [`HeartbeatExtensions`] stored in `plugins`. Registrations must be idempotent because plugin
+/// setup can be invoked more than once.
+pub async fn setup_frontend_heartbeat_extensions(
+    plugins: &mut Plugins,
+    _plugin_options: &[PluginOptions],
+    _instance: &Arc<Instance>,
+) -> Result<()> {
+    plugins.get_or_insert(HeartbeatExtensions::default);
     Ok(())
 }
 

--- a/src/plugins/src/lib.rs
+++ b/src/plugins/src/lib.rs
@@ -28,7 +28,8 @@ pub use flownode::{
     setup_flownode_plugins_post_build, setup_flownode_plugins_pre_build, start_flownode_plugins,
 };
 pub use frontend::{
-    setup_frontend_plugins_post_build, setup_frontend_plugins_pre_build, start_frontend_plugins,
+    setup_frontend_heartbeat_extensions, setup_frontend_plugins_post_build,
+    setup_frontend_plugins_pre_build, start_frontend_plugins,
 };
 pub use meta_srv::{
     setup_metasrv_plugins_post_build, setup_metasrv_plugins_pre_build, start_metasrv_plugins,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What this PR does

This PR adds a generic OSS frontend heartbeat extension SPI and hardens the heartbeat connection lifecycle. It does **not** implement any Bulk Load business behavior.

## Refer to a related PR or issue link (optional)

- Depends on GreptimeTeam/greptime-proto#333.
- The temporary dependency pin is the heartbeat-only commit `28b52f8d02b9f8fc5f036338c4e5ca46cdd57184` from GreptimeTeam/greptime-proto#333. After GreptimeTeam/greptime-proto#333 merges, this PR must be updated to its final merge/squash SHA and reviewed again at the new exact head before becoming ready.

## What's changed and what's your intention?

- Add an ordered, duplicate-safe `HeartbeatExtensions` registry and a generic `HeartbeatExtension` trait for:
  - dynamically generated request extensions on every heartbeat;
  - response handlers integrated with the existing heartbeat handler system;
  - per-successful-connection generation notifications;
  - cancellation-aware shutdown callbacks.
- Preserve the existing OSS heartbeat behavior when no extensions are registered.
- Isolate request-provider failures and extension response-handler errors/`Done` results so base heartbeat fields, other extensions, suspend handling, and cache invalidation continue safely. Conflicting extension keys are rejected atomically instead of silently overwriting existing values.
- Replace competing reconnect paths with one cancellable supervisor on the common heartbeat runtime. Repeated/concurrent starts are idempotent, send/receive failures create only one next generation, and shutdown cancels and joins handshakes, loops, retries, in-flight response handling, and extension lifecycle.
- Add a generic async OSS plugin assembly hook after `Arc<Instance>` is available and before the heartbeat task is built.
- Shut down an already-started heartbeat when frontend server startup fails, and stop heartbeat before normal server shutdown.

The wire dependency change is additive: it consumes the new `HeartbeatResponse.extensions` map from greptime-proto #333. This PR does not modify protobuf schemas.

Validation performed on exact head `d523fe20eaa4e53783f46da90b7f03a31501ccf6`:

- `cargo fmt --all -- --check`
- `cargo nextest run -p frontend -p cmd` — 193 passed, 0 skipped
- `cargo check -p frontend -p cmd`
- `cargo clippy -p frontend -p cmd --all-targets -- -D warnings`
- `git diff --check upstream/main...HEAD`
- Review Bridge/CODEX_TASK SUCCESSOR review — Round 1 CLEAN, local gate passed

`make check-udeps` could not run because `cargo-udeps` is not installed in the development environment.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
