### PR TITLE
fix(query): re-validate cached prepared plans against current table metadata

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -2713,6 +2713,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn qp_010_prepared_plan_errors_after_table_dropped() -> TestResult<()> {
+        let instance =
+            test_instance_with_tables(test_table(1024, "source")?, test_table(1025, "target")?)
+                .await?;
+
+        let query_ctx = QueryContext::arc();
+        let stmt = parse_test_sql("SELECT * FROM source").remove(0);
+
+        // Plan against the (about to be dropped) table.
+        let cached_plan = instance
+            .query_engine()
+            .planner()
+            .plan(
+                &query::parser::QueryStatement::Sql(stmt.clone()),
+                query_ctx.clone(),
+            )
+            .await
+            .expect("plan SELECT * FROM source");
+
+        // Drop the table: the cached plan is now stale (`current == None`).
+        // Pinned drop behavior: re-validation must fail with the re-planning
+        // error (table not found) instead of silently executing the stale plan.
+        let catalog = instance
+            .catalog_manager()
+            .as_any()
+            .downcast_ref::<catalog::memory::MemoryCatalogManager>()
+            .expect("memory catalog manager");
+        catalog
+            .deregister_table_sync(catalog::DeregisterTableRequest {
+                catalog: "greptime".to_string(),
+                schema: "public".to_string(),
+                table_name: "source".to_string(),
+            })
+            .expect("deregister source");
+
+        let result = instance
+            .validate_prepared_plan(&cached_plan, stmt, query_ctx)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "a dropped table must make the cached prepared plan fail to re-plan"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_restricted_endpoint_handlers_check_permissions() -> TestResult<()> {
         let checker = Arc::new(RejectEndpointPermissionChecker::default());
         let plugins = Plugins::new();

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -73,6 +73,7 @@ use promql_parser::label::Matcher;
 use query::QueryEngineRef;
 use query::metrics::OnDone;
 use query::parser::{PromQuery, QueryStatement};
+use query::plan::extract_prepared_plan_tables;
 use query::query_engine::DescribeResult;
 use query::query_engine::options::{QueryOptions, validate_catalog_and_schema};
 use servers::error::{
@@ -972,6 +973,51 @@ impl Instance {
             .await
             .context(error::CatalogSnafu)
     }
+
+    /// Re-validates a cached prepared plan against the current catalog. Returns
+    /// `Some(plan)` with a freshly planned plan when any base table referenced
+    /// by the cached plan changed (e.g. `ALTER TABLE` bumped its version or the
+    /// table was dropped/recreated), and `None` when the cached plan is still
+    /// valid.
+    async fn validate_prepared_plan_inner(
+        &self,
+        plan: &LogicalPlan,
+        stmt: Statement,
+        query_ctx: QueryContextRef,
+    ) -> Result<Option<LogicalPlan>> {
+        ensure!(!self.is_suspended(), error::SuspendedSnafu);
+
+        for table in extract_prepared_plan_tables(plan) {
+            let current = self
+                .catalog_manager
+                .table(
+                    &table.table_name.catalog_name,
+                    &table.table_name.schema_name,
+                    &table.table_name.table_name,
+                    Some(&query_ctx),
+                )
+                .await
+                .context(error::CatalogSnafu)?;
+            let stale = match current {
+                None => true,
+                Some(current) => {
+                    let ident = current.table_info().ident.clone();
+                    ident.table_id != table.table_id || ident.version != table.version
+                }
+            };
+            if stale {
+                // The cached plan is stale: re-plan against the current catalog.
+                let plan = self
+                    .query_engine
+                    .planner()
+                    .plan(&QueryStatement::Sql(stmt), query_ctx)
+                    .await
+                    .context(PlanStatementSnafu)?;
+                return Ok(Some(plan));
+            }
+        }
+        Ok(None)
+    }
 }
 
 #[async_trait]
@@ -1032,6 +1078,18 @@ impl SqlQueryHandler for Instance {
             .await
             .map_err(BoxedError::new)
             .context(server_error::DescribeStatementSnafu)
+    }
+
+    async fn validate_prepared_plan(
+        &self,
+        plan: &LogicalPlan,
+        stmt: Statement,
+        query_ctx: QueryContextRef,
+    ) -> server_error::Result<Option<LogicalPlan>> {
+        self.validate_prepared_plan_inner(plan, stmt, query_ctx)
+            .await
+            .map_err(BoxedError::new)
+            .context(server_error::ExecutePlanSnafu)
     }
 
     async fn is_valid_schema(&self, catalog: &str, schema: &str) -> server_error::Result<bool> {
@@ -2573,6 +2631,83 @@ mod tests {
                 .await?;
 
         let _event_recorder = instance.event_recorder();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn qp_010_prepared_plan_revalidated_after_schema_change() -> TestResult<()> {
+        let instance =
+            test_instance_with_tables(test_table(1024, "source")?, test_table(1025, "target")?)
+                .await?;
+
+        let query_ctx = QueryContext::arc();
+        let stmt = parse_test_sql("SELECT * FROM source").remove(0);
+
+        // Plan against the v1 table (version 0, columns [id, ts]).
+        let cached_plan = instance
+            .query_engine()
+            .planner()
+            .plan(
+                &query::parser::QueryStatement::Sql(stmt.clone()),
+                query_ctx.clone(),
+            )
+            .await
+            .expect("plan SELECT * FROM source");
+
+        // Simulate `ALTER TABLE source ADD COLUMN extra` by swapping the catalog
+        // table for a version-bumped table with an extra column.
+        let mut info = test_table_info(1024, "source")?.clone();
+        info.ident.version = 1;
+        info.meta.schema = Arc::new(GtSchema::new(vec![
+            ColumnSchema::new("id", ConcreteDataType::int32_datatype(), false),
+            ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+            ColumnSchema::new("extra", ConcreteDataType::int32_datatype(), true),
+        ]));
+        let table_v2 = EmptyTable::from_table_info(&info);
+        let catalog = instance
+            .catalog_manager()
+            .as_any()
+            .downcast_ref::<catalog::memory::MemoryCatalogManager>()
+            .expect("memory catalog manager");
+        catalog
+            .deregister_table_sync(catalog::DeregisterTableRequest {
+                catalog: "greptime".to_string(),
+                schema: "public".to_string(),
+                table_name: "source".to_string(),
+            })
+            .expect("deregister source");
+        catalog
+            .register_table_sync(catalog::RegisterTableRequest {
+                catalog: "greptime".to_string(),
+                schema: "public".to_string(),
+                table_name: "source".to_string(),
+                table_id: 1024,
+                table: table_v2,
+            })
+            .expect("register source");
+
+        // The cached plan must be re-planned against the new schema.
+        let revalidated = instance
+            .validate_prepared_plan(&cached_plan, stmt, query_ctx)
+            .await
+            .expect("validate prepared plan");
+        let fresh_plan = revalidated.expect("plan must be re-planned after schema change");
+        let names: Vec<String> = fresh_plan
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "extra"),
+            "re-planned plan must include the newly added column, got columns: {names:?}"
+        );
 
         Ok(())
     }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -2636,7 +2636,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn qp_010_prepared_plan_revalidated_after_schema_change() -> TestResult<()> {
+    async fn prepared_plan_revalidated_after_schema_change() -> TestResult<()> {
         let instance =
             test_instance_with_tables(test_table(1024, "source")?, test_table(1025, "target")?)
                 .await?;
@@ -2713,7 +2713,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn qp_010_prepared_plan_errors_after_table_dropped() -> TestResult<()> {
+    async fn prepared_plan_errors_after_table_dropped() -> TestResult<()> {
         let instance =
             test_instance_with_tables(test_table(1024, "source")?, test_table(1025, "target")?)
                 .await?;

--- a/src/query/src/plan.rs
+++ b/src/query/src/plan.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use datafusion::datasource::DefaultTableSource;
 use datafusion_common::TableReference;
-use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
+use datafusion_common::tree_node::{Transformed, TreeNodeRecursion, TreeNodeRewriter};
 use datafusion_expr::{Expr, LogicalPlan};
 use session::context::QueryContextRef;
 pub use table::metadata::TableType;
@@ -141,33 +141,36 @@ pub struct PreparedPlanTable {
 /// underlying table metadata (e.g. schema) changed.
 pub fn extract_prepared_plan_tables(plan: &LogicalPlan) -> Vec<PreparedPlanTable> {
     let mut tables = Vec::new();
-    collect_prepared_plan_tables(plan, &mut tables);
+    // `apply_with_subqueries` descends into expression-embedded subqueries
+    // (Expr::ScalarSubquery / Exists / InSubquery inside Projection/Filter/
+    // Aggregate) in addition to child plans, unlike `plan.inputs()` which only
+    // visits inputs. Without it, e.g. `WHERE x IN (SELECT ... FROM lookup)`
+    // would miss `lookup` and a cached prepared plan could go stale unnoticed
+    // after `lookup` is altered.
+    plan.apply_with_subqueries(|node| {
+        if let LogicalPlan::TableScan(scan) = node
+            && let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>()
+            && let Some(provider) = source
+                .table_provider
+                .as_any()
+                .downcast_ref::<DfTableProviderAdapter>()
+            && provider.table().table_type() == TableType::Base
+        {
+            let info = provider.table().table_info();
+            tables.push(PreparedPlanTable {
+                table_name: TableName::new(
+                    info.catalog_name.clone(),
+                    info.schema_name.clone(),
+                    info.name.clone(),
+                ),
+                table_id: info.ident.table_id,
+                version: info.ident.version,
+            });
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .expect("plan tree traversal cannot fail");
     tables
-}
-
-fn collect_prepared_plan_tables(plan: &LogicalPlan, tables: &mut Vec<PreparedPlanTable>) {
-    if let LogicalPlan::TableScan(scan) = plan
-        && let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>()
-        && let Some(provider) = source
-            .table_provider
-            .as_any()
-            .downcast_ref::<DfTableProviderAdapter>()
-        && provider.table().table_type() == TableType::Base
-    {
-        let info = provider.table().table_info();
-        tables.push(PreparedPlanTable {
-            table_name: TableName::new(
-                info.catalog_name.clone(),
-                info.schema_name.clone(),
-                info.name.clone(),
-            ),
-            table_id: info.ident.table_id,
-            version: info.ident.version,
-        });
-    }
-    for input in plan.inputs() {
-        collect_prepared_plan_tables(input, tables);
-    }
 }
 
 /// A trait to extract expressions from a logical plan.
@@ -190,10 +193,12 @@ pub(crate) mod tests {
     use std::sync::Arc;
 
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
-    use common_catalog::consts::DEFAULT_CATALOG_NAME;
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use datafusion::datasource::DefaultTableSource;
     use datafusion::logical_expr::builder::LogicalTableSource;
     use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder, col, lit, scalar_subquery};
     use session::context::QueryContextBuilder;
+    use table::test_util::MemTable;
 
     use super::*;
 
@@ -356,6 +361,42 @@ pub(crate) mod tests {
         assert_nested_scalar_subquery_table_name(
             &plan,
             TableReference::full("qp031_external_catalog", "qp031_external_schema", "lookup"),
+        );
+    }
+
+    #[test]
+    fn test_extract_prepared_plan_tables_from_scalar_subquery() {
+        // Build `SELECT scalar_subquery FROM ...` where the subquery scans a
+        // Greptime table (`DefaultTableSource` + `DfTableProviderAdapter`). The
+        // subquery's table only lives inside the Projection expression, so a
+        // traversal over `plan.inputs()` alone would miss it.
+        let table = MemTable::default_numbers_table();
+        let subquery = LogicalPlanBuilder::scan(
+            TableReference::bare("numbers"),
+            Arc::new(DefaultTableSource {
+                table_provider: Arc::new(DfTableProviderAdapter::new(table)),
+            }),
+            None,
+        )
+        .unwrap()
+        .project(vec![col("uint32s")])
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let plan = LogicalPlanBuilder::empty(false)
+            .project(vec![scalar_subquery(Arc::new(subquery))])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            vec![PreparedPlanTable {
+                table_name: TableName::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, "numbers"),
+                table_id: 1,
+                version: 0,
+            }],
+            extract_prepared_plan_tables(&plan)
         );
     }
 }

--- a/src/query/src/plan.rs
+++ b/src/query/src/plan.rs
@@ -20,6 +20,7 @@ use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
 use datafusion_expr::{Expr, LogicalPlan};
 use session::context::QueryContextRef;
 pub use table::metadata::TableType;
+use table::metadata::{TableId, TableVersion};
 use table::table::adapter::DfTableProviderAdapter;
 use table::table_name::TableName;
 
@@ -118,6 +119,55 @@ pub fn extract_and_rewrite_full_table_names(
     let mut extractor = TableNamesExtractAndRewriter::new(query_ctx);
     let plan = plan.rewrite_with_subqueries(&mut extractor)?;
     Ok((extractor.table_names, plan.data))
+}
+
+/// A base table referenced by a logical plan, together with the table id and
+/// version the plan was created against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedPlanTable {
+    /// The fully qualified table name.
+    pub table_name: TableName,
+    /// The table id captured when the plan was created.
+    pub table_id: TableId,
+    /// The table version captured when the plan was created. It is bumped when
+    /// the table metadata (e.g. schema) changes.
+    pub version: TableVersion,
+}
+
+/// Collects the base tables referenced by a logical plan (including subqueries)
+/// together with the (table id, version) captured when the plan was created.
+///
+/// Used to detect whether a cached prepared plan became stale after the
+/// underlying table metadata (e.g. schema) changed.
+pub fn extract_prepared_plan_tables(plan: &LogicalPlan) -> Vec<PreparedPlanTable> {
+    let mut tables = Vec::new();
+    collect_prepared_plan_tables(plan, &mut tables);
+    tables
+}
+
+fn collect_prepared_plan_tables(plan: &LogicalPlan, tables: &mut Vec<PreparedPlanTable>) {
+    if let LogicalPlan::TableScan(scan) = plan
+        && let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>()
+        && let Some(provider) = source
+            .table_provider
+            .as_any()
+            .downcast_ref::<DfTableProviderAdapter>()
+        && provider.table().table_type() == TableType::Base
+    {
+        let info = provider.table().table_info();
+        tables.push(PreparedPlanTable {
+            table_name: TableName::new(
+                info.catalog_name.clone(),
+                info.schema_name.clone(),
+                info.name.clone(),
+            ),
+            table_id: info.ident.table_id,
+            version: info.ident.version,
+        });
+    }
+    for input in plan.inputs() {
+        collect_prepared_plan_tables(input, tables);
+    }
 }
 
 /// A trait to extract expressions from a logical plan.

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -1320,7 +1320,7 @@ mod tests {
         let schema = Arc::new(Schema::new(column_schemas));
         let vectors: Vec<VectorRef> = columns
             .iter()
-            .map(|_| Arc::new(Int64Vector::from_slice(values.to_vec())) as VectorRef)
+            .map(|_| Arc::new(Int64Vector::from_slice(values)) as VectorRef)
             .collect();
         let recordbatch = RecordBatch::new(schema, vectors).unwrap();
         MemTable::table(name, recordbatch)

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -276,6 +276,28 @@ impl MysqlInstanceShim {
 
         let outputs = match sql_plan {
             SqlPlan::Plan(plan, stmt) => {
+                // Re-validate the cached plan against the current catalog: a
+                // schema change (e.g. ALTER TABLE) may have made the cached
+                // table providers stale. When that happens, re-plan and refresh
+                // the cache entry.
+                let plan = match self
+                    .query_handler
+                    .validate_prepared_plan(&plan, stmt.clone(), query_ctx.clone())
+                    .await?
+                {
+                    Some(fresh_plan) => {
+                        self.save_plan(
+                            SqlPlan::Plan(fresh_plan.clone(), stmt.clone()),
+                            stmt_key.clone(),
+                        )
+                        .inspect_err(|e| {
+                            error!(e; "Failed to refresh prepared statement");
+                        })?;
+                        fresh_plan
+                    }
+                    None => plan,
+                };
+
                 let param_types = DfLogicalPlanner::get_inferred_parameter_types(&plan)
                     .context(InferParameterTypesSnafu)?
                     .into_iter()
@@ -926,15 +948,24 @@ fn all_params_have_types(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
     use common_query::Output;
+    use common_recordbatch::RecordBatch;
+    use datafusion::datasource::DefaultTableSource;
     use datafusion_expr::LogicalPlan;
+    use datafusion_expr::logical_plan::builder::LogicalPlanBuilder;
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
+    use datatypes::vectors::{Int64Vector, VectorRef};
     use query::parser::PromQuery;
     use query::query_engine::DescribeResult;
     use session::context::QueryContext;
     use sql::statements::statement::Statement;
+    use table::TableRef;
+    use table::table::adapter::DfTableProviderAdapter;
+    use table::test_util::MemTable;
 
     use super::*;
     use crate::error::Result;
@@ -1190,5 +1221,156 @@ mod tests {
             }
             other => panic!("Expected RecordBatches, got {:?}", other),
         }
+    }
+
+    /// Handler that plans `SELECT * FROM t` against a mutable "current" table,
+    /// so a test can simulate an `ALTER TABLE` schema change between prepare and
+    /// execute. Executed plans are recorded for inspection.
+    struct StaleSchemaHandler {
+        current_table: Arc<RwLock<TableRef>>,
+        executed_plans: Arc<Mutex<Vec<LogicalPlan>>>,
+    }
+
+    impl StaleSchemaHandler {
+        fn plan_for(&self, table: &TableRef) -> LogicalPlan {
+            let table_provider = Arc::new(DfTableProviderAdapter::new(table.clone()));
+            LogicalPlanBuilder::scan("t", Arc::new(DefaultTableSource { table_provider }), None)
+                .unwrap()
+                .build()
+                .unwrap()
+        }
+    }
+
+    /// Returns the greptime schema captured by the table scan of the plan, if any.
+    fn cached_plan_table_schema(plan: &LogicalPlan) -> Option<SchemaRef> {
+        let LogicalPlan::TableScan(scan) = plan else {
+            return None;
+        };
+        let source = scan.source.as_any().downcast_ref::<DefaultTableSource>()?;
+        let provider = source
+            .table_provider
+            .as_any()
+            .downcast_ref::<DfTableProviderAdapter>()?;
+        Some(provider.table().schema())
+    }
+
+    #[async_trait]
+    impl SqlQueryHandler for StaleSchemaHandler {
+        async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
+            unimplemented!()
+        }
+
+        async fn do_analyze_stream_query(&self, _: &str, _: QueryContextRef) -> Result<Output> {
+            unimplemented!()
+        }
+
+        async fn do_promql_query(&self, _: &PromQuery, _: QueryContextRef) -> Vec<Result<Output>> {
+            unimplemented!()
+        }
+
+        async fn do_exec_plan(
+            &self,
+            plan: LogicalPlan,
+            _: Option<Statement>,
+            _: QueryContextRef,
+        ) -> Result<Output> {
+            self.executed_plans.lock().unwrap().push(plan);
+            Ok(Output::new_with_affected_rows(0))
+        }
+
+        async fn do_describe(
+            &self,
+            _: Statement,
+            _: QueryContextRef,
+        ) -> Result<Option<DescribeResult>> {
+            let table = self.current_table.read().clone();
+            Ok(Some(DescribeResult {
+                logical_plan: self.plan_for(&table),
+            }))
+        }
+
+        async fn is_valid_schema(&self, _: &str, _: &str) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn validate_prepared_plan(
+            &self,
+            plan: &LogicalPlan,
+            _stmt: Statement,
+            _query_ctx: QueryContextRef,
+        ) -> Result<Option<LogicalPlan>> {
+            // Re-plan when the current table's schema differs from the one the
+            // cached plan was built against.
+            let current = self.current_table.read().clone();
+            let current_schema = current.schema();
+            let stale = cached_plan_table_schema(plan).as_ref() != Some(&current_schema);
+            if stale {
+                Ok(Some(self.plan_for(&current)))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    fn mem_table(name: &str, columns: &[&str], values: &[i64]) -> TableRef {
+        let column_schemas = columns
+            .iter()
+            .map(|c| ColumnSchema::new(*c, ConcreteDataType::int64_datatype(), true))
+            .collect();
+        let schema = Arc::new(Schema::new(column_schemas));
+        let vectors: Vec<VectorRef> = columns
+            .iter()
+            .map(|_| Arc::new(Int64Vector::from_slice(values.to_vec())) as VectorRef)
+            .collect();
+        let recordbatch = RecordBatch::new(schema, vectors).unwrap();
+        MemTable::table(name, recordbatch)
+    }
+
+    #[tokio::test]
+    async fn qp_010_prepared_plan_revalidated_after_schema_change() {
+        let table_v1 = mem_table("t", &["a"], &[1_i64]);
+        let table_v2 = mem_table("t", &["a", "b"], &[1_i64, 2_i64]);
+
+        let current_table = Arc::new(RwLock::new(table_v1));
+        let executed_plans = Arc::new(Mutex::new(Vec::new()));
+        let handler = Arc::new(StaleSchemaHandler {
+            current_table: current_table.clone(),
+            executed_plans: executed_plans.clone(),
+        });
+
+        let mut shim =
+            MysqlInstanceShim::create(handler, None, "127.0.0.1:3306".parse().unwrap(), 1, 1024);
+        let query_ctx = QueryContext::arc();
+        let stmt_key = "qp_010".to_string();
+
+        // Prepare against the v1 schema and cache the plan.
+        shim.do_prepare("SELECT * FROM t", query_ctx.clone(), stmt_key.clone())
+            .await
+            .unwrap();
+        assert!(matches!(shim.plan(&stmt_key), Some(SqlPlan::Plan(_, _))));
+
+        // Simulate `ALTER TABLE t ADD COLUMN b` by swapping in a new table.
+        *current_table.write() = table_v2;
+
+        // Executing the prepared statement must reflect the new schema.
+        shim.do_execute(query_ctx, stmt_key, Params::CliParams(vec![]))
+            .await
+            .unwrap();
+
+        let executed = executed_plans
+            .lock()
+            .unwrap()
+            .pop()
+            .expect("prepared plan should have been executed");
+        let names: Vec<String> = executed
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "b"),
+            "executed prepared plan must include the newly added column, got columns: {names:?}"
+        );
     }
 }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -1327,7 +1327,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn qp_010_prepared_plan_revalidated_after_schema_change() {
+    async fn prepared_plan_revalidated_after_schema_change() {
         let table_v1 = mem_table("t", &["a"], &[1_i64]);
         let table_v2 = mem_table("t", &["a", "b"], &[1_i64, 2_i64]);
 
@@ -1341,7 +1341,7 @@ mod tests {
         let mut shim =
             MysqlInstanceShim::create(handler, None, "127.0.0.1:3306".parse().unwrap(), 1, 1024);
         let query_ctx = QueryContext::arc();
-        let stmt_key = "qp_010".to_string();
+        let stmt_key = "prepared_plan".to_string();
 
         // Prepare against the v1 schema and cache the plan.
         shim.do_prepare("SELECT * FROM t", query_ctx.clone(), stmt_key.clone())

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -807,7 +807,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn qp_010_postgres_prepared_plan_revalidated_after_schema_change() {
+    async fn postgres_prepared_plan_revalidated_after_schema_change() {
         let cached_plan = pg_plan_for(&MemTable::default_numbers_table());
         // The "fresh" plan differs from the cached plan so we can tell them
         // apart below.

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -443,9 +443,13 @@ impl ExtendedQueryHandler for PostgresServerHandlerInner {
                 }
             }
             SqlPlan::Plan(plan, stmt) => {
-                let values = parameters_to_scalar_values(plan, portal)?;
+                // Re-validate the cached plan against the current catalog: a
+                // schema change (e.g. ALTER TABLE) may have made the cached
+                // table providers stale. When that happens, execute a freshly
+                // re-planned plan instead (parameters are bound afterwards).
+                let plan = self.revalidated_plan(plan, stmt, query_ctx.clone()).await?;
+                let values = parameters_to_scalar_values(&plan, portal)?;
                 let plan = plan
-                    .clone()
                     .replace_params_with_values(&ParamValues::List(
                         values.into_iter().map(Into::into).collect(),
                     ))
@@ -545,6 +549,29 @@ impl ExtendedQueryHandler for PostgresServerHandlerInner {
         let fields = describe_fields(sql_plan, format, &self.session)?;
 
         Ok(DescribePortalResponse::new(fields))
+    }
+}
+
+impl PostgresServerHandlerInner {
+    /// Re-validates a cached prepared plan against the current catalog before
+    /// it is executed. Returns the plan to execute: a freshly re-planned plan
+    /// when the cached plan is stale (e.g. an underlying table was altered),
+    /// otherwise the cached plan itself.
+    async fn revalidated_plan(
+        &self,
+        plan: &LogicalPlan,
+        stmt: &Statement,
+        query_ctx: QueryContextRef,
+    ) -> PgWireResult<LogicalPlan> {
+        match self
+            .query_handler
+            .validate_prepared_plan(plan, stmt.clone(), query_ctx)
+            .await
+            .map_err(convert_err)?
+        {
+            Some(fresh_plan) => Ok(fresh_plan),
+            None => Ok(plan.clone()),
+        }
     }
 }
 
@@ -670,14 +697,153 @@ fn check_copy_to_stdout(statement: &SqlParserStatement) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use common_query::Output;
+    use datafusion::datasource::DefaultTableSource;
+    use datafusion_expr::LogicalPlan;
+    use datafusion_expr::logical_plan::builder::LogicalPlanBuilder;
     use datafusion_pg_catalog::sql::PostgresCompatibilityParser;
+    use query::parser::PromQuery;
+    use query::query_engine::DescribeResult;
+    use session::context::{Channel, QueryContext};
+    use sql::statements::statement::Statement;
+    use table::TableRef;
+    use table::table::adapter::DfTableProviderAdapter;
+    use table::test_util::MemTable;
 
     use super::*;
+    use crate::error::Result;
+    use crate::postgres::GreptimeDBStartupParameters;
+    use crate::postgres::auth_handler::PgLoginVerifier;
+    use crate::query_handler::sql::SqlQueryHandler;
 
     fn parse_copy_statement(sql: &str) -> SqlParserStatement {
         let parser = PostgresCompatibilityParser::new();
         let statements = parser.parse(sql).unwrap();
         statements.into_iter().next().unwrap()
+    }
+
+    fn pg_plan_for(table: &TableRef) -> LogicalPlan {
+        let table_provider = Arc::new(DfTableProviderAdapter::new(table.clone()));
+        LogicalPlanBuilder::scan(
+            "numbers",
+            Arc::new(DefaultTableSource { table_provider }),
+            None,
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+    }
+
+    /// A fake [`SqlQueryHandler`] that counts `validate_prepared_plan` calls
+    /// and always reports the cached plan as stale, returning a fresh plan.
+    struct StalePlanHandler {
+        validate_calls: Arc<AtomicUsize>,
+        fresh_plan: LogicalPlan,
+    }
+
+    #[async_trait]
+    impl SqlQueryHandler for StalePlanHandler {
+        async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
+            unimplemented!()
+        }
+
+        async fn do_analyze_stream_query(&self, _: &str, _: QueryContextRef) -> Result<Output> {
+            unimplemented!()
+        }
+
+        async fn do_promql_query(&self, _: &PromQuery, _: QueryContextRef) -> Vec<Result<Output>> {
+            unimplemented!()
+        }
+
+        async fn do_exec_plan(
+            &self,
+            _: LogicalPlan,
+            _: Option<Statement>,
+            _: QueryContextRef,
+        ) -> Result<Output> {
+            unimplemented!()
+        }
+
+        async fn do_describe(
+            &self,
+            _: Statement,
+            _: QueryContextRef,
+        ) -> Result<Option<DescribeResult>> {
+            unimplemented!()
+        }
+
+        async fn is_valid_schema(&self, _: &str, _: &str) -> Result<bool> {
+            unimplemented!()
+        }
+
+        async fn validate_prepared_plan(
+            &self,
+            _plan: &LogicalPlan,
+            _stmt: Statement,
+            _query_ctx: QueryContextRef,
+        ) -> Result<Option<LogicalPlan>> {
+            self.validate_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(self.fresh_plan.clone()))
+        }
+    }
+
+    fn postgres_handler(query_handler: ServerSqlQueryHandlerRef) -> PostgresServerHandlerInner {
+        let session = Arc::new(Session::new(None, Channel::Postgres, Default::default(), 1));
+        PostgresServerHandlerInner {
+            query_handler: query_handler.clone(),
+            login_verifier: PgLoginVerifier::new(None),
+            force_tls: false,
+            param_provider: Arc::new(GreptimeDBStartupParameters::new()),
+            session: session.clone(),
+            query_parser: Arc::new(DefaultQueryParser::new(
+                query_handler.clone(),
+                session.clone(),
+            )),
+        }
+    }
+
+    #[tokio::test]
+    async fn qp_010_postgres_prepared_plan_revalidated_after_schema_change() {
+        let cached_plan = pg_plan_for(&MemTable::default_numbers_table());
+        // The "fresh" plan differs from the cached plan so we can tell them
+        // apart below.
+        let fresh_plan = LogicalPlanBuilder::from(cached_plan.clone())
+            .filter(datafusion_expr::col("uint32s").gt(datafusion_expr::lit(5)))
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let validate_calls = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(StalePlanHandler {
+            validate_calls: validate_calls.clone(),
+            fresh_plan: fresh_plan.clone(),
+        });
+        let inner = postgres_handler(handler);
+
+        let query_ctx = QueryContext::arc();
+        let stmt = ParserContext::create_with_dialect(
+            "SELECT 1",
+            &PostgreSqlDialect {},
+            ParseOptions::default(),
+        )
+        .unwrap()
+        .remove(0);
+
+        // The cached plan is stale: the Postgres extended-query path must
+        // invoke `validate_prepared_plan` and execute the fresh plan.
+        let plan = inner
+            .revalidated_plan(&cached_plan, &stmt, query_ctx)
+            .await
+            .unwrap();
+        assert_eq!(
+            fresh_plan, plan,
+            "stale cached plan must be replaced by the re-planned one"
+        );
+        assert_eq!(1, validate_calls.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/src/servers/src/query_handler/sql.rs
+++ b/src/servers/src/query_handler/sql.rs
@@ -65,4 +65,20 @@ pub trait SqlQueryHandler {
     ) -> Result<Option<DescribeResult>>;
 
     async fn is_valid_schema(&self, catalog: &str, schema: &str) -> Result<bool>;
+
+    /// Re-validates a cached prepared plan against the current catalog before it
+    /// is executed.
+    ///
+    /// Returns `Some(plan)` when the cached plan must be replaced (e.g. because
+    /// an underlying table's schema changed since the statement was prepared)
+    /// and `None` when the cached plan is still valid. The default
+    /// implementation performs no validation.
+    async fn validate_prepared_plan(
+        &self,
+        _plan: &LogicalPlan,
+        _stmt: Statement,
+        _query_ctx: QueryContextRef,
+    ) -> Result<Option<LogicalPlan>> {
+        Ok(None)
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

Fixes QP-010: a cached prepared plan retained the table provider/schema captured when the statement was prepared. After the underlying table changed (e.g. `ALTER TABLE` added/dropped a column), executing the prepared statement still used the stale provider, producing results inconsistent with the current table definition.

Before executing a cached prepared plan, every base table it references is re-validated against the current catalog:

- `query::plan::extract_prepared_plan_tables` collects `(table_name, table_id, table_version)` from all `TableScan`s of a logical plan (including subqueries). The version is the table metadata version, bumped on any table metadata change.
- `frontend::Instance::validate_prepared_plan` looks up each referenced table in the current catalog and re-plans the statement when the table id or version differs, or the table is gone. The trait default in `servers` performs no validation, so other handlers are unaffected.
- The MySQL prepared-statement path calls `validate_prepared_plan` before executing a cached plan.

The performance benefit of caching is preserved for unchanged tables (validation is a cheap metadata comparison; re-planning happens only on staleness).

Tests added (`qp_010_*`): a prepared statement reflects a schema change after re-validation (RED before the fix — the executed plan retained the old schema). Existing MySQL prepared-statement and query plan suites pass unchanged.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
