### PR TITLE
feat: support enabling skip_wal with ALTER TABLE

### DIFF
--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -16,6 +16,7 @@ mod executor;
 mod metadata;
 mod region_request;
 
+use std::collections::HashSet;
 use std::vec;
 
 use api::region::RegionResponse;
@@ -73,6 +74,9 @@ pub struct AlterTableProcedure {
     /// The alter table executor.
     executor: AlterTableExecutor,
 }
+
+#[derive(Debug)]
+pub(crate) struct RegionRouteChanged;
 
 /// Builds the executor from the [`AlterTableData`].
 ///
@@ -170,6 +174,24 @@ impl AlterTableProcedure {
                     operation: "setting skip_wal on logical tables".to_string()
                 }
             );
+            let current_region_ids = physical_table_route
+                .region_routes
+                .iter()
+                .map(|route| route.region.id)
+                .collect::<HashSet<_>>();
+            let locked_region_ids = self
+                .data
+                .region_locks
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>();
+            if physical_table_route.region_routes.len() != self.data.region_locks.len()
+                || current_region_ids != locked_region_ids
+            {
+                // Procedure lock keys are fixed at submission. Finish this attempt so the
+                // DDL manager can submit another procedure with locks for the current route.
+                return Ok(Status::done_with_output(RegionRouteChanged));
+            }
             self.data.region_distribution =
                 Some(region_distribution(&physical_table_route.region_routes));
             self.data.alter_regions_after_metadata = true;

--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -244,23 +244,47 @@ impl AlterTableProcedure {
         // Puts the poison before submitting alter region requests to datanodes.
         self.put_poison(ctx_provider, procedure_id).await?;
         let flow = self.data.flow();
-        let results = if flow == AlterTableFlow::MetadataFirst {
-            self.executor
+        if flow == AlterTableFlow::MetadataFirst {
+            let results = self
+                .executor
                 .on_alter_skip_wal_regions(
                     &self.context.node_manager,
                     &physical_table_route.region_routes,
                     alter_kind,
                 )
-                .await
-        } else {
-            self.executor
-                .on_alter_regions(
-                    &self.context.node_manager,
-                    &physical_table_route.region_routes,
-                    alter_kind,
-                )
-                .await
-        };
+                .await;
+
+            return match handle_multiple_results(results) {
+                MultipleResults::PartialRetryable(error) => Err(error),
+                MultipleResults::PartialNonRetryable(error)
+                | MultipleResults::AllNonRetryable(error) => {
+                    // The metadata already enables skip-WAL. Keep retrying until every
+                    // replica applies the runtime option instead of leaving the table in
+                    // a permanently inconsistent state.
+                    Err(BoxedError::new(error)).context(RetryLaterSnafu {
+                        clean_poisons: true,
+                    })
+                }
+                MultipleResults::AllRetryable(error) => {
+                    Err(BoxedError::new(error)).context(RetryLaterSnafu {
+                        clean_poisons: true,
+                    })
+                }
+                MultipleResults::Ok(results) => {
+                    self.handle_alter_region_response(results)?;
+                    Ok(Status::executing_with_clean_poisons(true))
+                }
+            };
+        }
+
+        let results = self
+            .executor
+            .on_alter_regions(
+                &self.context.node_manager,
+                &physical_table_route.region_routes,
+                alter_kind,
+            )
+            .await;
 
         match handle_multiple_results(results) {
             MultipleResults::PartialRetryable(error) => {
@@ -268,11 +292,6 @@ impl AlterTableProcedure {
                 Err(error)
             }
             MultipleResults::PartialNonRetryable(error) => {
-                if flow == AlterTableFlow::MetadataFirst {
-                    return Err(BoxedError::new(error)).context(RetryLaterSnafu {
-                        clean_poisons: true,
-                    });
-                }
                 error!(error; "Partial non-retryable errors occurred during alter table, table {}, table_id: {}", self.data.table_ref(), self.data.table_id());
                 // No retry will be done.
                 Ok(Status::poisoned(
@@ -288,19 +307,12 @@ impl AlterTableProcedure {
                 })
             }
             MultipleResults::Ok(results) => {
-                if flow != AlterTableFlow::MetadataFirst {
-                    self.submit_sync_region_requests(&results, &physical_table_route.region_routes)
-                        .await;
-                }
+                self.submit_sync_region_requests(&results, &physical_table_route.region_routes)
+                    .await;
                 self.handle_alter_region_response(results)?;
                 Ok(Status::executing_with_clean_poisons(true))
             }
             MultipleResults::AllNonRetryable(error) => {
-                if flow == AlterTableFlow::MetadataFirst {
-                    return Err(BoxedError::new(error)).context(RetryLaterSnafu {
-                        clean_poisons: true,
-                    });
-                }
                 error!(error; "All alter requests returned non-retryable errors for table {}, table_id: {}", self.data.table_ref(), self.data.table_id());
                 // It assumes the metadata on datanode is not changed.
                 // Case: The alter region request is sent but not applied. (e.g., InvalidArgument)

--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -194,13 +194,8 @@ impl AlterTableProcedure {
             }
             self.data.region_distribution =
                 Some(region_distribution(&physical_table_route.region_routes));
-            self.data.alter_regions_after_metadata = true;
-            self.data.state = AlterTableState::UpdateMetadata;
-        } else if is_metadata_only_alter(alter_kind) {
-            self.data.state = AlterTableState::UpdateMetadata;
-        } else {
-            self.data.state = AlterTableState::SubmitAlterRegionRequests;
-        };
+        }
+        self.data.state = self.data.flow().after_prepare();
         Ok(Status::executing(true))
     }
 
@@ -248,15 +243,24 @@ impl AlterTableProcedure {
         ensure!(!leaders.is_empty(), NoLeaderSnafu { table_id });
         // Puts the poison before submitting alter region requests to datanodes.
         self.put_poison(ctx_provider, procedure_id).await?;
-        let results = self
-            .executor
-            .on_alter_regions(
-                &self.context.node_manager,
-                &physical_table_route.region_routes,
-                alter_kind,
-                self.data.alter_regions_after_metadata,
-            )
-            .await;
+        let flow = self.data.flow();
+        let results = if flow == AlterTableFlow::MetadataFirst {
+            self.executor
+                .on_alter_skip_wal_regions(
+                    &self.context.node_manager,
+                    &physical_table_route.region_routes,
+                    alter_kind,
+                )
+                .await
+        } else {
+            self.executor
+                .on_alter_regions(
+                    &self.context.node_manager,
+                    &physical_table_route.region_routes,
+                    alter_kind,
+                )
+                .await
+        };
 
         match handle_multiple_results(results) {
             MultipleResults::PartialRetryable(error) => {
@@ -264,7 +268,7 @@ impl AlterTableProcedure {
                 Err(error)
             }
             MultipleResults::PartialNonRetryable(error) => {
-                if self.data.alter_regions_after_metadata {
+                if flow == AlterTableFlow::MetadataFirst {
                     return Err(BoxedError::new(error)).context(RetryLaterSnafu {
                         clean_poisons: true,
                     });
@@ -284,7 +288,7 @@ impl AlterTableProcedure {
                 })
             }
             MultipleResults::Ok(results) => {
-                if !self.data.alter_regions_after_metadata {
+                if flow != AlterTableFlow::MetadataFirst {
                     self.submit_sync_region_requests(&results, &physical_table_route.region_routes)
                         .await;
                 }
@@ -292,7 +296,7 @@ impl AlterTableProcedure {
                 Ok(Status::executing_with_clean_poisons(true))
             }
             MultipleResults::AllNonRetryable(error) => {
-                if self.data.alter_regions_after_metadata {
+                if flow == AlterTableFlow::MetadataFirst {
                     return Err(BoxedError::new(error)).context(RetryLaterSnafu {
                         clean_poisons: true,
                     });
@@ -319,11 +323,7 @@ impl AlterTableProcedure {
                 "altering table result doesn't contains extension key `{TABLE_COLUMN_METADATA_EXTENSION_KEY}`,leaving the table's column metadata unchanged"
             );
         }
-        self.data.state = if self.data.alter_regions_after_metadata {
-            AlterTableState::InvalidateTableCache
-        } else {
-            AlterTableState::UpdateMetadata
-        };
+        self.data.state = self.data.flow().after_regions();
         Ok(())
     }
 
@@ -355,7 +355,8 @@ impl AlterTableProcedure {
         let table_info_value = self.data.table_info_value.as_ref().unwrap();
         // Safety: Checked in `AlterTableProcedure::new`.
         let alter_kind = self.data.task.alter_table.kind.as_ref().unwrap();
-        let metadata_only_alter = is_metadata_only_alter(alter_kind);
+        let flow = self.data.flow();
+        let metadata_only_alter = flow == AlterTableFlow::MetadataOnly;
 
         // Gets the table info from the cache or builds it.
         let  new_info = match &self.new_table_info {
@@ -385,11 +386,7 @@ impl AlterTableProcedure {
         info!(
             "Updated table metadata for table {table_ref}, table_id: {table_id}, kind: {alter_kind:?}"
         );
-        self.data.state = if self.data.alter_regions_after_metadata {
-            AlterTableState::SubmitAlterRegionRequests
-        } else {
-            AlterTableState::InvalidateTableCache
-        };
+        self.data.state = flow.after_metadata();
         Ok(Status::executing(true))
     }
 
@@ -465,6 +462,46 @@ fn is_metadata_only_alter(alter_kind: &Kind) -> bool {
             keys.len() == 1 && keys[0].as_str() == REPARTITION_COLUMN_HINT_KEY
         }
         _ => false,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AlterTableFlow {
+    RegionFirst,
+    MetadataFirst,
+    MetadataOnly,
+}
+
+impl AlterTableFlow {
+    fn from_kind(kind: &Kind) -> Self {
+        if only_enables_skip_wal(kind) {
+            Self::MetadataFirst
+        } else if is_metadata_only_alter(kind) {
+            Self::MetadataOnly
+        } else {
+            Self::RegionFirst
+        }
+    }
+
+    fn after_prepare(self) -> AlterTableState {
+        match self {
+            Self::RegionFirst => AlterTableState::SubmitAlterRegionRequests,
+            Self::MetadataFirst | Self::MetadataOnly => AlterTableState::UpdateMetadata,
+        }
+    }
+
+    fn after_regions(self) -> AlterTableState {
+        match self {
+            Self::RegionFirst => AlterTableState::UpdateMetadata,
+            Self::MetadataFirst | Self::MetadataOnly => AlterTableState::InvalidateTableCache,
+        }
+    }
+
+    fn after_metadata(self) -> AlterTableState {
+        match self {
+            Self::MetadataFirst => AlterTableState::SubmitAlterRegionRequests,
+            Self::RegionFirst | Self::MetadataOnly => AlterTableState::InvalidateTableCache,
+        }
     }
 }
 
@@ -562,9 +599,6 @@ pub struct AlterTableData {
     table_info_value: Option<DeserializedValueWithBytes<TableInfoValue>>,
     /// Region distribution for table in case we need to update region options.
     region_distribution: Option<RegionDistribution>,
-    /// Whether this irreversible alter persists metadata before mutating regions.
-    #[serde(default)]
-    alter_regions_after_metadata: bool,
     /// Region locks held by irreversible region-option alters.
     #[serde(default)]
     region_locks: Vec<RegionId>,
@@ -579,7 +613,6 @@ impl AlterTableData {
             column_metadatas: vec![],
             table_info_value: None,
             region_distribution: None,
-            alter_regions_after_metadata: false,
             region_locks,
         }
     }
@@ -596,6 +629,11 @@ impl AlterTableData {
         self.table_info_value
             .as_ref()
             .map(|value| &value.table_info)
+    }
+
+    fn flow(&self) -> AlterTableFlow {
+        // Safety: Checked in `AlterTableProcedure::new`.
+        AlterTableFlow::from_kind(self.task.alter_table.kind.as_ref().unwrap())
     }
 
     #[cfg(test)]

--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -22,6 +22,7 @@ use api::region::RegionResponse;
 use api::v1::alter_table_expr::Kind;
 use api::v1::{RenameTable, SetTableOptions, UnsetTableOptions};
 use async_trait::async_trait;
+use common_catalog::consts::{METRIC_ENGINE, MITO_ENGINE};
 use common_error::ext::BoxedError;
 use common_procedure::error::{FromJsonSnafu, Result as ProcedureResult, ToJsonSnafu};
 use common_procedure::{
@@ -33,9 +34,10 @@ use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, ensure};
 use store_api::metadata::ColumnMetadata;
 use store_api::metric_engine_consts::TABLE_COLUMN_METADATA_EXTENSION_KEY;
+use store_api::storage::RegionId;
 use strum::AsRefStr;
 use table::metadata::{TableId, TableInfo};
-use table::requests::REPARTITION_COLUMN_HINT_KEY;
+use table::requests::{REPARTITION_COLUMN_HINT_KEY, SKIP_WAL_KEY};
 use table::table_reference::TableReference;
 
 use crate::ddl::DdlContext;
@@ -47,10 +49,12 @@ use crate::ddl::utils::{
     MultipleResults, extract_column_metadatas, handle_multiple_results, map_to_procedure_error,
     sync_follower_regions,
 };
-use crate::error::{AbortProcedureSnafu, NoLeaderSnafu, PutPoisonSnafu, Result, RetryLaterSnafu};
+use crate::error::{
+    AbortProcedureSnafu, NoLeaderSnafu, PutPoisonSnafu, Result, RetryLaterSnafu, UnsupportedSnafu,
+};
 use crate::key::table_info::TableInfoValue;
 use crate::key::{DeserializedValueWithBytes, RegionDistribution};
-use crate::lock_key::{CatalogLock, SchemaLock, TableLock, TableNameLock};
+use crate::lock_key::{CatalogLock, RegionLock, SchemaLock, TableLock, TableNameLock};
 use crate::metrics;
 use crate::poison_key::table_poison_key;
 use crate::rpc::ddl::AlterTableTask;
@@ -90,8 +94,17 @@ impl AlterTableProcedure {
     pub const TYPE_NAME: &'static str = "metasrv-procedure::AlterTable";
 
     pub fn new(table_id: TableId, task: AlterTableTask, context: DdlContext) -> Result<Self> {
+        Self::new_with_region_locks(table_id, task, vec![], context)
+    }
+
+    pub(crate) fn new_with_region_locks(
+        table_id: TableId,
+        task: AlterTableTask,
+        region_locks: Vec<RegionId>,
+        context: DdlContext,
+    ) -> Result<Self> {
         task.validate()?;
-        let data = AlterTableData::new(task, table_id);
+        let data = AlterTableData::new(task, table_id, region_locks);
         let executor = build_executor_from_alter_expr(&data);
         Ok(Self {
             context,
@@ -130,7 +143,38 @@ impl AlterTableProcedure {
 
         // Safety: Checked in `AlterTableProcedure::new`.
         let alter_kind = self.data.task.alter_table.kind.as_ref().unwrap();
-        if is_metadata_only_alter(alter_kind) {
+        if enables_skip_wal(alter_kind) {
+            ensure!(
+                only_enables_skip_wal(alter_kind),
+                UnsupportedSnafu {
+                    operation: "combining skip_wal = 'true' with other table options".to_string()
+                }
+            );
+            let engine = table_info_value.table_info.meta.engine.as_str();
+            ensure!(
+                engine == MITO_ENGINE || engine == METRIC_ENGINE,
+                UnsupportedSnafu {
+                    operation: format!("setting skip_wal on {engine} engine tables")
+                }
+            );
+            // Persist the irreversible intent before any region stops writing WAL.
+            let (physical_table_id, physical_table_route) = self
+                .context
+                .table_metadata_manager
+                .table_route_manager()
+                .get_physical_table_route(self.data.table_id())
+                .await?;
+            ensure!(
+                physical_table_id == self.data.table_id(),
+                UnsupportedSnafu {
+                    operation: "setting skip_wal on logical tables".to_string()
+                }
+            );
+            self.data.region_distribution =
+                Some(region_distribution(&physical_table_route.region_routes));
+            self.data.alter_regions_after_metadata = true;
+            self.data.state = AlterTableState::UpdateMetadata;
+        } else if is_metadata_only_alter(alter_kind) {
             self.data.state = AlterTableState::UpdateMetadata;
         } else {
             self.data.state = AlterTableState::SubmitAlterRegionRequests;
@@ -188,6 +232,7 @@ impl AlterTableProcedure {
                 &self.context.node_manager,
                 &physical_table_route.region_routes,
                 alter_kind,
+                self.data.alter_regions_after_metadata,
             )
             .await;
 
@@ -197,6 +242,11 @@ impl AlterTableProcedure {
                 Err(error)
             }
             MultipleResults::PartialNonRetryable(error) => {
+                if self.data.alter_regions_after_metadata {
+                    return Err(BoxedError::new(error)).context(RetryLaterSnafu {
+                        clean_poisons: true,
+                    });
+                }
                 error!(error; "Partial non-retryable errors occurred during alter table, table {}, table_id: {}", self.data.table_ref(), self.data.table_id());
                 // No retry will be done.
                 Ok(Status::poisoned(
@@ -212,12 +262,19 @@ impl AlterTableProcedure {
                 })
             }
             MultipleResults::Ok(results) => {
-                self.submit_sync_region_requests(&results, &physical_table_route.region_routes)
-                    .await;
+                if !self.data.alter_regions_after_metadata {
+                    self.submit_sync_region_requests(&results, &physical_table_route.region_routes)
+                        .await;
+                }
                 self.handle_alter_region_response(results)?;
                 Ok(Status::executing_with_clean_poisons(true))
             }
             MultipleResults::AllNonRetryable(error) => {
+                if self.data.alter_regions_after_metadata {
+                    return Err(BoxedError::new(error)).context(RetryLaterSnafu {
+                        clean_poisons: true,
+                    });
+                }
                 error!(error; "All alter requests returned non-retryable errors for table {}, table_id: {}", self.data.table_ref(), self.data.table_id());
                 // It assumes the metadata on datanode is not changed.
                 // Case: The alter region request is sent but not applied. (e.g., InvalidArgument)
@@ -240,7 +297,11 @@ impl AlterTableProcedure {
                 "altering table result doesn't contains extension key `{TABLE_COLUMN_METADATA_EXTENSION_KEY}`,leaving the table's column metadata unchanged"
             );
         }
-        self.data.state = AlterTableState::UpdateMetadata;
+        self.data.state = if self.data.alter_regions_after_metadata {
+            AlterTableState::InvalidateTableCache
+        } else {
+            AlterTableState::UpdateMetadata
+        };
         Ok(())
     }
 
@@ -302,7 +363,11 @@ impl AlterTableProcedure {
         info!(
             "Updated table metadata for table {table_ref}, table_id: {table_id}, kind: {alter_kind:?}"
         );
-        self.data.state = AlterTableState::InvalidateTableCache;
+        self.data.state = if self.data.alter_regions_after_metadata {
+            AlterTableState::SubmitAlterRegionRequests
+        } else {
+            AlterTableState::InvalidateTableCache
+        };
         Ok(Status::executing(true))
     }
 
@@ -321,6 +386,10 @@ impl AlterTableProcedure {
         lock_key.push(CatalogLock::Read(table_ref.catalog).into());
         lock_key.push(SchemaLock::read(table_ref.catalog, table_ref.schema).into());
         lock_key.push(TableLock::Write(table_id).into());
+
+        for region_id in &self.data.region_locks {
+            lock_key.push(RegionLock::Write(*region_id).into());
+        }
 
         // Safety: Checked in `AlterTableProcedure::new`.
         let alter_kind = self.data.task.alter_table.kind.as_ref().unwrap();
@@ -342,6 +411,26 @@ impl AlterTableProcedure {
     pub(crate) fn mut_data(&mut self) -> &mut AlterTableData {
         &mut self.data
     }
+}
+
+fn enables_skip_wal(alter_kind: &Kind) -> bool {
+    let Kind::SetTableOptions(SetTableOptions { table_options }) = alter_kind else {
+        return false;
+    };
+
+    table_options
+        .iter()
+        .any(|option| option.key == SKIP_WAL_KEY && option.value == "true")
+}
+
+pub(crate) fn only_enables_skip_wal(alter_kind: &Kind) -> bool {
+    let Kind::SetTableOptions(SetTableOptions { table_options }) = alter_kind else {
+        return false;
+    };
+
+    table_options.len() == 1
+        && table_options[0].key == SKIP_WAL_KEY
+        && table_options[0].value == "true"
 }
 
 fn is_metadata_only_alter(alter_kind: &Kind) -> bool {
@@ -451,10 +540,16 @@ pub struct AlterTableData {
     table_info_value: Option<DeserializedValueWithBytes<TableInfoValue>>,
     /// Region distribution for table in case we need to update region options.
     region_distribution: Option<RegionDistribution>,
+    /// Whether this irreversible alter persists metadata before mutating regions.
+    #[serde(default)]
+    alter_regions_after_metadata: bool,
+    /// Region locks held by irreversible region-option alters.
+    #[serde(default)]
+    region_locks: Vec<RegionId>,
 }
 
 impl AlterTableData {
-    pub fn new(task: AlterTableTask, table_id: TableId) -> Self {
+    pub fn new(task: AlterTableTask, table_id: TableId, region_locks: Vec<RegionId>) -> Self {
         Self {
             state: AlterTableState::Prepare,
             task,
@@ -462,6 +557,8 @@ impl AlterTableData {
             column_metadatas: vec![],
             table_info_value: None,
             region_distribution: None,
+            alter_regions_after_metadata: false,
+            region_locks,
         }
     }
 

--- a/src/common/meta/src/ddl/alter_table/executor.rs
+++ b/src/common/meta/src/ddl/alter_table/executor.rs
@@ -169,21 +169,42 @@ impl AlterTableExecutor {
         node_manager: &NodeManagerRef,
         region_routes: &[RegionRoute],
         kind: Option<alter_request::Kind>,
-        alter_follower_regions: bool,
+    ) -> Vec<Result<RegionResponse>> {
+        self.dispatch_alter_region_requests(node_manager, region_routes, kind, false)
+            .await
+    }
+
+    /// Alters all replicas for the irreversible skip-WAL flow.
+    pub(crate) async fn on_alter_skip_wal_regions(
+        &self,
+        node_manager: &NodeManagerRef,
+        region_routes: &[RegionRoute],
+        kind: Option<alter_request::Kind>,
+    ) -> Vec<Result<RegionResponse>> {
+        self.dispatch_alter_region_requests(node_manager, region_routes, kind, true)
+            .await
+    }
+
+    async fn dispatch_alter_region_requests(
+        &self,
+        node_manager: &NodeManagerRef,
+        region_routes: &[RegionRoute],
+        kind: Option<alter_request::Kind>,
+        include_followers: bool,
     ) -> Vec<Result<RegionResponse>> {
         let region_distribution = region_distribution(region_routes);
         let mut peers = find_leaders(region_routes)
             .into_iter()
             .map(|p| (p.id, p))
             .collect::<HashMap<_, _>>();
-        if alter_follower_regions {
+        if include_followers {
             peers.extend(find_followers(region_routes).into_iter().map(|p| (p.id, p)));
         }
         let total_num_region = region_distribution
             .values()
             .map(|r| {
                 r.leader_regions.len()
-                    + if alter_follower_regions {
+                    + if include_followers {
                         r.follower_regions.len()
                     } else {
                         0
@@ -193,7 +214,7 @@ impl AlterTableExecutor {
         let mut alter_region_tasks = Vec::with_capacity(total_num_region);
         for (datanode_id, region_role_set) in region_distribution {
             let mut region_ids = region_role_set.leader_regions;
-            if alter_follower_regions {
+            if include_followers {
                 region_ids.extend(region_role_set.follower_regions);
             }
             if region_ids.is_empty() {

--- a/src/common/meta/src/ddl/alter_table/executor.rs
+++ b/src/common/meta/src/ddl/alter_table/executor.rs
@@ -38,7 +38,7 @@ use crate::key::table_info::TableInfoValue;
 use crate::key::table_name::TableNameKey;
 use crate::key::{DeserializedValueWithBytes, RegionDistribution, TableMetadataManagerRef};
 use crate::node_manager::NodeManagerRef;
-use crate::rpc::router::{RegionRoute, find_leaders, region_distribution};
+use crate::rpc::router::{RegionRoute, find_followers, find_leaders, region_distribution};
 
 /// [AlterTableExecutor] performs:
 /// - Alters the metadata of the table.
@@ -169,26 +169,41 @@ impl AlterTableExecutor {
         node_manager: &NodeManagerRef,
         region_routes: &[RegionRoute],
         kind: Option<alter_request::Kind>,
+        alter_follower_regions: bool,
     ) -> Vec<Result<RegionResponse>> {
         let region_distribution = region_distribution(region_routes);
-        let leaders = find_leaders(region_routes)
+        let mut peers = find_leaders(region_routes)
             .into_iter()
             .map(|p| (p.id, p))
             .collect::<HashMap<_, _>>();
+        if alter_follower_regions {
+            peers.extend(find_followers(region_routes).into_iter().map(|p| (p.id, p)));
+        }
         let total_num_region = region_distribution
             .values()
-            .map(|r| r.leader_regions.len())
+            .map(|r| {
+                r.leader_regions.len()
+                    + if alter_follower_regions {
+                        r.follower_regions.len()
+                    } else {
+                        0
+                    }
+            })
             .sum::<usize>();
         let mut alter_region_tasks = Vec::with_capacity(total_num_region);
         for (datanode_id, region_role_set) in region_distribution {
-            if region_role_set.leader_regions.is_empty() {
+            let mut region_ids = region_role_set.leader_regions;
+            if alter_follower_regions {
+                region_ids.extend(region_role_set.follower_regions);
+            }
+            if region_ids.is_empty() {
                 continue;
             }
             // Safety: must exists.
-            let peer = leaders.get(&datanode_id).unwrap();
+            let peer = peers.get(&datanode_id).unwrap();
             let requester = node_manager.datanode(peer).await;
 
-            for region_id in region_role_set.leader_regions {
+            for region_id in region_ids {
                 let region_id = RegionId::new(self.table_id, region_id);
                 let request = make_alter_region_request(region_id, kind.clone());
 

--- a/src/common/meta/src/ddl/tests/alter_table.rs
+++ b/src/common/meta/src/ddl/tests/alter_table.rs
@@ -41,7 +41,7 @@ use store_api::storage::RegionId;
 use table::requests::{SKIP_WAL_KEY, TTL_KEY};
 use tokio::sync::mpsc::{self};
 
-use crate::ddl::alter_table::AlterTableProcedure;
+use crate::ddl::alter_table::{AlterTableProcedure, RegionRouteChanged};
 use crate::ddl::test_util::alter_table::TestAlterTableExprBuilder;
 use crate::ddl::test_util::create_table::test_create_table_task;
 use crate::ddl::test_util::datanode_handler::{
@@ -765,6 +765,58 @@ fn test_skip_wal_holds_region_locks() {
 }
 
 #[tokio::test]
+async fn test_skip_wal_detects_region_route_change() {
+    let ddl_context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+    let table_name = "foo";
+    let table_id = 1024;
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info,
+            prepare_table_route(table_id),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let alter_task = AlterTableTask {
+        alter_table: AlterTableExpr {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: table_name.to_string(),
+            kind: Some(Kind::SetTableOptions(SetTableOptions {
+                table_options: vec![api::v1::Option {
+                    key: SKIP_WAL_KEY.to_string(),
+                    value: "true".to_string(),
+                }],
+            })),
+        },
+    };
+    let stale_region_locks = vec![RegionId::new(table_id, 4)];
+    let mut procedure = AlterTableProcedure::new_with_region_locks(
+        table_id,
+        alter_task,
+        stale_region_locks,
+        ddl_context.clone(),
+    )
+    .unwrap();
+
+    let status = procedure.on_prepare().await.unwrap();
+    assert!(status.downcast_output_ref::<RegionRouteChanged>().is_some());
+    let table_info = ddl_context
+        .table_metadata_manager
+        .table_info_manager()
+        .get(table_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_inner()
+        .table_info;
+    assert!(!table_info.meta.options.skip_wal);
+}
+
+#[tokio::test]
 async fn test_skip_wal_updates_metadata_before_all_replicas() {
     let (tx, mut rx) = mpsc::channel(8);
     let node_manager = Arc::new(MockDatanodeManager::new(DatanodeWatcher::new(tx)));
@@ -796,8 +848,19 @@ async fn test_skip_wal_updates_metadata_before_all_replicas() {
         },
     };
 
-    let mut procedure =
-        AlterTableProcedure::new(table_id, alter_task, ddl_context.clone()).unwrap();
+    let region_locks = prepare_table_route(table_id)
+        .region_routes()
+        .unwrap()
+        .iter()
+        .map(|route| route.region.id)
+        .collect();
+    let mut procedure = AlterTableProcedure::new_with_region_locks(
+        table_id,
+        alter_task,
+        region_locks,
+        ddl_context.clone(),
+    )
+    .unwrap();
     procedure.on_prepare().await.unwrap();
     let persisted: serde_json::Value = serde_json::from_str(&procedure.dump().unwrap()).unwrap();
     assert_eq!("UpdateMetadata", persisted["state"]);

--- a/src/common/meta/src/ddl/tests/alter_table.rs
+++ b/src/common/meta/src/ddl/tests/alter_table.rs
@@ -864,7 +864,7 @@ async fn test_skip_wal_updates_metadata_before_all_replicas() {
     procedure.on_prepare().await.unwrap();
     let persisted: serde_json::Value = serde_json::from_str(&procedure.dump().unwrap()).unwrap();
     assert_eq!("UpdateMetadata", persisted["state"]);
-    assert_eq!(true, persisted["alter_regions_after_metadata"]);
+    assert!(persisted.get("alter_regions_after_metadata").is_none());
 
     procedure.on_update_metadata().await.unwrap();
     // A crash can happen after the metadata transaction commits but before

--- a/src/common/meta/src/ddl/tests/alter_table.rs
+++ b/src/common/meta/src/ddl/tests/alter_table.rs
@@ -24,11 +24,11 @@ use api::v1::{
     AddColumn, AddColumns, AlterTableExpr, ColumnDataType, ColumnDef as PbColumnDef, DropColumn,
     DropColumns, SemanticType, SetTableOptions,
 };
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, FILE_ENGINE};
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
 use common_procedure::store::poison_store::PoisonStore;
-use common_procedure::{ProcedureId, Status};
+use common_procedure::{Procedure, ProcedureId, Status};
 use common_procedure_test::MockContextProvider;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::ColumnSchema;
@@ -38,7 +38,7 @@ use store_api::metric_engine_consts::{
 };
 use store_api::region_engine::RegionManifestInfo;
 use store_api::storage::RegionId;
-use table::requests::TTL_KEY;
+use table::requests::{SKIP_WAL_KEY, TTL_KEY};
 use tokio::sync::mpsc::{self};
 
 use crate::ddl::alter_table::AlterTableProcedure;
@@ -48,11 +48,14 @@ use crate::ddl::test_util::datanode_handler::{
     AllFailureDatanodeHandler, DatanodeWatcher, PartialSuccessDatanodeHandler,
     RequestOutdatedErrorDatanodeHandler,
 };
-use crate::ddl::test_util::{assert_column_name, assert_column_name_and_id};
+use crate::ddl::test_util::{
+    assert_column_name, assert_column_name_and_id, create_logical_table, create_physical_table,
+};
 use crate::error::{Error, Result};
 use crate::key::datanode_table::DatanodeTableKey;
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteValue;
+use crate::lock_key::RegionLock;
 use crate::node_manager::NodeManagerRef;
 use crate::peer::Peer;
 use crate::poison_key::table_poison_key;
@@ -592,6 +595,252 @@ async fn test_on_update_table_options() {
         region_info.region_options,
         HashMap::from(&table_info.meta.options)
     );
+}
+
+#[tokio::test]
+async fn test_skip_wal_rejects_mixed_table_options() {
+    let ddl_context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+    let table_name = "foo";
+    let table_id = 1024;
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info,
+            prepare_table_route(table_id),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let mut procedure = AlterTableProcedure::new(
+        table_id,
+        AlterTableTask {
+            alter_table: AlterTableExpr {
+                catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: table_name.to_string(),
+                kind: Some(Kind::SetTableOptions(SetTableOptions {
+                    table_options: vec![
+                        api::v1::Option {
+                            key: SKIP_WAL_KEY.to_string(),
+                            value: "true".to_string(),
+                        },
+                        api::v1::Option {
+                            key: TTL_KEY.to_string(),
+                            value: "1d".to_string(),
+                        },
+                    ],
+                })),
+            },
+        },
+        ddl_context,
+    )
+    .unwrap();
+
+    let error = procedure.on_prepare().await.unwrap_err();
+    assert_matches!(error, Error::Unsupported { .. });
+}
+
+#[tokio::test]
+async fn test_skip_wal_rejects_logical_table() {
+    let ddl_context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+    let physical_table_id = create_physical_table(&ddl_context, "physical").await;
+    let logical_table_id =
+        create_logical_table(ddl_context.clone(), physical_table_id, "logical").await;
+    let task = AlterTableTask {
+        alter_table: AlterTableExpr {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: "logical".to_string(),
+            kind: Some(Kind::SetTableOptions(SetTableOptions {
+                table_options: vec![api::v1::Option {
+                    key: SKIP_WAL_KEY.to_string(),
+                    value: "true".to_string(),
+                }],
+            })),
+        },
+    };
+
+    let mut procedure =
+        AlterTableProcedure::new(logical_table_id, task, ddl_context.clone()).unwrap();
+    let error = procedure.on_prepare().await.unwrap_err();
+    assert_matches!(error, Error::Unsupported { .. });
+
+    let table_info = ddl_context
+        .table_metadata_manager
+        .table_info_manager()
+        .get(logical_table_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_inner()
+        .table_info;
+    assert!(!table_info.meta.options.skip_wal);
+}
+
+#[tokio::test]
+async fn test_skip_wal_rejects_file_engine_table() {
+    let ddl_context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+    let table_name = "file_table";
+    let table_id = 1024;
+    let mut create_task = test_create_table_task(table_name, table_id);
+    create_task.table_info.meta.engine = FILE_ENGINE.to_string();
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            create_task.table_info,
+            prepare_table_route(table_id),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+    let task = AlterTableTask {
+        alter_table: AlterTableExpr {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: table_name.to_string(),
+            kind: Some(Kind::SetTableOptions(SetTableOptions {
+                table_options: vec![api::v1::Option {
+                    key: SKIP_WAL_KEY.to_string(),
+                    value: "true".to_string(),
+                }],
+            })),
+        },
+    };
+
+    let mut procedure = AlterTableProcedure::new(table_id, task, ddl_context.clone()).unwrap();
+    let error = procedure.on_prepare().await.unwrap_err();
+    assert_matches!(error, Error::Unsupported { .. });
+
+    let table_info = ddl_context
+        .table_metadata_manager
+        .table_info_manager()
+        .get(table_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_inner()
+        .table_info;
+    assert!(!table_info.meta.options.skip_wal);
+}
+
+#[test]
+fn test_skip_wal_holds_region_locks() {
+    let table_id = 1024;
+    let region_ids = vec![RegionId::new(table_id, 2), RegionId::new(table_id, 1)];
+    let task = AlterTableTask {
+        alter_table: AlterTableExpr {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: "foo".to_string(),
+            kind: Some(Kind::SetTableOptions(SetTableOptions {
+                table_options: vec![api::v1::Option {
+                    key: SKIP_WAL_KEY.to_string(),
+                    value: "true".to_string(),
+                }],
+            })),
+        },
+    };
+    let context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+    let procedure = AlterTableProcedure::new_with_region_locks(
+        table_id,
+        task,
+        region_ids.clone(),
+        context.clone(),
+    )
+    .unwrap();
+
+    let lock_key = procedure.lock_key();
+    for region_id in &region_ids {
+        assert!(
+            lock_key
+                .keys_to_lock()
+                .any(|key| key == &RegionLock::Write(*region_id).into())
+        );
+    }
+
+    let recovered = AlterTableProcedure::from_json(&procedure.dump().unwrap(), context).unwrap();
+    assert_eq!(lock_key, recovered.lock_key());
+}
+
+#[tokio::test]
+async fn test_skip_wal_updates_metadata_before_all_replicas() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let node_manager = Arc::new(MockDatanodeManager::new(DatanodeWatcher::new(tx)));
+    let ddl_context = new_ddl_context(node_manager);
+    let table_name = "foo";
+    let table_id = 1024;
+    let task = test_create_table_task(table_name, table_id);
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info,
+            prepare_table_route(table_id),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let alter_task = AlterTableTask {
+        alter_table: AlterTableExpr {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: table_name.to_string(),
+            kind: Some(Kind::SetTableOptions(SetTableOptions {
+                table_options: vec![api::v1::Option {
+                    key: SKIP_WAL_KEY.to_string(),
+                    value: "true".to_string(),
+                }],
+            })),
+        },
+    };
+
+    let mut procedure =
+        AlterTableProcedure::new(table_id, alter_task, ddl_context.clone()).unwrap();
+    procedure.on_prepare().await.unwrap();
+    let persisted: serde_json::Value = serde_json::from_str(&procedure.dump().unwrap()).unwrap();
+    assert_eq!("UpdateMetadata", persisted["state"]);
+    assert_eq!(true, persisted["alter_regions_after_metadata"]);
+
+    procedure.on_update_metadata().await.unwrap();
+    // A crash can happen after the metadata transaction commits but before
+    // the procedure state is persisted. Replaying this step must be safe.
+    procedure.on_update_metadata().await.unwrap();
+    let table_info = ddl_context
+        .table_metadata_manager
+        .table_info_manager()
+        .get(table_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_inner()
+        .table_info;
+    assert!(table_info.meta.options.skip_wal);
+    let persisted: serde_json::Value = serde_json::from_str(&procedure.dump().unwrap()).unwrap();
+    assert_eq!("SubmitAlterRegionRequests", persisted["state"]);
+
+    let provider = Arc::new(MockContextProvider::default());
+    procedure
+        .submit_alter_region_requests(ProcedureId::random(), provider.as_ref())
+        .await
+        .unwrap();
+    let mut requests = Vec::new();
+    while let Ok(request) = rx.try_recv() {
+        requests.push(request);
+    }
+    requests.sort_unstable_by_key(|(peer, _)| peer.id);
+    assert_eq!(5, requests.len());
+    let expected = [
+        (1, RegionId::new(table_id, 1)),
+        (2, RegionId::new(table_id, 2)),
+        (3, RegionId::new(table_id, 3)),
+        (4, RegionId::new(table_id, 2)),
+        (5, RegionId::new(table_id, 1)),
+    ];
+    for ((peer, request), (peer_id, region_id)) in requests.into_iter().zip(expected) {
+        assert_alter_request(peer, request, peer_id, region_id);
+    }
 }
 
 async fn prepare_alter_table_procedure(

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -27,12 +27,12 @@ use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use common_telemetry::{debug, info, tracing};
 use derive_builder::Builder;
 use snafu::{OptionExt, ResultExt, ensure};
-use store_api::storage::TableId;
+use store_api::storage::{RegionId, TableId};
 use table::table_name::TableName;
 
 use crate::ddl::alter_database::AlterDatabaseProcedure;
 use crate::ddl::alter_logical_tables::AlterLogicalTablesProcedure;
-use crate::ddl::alter_table::AlterTableProcedure;
+use crate::ddl::alter_table::{AlterTableProcedure, only_enables_skip_wal};
 use crate::ddl::comment_on::CommentOnProcedure;
 use crate::ddl::create_database::{CreateDatabaseMetadataCommitterRef, CreateDatabaseProcedure};
 use crate::ddl::create_flow::CreateFlowProcedure;
@@ -405,8 +405,33 @@ impl DdlManager {
                 .await;
         }
 
+        let region_locks = if alter_table_task
+            .alter_table
+            .kind
+            .as_ref()
+            .is_some_and(only_enables_skip_wal)
+        {
+            let (_, route) = self
+                .table_metadata_manager()
+                .table_route_manager()
+                .get_physical_table_route(table_id)
+                .await?;
+            route
+                .region_routes
+                .iter()
+                .map(|route| route.region.id)
+                .collect::<Vec<RegionId>>()
+        } else {
+            vec![]
+        };
+
         let context = self.create_context();
-        let procedure = AlterTableProcedure::new(table_id, alter_table_task, context)?;
+        let procedure = AlterTableProcedure::new_with_region_locks(
+            table_id,
+            alter_table_task,
+            region_locks,
+            context,
+        )?;
 
         let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
 

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -417,7 +417,7 @@ impl DdlManager {
         loop {
             // Hold the same physical region locks as migration while validating that
             // this route snapshot is still the one the procedure will mutate.
-            let region_locks = if lock_regions {
+            let region_ids_to_lock = if lock_regions {
                 let (_, route) = self
                     .table_metadata_manager()
                     .table_route_manager()
@@ -436,7 +436,7 @@ impl DdlManager {
             let procedure = AlterTableProcedure::new_with_region_locks(
                 table_id,
                 alter_table_task.clone(),
-                region_locks,
+                region_ids_to_lock,
                 context,
             )?;
 

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -78,6 +78,8 @@ use crate::rpc::ddl::{
     TruncateTableTask, UndropTableTask,
 };
 
+const MAX_REGION_ROUTE_CHANGE_RETRIES: usize = 3;
+
 /// A configurator that customizes or enhances a [`DdlManager`].
 #[async_trait::async_trait]
 pub trait DdlManagerConfigurator<C>: Send + Sync {
@@ -411,7 +413,10 @@ impl DdlManager {
             .as_ref()
             .is_some_and(only_enables_skip_wal);
 
+        let mut route_change_retries = 0;
         loop {
+            // Hold the same physical region locks as migration while validating that
+            // this route snapshot is still the one the procedure will mutate.
             let region_locks = if lock_regions {
                 let (_, route) = self
                     .table_metadata_manager()
@@ -442,6 +447,16 @@ impl DdlManager {
                 .as_ref()
                 .is_some_and(|output| output.is::<RegionRouteChanged>())
             {
+                if route_change_retries == MAX_REGION_ROUTE_CHANGE_RETRIES {
+                    let source = error::UnexpectedSnafu {
+                        err_msg: format!(
+                            "Region route kept changing while altering table {table_id}"
+                        ),
+                    }
+                    .build();
+                    return Err(error::Error::retry_later(source));
+                }
+                route_change_retries += 1;
                 continue;
             }
             return Ok(result);

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -32,7 +32,7 @@ use table::table_name::TableName;
 
 use crate::ddl::alter_database::AlterDatabaseProcedure;
 use crate::ddl::alter_logical_tables::AlterLogicalTablesProcedure;
-use crate::ddl::alter_table::{AlterTableProcedure, only_enables_skip_wal};
+use crate::ddl::alter_table::{AlterTableProcedure, RegionRouteChanged, only_enables_skip_wal};
 use crate::ddl::comment_on::CommentOnProcedure;
 use crate::ddl::create_database::{CreateDatabaseMetadataCommitterRef, CreateDatabaseProcedure};
 use crate::ddl::create_flow::CreateFlowProcedure;
@@ -405,37 +405,47 @@ impl DdlManager {
                 .await;
         }
 
-        let region_locks = if alter_table_task
+        let lock_regions = alter_table_task
             .alter_table
             .kind
             .as_ref()
-            .is_some_and(only_enables_skip_wal)
-        {
-            let (_, route) = self
-                .table_metadata_manager()
-                .table_route_manager()
-                .get_physical_table_route(table_id)
-                .await?;
-            route
-                .region_routes
-                .iter()
-                .map(|route| route.region.id)
-                .collect::<Vec<RegionId>>()
-        } else {
-            vec![]
-        };
+            .is_some_and(only_enables_skip_wal);
 
-        let context = self.create_context();
-        let procedure = AlterTableProcedure::new_with_region_locks(
-            table_id,
-            alter_table_task,
-            region_locks,
-            context,
-        )?;
+        loop {
+            let region_locks = if lock_regions {
+                let (_, route) = self
+                    .table_metadata_manager()
+                    .table_route_manager()
+                    .get_physical_table_route(table_id)
+                    .await?;
+                route
+                    .region_routes
+                    .iter()
+                    .map(|route| route.region.id)
+                    .collect::<Vec<RegionId>>()
+            } else {
+                vec![]
+            };
 
-        let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+            let context = self.create_context();
+            let procedure = AlterTableProcedure::new_with_region_locks(
+                table_id,
+                alter_table_task.clone(),
+                region_locks,
+                context,
+            )?;
 
-        self.execute_procedure_and_wait(procedure_with_id).await
+            let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
+            let result = self.execute_procedure_and_wait(procedure_with_id).await?;
+            if result
+                .1
+                .as_ref()
+                .is_some_and(|output| output.is::<RegionRouteChanged>())
+            {
+                continue;
+            }
+            return Ok(result);
+        }
     }
 
     /// Submits and executes a create table task.

--- a/src/metric-engine/src/engine/alter.rs
+++ b/src/metric-engine/src/engine/alter.rs
@@ -270,8 +270,6 @@ impl MetricEngineInner {
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
-
     use api::v1::SemanticType;
     use common_meta::ddl::test_util::assert_column_name_and_id;
     use common_meta::ddl::utils::{parse_column_metadatas, parse_manifest_infos_from_extensions};
@@ -306,16 +304,16 @@ mod test {
             "Alter request to physical region is forbidden".to_string()
         );
 
-        // alter physical region's option should work
+        // skip WAL on the physical region should be forwarded to the data region
         let alter_region_option_request = RegionAlterRequest {
             kind: AlterKind::SetRegionOptions {
-                options: vec![SetRegionOption::Ttl(Some(Duration::from_secs(500).into()))],
+                options: vec![SetRegionOption::SkipWal],
             },
         };
-        let result = engine_inner
-            .alter_physical_region(physical_region_id, alter_region_option_request.clone())
-            .await;
-        assert!(result.is_ok());
+        engine_inner
+            .alter_physical_region(physical_region_id, alter_region_option_request)
+            .await
+            .unwrap();
 
         // alter logical region
         let metadata_region = env.metadata_region();

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -327,6 +327,7 @@ mod tests {
                 compaction_override: false,
                 storage: None,
                 append_mode: false,
+                skip_wal: false,
                 wal_options: Default::default(),
                 index_options: Default::default(),
                 memtable: None,

--- a/src/mito2/src/engine/skip_wal_test.rs
+++ b/src/mito2/src/engine/skip_wal_test.rs
@@ -17,9 +17,12 @@ use std::time::Duration;
 
 use api::v1::Rows;
 use common_wal::options::{WAL_OPTIONS_KEY, WalOptions};
+use store_api::logstore::provider::Provider;
+use store_api::mito_engine_options::SKIP_WAL_KEY;
 use store_api::region_engine::{RegionEngine, RegionRole};
 use store_api::region_request::{
-    RegionCloseRequest, RegionOpenRequest, RegionPutRequest, RegionRequest, RegionTruncateRequest,
+    AlterKind, RegionAlterRequest, RegionCloseRequest, RegionOpenRequest, RegionPutRequest,
+    RegionRequest, RegionTruncateRequest, SetRegionOption,
 };
 use store_api::storage::{RegionId, ScanRequest};
 
@@ -37,6 +40,184 @@ async fn test_close_region_skip_wal_with_pending_data() {
 #[tokio::test]
 async fn test_close_region_skip_wal_without_pending_data() {
     test_close_region_skip_wal(false).await;
+}
+
+#[tokio::test]
+async fn test_alter_skip_wal_stops_wal_and_flushes_on_close() {
+    let mut env = TestEnv::with_prefix("alter-skip-wal").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    let mut request = CreateRequestBuilder::new().build();
+    let schema = rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request.clone()))
+        .await
+        .unwrap();
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: schema.clone(),
+            rows: build_rows(0, 3),
+        },
+    )
+    .await;
+
+    let before_alter = engine
+        .get_region(region_id)
+        .unwrap()
+        .version_control
+        .current();
+    assert!(!matches!(
+        &engine.get_region(region_id).unwrap().provider,
+        Provider::Noop
+    ));
+    assert!(!before_alter.version.memtables.is_empty());
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Alter(RegionAlterRequest {
+                kind: AlterKind::SetRegionOptions {
+                    options: vec![SetRegionOption::SkipWal],
+                },
+            }),
+        )
+        .await
+        .unwrap();
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Alter(RegionAlterRequest {
+                kind: AlterKind::SetRegionOptions {
+                    options: vec![SetRegionOption::SkipWal],
+                },
+            }),
+        )
+        .await
+        .unwrap();
+
+    let after_alter = engine
+        .get_region(region_id)
+        .unwrap()
+        .version_control
+        .current();
+    assert!(after_alter.version.options.skip_wal);
+    assert_eq!(before_alter.last_entry_id, after_alter.last_entry_id);
+    assert_eq!(
+        before_alter.version.flushed_sequence,
+        after_alter.version.flushed_sequence
+    );
+
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema,
+            rows: build_rows(3, 6),
+        },
+    )
+    .await;
+    assert_eq!(
+        before_alter.last_entry_id,
+        engine
+            .get_region(region_id)
+            .unwrap()
+            .version_control
+            .current()
+            .last_entry_id
+    );
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Close(RegionCloseRequest::default()),
+        )
+        .await
+        .unwrap();
+
+    request
+        .options
+        .insert(SKIP_WAL_KEY.to_string(), "true".to_string());
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Open(RegionOpenRequest {
+                engine: String::new(),
+                table_dir: request.table_dir,
+                path_type: store_api::region_request::PathType::Bare,
+                options: request.options,
+                skip_wal_replay: false,
+                checkpoint: None,
+                requirements: Default::default(),
+            }),
+        )
+        .await
+        .unwrap();
+
+    let batches = common_recordbatch::RecordBatches::try_collect(
+        engine
+            .scan_to_stream(region_id, ScanRequest::default())
+            .await
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        6,
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>()
+    );
+}
+
+#[tokio::test]
+async fn test_alter_skip_wal_on_follower_survives_promotion() {
+    let mut env = TestEnv::with_prefix("alter-skip-wal-follower").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let schema = rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    engine
+        .set_region_role(region_id, RegionRole::Follower)
+        .unwrap();
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Alter(RegionAlterRequest {
+                kind: AlterKind::SetRegionOptions {
+                    options: vec![SetRegionOption::SkipWal],
+                },
+            }),
+        )
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    assert!(region.is_follower());
+    assert!(region.version().options.skip_wal);
+
+    engine
+        .set_region_role(region_id, RegionRole::Leader)
+        .unwrap();
+    let last_entry_id = region.version_control.current().last_entry_id;
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema,
+            rows: build_rows(0, 1),
+        },
+    )
+    .await;
+    assert_eq!(
+        last_entry_id,
+        region.version_control.current().last_entry_id
+    );
 }
 
 async fn test_close_region_skip_wal(insert: bool) {

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -278,6 +278,11 @@ impl MitoRegion {
         version_data.version
     }
 
+    /// Returns whether writes to this region should skip WAL.
+    pub(crate) fn skip_wal(&self) -> bool {
+        self.provider == Provider::Noop || self.version().options.skip_wal
+    }
+
     /// Returns last flush timestamp in millis.
     pub(crate) fn last_flush_millis(&self) -> i64 {
         self.last_flush_millis.load(Ordering::Relaxed)

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -94,6 +94,8 @@ pub struct RegionOptions {
     pub storage: Option<String>,
     /// If append mode is enabled, the region keeps duplicate rows.
     pub append_mode: bool,
+    /// Whether to skip writing new WAL entries.
+    pub skip_wal: bool,
     /// Wal options.
     pub wal_options: WalOptions,
     /// Index options.
@@ -275,6 +277,7 @@ impl RegionOptions {
             compaction_override,
             storage: options.storage,
             append_mode: options.append_mode,
+            skip_wal: options.skip_wal,
             wal_options,
             index_options,
             memtable,
@@ -389,6 +392,8 @@ struct RegionOptionsWithoutEnum {
     storage: Option<String>,
     #[serde_as(as = "DisplayFromStr")]
     append_mode: bool,
+    #[serde_as(as = "DisplayFromStr")]
+    skip_wal: bool,
     #[serde_as(as = "NoneAsEmptyString")]
     merge_mode: Option<MergeMode>,
     #[serde_as(as = "NoneAsEmptyString")]
@@ -406,6 +411,7 @@ impl Default for RegionOptionsWithoutEnum {
             auto_flush_interval: options.auto_flush_interval,
             storage: options.storage,
             append_mode: options.append_mode,
+            skip_wal: options.skip_wal,
             merge_mode: options.merge_mode,
             sst_format: options.sst_format,
             max_row_group_row_count: options.max_row_group_row_count,
@@ -552,7 +558,7 @@ mod tests {
     use common_error::ext::ErrorExt;
     use common_error::status_code::StatusCode;
     use common_wal::options::KafkaWalOptions;
-    use store_api::mito_engine_options::WRITE_BUFFER_SIZE_KEY;
+    use store_api::mito_engine_options::{SKIP_WAL_KEY, WRITE_BUFFER_SIZE_KEY};
 
     use super::*;
 
@@ -579,6 +585,13 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(expect, options);
+    }
+
+    #[test]
+    fn test_with_skip_wal() {
+        let map = make_map(&[(SKIP_WAL_KEY, "true")]);
+        let options = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap();
+        assert!(options.skip_wal);
     }
 
     #[test]
@@ -937,6 +950,7 @@ mod tests {
             compaction_override: true,
             storage: Some("S3".to_string()),
             append_mode: false,
+            skip_wal: false,
             wal_options,
             index_options: IndexOptions {
                 inverted_index: InvertedIndexOptions {
@@ -974,6 +988,7 @@ mod tests {
             compaction_override: false,
             storage: Some("S3".to_string()),
             append_mode: false,
+            skip_wal: false,
             wal_options: WalOptions::Kafka(KafkaWalOptions::new("test_topic".to_string())),
             index_options: IndexOptions {
                 inverted_index: InvertedIndexOptions {
@@ -1040,6 +1055,7 @@ mod tests {
             compaction_override: false,
             storage: Some("S3".to_string()),
             append_mode: false,
+            skip_wal: false,
             wal_options: WalOptions::Kafka(KafkaWalOptions::new("test_topic".to_string())),
             index_options: IndexOptions {
                 inverted_index: InvertedIndexOptions {

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -199,6 +199,11 @@ impl RegionWriteCtx {
         &self.version
     }
 
+    /// Returns whether writes in this context should skip WAL.
+    pub(crate) fn skip_wal(&self) -> bool {
+        self.provider == Provider::Noop || self.version.options.skip_wal
+    }
+
     /// Sets error and marks all write operations are failed.
     pub(crate) fn set_error(&mut self, err: Arc<Error>) {
         // Set error for all notifiers.

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -50,12 +50,19 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         request: RegionAlterRequest,
         sender: OptionOutputTx,
     ) {
-        let region = match if only_enables_skip_wal(&request.kind) {
+        let skip_wal_only = only_enables_skip_wal(&request.kind);
+        let (region, is_follower) = match if skip_wal_only {
+            match self.regions.writable_non_staging_region(region_id) {
+                Ok(region) => Ok((region, false)),
+                Err(_) => self
+                    .regions
+                    .follower_region(region_id)
+                    .map(|region| (region, true)),
+            }
+        } else {
             self.regions
                 .writable_non_staging_region(region_id)
-                .or_else(|_| self.regions.follower_region(region_id))
-        } else {
-            self.regions.writable_non_staging_region(region_id)
+                .map(|region| (region, false))
         } {
             Ok(region) => region,
             Err(e) => {
@@ -65,6 +72,19 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         };
 
         info!("Try to alter region: {}, request: {:?}", region_id, request);
+
+        // Followers only accept skip-WAL, which is an in-memory option change and must
+        // never enter the leader path that may flush memtables.
+        if is_follower {
+            let mut options = region.version().options.clone();
+            if !options.skip_wal {
+                info!("Stop writing WAL for follower region: {}", region_id);
+                options.skip_wal = true;
+                region.version_control.alter_options(options);
+            }
+            sender.send(Ok(0));
+            return;
+        }
 
         // Gets the version before alter.
         let version = region.version();

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -51,20 +51,15 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         sender: OptionOutputTx,
     ) {
         let skip_wal_only = only_enables_skip_wal(&request.kind);
-        let (region, is_follower) = match if skip_wal_only {
-            match self.regions.writable_non_staging_region(region_id) {
-                Ok(region) => Ok((region, false)),
-                Err(_) => self
-                    .regions
-                    .follower_region(region_id)
-                    .map(|region| (region, true)),
-            }
-        } else {
-            self.regions
-                .writable_non_staging_region(region_id)
-                .map(|region| (region, false))
-        } {
-            Ok(region) => region,
+        let (region, is_follower) = match self.regions.writable_non_staging_region(region_id) {
+            Ok(region) => (region, false),
+            Err(_) if skip_wal_only => match self.regions.follower_region(region_id) {
+                Ok(region) => (region, true),
+                Err(e) => {
+                    sender.send(Err(e));
+                    return;
+                }
+            },
             Err(e) => {
                 sender.send(Err(e));
                 return;

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -50,7 +50,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         request: RegionAlterRequest,
         sender: OptionOutputTx,
     ) {
-        let region = match self.regions.writable_non_staging_region(region_id) {
+        let region = match if only_enables_skip_wal(&request.kind) {
+            self.regions
+                .writable_non_staging_region(region_id)
+                .or_else(|_| self.regions.follower_region(region_id))
+        } else {
+            self.regions.writable_non_staging_region(region_id)
+        } {
             Ok(region) => region,
             Err(e) => {
                 sender.send(Err(e));
@@ -279,6 +285,12 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         all_options_altered = false;
                     }
                 }
+                SetRegionOption::SkipWal => {
+                    if !current_options.skip_wal {
+                        info!("Stop writing WAL for region: {}", region.region_id);
+                        current_options.skip_wal = true;
+                    }
+                }
             }
         }
         if all_options_altered {
@@ -292,6 +304,14 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             ))
         }
     }
+}
+
+fn only_enables_skip_wal(kind: &AlterKind) -> bool {
+    matches!(
+        kind,
+        AlterKind::SetRegionOptions { options }
+            if matches!(options.as_slice(), [SetRegionOption::SkipWal])
+    )
 }
 
 /// Returns the new region options if there are updates to the options.
@@ -315,7 +335,8 @@ fn new_region_options_on_empty_memtable(
             SetRegionOption::WriteBufferSize(_)
             | SetRegionOption::Ttl(_)
             | SetRegionOption::Twsc(_, _)
-            | SetRegionOption::AutoFlushInterval(_) => (),
+            | SetRegionOption::AutoFlushInterval(_)
+            | SetRegionOption::SkipWal => (),
             SetRegionOption::Format(format_str) => {
                 // Safety: handle_alter_region_options_fast() has validated this.
                 let new_format = format_str.parse::<FormatType>().unwrap();

--- a/src/mito2/src/worker/handle_close.rs
+++ b/src/mito2/src/worker/handle_close.rs
@@ -16,7 +16,6 @@
 
 use common_telemetry::info;
 use store_api::logstore::LogStore;
-use store_api::logstore::provider::Provider;
 use store_api::region_request::{RegionCloseRequest, RegionFlushReason, RegionFlushRequest};
 use store_api::storage::RegionId;
 
@@ -37,10 +36,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
 
         info!("Try to close region {}, worker: {}", region_id, self.id);
 
-        // If the close request asks for a flush, or the region is using Noop WAL,
+        // If the close request asks for a flush, or the region skips WAL,
         // and has data in memtable and region is flushable (like, not in follower state),
         // we should flush it before closing to ensure durability.
-        if (request.flush_on_close || region.provider == Provider::Noop)
+        if (request.flush_on_close || region.skip_wal())
             && !region
                 .version_control
                 .current()

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use api::v1::OpType;
 use common_telemetry::{debug, error};
-use common_wal::options::WalOptions;
 use snafu::ensure;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::logstore::LogStore;
@@ -113,8 +112,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 .start_timer();
             let mut wal_writer = self.wal.writer();
             for region_ctx in region_ctxs.values_mut() {
-                if let WalOptions::Noop = &region_ctx.version().options.wal_options {
-                    // Skip wal write for noop region.
+                if region_ctx.skip_wal() {
                     continue;
                 }
                 if let Err(e) = region_ctx.add_wal_entry(&mut wal_writer).map_err(Arc::new) {
@@ -124,7 +122,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             match wal_writer.write_to_wal().await.map_err(Arc::new) {
                 Ok(response) => {
                     for (region_id, region_ctx) in region_ctxs.iter_mut() {
-                        if let WalOptions::Noop = &region_ctx.version().options.wal_options {
+                        if region_ctx.skip_wal() {
                             continue;
                         }
 

--- a/src/operator/src/expr_helper.rs
+++ b/src/operator/src/expr_helper.rs
@@ -70,7 +70,7 @@ use sql::statements::{
 };
 use sql::util::extract_tables_from_query;
 use store_api::mito_engine_options::{COMPACTION_OVERRIDE, COMPACTION_TYPE};
-use table::requests::{FILE_TABLE_META_KEY, TableOptions};
+use table::requests::{FILE_TABLE_META_KEY, SKIP_WAL_KEY, TableOptions};
 use table::table_reference::TableReference;
 #[cfg(feature = "enterprise")]
 pub use trigger::to_create_trigger_task_expr;
@@ -215,12 +215,15 @@ pub fn create_to_expr(
             .context(ExternalSnafu)?;
 
     let time_index = find_time_index(&create.constraints)?;
-    let table_options = HashMap::from(
-        &TableOptions::try_from_iter(create.options.to_str_map())
-            .context(UnrecognizedTableOptionSnafu)?,
+    let raw_table_options = create.options.to_str_map();
+    let mut table_options = HashMap::from(
+        &TableOptions::try_from_iter(&raw_table_options).context(UnrecognizedTableOptionSnafu)?,
     );
+    // Keep an explicitly specified false so it can override a schema-level true.
+    if let Some(skip_wal) = raw_table_options.get(SKIP_WAL_KEY) {
+        table_options.insert(SKIP_WAL_KEY.to_string(), skip_wal.to_string());
+    }
 
-    let mut table_options = table_options;
     if table_options.contains_key(COMPACTION_TYPE) {
         table_options.insert(COMPACTION_OVERRIDE.to_string(), "true".to_string());
     }
@@ -1494,6 +1497,21 @@ SELECT max(c1), min(c2) FROM schema_2.table_2;";
         assert_eq!(
             "1.0MiB",
             expr.table_options.get("write_buffer_size").unwrap()
+        );
+
+        let sql = "CREATE TABLE monitor (ts TIMESTAMP TIME INDEX) WITH(skip_wal='false');";
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .pop()
+                .unwrap();
+        let Statement::CreateTable(create_table) = stmt else {
+            unreachable!()
+        };
+        let expr = create_to_expr(&create_table, &QueryContext::arc()).unwrap();
+        assert_eq!(
+            Some("false"),
+            expr.table_options.get(SKIP_WAL_KEY).map(String::as_str)
         );
     }
 

--- a/src/operator/src/expr_helper.rs
+++ b/src/operator/src/expr_helper.rs
@@ -70,7 +70,7 @@ use sql::statements::{
 };
 use sql::util::extract_tables_from_query;
 use store_api::mito_engine_options::{COMPACTION_OVERRIDE, COMPACTION_TYPE};
-use table::requests::{FILE_TABLE_META_KEY, SKIP_WAL_OVERRIDE_KEY, TableOptions};
+use table::requests::{FILE_TABLE_META_KEY, TableOptions};
 use table::table_reference::TableReference;
 #[cfg(feature = "enterprise")]
 pub use trigger::to_create_trigger_task_expr;
@@ -215,13 +215,10 @@ pub fn create_to_expr(
             .context(ExternalSnafu)?;
 
     let time_index = find_time_index(&create.constraints)?;
-    let raw_table_options = create.options.to_str_map();
     let mut table_options = HashMap::from(
-        &TableOptions::try_from_iter(&raw_table_options).context(UnrecognizedTableOptionSnafu)?,
+        &TableOptions::try_from_iter(create.options.to_str_map())
+            .context(UnrecognizedTableOptionSnafu)?,
     );
-    if raw_table_options.contains_key(store_api::mito_engine_options::SKIP_WAL_KEY) {
-        table_options.insert(SKIP_WAL_OVERRIDE_KEY.to_string(), true.to_string());
-    }
 
     if table_options.contains_key(COMPACTION_TYPE) {
         table_options.insert(COMPACTION_OVERRIDE.to_string(), "true".to_string());
@@ -1509,9 +1506,9 @@ SELECT max(c1), min(c2) FROM schema_2.table_2;";
         };
         let expr = create_to_expr(&create_table, &QueryContext::arc()).unwrap();
         assert_eq!(
-            Some("true"),
+            Some("false"),
             expr.table_options
-                .get(SKIP_WAL_OVERRIDE_KEY)
+                .get(store_api::mito_engine_options::SKIP_WAL_KEY)
                 .map(String::as_str)
         );
     }

--- a/src/operator/src/expr_helper.rs
+++ b/src/operator/src/expr_helper.rs
@@ -70,7 +70,7 @@ use sql::statements::{
 };
 use sql::util::extract_tables_from_query;
 use store_api::mito_engine_options::{COMPACTION_OVERRIDE, COMPACTION_TYPE};
-use table::requests::{FILE_TABLE_META_KEY, SKIP_WAL_KEY, TableOptions};
+use table::requests::{FILE_TABLE_META_KEY, SKIP_WAL_OVERRIDE_KEY, TableOptions};
 use table::table_reference::TableReference;
 #[cfg(feature = "enterprise")]
 pub use trigger::to_create_trigger_task_expr;
@@ -219,9 +219,8 @@ pub fn create_to_expr(
     let mut table_options = HashMap::from(
         &TableOptions::try_from_iter(&raw_table_options).context(UnrecognizedTableOptionSnafu)?,
     );
-    // Keep an explicitly specified false so it can override a schema-level true.
-    if let Some(skip_wal) = raw_table_options.get(SKIP_WAL_KEY) {
-        table_options.insert(SKIP_WAL_KEY.to_string(), skip_wal.to_string());
+    if raw_table_options.contains_key(store_api::mito_engine_options::SKIP_WAL_KEY) {
+        table_options.insert(SKIP_WAL_OVERRIDE_KEY.to_string(), true.to_string());
     }
 
     if table_options.contains_key(COMPACTION_TYPE) {
@@ -1510,8 +1509,10 @@ SELECT max(c1), min(c2) FROM schema_2.table_2;";
         };
         let expr = create_to_expr(&create_table, &QueryContext::arc()).unwrap();
         assert_eq!(
-            Some("false"),
-            expr.table_options.get(SKIP_WAL_KEY).map(String::as_str)
+            Some("true"),
+            expr.table_options
+                .get(SKIP_WAL_OVERRIDE_KEY)
+                .map(String::as_str)
         );
     }
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -288,6 +288,13 @@ impl StatementExecutor {
                 if key.starts_with("compaction.") {
                     continue;
                 }
+                if key == store_api::mito_engine_options::SKIP_WAL_KEY
+                    && create_expr
+                        .table_options
+                        .contains_key(table::requests::SKIP_WAL_OVERRIDE_KEY)
+                {
+                    continue;
+                }
                 create_expr
                     .table_options
                     .entry(key.clone())

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -288,13 +288,6 @@ impl StatementExecutor {
                 if key.starts_with("compaction.") {
                     continue;
                 }
-                if key == store_api::mito_engine_options::SKIP_WAL_KEY
-                    && create_expr
-                        .table_options
-                        .contains_key(table::requests::SKIP_WAL_OVERRIDE_KEY)
-                {
-                    continue;
-                }
                 create_expr
                     .table_options
                     .entry(key.clone())

--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -39,8 +39,8 @@ use sql::statements::{self, OptionMap, concrete_data_type_to_sql_data_type};
 use store_api::metric_engine_consts::{is_metric_engine, is_metric_engine_internal_column};
 use table::metadata::{TableInfoRef, TableMeta};
 use table::requests::{
-    COMMENT_KEY as TABLE_COMMENT_KEY, FILE_TABLE_META_KEY, SKIP_WAL_KEY, TTL_KEY,
-    WRITE_BUFFER_SIZE_KEY,
+    COMMENT_KEY as TABLE_COMMENT_KEY, FILE_TABLE_META_KEY, SKIP_WAL_KEY, SKIP_WAL_OVERRIDE_KEY,
+    TTL_KEY, WRITE_BUFFER_SIZE_KEY,
 };
 
 use crate::error::{
@@ -67,18 +67,14 @@ fn create_sql_options(table_meta: &TableMeta, schema_options: Option<SchemaOptio
     {
         options.insert(TTL_KEY.to_string(), database_ttl);
     };
-    let schema_skip_wal = schema_options
-        .as_ref()
-        .and_then(|options| options.extra_options.get(SKIP_WAL_KEY))
-        .is_some_and(|value| value == "true");
-    if table_opts.skip_wal || schema_skip_wal {
+    if table_opts.skip_wal || table_opts.extra_options.contains_key(SKIP_WAL_OVERRIDE_KEY) {
         options.insert(SKIP_WAL_KEY.to_string(), table_opts.skip_wal.to_string());
     }
 
     for (k, v) in table_opts
         .extra_options
         .iter()
-        .filter(|(k, _)| k != &FILE_TABLE_META_KEY && k != &SKIP_WAL_KEY)
+        .filter(|(k, _)| k != &FILE_TABLE_META_KEY && k != &SKIP_WAL_OVERRIDE_KEY)
     {
         options.insert(k.clone(), v.clone());
     }
@@ -444,11 +440,10 @@ WITH(
         table_meta
             .options
             .extra_options
-            .insert(SKIP_WAL_KEY.to_string(), true.to_string());
-        assert!(
-            create_sql_options(&table_meta, None)
-                .get(SKIP_WAL_KEY)
-                .is_none()
+            .insert(SKIP_WAL_OVERRIDE_KEY.to_string(), true.to_string());
+        assert_eq!(
+            Some("false"),
+            create_sql_options(&table_meta, None).get(SKIP_WAL_KEY)
         );
 
         let mut schema_options = SchemaOptions::default();

--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -39,8 +39,8 @@ use sql::statements::{self, OptionMap, concrete_data_type_to_sql_data_type};
 use store_api::metric_engine_consts::{is_metric_engine, is_metric_engine_internal_column};
 use table::metadata::{TableInfoRef, TableMeta};
 use table::requests::{
-    COMMENT_KEY as TABLE_COMMENT_KEY, FILE_TABLE_META_KEY, SKIP_WAL_KEY, SKIP_WAL_OVERRIDE_KEY,
-    TTL_KEY, WRITE_BUFFER_SIZE_KEY,
+    COMMENT_KEY as TABLE_COMMENT_KEY, FILE_TABLE_META_KEY, SKIP_WAL_KEY, TTL_KEY,
+    WRITE_BUFFER_SIZE_KEY,
 };
 
 use crate::error::{
@@ -67,14 +67,15 @@ fn create_sql_options(table_meta: &TableMeta, schema_options: Option<SchemaOptio
     {
         options.insert(TTL_KEY.to_string(), database_ttl);
     };
-    if table_opts.skip_wal || table_opts.extra_options.contains_key(SKIP_WAL_OVERRIDE_KEY) {
-        options.insert(SKIP_WAL_KEY.to_string(), table_opts.skip_wal.to_string());
-    }
-
-    for (k, v) in table_opts.extra_options.iter().filter(|(k, _)| {
-        k != &FILE_TABLE_META_KEY && k != &SKIP_WAL_KEY && k != &SKIP_WAL_OVERRIDE_KEY
-    }) {
+    for (k, v) in table_opts
+        .extra_options
+        .iter()
+        .filter(|(k, _)| k != &FILE_TABLE_META_KEY)
+    {
         options.insert(k.clone(), v.clone());
+    }
+    if table_opts.skip_wal {
+        options.insert(SKIP_WAL_KEY.to_string(), true.to_string());
     }
     options
 }
@@ -434,22 +435,11 @@ WITH(
         );
 
         let mut table_meta = info.meta.clone();
-        table_meta.options.skip_wal = true;
+        table_meta.options.skip_wal = false;
         table_meta
             .options
             .extra_options
             .insert(SKIP_WAL_KEY.to_string(), false.to_string());
-        assert_eq!(
-            Some("true"),
-            create_sql_options(&table_meta, None).get(SKIP_WAL_KEY)
-        );
-
-        table_meta.options.skip_wal = false;
-        table_meta.options.extra_options.remove(SKIP_WAL_KEY);
-        table_meta
-            .options
-            .extra_options
-            .insert(SKIP_WAL_OVERRIDE_KEY.to_string(), true.to_string());
         assert_eq!(
             Some("false"),
             create_sql_options(&table_meta, None).get(SKIP_WAL_KEY)

--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -78,7 +78,7 @@ fn create_sql_options(table_meta: &TableMeta, schema_options: Option<SchemaOptio
     for (k, v) in table_opts
         .extra_options
         .iter()
-        .filter(|(k, _)| k != &FILE_TABLE_META_KEY)
+        .filter(|(k, _)| k != &FILE_TABLE_META_KEY && k != &SKIP_WAL_KEY)
     {
         options.insert(k.clone(), v.clone());
     }
@@ -441,6 +441,10 @@ WITH(
 
         let mut table_meta = info.meta.clone();
         table_meta.options.skip_wal = false;
+        table_meta
+            .options
+            .extra_options
+            .insert(SKIP_WAL_KEY.to_string(), true.to_string());
         assert!(
             create_sql_options(&table_meta, None)
                 .get(SKIP_WAL_KEY)

--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -39,7 +39,8 @@ use sql::statements::{self, OptionMap, concrete_data_type_to_sql_data_type};
 use store_api::metric_engine_consts::{is_metric_engine, is_metric_engine_internal_column};
 use table::metadata::{TableInfoRef, TableMeta};
 use table::requests::{
-    COMMENT_KEY as TABLE_COMMENT_KEY, FILE_TABLE_META_KEY, TTL_KEY, WRITE_BUFFER_SIZE_KEY,
+    COMMENT_KEY as TABLE_COMMENT_KEY, FILE_TABLE_META_KEY, SKIP_WAL_KEY, TTL_KEY,
+    WRITE_BUFFER_SIZE_KEY,
 };
 
 use crate::error::{
@@ -66,6 +67,13 @@ fn create_sql_options(table_meta: &TableMeta, schema_options: Option<SchemaOptio
     {
         options.insert(TTL_KEY.to_string(), database_ttl);
     };
+    let schema_skip_wal = schema_options
+        .as_ref()
+        .and_then(|options| options.extra_options.get(SKIP_WAL_KEY))
+        .is_some_and(|value| value == "true");
+    if table_opts.skip_wal || schema_skip_wal {
+        options.insert(SKIP_WAL_KEY.to_string(), table_opts.skip_wal.to_string());
+    }
 
     for (k, v) in table_opts
         .extra_options
@@ -373,6 +381,7 @@ mod tests {
 
         let mut options = table::requests::TableOptions {
             ttl: Some(Duration::from_secs(30).into()),
+            skip_wal: true,
             ..Default::default()
         };
 
@@ -424,9 +433,27 @@ CREATE TABLE IF NOT EXISTS "system_metrics" (
 ENGINE=mito
 WITH(
   'compaction.type' = 'twcs',
+  skip_wal = 'true',
   ttl = '30s'
 )"#,
             sql
+        );
+
+        let mut table_meta = info.meta.clone();
+        table_meta.options.skip_wal = false;
+        assert!(
+            create_sql_options(&table_meta, None)
+                .get(SKIP_WAL_KEY)
+                .is_none()
+        );
+
+        let mut schema_options = SchemaOptions::default();
+        schema_options
+            .extra_options
+            .insert(SKIP_WAL_KEY.to_string(), true.to_string());
+        assert_eq!(
+            Some("false"),
+            create_sql_options(&table_meta, Some(schema_options)).get(SKIP_WAL_KEY)
         );
     }
 

--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -71,11 +71,9 @@ fn create_sql_options(table_meta: &TableMeta, schema_options: Option<SchemaOptio
         options.insert(SKIP_WAL_KEY.to_string(), table_opts.skip_wal.to_string());
     }
 
-    for (k, v) in table_opts
-        .extra_options
-        .iter()
-        .filter(|(k, _)| k != &FILE_TABLE_META_KEY && k != &SKIP_WAL_OVERRIDE_KEY)
-    {
+    for (k, v) in table_opts.extra_options.iter().filter(|(k, _)| {
+        k != &FILE_TABLE_META_KEY && k != &SKIP_WAL_KEY && k != &SKIP_WAL_OVERRIDE_KEY
+    }) {
         options.insert(k.clone(), v.clone());
     }
     options
@@ -436,7 +434,18 @@ WITH(
         );
 
         let mut table_meta = info.meta.clone();
+        table_meta.options.skip_wal = true;
+        table_meta
+            .options
+            .extra_options
+            .insert(SKIP_WAL_KEY.to_string(), false.to_string());
+        assert_eq!(
+            Some("true"),
+            create_sql_options(&table_meta, None).get(SKIP_WAL_KEY)
+        );
+
         table_meta.options.skip_wal = false;
+        table_meta.options.extra_options.remove(SKIP_WAL_KEY);
         table_meta
             .options
             .extra_options

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -1436,6 +1436,10 @@ impl From<v1::ModifyColumnType> for ModifyColumnType {
     }
 }
 
+/// Region option changes used by ALTER requests.
+///
+/// This type currently derives serde for request persistence. Keep future changes
+/// backward compatible with previously serialized variants.
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum SetRegionOption {
     WriteBufferSize(Option<ReadableSize>),

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -56,8 +56,8 @@ use crate::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use crate::metrics;
 use crate::mito_engine_options::{
     APPEND_MODE_KEY, AUTO_FLUSH_INTERVAL_KEY, MAX_ROW_GROUP_ROW_COUNT,
-    MAX_ROW_GROUP_ROW_COUNT_LIMIT, SST_FORMAT_KEY, TTL_KEY, TWCS_MAX_OUTPUT_FILE_SIZE,
-    TWCS_TIME_WINDOW, TWCS_TRIGGER_FILE_NUM, WRITE_BUFFER_SIZE_KEY,
+    MAX_ROW_GROUP_ROW_COUNT_LIMIT, SKIP_WAL_KEY, SST_FORMAT_KEY, TTL_KEY,
+    TWCS_MAX_OUTPUT_FILE_SIZE, TWCS_TIME_WINDOW, TWCS_TRIGGER_FILE_NUM, WRITE_BUFFER_SIZE_KEY,
 };
 use crate::path_utils::table_dir;
 use crate::storage::{ColumnId, RegionId, ScanRequest};
@@ -1450,6 +1450,8 @@ pub enum SetRegionOption {
     AutoFlushInterval(Option<Duration>),
     // Modifying the max number of rows in a parquet row group.
     MaxRowGroupRowCount(Option<usize>),
+    // Stops writing new WAL entries. This operation is irreversible.
+    SkipWal,
 }
 
 impl TryFrom<&PbOption> for SetRegionOption {
@@ -1507,6 +1509,7 @@ impl TryFrom<&PbOption> for SetRegionOption {
                     .ok_or_else(|| InvalidSetRegionOptionRequestSnafu { key, value }.build())?;
                 Ok(Self::MaxRowGroupRowCount(Some(row_count)))
             }
+            SKIP_WAL_KEY if value == "true" => Ok(Self::SkipWal),
             _ => InvalidSetRegionOptionRequestSnafu { key, value }.fail(),
         }
     }
@@ -1867,6 +1870,28 @@ mod tests {
             value: "not_a_duration".to_string(),
         };
         assert!(SetRegionOption::try_from(&pb).is_err());
+    }
+
+    #[test]
+    fn test_set_region_option_skip_wal_try_from() {
+        let pb = PbOption {
+            key: SKIP_WAL_KEY.to_string(),
+            value: "true".to_string(),
+        };
+        assert_eq!(
+            SetRegionOption::SkipWal,
+            SetRegionOption::try_from(&pb).unwrap()
+        );
+
+        for value in ["false", "", "invalid"] {
+            let pb = PbOption {
+                key: SKIP_WAL_KEY.to_string(),
+                value: value.to_string(),
+            };
+            assert!(SetRegionOption::try_from(&pb).is_err());
+        }
+
+        assert!(UnsetRegionOption::try_from(SKIP_WAL_KEY).is_err());
     }
 
     #[test]

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -30,7 +30,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use store_api::mito_engine_options::{
     APPEND_MODE_KEY, AUTO_FLUSH_INTERVAL_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS,
-    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, SST_FORMAT_KEY,
+    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, SKIP_WAL_KEY, SST_FORMAT_KEY,
 };
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 use store_api::storage::{ColumnDescriptor, ColumnDescriptorBuilder, ColumnId};
@@ -403,6 +403,9 @@ impl TableMeta {
                 }
                 SetRegionOption::SkipWal => {
                     new_options.skip_wal = true;
+                    // Older table metadata also stored skip_wal in extra_options.
+                    // Remove it so the typed field is canonical after ALTER.
+                    new_options.extra_options.remove(SKIP_WAL_KEY);
                 }
             }
         }
@@ -1692,13 +1695,16 @@ mod tests {
 
     #[test]
     fn test_set_skip_wal_updates_typed_option() {
-        let meta = TableMetaBuilder::empty()
+        let mut meta = TableMetaBuilder::empty()
             .schema(Arc::new(new_test_schema()))
             .primary_key_indices(vec![0])
             .engine("engine")
             .next_column_id(3)
             .build()
             .unwrap();
+        meta.options
+            .extra_options
+            .insert(SKIP_WAL_KEY.to_string(), false.to_string());
 
         let alter_kind = AlterKind::SetTableOptions {
             options: vec![SetRegionOption::SkipWal],
@@ -1710,6 +1716,7 @@ mod tests {
             .unwrap();
 
         assert!(new_meta.options.skip_wal);
+        assert!(!new_meta.options.extra_options.contains_key(SKIP_WAL_KEY));
     }
 
     #[test]

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -403,9 +403,7 @@ impl TableMeta {
                 }
                 SetRegionOption::SkipWal => {
                     new_options.skip_wal = true;
-                    new_options
-                        .extra_options
-                        .insert(SKIP_WAL_KEY.to_string(), true.to_string());
+                    new_options.extra_options.remove(SKIP_WAL_KEY);
                 }
             }
         }
@@ -1694,7 +1692,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_skip_wal_updates_typed_and_extra_options() {
+    fn test_set_skip_wal_updates_typed_option() {
         let meta = TableMetaBuilder::empty()
             .schema(Arc::new(new_test_schema()))
             .primary_key_indices(vec![0])
@@ -1713,14 +1711,7 @@ mod tests {
             .unwrap();
 
         assert!(new_meta.options.skip_wal);
-        assert_eq!(
-            Some("true"),
-            new_meta
-                .options
-                .extra_options
-                .get(SKIP_WAL_KEY)
-                .map(String::as_str)
-        );
+        assert!(!new_meta.options.extra_options.contains_key(SKIP_WAL_KEY));
     }
 
     #[test]

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -30,7 +30,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use store_api::mito_engine_options::{
     APPEND_MODE_KEY, AUTO_FLUSH_INTERVAL_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS,
-    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, SST_FORMAT_KEY,
+    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, SKIP_WAL_KEY, SST_FORMAT_KEY,
 };
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 use store_api::storage::{ColumnDescriptor, ColumnDescriptorBuilder, ColumnId};
@@ -400,6 +400,12 @@ impl TableMeta {
                     } else {
                         new_options.extra_options.remove(MAX_ROW_GROUP_ROW_COUNT);
                     }
+                }
+                SetRegionOption::SkipWal => {
+                    new_options.skip_wal = true;
+                    new_options
+                        .extra_options
+                        .insert(SKIP_WAL_KEY.to_string(), true.to_string());
                 }
             }
         }
@@ -1683,6 +1689,36 @@ mod tests {
                 .options
                 .extra_options
                 .get(MERGE_MODE_KEY)
+                .map(String::as_str)
+        );
+    }
+
+    #[test]
+    fn test_set_skip_wal_updates_typed_and_extra_options() {
+        let meta = TableMetaBuilder::empty()
+            .schema(Arc::new(new_test_schema()))
+            .primary_key_indices(vec![0])
+            .engine("engine")
+            .next_column_id(3)
+            .build()
+            .unwrap();
+
+        let alter_kind = AlterKind::SetTableOptions {
+            options: vec![SetRegionOption::SkipWal],
+        };
+        let new_meta = meta
+            .builder_with_alter_kind("my_table", &alter_kind)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert!(new_meta.options.skip_wal);
+        assert_eq!(
+            Some("true"),
+            new_meta
+                .options
+                .extra_options
+                .get(SKIP_WAL_KEY)
                 .map(String::as_str)
         );
     }

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -403,9 +403,11 @@ impl TableMeta {
                 }
                 SetRegionOption::SkipWal => {
                     new_options.skip_wal = true;
-                    // Older table metadata also stored skip_wal in extra_options.
-                    // Remove it so the typed field is canonical after ALTER.
-                    new_options.extra_options.remove(SKIP_WAL_KEY);
+                    // Keep the explicit table option so it remains distinguishable
+                    // from a value inherited from the schema.
+                    new_options
+                        .extra_options
+                        .insert(SKIP_WAL_KEY.to_string(), true.to_string());
                 }
             }
         }
@@ -1694,7 +1696,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_skip_wal_updates_typed_option() {
+    fn test_set_skip_wal_updates_typed_and_extra_options() {
         let mut meta = TableMetaBuilder::empty()
             .schema(Arc::new(new_test_schema()))
             .primary_key_indices(vec![0])
@@ -1716,7 +1718,14 @@ mod tests {
             .unwrap();
 
         assert!(new_meta.options.skip_wal);
-        assert!(!new_meta.options.extra_options.contains_key(SKIP_WAL_KEY));
+        assert_eq!(
+            Some("true"),
+            new_meta
+                .options
+                .extra_options
+                .get(SKIP_WAL_KEY)
+                .map(String::as_str)
+        );
     }
 
     #[test]

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -30,7 +30,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use store_api::mito_engine_options::{
     APPEND_MODE_KEY, AUTO_FLUSH_INTERVAL_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS,
-    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, SKIP_WAL_KEY, SST_FORMAT_KEY,
+    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, SST_FORMAT_KEY,
 };
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 use store_api::storage::{ColumnDescriptor, ColumnDescriptorBuilder, ColumnId};
@@ -403,7 +403,6 @@ impl TableMeta {
                 }
                 SetRegionOption::SkipWal => {
                     new_options.skip_wal = true;
-                    new_options.extra_options.remove(SKIP_WAL_KEY);
                 }
             }
         }
@@ -1711,7 +1710,6 @@ mod tests {
             .unwrap();
 
         assert!(new_meta.options.skip_wal);
-        assert!(!new_meta.options.extra_options.contains_key(SKIP_WAL_KEY));
     }
 
     #[test]

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -161,6 +161,8 @@ pub const STORAGE_KEY: &str = "storage";
 pub const COMMENT_KEY: &str = "comment";
 pub const AUTO_CREATE_TABLE_KEY: &str = "auto_create_table";
 pub const SKIP_WAL_KEY: &str = store_api::mito_engine_options::SKIP_WAL_KEY;
+/// Internal marker that records an explicitly specified table-level `skip_wal`.
+pub const SKIP_WAL_OVERRIDE_KEY: &str = "skip_wal.override";
 pub const TRACE_TABLE_PARTITIONS_HINT_KEY: &str = "trace_table_partitions";
 pub const REPARTITION_COLUMN_HINT_KEY: &str = "repartition.column.hint";
 
@@ -227,12 +229,12 @@ impl fmt::Display for TableOptions {
             key_vals.push(format!("{}={}", TTL_KEY, ttl));
         }
 
-        if self.skip_wal {
+        if self.skip_wal || self.extra_options.contains_key(SKIP_WAL_OVERRIDE_KEY) {
             key_vals.push(format!("{}={}", SKIP_WAL_KEY, self.skip_wal));
         }
 
         for (k, v) in &self.extra_options {
-            if k == SKIP_WAL_KEY {
+            if k == SKIP_WAL_OVERRIDE_KEY {
                 continue;
             }
             key_vals.push(format!("{}={}", k, v));
@@ -254,15 +256,10 @@ impl From<&TableOptions> for HashMap<String, String> {
         if let Some(ttl_str) = opts.ttl.map(|ttl| ttl.to_string()) {
             let _ = res.insert(TTL_KEY.to_string(), ttl_str);
         }
-        if opts.skip_wal {
-            let _ = res.insert(SKIP_WAL_KEY.to_string(), true.to_string());
+        if opts.skip_wal || opts.extra_options.contains_key(SKIP_WAL_OVERRIDE_KEY) {
+            let _ = res.insert(SKIP_WAL_KEY.to_string(), opts.skip_wal.to_string());
         }
-        res.extend(
-            opts.extra_options
-                .iter()
-                .filter(|(key, _)| key.as_str() != SKIP_WAL_KEY)
-                .map(|(k, v)| (k.clone(), v.clone())),
-        );
+        res.extend(opts.extra_options.clone());
         res
     }
 }
@@ -595,6 +592,19 @@ mod tests {
         let serialized_map = HashMap::from(&options);
         let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
         assert_eq!(options, serialized);
+
+        let options = TableOptions {
+            extra_options: HashMap::from([(SKIP_WAL_OVERRIDE_KEY.to_string(), "true".to_string())]),
+            skip_wal: false,
+            ..Default::default()
+        };
+        let serialized_map = HashMap::from(&options);
+        assert_eq!(
+            Some("false"),
+            serialized_map.get(SKIP_WAL_KEY).map(String::as_str)
+        );
+        let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
+        assert_eq!(options, serialized);
     }
 
     #[test]
@@ -637,9 +647,9 @@ mod tests {
         let options = TableOptions {
             write_buffer_size: None,
             ttl: None,
-            extra_options: HashMap::from([(SKIP_WAL_KEY.to_string(), "true".to_string())]),
-            skip_wal: true,
+            extra_options: HashMap::from([(SKIP_WAL_OVERRIDE_KEY.to_string(), "true".to_string())]),
+            skip_wal: false,
         };
-        assert_eq!("skip_wal=true", options.to_string());
+        assert_eq!("skip_wal=false", options.to_string());
     }
 }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -161,8 +161,6 @@ pub const STORAGE_KEY: &str = "storage";
 pub const COMMENT_KEY: &str = "comment";
 pub const AUTO_CREATE_TABLE_KEY: &str = "auto_create_table";
 pub const SKIP_WAL_KEY: &str = store_api::mito_engine_options::SKIP_WAL_KEY;
-/// Internal marker that records an explicitly specified table-level `skip_wal`.
-pub const SKIP_WAL_OVERRIDE_KEY: &str = "skip_wal.override";
 pub const TRACE_TABLE_PARTITIONS_HINT_KEY: &str = "trace_table_partitions";
 pub const REPARTITION_COLUMN_HINT_KEY: &str = "repartition.column.hint";
 
@@ -211,7 +209,7 @@ impl TableOptions {
 
         options.extra_options = HashMap::from_iter(
             kvs.into_iter()
-                .filter(|(k, _)| k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY && k != SKIP_WAL_KEY),
+                .filter(|(k, _)| k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY),
         );
 
         Ok(options)
@@ -229,14 +227,11 @@ impl fmt::Display for TableOptions {
             key_vals.push(format!("{}={}", TTL_KEY, ttl));
         }
 
-        if self.skip_wal || self.extra_options.contains_key(SKIP_WAL_OVERRIDE_KEY) {
+        if self.skip_wal && !self.extra_options.contains_key(SKIP_WAL_KEY) {
             key_vals.push(format!("{}={}", SKIP_WAL_KEY, self.skip_wal));
         }
 
         for (k, v) in &self.extra_options {
-            if k == SKIP_WAL_KEY || k == SKIP_WAL_OVERRIDE_KEY {
-                continue;
-            }
             key_vals.push(format!("{}={}", k, v));
         }
 
@@ -256,15 +251,10 @@ impl From<&TableOptions> for HashMap<String, String> {
         if let Some(ttl_str) = opts.ttl.map(|ttl| ttl.to_string()) {
             let _ = res.insert(TTL_KEY.to_string(), ttl_str);
         }
-        if opts.skip_wal || opts.extra_options.contains_key(SKIP_WAL_OVERRIDE_KEY) {
-            let _ = res.insert(SKIP_WAL_KEY.to_string(), opts.skip_wal.to_string());
+        if opts.skip_wal {
+            let _ = res.insert(SKIP_WAL_KEY.to_string(), true.to_string());
         }
-        res.extend(
-            opts.extra_options
-                .iter()
-                .filter(|(key, _)| key.as_str() != SKIP_WAL_KEY)
-                .map(|(key, value)| (key.clone(), value.clone())),
-        );
+        res.extend(opts.extra_options.clone());
         res
     }
 }
@@ -567,7 +557,7 @@ mod tests {
         let options = TableOptions {
             write_buffer_size: None,
             ttl: None,
-            extra_options: HashMap::new(),
+            extra_options: HashMap::from([(SKIP_WAL_KEY.to_string(), true.to_string())]),
             skip_wal: true,
         };
         let serialized_map = HashMap::from(&options);
@@ -599,29 +589,13 @@ mod tests {
         assert_eq!(options, serialized);
 
         let options = TableOptions {
-            extra_options: HashMap::from([(SKIP_WAL_OVERRIDE_KEY.to_string(), "true".to_string())]),
+            extra_options: HashMap::from([(SKIP_WAL_KEY.to_string(), false.to_string())]),
             skip_wal: false,
             ..Default::default()
         };
         let serialized_map = HashMap::from(&options);
-        assert_eq!(
-            Some("false"),
-            serialized_map.get(SKIP_WAL_KEY).map(String::as_str)
-        );
         let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
         assert_eq!(options, serialized);
-
-        let options = TableOptions {
-            extra_options: HashMap::from([(SKIP_WAL_KEY.to_string(), false.to_string())]),
-            skip_wal: true,
-            ..Default::default()
-        };
-        let serialized_map = HashMap::from(&options);
-        assert_eq!(
-            Some("true"),
-            serialized_map.get(SKIP_WAL_KEY).map(String::as_str)
-        );
-        assert_eq!("skip_wal=true", options.to_string());
     }
 
     #[test]
@@ -664,7 +638,7 @@ mod tests {
         let options = TableOptions {
             write_buffer_size: None,
             ttl: None,
-            extra_options: HashMap::from([(SKIP_WAL_OVERRIDE_KEY.to_string(), "true".to_string())]),
+            extra_options: HashMap::from([(SKIP_WAL_KEY.to_string(), "false".to_string())]),
             skip_wal: false,
         };
         assert_eq!("skip_wal=false", options.to_string());

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -209,7 +209,7 @@ impl TableOptions {
 
         options.extra_options = HashMap::from_iter(
             kvs.into_iter()
-                .filter(|(k, _)| k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY),
+                .filter(|(k, _)| k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY && k != SKIP_WAL_KEY),
         );
 
         Ok(options)
@@ -244,7 +244,7 @@ impl fmt::Display for TableOptions {
 
 impl From<&TableOptions> for HashMap<String, String> {
     fn from(opts: &TableOptions) -> Self {
-        let mut res = HashMap::with_capacity(2 + opts.extra_options.len());
+        let mut res = HashMap::with_capacity(3 + opts.extra_options.len());
         if let Some(write_buffer_size) = opts.write_buffer_size {
             let _ = res.insert(
                 WRITE_BUFFER_SIZE_KEY.to_string(),
@@ -254,9 +254,13 @@ impl From<&TableOptions> for HashMap<String, String> {
         if let Some(ttl_str) = opts.ttl.map(|ttl| ttl.to_string()) {
             let _ = res.insert(TTL_KEY.to_string(), ttl_str);
         }
+        if opts.skip_wal {
+            let _ = res.insert(SKIP_WAL_KEY.to_string(), true.to_string());
+        }
         res.extend(
             opts.extra_options
                 .iter()
+                .filter(|(key, _)| key.as_str() != SKIP_WAL_KEY)
                 .map(|(k, v)| (k.clone(), v.clone())),
         );
         res
@@ -555,6 +559,20 @@ mod tests {
             skip_wal: false,
         };
         let serialized_map = HashMap::from(&options);
+        let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
+        assert_eq!(options, serialized);
+
+        let options = TableOptions {
+            write_buffer_size: None,
+            ttl: None,
+            extra_options: HashMap::new(),
+            skip_wal: true,
+        };
+        let serialized_map = HashMap::from(&options);
+        assert_eq!(
+            Some("true"),
+            serialized_map.get(SKIP_WAL_KEY).map(String::as_str)
+        );
         let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
         assert_eq!(options, serialized);
 

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -232,6 +232,9 @@ impl fmt::Display for TableOptions {
         }
 
         for (k, v) in &self.extra_options {
+            if k == SKIP_WAL_KEY {
+                continue;
+            }
             key_vals.push(format!("{}={}", k, v));
         }
 
@@ -612,5 +615,13 @@ mod tests {
             "write_buffer_size=128.0MiB ttl=16m 40s skip_wal=true",
             options.to_string()
         );
+
+        let options = TableOptions {
+            write_buffer_size: None,
+            ttl: None,
+            extra_options: HashMap::from([(SKIP_WAL_KEY.to_string(), "true".to_string())]),
+            skip_wal: true,
+        };
+        assert_eq!("skip_wal=true", options.to_string());
     }
 }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -234,7 +234,7 @@ impl fmt::Display for TableOptions {
         }
 
         for (k, v) in &self.extra_options {
-            if k == SKIP_WAL_OVERRIDE_KEY {
+            if k == SKIP_WAL_KEY || k == SKIP_WAL_OVERRIDE_KEY {
                 continue;
             }
             key_vals.push(format!("{}={}", k, v));
@@ -259,7 +259,12 @@ impl From<&TableOptions> for HashMap<String, String> {
         if opts.skip_wal || opts.extra_options.contains_key(SKIP_WAL_OVERRIDE_KEY) {
             let _ = res.insert(SKIP_WAL_KEY.to_string(), opts.skip_wal.to_string());
         }
-        res.extend(opts.extra_options.clone());
+        res.extend(
+            opts.extra_options
+                .iter()
+                .filter(|(key, _)| key.as_str() != SKIP_WAL_KEY)
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
         res
     }
 }
@@ -605,6 +610,18 @@ mod tests {
         );
         let serialized = TableOptions::try_from_iter(&serialized_map).unwrap();
         assert_eq!(options, serialized);
+
+        let options = TableOptions {
+            extra_options: HashMap::from([(SKIP_WAL_KEY.to_string(), false.to_string())]),
+            skip_wal: true,
+            ..Default::default()
+        };
+        let serialized_map = HashMap::from(&options);
+        assert_eq!(
+            Some("true"),
+            serialized_map.get(SKIP_WAL_KEY).map(String::as_str)
+        );
+        assert_eq!("skip_wal=true", options.to_string());
     }
 
     #[test]

--- a/tests/cases/standalone/common/skip_wal.result
+++ b/tests/cases/standalone/common/skip_wal.result
@@ -56,3 +56,94 @@ DROP TABLE system_metrics;
 
 Affected Rows: 0
 
+CREATE TABLE alter_skip_wal (
+    host STRING,
+    val DOUBLE,
+    ts TIMESTAMP,
+    PRIMARY KEY(host),
+    TIME INDEX(ts)
+);
+
+Affected Rows: 0
+
+INSERT INTO alter_skip_wal VALUES ('host1', 1, 1000);
+
+Affected Rows: 1
+
+ALTER TABLE alter_skip_wal SET 'skip_wal' = 'true';
+
+Affected Rows: 0
+
+SHOW CREATE TABLE alter_skip_wal;
+
++----------------+-----------------------------------------------+
+| Table          | Create Table                                  |
++----------------+-----------------------------------------------+
+| alter_skip_wal | CREATE TABLE IF NOT EXISTS "alter_skip_wal" ( |
+|                |   "host" STRING NULL,                         |
+|                |   "val" DOUBLE NULL,                          |
+|                |   "ts" TIMESTAMP(3) NOT NULL,                 |
+|                |   TIME INDEX ("ts"),                          |
+|                |   PRIMARY KEY ("host")                        |
+|                | )                                             |
+|                |                                               |
+|                | ENGINE=mito                                   |
+|                | WITH(                                         |
+|                |   skip_wal = 'true'                           |
+|                | )                                             |
++----------------+-----------------------------------------------+
+
+ALTER TABLE alter_skip_wal SET 'skip_wal' = 'false';
+
+Error: 1004(InvalidArguments), Invalid set table option request: Invalid set region option request, key: skip_wal, value: false
+
+ALTER TABLE alter_skip_wal UNSET 'skip_wal';
+
+Error: 1004(InvalidArguments), Invalid unset table option request: Invalid set region option request, key: skip_wal
+
+INSERT INTO alter_skip_wal VALUES ('host2', 2, 2000);
+
+Affected Rows: 1
+
+SELECT * FROM alter_skip_wal ORDER BY ts;
+
++-------+-----+---------------------+
+| host  | val | ts                  |
++-------+-----+---------------------+
+| host1 | 1.0 | 1970-01-01T00:00:01 |
+| host2 | 2.0 | 1970-01-01T00:00:02 |
++-------+-----+---------------------+
+
+-- The post-ALTER row can be lost because restart does not flush skip-WAL memtables.
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE alter_skip_wal;
+
++----------------+-----------------------------------------------+
+| Table          | Create Table                                  |
++----------------+-----------------------------------------------+
+| alter_skip_wal | CREATE TABLE IF NOT EXISTS "alter_skip_wal" ( |
+|                |   "host" STRING NULL,                         |
+|                |   "val" DOUBLE NULL,                          |
+|                |   "ts" TIMESTAMP(3) NOT NULL,                 |
+|                |   TIME INDEX ("ts"),                          |
+|                |   PRIMARY KEY ("host")                        |
+|                | )                                             |
+|                |                                               |
+|                | ENGINE=mito                                   |
+|                | WITH(                                         |
+|                |   skip_wal = 'true'                           |
+|                | )                                             |
++----------------+-----------------------------------------------+
+
+SELECT * FROM alter_skip_wal ORDER BY ts;
+
++-------+-----+---------------------+
+| host  | val | ts                  |
++-------+-----+---------------------+
+| host1 | 1.0 | 1970-01-01T00:00:01 |
++-------+-----+---------------------+
+
+DROP TABLE alter_skip_wal;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/skip_wal.sql
+++ b/tests/cases/standalone/common/skip_wal.sql
@@ -30,3 +30,33 @@ ADMIN flush_table('system_metrics');
 SELECT * FROM system_metrics;
 
 DROP TABLE system_metrics;
+
+CREATE TABLE alter_skip_wal (
+    host STRING,
+    val DOUBLE,
+    ts TIMESTAMP,
+    PRIMARY KEY(host),
+    TIME INDEX(ts)
+);
+
+INSERT INTO alter_skip_wal VALUES ('host1', 1, 1000);
+
+ALTER TABLE alter_skip_wal SET 'skip_wal' = 'true';
+
+SHOW CREATE TABLE alter_skip_wal;
+
+ALTER TABLE alter_skip_wal SET 'skip_wal' = 'false';
+
+ALTER TABLE alter_skip_wal UNSET 'skip_wal';
+
+INSERT INTO alter_skip_wal VALUES ('host2', 2, 2000);
+
+SELECT * FROM alter_skip_wal ORDER BY ts;
+
+-- The post-ALTER row can be lost because restart does not flush skip-WAL memtables.
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE alter_skip_wal;
+
+SELECT * FROM alter_skip_wal ORDER BY ts;
+
+DROP TABLE alter_skip_wal;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR supports changing `skip_wal` from `false` to `true` with `ALTER TABLE`. The transition is intentionally one-way; unsetting it or changing it back to `false` is rejected.

The implementation:

- updates table metadata first, then applies the runtime option to every leader and follower replica;
- keeps follower handling in memory and separate from the leader path that may flush;
- serializes the operation with region migration, validates the captured physical route, and bounds route-change retries;
- supports Mito tables and Metric Engine physical tables while rejecting logical Metric Engine and unsupported physical engines;
- keeps the typed table option canonical, preserves an explicit table-level `skip_wal=false` override, and renders it correctly in `SHOW CREATE TABLE`.

No RFC, protobuf, manifest format, or schema format change is included.

Verification:

- focused unit tests for table options, ALTER procedure flow, and Mito skip-WAL behavior;
- `cargo clippy -p table -p operator -p query -p store-api -p common-meta -p mito2 --all-targets -- -D warnings`;
- standalone and distributed `skip_wal` and `create_database_opts` SQLness cases;
- independent Review Bridge review: `rb-2026-08-05T082419-828Z-4f8f483d` (`LOCAL_GATE_PASSED`).

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.