### PR TITLE
fix(object-store): skip removed-entry lister test on Windows

### DIFF
--- a/src/object-store/src/secure_fs.rs
+++ b/src/object-store/src/secure_fs.rs
@@ -622,6 +622,14 @@ mod tests {
         assert!(operator.list("file/").await.unwrap().is_empty());
     }
 
+    // On Windows, `std::fs::DirEntry` is a snapshot taken by
+    // `FindFirstFileW`: `file_type()` and `metadata()` keep returning the
+    // cached data even after the file is removed, so `read_list_entry`
+    // cannot observe the deletion and returns `Some` instead of `None`.
+    // This test only applies to platforms where metadata is fetched from
+    // the live filesystem (e.g. Unix `lstat` returns `ENOENT` after
+    // removal, which `read_list_entry` turns into `None`).
+    #[cfg(not(windows))]
     #[test]
     fn test_lister_skips_entry_removed_during_iteration() {
         let temp_dir = create_temp_dir("secure_fs_lister_removed_entry");


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Introduced by #8708; fixes nightly CI failure.

## What's changed and what's your intention?

`test_lister_skips_entry_removed_during_iteration` in `src/object-store/src/secure_fs.rs` fails deterministically on Windows nightly CI (4/4 retries). On Windows, `std::fs::DirEntry` is a snapshot taken by `FindFirstFileW`: `file_type()` and `metadata()` keep returning cached data after the file is removed, so `read_list_entry()` cannot observe the deletion and returns `Some` instead of the asserted `None`.

The test asserts Unix-specific behavior (`lstat` returns `ENOENT` after removal). The lister's skip-removed-entry logic is correct on Unix; the test just cannot pass on Windows by design. This PR gates the test with `#[cfg(not(windows))]` plus a comment explaining the platform difference.

**Limitations**: On Windows the lister may still yield entries removed mid-iteration, matching `std::fs::ReadDir` semantics; production behavior is unchanged.

This PR does **not** break API or data compatibility (test-only change).

## PR Checklist

- [x] I have written the necessary rustdoc comments. (comment added explaining the platform gate)
- [x] I have added the necessary unit tests and integration tests. (test verified on Linux: `cargo nextest run -p object-store --lib -E 'test(test_lister_skips_entry_removed_during_iteration)'` → 1 passed)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.