### PR TITLE
fix(promql): return errors instead of panicking on missing extension columns

### DIFF
--- a/src/promql/benches/bench_range_fn.rs
+++ b/src/promql/benches/bench_range_fn.rs
@@ -750,7 +750,9 @@ fn bench_range_manipulate_wall_time(c: &mut Criterion) {
         let physical_input: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
             MemorySourceConfig::try_new(&[vec![input_batch]], input_schema, None).unwrap(),
         )));
-        let execution_plan = logical_plan.to_execution_plan(physical_input);
+        let execution_plan = logical_plan
+            .to_execution_plan(physical_input)
+            .expect("failed to build RangeManipulate execution plan");
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let task_ctx = datafusion::prelude::SessionContext::new().task_ctx();
 

--- a/src/promql/src/extension_plan/absent.rs
+++ b/src/promql/src/extension_plan/absent.rs
@@ -21,6 +21,7 @@ use std::task::{Context, Poll};
 
 use datafusion::arrow::array::Array;
 use datafusion::common::{DFSchemaRef, Result as DataFusionResult};
+use datafusion::error::DataFusionError;
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion::physical_expr::{
@@ -233,7 +234,24 @@ impl Absent {
         "prom_absent"
     }
 
-    pub fn to_execution_plan(&self, exec_input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    pub fn to_execution_plan(
+        &self,
+        exec_input: Arc<dyn ExecutionPlan>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        // `try_new` only builds the output schema and does not validate the input
+        // columns. Validate the time index column against the *physical* input
+        // schema here so a missing column fails with an error instead of panicking
+        // later in `execute` or `required_input_ordering`.
+        let input_schema = exec_input.schema();
+        input_schema
+            .index_of(&self.time_index_column)
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Absent: time index column {} not found in input schema: {e}",
+                    self.time_index_column
+                ))
+            })?;
+
         let output_schema = Arc::new(self.output_schema.as_arrow().clone());
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
@@ -241,7 +259,7 @@ impl Absent {
             EmissionType::Incremental,
             Boundedness::Bounded,
         ));
-        Arc::new(AbsentExec {
+        Ok(Arc::new(AbsentExec {
             start: self.start,
             end: self.end,
             step: self.step,
@@ -252,7 +270,7 @@ impl Absent {
             input: exec_input,
             properties,
             metric: ExecutionPlanMetricsSet::new(),
-        })
+        }))
     }
 
     pub fn serialize(&self) -> Vec<u8> {
@@ -390,16 +408,24 @@ impl ExecutionPlan for AbsentExec {
         let batch_size = context.session_config().batch_size();
         let input = self.input.execute(partition, context)?;
 
+        let time_index_column_index = self
+            .input
+            .schema()
+            .column_with_name(&self.time_index_column)
+            .map(|(idx, _)| idx)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "time index column {} not found in input schema {:?}",
+                    self.time_index_column,
+                    self.input.schema()
+                ))
+            })?;
+
         Ok(Box::pin(AbsentStream {
             end: self.end,
             step: self.step,
             batch_size,
-            time_index_column_index: self
-                .input
-                .schema()
-                .column_with_name(&self.time_index_column)
-                .unwrap() // Safety: we have checked the column name in `try_new`
-                .0,
+            time_index_column_index,
             output_schema: self.output_schema.clone(),
             fake_labels: self.fake_labels.clone(),
             input,
@@ -612,6 +638,7 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::catalog::memory::DataSourceExec;
+    use datafusion::common::ToDFSchema;
     use datafusion::datasource::memory::MemorySourceConfig;
     use datafusion::prelude::{SessionConfig, SessionContext};
     use datatypes::arrow::array::{Float64Array, TimestampMillisecondArray};
@@ -690,6 +717,88 @@ mod tests {
         // Should output absent timestamps: 1000, 3000, 5000
         // (0, 2000, 4000 exist in input, so 1000, 3000, 5000 are absent)
         assert_eq!(output_timestamps, vec![1000, 3000, 5000]);
+    }
+
+    #[test]
+    fn to_execution_plan_errors_on_missing_time_index() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Float64,
+            true,
+        )]));
+        let df_schema = schema.clone().to_dfschema_ref().unwrap();
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: df_schema,
+        });
+        let plan = Absent::try_new(
+            0,
+            5000,
+            1000,
+            "timestamp".to_string(),
+            "value".to_string(),
+            vec![],
+            input,
+        )
+        .unwrap();
+
+        // Malformed physical child: missing the time index column.
+        let broken_exec: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[], schema, None).unwrap(),
+        )));
+        let result = plan.to_execution_plan(broken_exec);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_returns_error_when_input_missing_time_index() {
+        // Bypass `to_execution_plan` validation and feed a malformed child directly
+        // to `execute`: it must return an error instead of panicking.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Float64,
+            true,
+        )]));
+        let value_array = Arc::new(Float64Array::from(vec![1.0, 2.0]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![value_array]).unwrap();
+        let memory_exec = DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap(),
+        ));
+
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                true,
+            ),
+            Field::new("value", DataType::Float64, true),
+        ]));
+        let absent_exec = AbsentExec {
+            start: 0,
+            end: 5000,
+            step: 1000,
+            time_index_column: "timestamp".to_string(),
+            value_column: "value".to_string(),
+            fake_labels: vec![],
+            output_schema: output_schema.clone(),
+            input: Arc::new(memory_exec),
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(output_schema.clone()),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )),
+            metric: ExecutionPlanMetricsSet::new(),
+        };
+
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let result = datafusion::physical_plan::collect(
+            Arc::new(absent_exec) as Arc<dyn ExecutionPlan>,
+            task_ctx,
+        )
+        .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/promql/src/extension_plan/histogram_fold.rs
+++ b/src/promql/src/extension_plan/histogram_fold.rs
@@ -263,21 +263,27 @@ impl HistogramFold {
         check_column(field_column)
     }
 
-    pub fn to_execution_plan(&self, exec_input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-        let input_schema = self.input.schema();
-        // safety: those fields are checked in `check_schema()`
-        let le_column_index = input_schema
-            .index_of_column_by_name(None, &self.le_column)
-            .unwrap();
-        let field_column_index = input_schema
-            .index_of_column_by_name(None, &self.field_column)
-            .unwrap();
-        let ts_column_index = input_schema
-            .index_of_column_by_name(None, &self.ts_column)
-            .unwrap();
+    pub fn to_execution_plan(
+        &self,
+        exec_input: Arc<dyn ExecutionPlan>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        // Resolve column indices against the *physical* input schema. The logical
+        // schema can be out of sync with the physical one (e.g. after column
+        // pruning); using logical-schema indices on the physical input would panic
+        // or silently read the wrong column.
+        let input_schema = exec_input.schema();
+        let lookup_index = |name: &str| {
+            input_schema.index_of(name).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "HistogramFold: column {name} not found in input schema: {e}"
+                ))
+            })
+        };
+        let le_column_index = lookup_index(&self.le_column)?;
+        let field_column_index = lookup_index(&self.field_column)?;
+        let ts_column_index = lookup_index(&self.ts_column)?;
 
-        let tag_columns = exec_input
-            .schema()
+        let tag_columns = input_schema
             .fields()
             .iter()
             .enumerate()
@@ -292,7 +298,7 @@ impl HistogramFold {
 
         let mut partition_exprs = tag_columns.clone();
         partition_exprs.push(Arc::new(PhyColumn::new(
-            self.input.schema().field(ts_column_index).name(),
+            input_schema.field(ts_column_index).name(),
             ts_column_index,
         )) as _);
 
@@ -306,7 +312,7 @@ impl HistogramFold {
             EmissionType::Incremental,
             Boundedness::Bounded,
         ));
-        Arc::new(HistogramFoldExec {
+        Ok(Arc::new(HistogramFoldExec {
             le_column_index,
             field_column_index,
             ts_column_index,
@@ -317,7 +323,7 @@ impl HistogramFold {
             output_schema,
             metric: ExecutionPlanMetricsSet::new(),
             properties,
-        })
+        }))
     }
 
     /// Transform the schema
@@ -1129,7 +1135,6 @@ mod test {
     use datafusion::logical_expr::EmptyRelation;
     use datafusion::prelude::SessionContext;
     use datatypes::arrow_array::StringArray;
-    use futures::FutureExt;
 
     use super::*;
 
@@ -1424,7 +1429,7 @@ mod test {
             MemorySourceConfig::try_new(&[vec![projected]], projected_schema, None).unwrap(),
         )));
 
-        let fold_exec = plan.to_execution_plan(memory_exec);
+        let fold_exec = plan.to_execution_plan(memory_exec).unwrap();
         let session_context = SessionContext::default();
         let output_batches =
             datafusion::physical_plan::collect(fold_exec, session_context.task_ctx())
@@ -1467,14 +1472,67 @@ mod test {
         let broken_exec = Arc::new(DataSourceExec::new(Arc::new(
             MemorySourceConfig::try_new(&[vec![broken]], broken_schema, None).unwrap(),
         )));
-        let broken_fold_exec = plan.to_execution_plan(broken_exec);
-        let session_context = SessionContext::default();
-        let broken_result = std::panic::AssertUnwindSafe(async {
-            datafusion::physical_plan::collect(broken_fold_exec, session_context.task_ctx()).await
-        })
-        .catch_unwind()
-        .await;
+        // A missing `le` column must fail with an error instead of panicking.
+        let broken_result = plan.to_execution_plan(broken_exec);
         assert!(broken_result.is_err());
+    }
+
+    #[test]
+    fn to_execution_plan_errors_on_missing_required_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("ts", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+            Field::new("le", DataType::Utf8, true),
+            Field::new("val", DataType::Float64, true),
+        ]));
+        let df_schema = schema.clone().to_dfschema_ref().unwrap();
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: df_schema,
+        });
+        let plan = HistogramFold::new(
+            "le".to_string(),
+            "val".to_string(),
+            "ts".to_string(),
+            0.5,
+            input,
+        )
+        .unwrap();
+
+        let build_broken_exec = |schema: SchemaRef| -> Arc<dyn ExecutionPlan> {
+            Arc::new(DataSourceExec::new(Arc::new(
+                MemorySourceConfig::try_new(&[], schema, None).unwrap(),
+            )))
+        };
+
+        // Missing the `le` column.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new("ts", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+            Field::new("val", DataType::Float64, true),
+        ]));
+        assert!(
+            plan.to_execution_plan(build_broken_exec(broken_schema))
+                .is_err()
+        );
+
+        // Missing the `ts` column.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new("le", DataType::Utf8, true),
+            Field::new("val", DataType::Float64, true),
+        ]));
+        assert!(
+            plan.to_execution_plan(build_broken_exec(broken_schema))
+                .is_err()
+        );
+
+        // Missing the field column.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new("ts", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+            Field::new("le", DataType::Utf8, true),
+        ]));
+        assert!(
+            plan.to_execution_plan(build_broken_exec(broken_schema))
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -383,8 +383,13 @@ impl ExecutionPlan for InstantManipulateExec {
         let schema = input.schema();
         let time_index = schema
             .column_with_name(&self.time_index_column)
-            .expect("time index column not found")
-            .0;
+            .map(|(idx, _)| idx)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "time index column {} not found in input schema {schema:?}",
+                    self.time_index_column
+                ))
+            })?;
         let field_index = self
             .field_column
             .as_ref()
@@ -872,6 +877,39 @@ mod test {
         .to_execution_plan(exec_input);
 
         assert!(format!("{exec:?}").contains("reuse_tsid_column: true"));
+    }
+
+    #[tokio::test]
+    async fn execute_returns_error_when_input_missing_time_index() {
+        // Feed a malformed physical child (no time index column) directly to
+        // `execute`: it must return an error instead of panicking.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Float64, true),
+            Field::new("host", DataType::Utf8, true),
+        ]));
+        let value_column =
+            Arc::new(datafusion::arrow::array::Float64Array::from(vec![1.0, 2.0])) as _;
+        let host_column = Arc::new(datafusion::arrow::array::StringArray::from(vec![
+            "foo", "foo",
+        ])) as _;
+        let batch = RecordBatch::try_new(schema.clone(), vec![value_column, host_column]).unwrap();
+        let exec_input: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap(),
+        )));
+        let exec = Arc::new(InstantManipulateExec {
+            start: 0,
+            end: 5_000,
+            lookback_delta: 1_000,
+            interval: 1_000,
+            time_index_column: TIME_INDEX_COLUMN.to_string(),
+            field_column: Some("value".to_string()),
+            reuse_tsid_column: false,
+            input: exec_input,
+            metric: ExecutionPlanMetricsSet::new(),
+        });
+        let session_context = SessionContext::default();
+        let result = datafusion::physical_plan::collect(exec, session_context.task_ctx()).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -200,15 +200,38 @@ impl SeriesNormalize {
         "SeriesNormalize"
     }
 
-    pub fn to_execution_plan(&self, exec_input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-        Arc::new(SeriesNormalizeExec {
+    pub fn to_execution_plan(
+        &self,
+        exec_input: Arc<dyn ExecutionPlan>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        // Validate the required columns against the *physical* input schema so a
+        // missing time index/tag column fails with an error instead of panicking
+        // later in `execute` or `required_input_distribution`.
+        let input_schema = exec_input.schema();
+        input_schema
+            .index_of(&self.time_index_column_name)
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "SeriesNormalize: time index column {} not found in input schema: {e}",
+                    self.time_index_column_name
+                ))
+            })?;
+        for tag in &self.tag_columns {
+            input_schema.index_of(tag).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "SeriesNormalize: tag column {tag} not found in input schema: {e}"
+                ))
+            })?;
+        }
+
+        Ok(Arc::new(SeriesNormalizeExec {
             offset: self.offset,
             time_index_column_name: self.time_index_column_name.clone(),
             filter_stale_markers: self.filter_stale_markers,
             input: exec_input,
             tag_columns: self.tag_columns.clone(),
             metric: ExecutionPlanMetricsSet::new(),
-        })
+        }))
     }
 
     pub fn serialize(&self) -> Vec<u8> {
@@ -331,8 +354,13 @@ impl ExecutionPlan for SeriesNormalizeExec {
         let schema = input.schema();
         let time_index = schema
             .column_with_name(&self.time_index_column_name)
-            .expect("time index column not found")
-            .0;
+            .map(|(idx, _)| idx)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "time index column {} not found in input schema {schema:?}",
+                    self.time_index_column_name
+                ))
+            })?;
         Ok(Box::pin(SeriesNormalizeStream {
             offset: self.offset,
             time_index,
@@ -566,6 +594,68 @@ mod test {
         let required = plan.necessary_children_exprs(&output_columns).unwrap();
         let required = &required[0];
         assert_eq!(required.as_slice(), &[0, 1, 2]);
+    }
+
+    #[test]
+    fn to_execution_plan_errors_on_missing_required_columns() {
+        let df_schema = prepare_test_data().schema().to_dfschema_ref().unwrap();
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: df_schema,
+        });
+        let plan =
+            SeriesNormalize::new(0, TIME_INDEX_COLUMN, true, vec!["path".to_string()], input);
+
+        // Malformed physical child: missing the tag column.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new(TIME_INDEX_COLUMN, TimestampMillisecondType::DATA_TYPE, true),
+            Field::new("value", DataType::Float64, true),
+        ]));
+        let broken_exec: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[], broken_schema, None).unwrap(),
+        )));
+        let result = plan.to_execution_plan(broken_exec);
+        assert!(result.is_err());
+
+        // Malformed physical child: missing the time index column.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Float64, true),
+            Field::new("path", DataType::Utf8, true),
+        ]));
+        let broken_exec: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[], broken_schema, None).unwrap(),
+        )));
+        let result = plan.to_execution_plan(broken_exec);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_returns_error_when_input_missing_time_index() {
+        // Bypass `to_execution_plan` validation and feed a malformed child directly
+        // to `execute`: it must return an error instead of panicking.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Float64, true),
+            Field::new("path", DataType::Utf8, true),
+        ]));
+        let value_column = Arc::new(Float64Array::from(vec![1.0, 2.0])) as _;
+        let path_column = Arc::new(StringArray::from(vec!["foo", "foo"])) as _;
+        let batch =
+            RecordBatch::try_new(broken_schema.clone(), vec![value_column, path_column]).unwrap();
+        let memory_exec = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], broken_schema, None).unwrap(),
+        )));
+        let normalize_exec = Arc::new(SeriesNormalizeExec {
+            offset: 0,
+            time_index_column_name: TIME_INDEX_COLUMN.to_string(),
+            filter_stale_markers: true,
+            input: memory_exec,
+            tag_columns: vec!["path".to_string()],
+            metric: ExecutionPlanMetricsSet::new(),
+        });
+        let session_context = SessionContext::default();
+        let result =
+            datafusion::physical_plan::collect(normalize_exec, session_context.task_ctx()).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/promql/src/extension_plan/planner.rs
+++ b/src/promql/src/extension_plan/planner.rs
@@ -39,26 +39,26 @@ impl ExtensionPlanner for PromExtensionPlanner {
         session_state: &SessionState,
     ) -> DfResult<Option<Arc<dyn ExecutionPlan>>> {
         if let Some(node) = node.as_any().downcast_ref::<SeriesNormalize>() {
-            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())))
+            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())?))
         } else if let Some(node) = node.as_any().downcast_ref::<InstantManipulate>() {
             Ok(Some(node.to_execution_plan(physical_inputs[0].clone())))
         } else if let Some(node) = node.as_any().downcast_ref::<RangeManipulate>() {
-            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())))
+            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())?))
         } else if let Some(node) = node.as_any().downcast_ref::<SeriesDivide>() {
-            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())))
+            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())?))
         } else if let Some(node) = node.as_any().downcast_ref::<EmptyMetric>() {
             Ok(Some(node.to_execution_plan(session_state, planner)?))
         } else if let Some(node) = node.as_any().downcast_ref::<ScalarCalculate>() {
             Ok(Some(node.to_execution_plan(physical_inputs[0].clone())?))
         } else if let Some(node) = node.as_any().downcast_ref::<HistogramFold>() {
-            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())))
+            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())?))
         } else if let Some(node) = node.as_any().downcast_ref::<UnionDistinctOn>() {
             Ok(Some(node.to_execution_plan(
                 physical_inputs[0].clone(),
                 physical_inputs[1].clone(),
             )))
         } else if let Some(node) = node.as_any().downcast_ref::<Absent>() {
-            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())))
+            Ok(Some(node.to_execution_plan(physical_inputs[0].clone())?))
         } else {
             Ok(None)
         }

--- a/src/promql/src/extension_plan/range_manipulate.rs
+++ b/src/promql/src/extension_plan/range_manipulate.rs
@@ -167,7 +167,30 @@ impl RangeManipulate {
         )?))
     }
 
-    pub fn to_execution_plan(&self, exec_input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    pub fn to_execution_plan(
+        &self,
+        exec_input: Arc<dyn ExecutionPlan>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        // The physical input schema can differ from the logical one (e.g. after
+        // column pruning). Validate the required columns here so a missing column
+        // fails with an error instead of panicking in `execute`.
+        let input_schema = exec_input.schema();
+        input_schema
+            .column_with_name(&self.time_index)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "RangeManipulate: time index column {} not found in input schema {:?}",
+                    self.time_index, input_schema
+                ))
+            })?;
+        for value_col in &self.field_columns {
+            input_schema.column_with_name(value_col).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "RangeManipulate: value column {value_col} not found in input schema {input_schema:?}"
+                ))
+            })?;
+        }
+
         let output_schema: SchemaRef = self.output_schema.inner().clone();
         let properties = exec_input.properties();
         let properties = Arc::new(PlanProperties::new(
@@ -176,7 +199,7 @@ impl RangeManipulate {
             properties.emission_type,
             properties.boundedness,
         ));
-        Arc::new(RangeManipulateExec {
+        Ok(Arc::new(RangeManipulateExec {
             start: self.start,
             end: self.end,
             interval: self.interval,
@@ -188,7 +211,7 @@ impl RangeManipulate {
             output_schema,
             metric: ExecutionPlanMetricsSet::new(),
             properties,
-        })
+        }))
     }
 
     pub fn serialize(&self) -> Vec<u8> {
@@ -503,7 +526,12 @@ impl ExecutionPlan for RangeManipulateExec {
         let schema = input.schema();
         let time_index = schema
             .column_with_name(&self.time_index_column)
-            .unwrap_or_else(|| panic!("time index column {} not found", self.time_index_column))
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "time index column {} not found in input schema {:?}",
+                    self.time_index_column, schema
+                ))
+            })?
             .0;
         let field_columns = self
             .field_columns
@@ -511,10 +539,14 @@ impl ExecutionPlan for RangeManipulateExec {
             .map(|value_col| {
                 schema
                     .column_with_name(value_col)
-                    .unwrap_or_else(|| panic!("value column {value_col} not found",))
-                    .0
+                    .map(|(idx, _)| idx)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "value column {value_col} not found in input schema {schema:?}"
+                        ))
+                    })
             })
-            .collect();
+            .collect::<DataFusionResult<Vec<usize>>>()?;
         let aligned_ts_array =
             RangeManipulateStream::build_aligned_ts_array(self.start, self.end, self.interval);
         Ok(Box::pin(RangeManipulateStream {
@@ -769,7 +801,6 @@ mod test {
     use datafusion::physical_plan::memory::MemoryStream;
     use datafusion::prelude::SessionContext;
     use datatypes::arrow::array::TimestampMillisecondArray;
-    use futures::FutureExt;
 
     use super::*;
 
@@ -941,7 +972,7 @@ mod test {
         let memory_exec = Arc::new(DataSourceExec::new(Arc::new(
             MemorySourceConfig::try_new(&[vec![projected]], projected_schema, None).unwrap(),
         )));
-        let range_exec = plan.to_execution_plan(memory_exec);
+        let range_exec = plan.to_execution_plan(memory_exec).unwrap();
         let session_context = SessionContext::default();
         let output_batches =
             datafusion::physical_plan::collect(range_exec, session_context.task_ctx())
@@ -964,14 +995,50 @@ mod test {
         let broken_exec = Arc::new(DataSourceExec::new(Arc::new(
             MemorySourceConfig::try_new(&[vec![broken]], broken_schema, None).unwrap(),
         )));
-        let broken_range_exec = plan.to_execution_plan(broken_exec);
-        let session_context = SessionContext::default();
-        let broken_result = std::panic::AssertUnwindSafe(async {
-            datafusion::physical_plan::collect(broken_range_exec, session_context.task_ctx()).await
-        })
-        .catch_unwind()
-        .await;
+        // A missing time index/value column must fail with an error instead of panicking.
+        let broken_result = plan.to_execution_plan(broken_exec);
         assert!(broken_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_returns_error_when_input_missing_required_columns() {
+        // Construct the exec directly (bypassing `to_execution_plan` validation) with a
+        // malformed physical child that lacks the time index and value columns. The
+        // `execute` path must return an error instead of panicking.
+        let schema = Arc::new(Schema::new(vec![Field::new("path", DataType::Utf8, true)]));
+        let path_column = Arc::new(StringArray::from(vec!["foo"; 2])) as _;
+        let batch = RecordBatch::try_new(schema.clone(), vec![path_column]).unwrap();
+        let memory_exec = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap(),
+        )));
+
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new(TIME_INDEX_COLUMN, TimestampMillisecondType::DATA_TYPE, true),
+            Field::new("value_1", DataType::Float64, true),
+        ]));
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(output_schema.clone()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+        let exec = Arc::new(RangeManipulateExec {
+            start: 0,
+            end: 10_000,
+            interval: 1_000,
+            range: 1_000,
+            field_columns: vec!["value_1".to_string()],
+            output_schema,
+            time_range_column: RangeManipulate::build_timestamp_range_name(TIME_INDEX_COLUMN),
+            time_index_column: TIME_INDEX_COLUMN.to_string(),
+            input: memory_exec,
+            metric: ExecutionPlanMetricsSet::new(),
+            properties,
+        });
+
+        let session_context = SessionContext::default();
+        let result = datafusion::physical_plan::collect(exec, session_context.task_ctx()).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/promql/src/extension_plan/scalar_calculate.rs
+++ b/src/promql/src/extension_plan/scalar_calculate.rs
@@ -138,6 +138,13 @@ impl ScalarCalculate {
         let val_index = input_schema
             .index_of(&self.field_column)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        // Validate the tag columns too: `execute` needs their indices and a
+        // missing tag column must fail with an error instead of panicking.
+        for tag in &self.tag_columns {
+            input_schema
+                .index_of(tag)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        }
         let schema = Arc::new(Schema::new(fields));
         let properties = exec_input.properties();
         let properties = Arc::new(PlanProperties::new(
@@ -444,10 +451,14 @@ impl ExecutionPlan for ScalarCalculateExec {
             .map(|tag| {
                 schema
                     .column_with_name(tag)
-                    .unwrap_or_else(|| panic!("tag column not found {tag}"))
-                    .0
+                    .map(|(idx, _)| idx)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "tag column {tag} not found in input schema {schema:?}"
+                        ))
+                    })
             })
-            .collect();
+            .collect::<DataFusionResult<Vec<usize>>>()?;
 
         Ok(Box::pin(ScalarCalculateStream {
             start: self.start,
@@ -749,6 +760,69 @@ mod test {
             .downcast_ref::<Float64Array>()
             .unwrap();
         assert_eq!(values.values(), &[1.0f64, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn to_execution_plan_errors_on_missing_required_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("ts", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+            Field::new("val", DataType::Float64, true),
+        ]));
+        let df_schema = Arc::new(DFSchema::try_from(schema.clone()).unwrap());
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: df_schema,
+        });
+        let tag_columns = vec!["tag1".to_string(), "tag2".to_string()];
+        let plan =
+            ScalarCalculate::new(0, 15_000, 5000, input, "ts", &tag_columns, "val", None).unwrap();
+
+        // Malformed physical child: missing the tag columns.
+        let broken_exec: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[], schema, None).unwrap(),
+        )));
+        let result = plan.to_execution_plan(broken_exec);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_returns_error_when_input_missing_tag_columns() {
+        // Bypass `to_execution_plan` validation and feed a malformed child directly
+        // to `execute`: it must return an error instead of panicking.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("ts", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+            Field::new("val", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![0, 5_000])),
+                Arc::new(Float64Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .unwrap();
+        let memory_exec: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], schema.clone(), None).unwrap(),
+        )));
+        let exec = Arc::new(ScalarCalculateExec {
+            start: 0,
+            end: 15_000,
+            interval: 5_000,
+            schema: schema.clone(),
+            project_index: (0, 1),
+            tag_columns: vec!["tag1".to_string(), "tag2".to_string()],
+            input: memory_exec,
+            metric: ExecutionPlanMetricsSet::new(),
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            )),
+        });
+        let session_context = SessionContext::default();
+        let result = datafusion::physical_plan::collect(exec, session_context.task_ctx()).await;
+        assert!(result.is_err());
     }
 
     fn prepare_test_data(series: Vec<RecordBatch>) -> DataSourceExec {

--- a/src/promql/src/extension_plan/series_divide.rs
+++ b/src/promql/src/extension_plan/series_divide.rs
@@ -21,7 +21,7 @@ use datafusion::arrow::array::{Array, ArrayRef, UInt64Array};
 use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DFSchema, DFSchemaRef};
-use datafusion::error::Result as DataFusionResult;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::TaskContext;
 use datafusion::logical_expr::{EmptyRelation, Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion::physical_expr::{LexRequirement, OrderingRequirements, PhysicalSortRequirement};
@@ -273,13 +273,37 @@ impl SeriesDivide {
         "SeriesDivide"
     }
 
-    pub fn to_execution_plan(&self, exec_input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
-        Arc::new(SeriesDivideExec {
+    pub fn to_execution_plan(
+        &self,
+        exec_input: Arc<dyn ExecutionPlan>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        // Validate the required columns against the *physical* input schema so a
+        // missing tag/time index column fails with an error instead of panicking
+        // later in `execute`, `required_input_distribution` or
+        // `required_input_ordering`.
+        let input_schema = exec_input.schema();
+        for tag in &self.tag_columns {
+            input_schema.index_of(tag).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "SeriesDivide: tag column {tag} not found in input schema: {e}"
+                ))
+            })?;
+        }
+        input_schema
+            .index_of(&self.time_index_column)
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "SeriesDivide: time index column {} not found in input schema: {e}",
+                    self.time_index_column
+                ))
+            })?;
+
+        Ok(Arc::new(SeriesDivideExec {
             tag_columns: self.tag_columns.clone(),
             time_index_column: self.time_index_column.clone(),
             input: exec_input,
             metric: ExecutionPlanMetricsSet::new(),
-        })
+        }))
     }
 
     pub fn tags(&self) -> &[String] {
@@ -435,10 +459,14 @@ impl ExecutionPlan for SeriesDivideExec {
             .map(|tag| {
                 schema
                     .column_with_name(tag)
-                    .unwrap_or_else(|| panic!("tag column not found {tag}"))
-                    .0
+                    .map(|(idx, _)| idx)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "tag column {tag} not found in input schema {schema:?}"
+                        ))
+                    })
             })
-            .collect();
+            .collect::<DataFusionResult<Vec<usize>>>()?;
         Ok(Box::pin(SeriesDivideStream {
             tag_indices,
             buffer: vec![],
@@ -740,6 +768,77 @@ mod test {
         let required = plan.necessary_children_exprs(&output_columns).unwrap();
         let required = &required[0];
         assert_eq!(required.as_slice(), &[0, 1, 2]);
+    }
+
+    #[test]
+    fn to_execution_plan_errors_on_missing_required_columns() {
+        let df_schema = prepare_test_data().schema().to_dfschema_ref().unwrap();
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: df_schema,
+        });
+        let plan = SeriesDivide::new(
+            vec!["host".to_string(), "path".to_string()],
+            "time_index".to_string(),
+            input,
+        );
+
+        // Malformed physical child: missing the tag columns.
+        let broken_schema = Arc::new(Schema::new(vec![Field::new(
+            "time_index",
+            DataType::Timestamp(datafusion::arrow::datatypes::TimeUnit::Millisecond, None),
+            false,
+        )]));
+        let broken_exec: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[], broken_schema, None).unwrap(),
+        )));
+        let result = plan.to_execution_plan(broken_exec);
+        assert!(result.is_err());
+
+        // Malformed physical child: missing the time index column.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new("host", DataType::Utf8, true),
+            Field::new("path", DataType::Utf8, true),
+        ]));
+        let broken_exec: Arc<dyn ExecutionPlan> = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[], broken_schema, None).unwrap(),
+        )));
+        let result = plan.to_execution_plan(broken_exec);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_returns_error_when_input_missing_tag_columns() {
+        // Bypass `to_execution_plan` validation and feed a malformed child directly
+        // to `execute`: it must return an error instead of panicking.
+        let broken_schema = Arc::new(Schema::new(vec![
+            Field::new("path", DataType::Utf8, true),
+            Field::new(
+                "time_index",
+                DataType::Timestamp(datafusion::arrow::datatypes::TimeUnit::Millisecond, None),
+                false,
+            ),
+        ]));
+        let path_column = Arc::new(StringArray::from(vec!["foo"; 2])) as _;
+        let time_index_column = Arc::new(datafusion::arrow::array::TimestampMillisecondArray::from(
+            vec![1000, 2000],
+        )) as _;
+        let batch =
+            RecordBatch::try_new(broken_schema.clone(), vec![path_column, time_index_column])
+                .unwrap();
+        let memory_exec = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], broken_schema, None).unwrap(),
+        )));
+        let divide_exec = Arc::new(SeriesDivideExec {
+            tag_columns: vec!["host".to_string(), "path".to_string()],
+            time_index_column: "time_index".to_string(),
+            input: memory_exec,
+            metric: ExecutionPlanMetricsSet::new(),
+        });
+        let session_context = SessionContext::default();
+        let result =
+            datafusion::physical_plan::collect(divide_exec, session_context.task_ctx()).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

Fixes QX-154: PromQL extension physical executors panicked (unwrap/expect/panic!) when their physical input schema lacked an expected column (time index, tag, value, or `le` column). A planner/optimizer/decoder producing a physical child inconsistent with the extension's retained metadata aborted the query task with a panic instead of a normal query error.

For the seven affected extensions — `range_manipulate`, `series_divide`, `normalize`, `instant_manipulate`, `absent`, `histogram_fold`, `scalar_calculate` — column/name lookups now validate against the physical input schema and return `DataFusionError::Execution` on mismatch; `to_execution_plan` paths are fallible where needed. Tests that previously asserted a panic now assert an error, and new malformed-child tests cover the no-panic guarantee. Behavior for valid inputs is unchanged.

Note: this is a separate lane from QX-046 (remote read schema race). QX-046 covers the remote `RegionMetadata` race variant; QX-154 removes unsafe schema assumptions at the extension consumers (local planning, child replacement, legacy decode paths remain outside QX-046's scope).

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
