### PR TITLE
fix(datatypes): make Value ordering total instead of panicking

### DIFF
--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -112,6 +113,41 @@ impl Display for JsonNumber {
             Self::NegInt(x) => write!(f, "{x}"),
             Self::Float(x) => write!(f, "{x}"),
         }
+    }
+}
+
+impl PartialOrd for JsonNumber {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for JsonNumber {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Compare by the lossy f64 value first to keep the order roughly
+        // numeric, then break ties by the exact variant/value. This is a
+        // total order that is consistent with `PartialEq`, which treats the
+        // three variants as distinct (e.g. `PosInt(0) != NegInt(0)`).
+        let ordering = self.as_f64().total_cmp(&other.as_f64());
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+        fn rank(n: &JsonNumber) -> u8 {
+            match n {
+                JsonNumber::PosInt(_) => 0,
+                JsonNumber::NegInt(_) => 1,
+                JsonNumber::Float(_) => 2,
+            }
+        }
+        rank(self)
+            .cmp(&rank(other))
+            .then_with(|| match (self, other) {
+                (JsonNumber::PosInt(a), JsonNumber::PosInt(b)) => a.cmp(b),
+                (JsonNumber::NegInt(a), JsonNumber::NegInt(b)) => a.cmp(b),
+                (JsonNumber::Float(a), JsonNumber::Float(b)) => a.cmp(b),
+                // Unreachable when both ranks are equal.
+                _ => Ordering::Equal,
+            })
     }
 }
 
@@ -293,6 +329,43 @@ impl Display for JsonVariant {
                 Ok(v) => write!(f, "{v}"),
                 Err(_) => write!(f, "{x:?}"),
             },
+        }
+    }
+}
+
+impl PartialOrd for JsonVariant {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for JsonVariant {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (JsonVariant::Null, JsonVariant::Null) => Ordering::Equal,
+            (JsonVariant::Bool(a), JsonVariant::Bool(b)) => a.cmp(b),
+            (JsonVariant::Number(a), JsonVariant::Number(b)) => a.cmp(b),
+            (JsonVariant::String(a), JsonVariant::String(b)) => a.cmp(b),
+            (JsonVariant::Array(a), JsonVariant::Array(b)) => a.cmp(b),
+            (JsonVariant::Object(a), JsonVariant::Object(b)) => a.cmp(b),
+            (JsonVariant::Variant(a), JsonVariant::Variant(b)) => a.cmp(b),
+            _ => {
+                // A deterministic total order across different variants,
+                // consistent with `PartialEq` (which never equates two
+                // different variants).
+                fn rank(v: &JsonVariant) -> u8 {
+                    match v {
+                        JsonVariant::Null => 0,
+                        JsonVariant::Bool(_) => 1,
+                        JsonVariant::Number(_) => 2,
+                        JsonVariant::String(_) => 3,
+                        JsonVariant::Array(_) => 4,
+                        JsonVariant::Object(_) => 5,
+                        JsonVariant::Variant(_) => 6,
+                    }
+                }
+                rank(self).cmp(&rank(other))
+            }
         }
     }
 }
@@ -661,6 +734,19 @@ impl Hash for JsonValue {
     }
 }
 
+impl PartialOrd for JsonValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for JsonValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Consistent with `PartialEq`, which compares `json_variant` only.
+        self.json_variant.cmp(&other.json_variant)
+    }
+}
+
 impl Display for JsonValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.json_variant)
@@ -900,6 +986,20 @@ impl PartialEq for JsonValueRef<'_> {
 }
 
 impl Eq for JsonValueRef<'_> {}
+
+impl PartialOrd for JsonValueRef<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for JsonValueRef<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Respect the order of `JsonValue` by converting into an owned value
+        // before comparison.
+        JsonValue::from(self.clone()).cmp(&JsonValue::from(other.clone()))
+    }
+}
 
 impl Clone for JsonValueRef<'_> {
     fn clone(&self) -> Self {

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -47,7 +47,10 @@ pub type OrderedF64 = OrderedFloat<f64>;
 
 /// Value holds a single arbitrary value of any [DataType](crate::data_type::DataType).
 ///
-/// Comparison between values with different types (expect Null) is not allowed.
+/// `Value` has a total order: same-type values compare by their payload
+/// (including `Json`, `Decimal128` and `Struct`), values of different types
+/// compare by their data type, and `Null` compares less than any non-null
+/// value.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Value {
     Null,
@@ -734,10 +737,32 @@ macro_rules! impl_ord_for_value_like {
                 ($Type::IntervalMonthDayNano(v1), $Type::IntervalMonthDayNano(v2)) => v1.cmp(v2),
                 ($Type::Duration(v1), $Type::Duration(v2)) => v1.cmp(v2),
                 ($Type::List(v1), $Type::List(v2)) => v1.cmp(v2),
-                _ => panic!(
-                    "Cannot compare different values {:?} and {:?}",
-                    $left, $right
-                ),
+                ($Type::Decimal128(v1), $Type::Decimal128(v2)) => {
+                    // `Decimal128` only implements a partial order (values with
+                    // different precision/scale are incomparable), so fall back
+                    // to comparing the metadata to make the order total. This
+                    // is consistent with `Eq`, which also distinguishes
+                    // decimals by precision/scale/value.
+                    match v1.partial_cmp(v2) {
+                        Some(ordering) => ordering,
+                        None => (v1.precision(), v1.scale(), v1.val()).cmp(&(
+                            v2.precision(),
+                            v2.scale(),
+                            v2.val(),
+                        )),
+                    }
+                }
+                ($Type::Struct(v1), $Type::Struct(v2)) => v1.cmp(v2),
+                ($Type::Json(v1), $Type::Json(v2)) => v1.cmp(v2),
+                _ => {
+                    // Fall back to comparing the data types so that values of
+                    // different types still have a deterministic total order.
+                    // Same-type values are handled by the arms above and two
+                    // different variants never share a `data_type()`, so this
+                    // never returns `Equal` for non-equal values and stays
+                    // consistent with `Eq`.
+                    $left.data_type().cmp(&$right.data_type())
+                }
             }
         }
     };
@@ -1105,6 +1130,23 @@ impl StructValue {
 impl Default for StructValue {
     fn default() -> StructValue {
         StructValue::try_new(vec![], StructType::new(Arc::new(vec![]))).unwrap()
+    }
+}
+
+impl PartialOrd for StructValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StructValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // A total order: compare the schema first, then the field values.
+        // Consistent with `Eq`, which requires both fields and items to be
+        // equal.
+        self.fields
+            .cmp(&other.fields)
+            .then_with(|| self.items.cmp(&other.items))
     }
 }
 
@@ -1785,6 +1827,87 @@ pub(crate) mod tests {
             Value::Timestamp(Timestamp::new_nanosecond(5)).try_negative(),
             Some(Value::Timestamp(Timestamp::new_nanosecond(-5)))
         );
+    }
+
+    #[test]
+    fn test_value_ordering_is_total() {
+        // Null vs non-null: null is ordered, regardless of the other type.
+        assert_eq!(Value::Null.cmp(&Value::Int32(1)), Ordering::Less);
+        assert_eq!(Value::Int32(1).cmp(&Value::Null), Ordering::Greater);
+        assert_eq!(Value::Null.cmp(&Value::Null), Ordering::Equal);
+
+        // Json null counts as null too.
+        let json_null = Value::Json(Box::new(JsonValue::null()));
+        assert_eq!(json_null.cmp(&Value::Int64(1)), Ordering::Less);
+        assert_eq!(Value::Int64(1).cmp(&json_null), Ordering::Greater);
+        assert_eq!(json_null.cmp(&json_null), Ordering::Equal);
+        // `Null` and `Json(null)` are different variants, so they are ordered
+        // (deterministically) rather than equal.
+        assert_ne!(json_null.cmp(&Value::Null), Ordering::Equal);
+
+        // Same-type Decimal128: numeric within the same precision/scale.
+        let d1 = Value::Decimal128(Decimal128::new(1, 10, 2));
+        let d2 = Value::Decimal128(Decimal128::new(2, 10, 2));
+        assert_eq!(d1.cmp(&d2), Ordering::Less);
+        assert_eq!(d2.cmp(&d1), Ordering::Greater);
+        assert_eq!(d1.cmp(&d1), Ordering::Equal);
+        // Different precision/scale: deterministic total order, never Equal.
+        let d3 = Value::Decimal128(Decimal128::new(1, 5, 1));
+        assert_ne!(d1.cmp(&d3), Ordering::Equal);
+
+        // Same-type Json.
+        let j1 = Value::Json(Box::new(JsonValue::from(1i64)));
+        let j2 = Value::Json(Box::new(JsonValue::from(2i64)));
+        assert_eq!(j1.cmp(&j2), Ordering::Less);
+        assert_eq!(j2.cmp(&j1), Ordering::Greater);
+        assert_eq!(j1.cmp(&j1), Ordering::Equal);
+        let j_str1 = Value::Json(Box::new(JsonValue::from("a")));
+        let j_str2 = Value::Json(Box::new(JsonValue::from("b")));
+        assert_eq!(j_str1.cmp(&j_str2), Ordering::Less);
+        // Json objects compare deterministically (BTreeMap key order).
+        let j_obj1 = Value::Json(Box::new(JsonValue::from([("a", 1i64), ("b", 2i64)])));
+        let j_obj2 = Value::Json(Box::new(JsonValue::from([("a", 1i64), ("b", 3i64)])));
+        assert_eq!(j_obj1.cmp(&j_obj2), Ordering::Less);
+
+        // Same-type Struct: equal schemas and items compare equal.
+        let s1 = build_struct_value();
+        let s2 = build_struct_value();
+        assert_eq!(s1.cmp(&s2), Ordering::Equal);
+        let struct_type = s1.struct_type().clone();
+        let mut items = s1.items().to_vec();
+        items[0] = Value::Int32(2);
+        let s3 = StructValue::new(items, struct_type);
+        assert_eq!(s1.cmp(&s3), Ordering::Less);
+
+        // Cross-type comparisons never panic and are deterministic.
+        let pairs = [
+            (Value::Int32(1), Value::String("x".into())),
+            (d1.clone(), Value::Float64(1.0.into())),
+            (j1.clone(), Value::Int64(1)),
+            (Value::Struct(s1.clone()), Value::Boolean(true)),
+            (d1.clone(), j2.clone()),
+        ];
+        for (a, b) in pairs {
+            let ab = a.cmp(&b);
+            assert_eq!(b.cmp(&a), ab.reverse());
+            assert_ne!(ab, Ordering::Equal);
+            // partial_cmp is consistent with cmp.
+            assert_eq!(a.partial_cmp(&b), Some(ab));
+            assert_eq!(b.partial_cmp(&a), Some(ab.reverse()));
+        }
+
+        // ValueRef shares the same ordering logic.
+        let vr1 = ValueRef::Decimal128(Decimal128::new(1, 10, 2));
+        let vr2 = ValueRef::Decimal128(Decimal128::new(2, 10, 2));
+        assert_eq!(vr1.cmp(&vr2), Ordering::Less);
+        assert_eq!(vr1.cmp(&vr1), Ordering::Equal);
+        let vr_cross = vr1.cmp(&ValueRef::String("x"));
+        assert_ne!(vr_cross, Ordering::Equal);
+        assert_eq!(ValueRef::String("x").cmp(&vr1), vr_cross.reverse());
+        let jr = ValueRef::Json(Box::new(JsonValueRef::null()));
+        assert_eq!(jr.cmp(&ValueRef::Int64(1)), Ordering::Less);
+        assert_ne!(jr.cmp(&ValueRef::Null), Ordering::Equal);
+        assert_eq!(jr.cmp(&jr), Ordering::Equal);
     }
 
     pub(crate) fn build_struct_type() -> StructType {

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -1044,11 +1044,14 @@ impl PartialOrd for ListValue {
 
 impl Ord for ListValue {
     fn cmp(&self, other: &Self) -> Ordering {
-        assert_eq!(
-            self.datatype, other.datatype,
-            "Cannot compare different datatypes!"
-        );
-        self.items.cmp(&other.items)
+        // A total order: compare the datatype first, then the items.
+        // Consistent with `Eq` (which requires both datatypes and items to be
+        // equal) and mirroring `StructValue`'s schema-first ordering. Lists
+        // with different item types are ordered by their datatype instead of
+        // panicking.
+        self.datatype
+            .cmp(&other.datatype)
+            .then_with(|| self.items.cmp(&other.items))
     }
 }
 
@@ -1878,6 +1881,47 @@ pub(crate) mod tests {
         items[0] = Value::Int32(2);
         let s3 = StructValue::new(items, struct_type);
         assert_eq!(s1.cmp(&s3), Ordering::Less);
+
+        // Same-type List: equal datatypes, items decide.
+        let list_bool_1 = Value::List(build_list_value());
+        let list_bool_2 = Value::List(ListValue::new(
+            vec![Value::Boolean(false), Value::Boolean(true)],
+            Arc::new(ConcreteDataType::boolean_datatype()),
+        ));
+        assert_eq!(list_bool_1.cmp(&list_bool_2), Ordering::Greater);
+        assert_eq!(list_bool_1.cmp(&list_bool_1), Ordering::Equal);
+
+        // Cross-item-type List (List<Boolean> vs List<Int32>): same variant
+        // but different datatypes — must not panic and orders by data_type()
+        // deterministically.
+        let list_int = Value::List(ListValue::new(
+            vec![Value::Int32(1), Value::Int32(2)],
+            Arc::new(ConcreteDataType::int32_datatype()),
+        ));
+        let ab = list_bool_1.cmp(&list_int);
+        assert_ne!(ab, Ordering::Equal);
+        // Antisymmetry and partial_cmp consistency.
+        assert_eq!(list_int.cmp(&list_bool_1), ab.reverse());
+        assert_eq!(list_bool_1.partial_cmp(&list_int), Some(ab));
+        assert_eq!(list_int.partial_cmp(&list_bool_1), Some(ab.reverse()));
+
+        // Float total order (documented caveat): `OrderedFloat` never panics,
+        // even though IEEE floats are only partially ordered. In this
+        // codebase's ordered-float version, -0.0 and +0.0 compare `Equal`
+        // (consistent with `Eq`), and NaN compares equal to NaN and greater
+        // than everything else. The test pins that documented `Ord` behavior.
+        let neg_zero = Value::Float64(OrderedF64::from(-0.0f64));
+        let pos_zero = Value::Float64(OrderedF64::from(0.0f64));
+        assert_eq!(neg_zero.cmp(&pos_zero), Ordering::Equal);
+        assert_eq!(pos_zero.cmp(&neg_zero), Ordering::Equal);
+        assert_eq!(neg_zero.cmp(&neg_zero), Ordering::Equal);
+        assert_eq!(neg_zero.partial_cmp(&pos_zero), Some(Ordering::Equal));
+        let nan = Value::Float64(OrderedF64::nan());
+        let one = Value::Float64(OrderedF64::from(1.0f64));
+        assert_eq!(nan.cmp(&one), Ordering::Greater);
+        assert_eq!(one.cmp(&nan), Ordering::Less);
+        assert_eq!(nan.cmp(&nan), Ordering::Equal);
+        assert_eq!(nan.partial_cmp(&one), Some(Ordering::Greater));
 
         // Cross-type comparisons never panic and are deterministic.
         let pairs = [

--- a/src/promql/src/extension_plan/histogram_fold.rs
+++ b/src/promql/src/extension_plan/histogram_fold.rs
@@ -697,7 +697,13 @@ impl HistogramFoldStream {
     ) -> DataFusionResult<Vec<Box<dyn MutableVector>>> {
         let mut builders = Vec::with_capacity(schema.fields().len() + 1);
         for field in schema.fields() {
-            let concrete_datatype = ConcreteDataType::try_from(field.data_type()).unwrap();
+            let concrete_datatype = ConcreteDataType::try_from(field.data_type()).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Unsupported Arrow field type {:?} while building output buffer: {}",
+                    field.data_type(),
+                    e
+                ))
+            })?;
             let mutable_vector = concrete_datatype.create_mutable_vector(0);
             builders.push(mutable_vector);
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

Fixes QX-157: `Value::partial_cmp` unconditionally called `cmp` and returned `Some`, while the `cmp` match fell through to `panic!` for same-type `Json`, `Decimal128`, and `Struct` values, and for every non-null cross-type pair. Reachable from ordered flow rows (`flow/src/repr.rs`) and any other `Value`-ordering consumer.

- Same-type ordering arms added: `Decimal128` (numeric partial order within precision/scale), `Struct` (field-wise), `Json` (total order via new `Ord` impls in `datatypes/src/json/value.rs`).
- Cross-type pairs now order by `data_type()` instead of panicking.
- `StructValue` gains `Ord`/`PartialOrd`.

Also includes a drive-by fix (QX-158) on the same branch: `HistogramFoldStream::empty_output_buffer` no longer unwraps `ConcreteDataType::try_from(field.data_type())` and returns `DataFusionError::Execution` for unsupported Arrow field types instead of panicking.

Tests: `test_value_ordering_is_total` (same-type Decimal128/Json/Struct + cross-type); the histogram_fold change compiles under the existing promql suite.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
