### PR TITLE
docs: rework README release badges, drop star history, fix grpc flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker run -p 127.0.0.1:4000-4003:4000-4003 \
   --name greptime --rm \
   greptime/greptimedb:latest standalone start \
   --http-addr 0.0.0.0:4000 \
-  --rpc-bind-addr 0.0.0.0:4001 \
+  --grpc-bind-addr 0.0.0.0:4001 \
   --mysql-addr 0.0.0.0:4002 \
   --postgres-addr 0.0.0.0:4003
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ replacing Prometheus, Loki, and Elasticsearch</h2>
 <img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?filter=!*-*&label=stable&color=brightgreen" alt="Stable"/>
 </a>
 <a href="https://github.com/GreptimeTeam/greptimedb/releases">
-<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=!*-*-*&label=latest&color=blueviolet" alt="Latest"/>
+<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=!*-*-*&label=canary&color=blueviolet" alt="Canary"/>
 </a>
 <a href="https://github.com/GreptimeTeam/greptimedb/releases">
 <img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=*-nightly-*&label=nightly&color=orange" alt="Nightly"/>

--- a/README.md
+++ b/README.md
@@ -19,11 +19,17 @@ replacing Prometheus, Loki, and Elasticsearch</h2>
 </h3>
 
 <a href="https://github.com/GreptimeTeam/greptimedb/releases/latest">
-<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb.svg" alt="Version"/>
+<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?filter=!*-*&label=stable&color=brightgreen" alt="Stable"/>
 </a>
-<a href="https://github.com/GreptimeTeam/greptimedb/releases/latest">
-<img src="https://img.shields.io/github/release-date/GreptimeTeam/greptimedb.svg" alt="Releases"/>
+<a href="https://github.com/GreptimeTeam/greptimedb/releases">
+<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=!*-*-*&label=latest&color=blueviolet" alt="Latest"/>
 </a>
+<a href="https://github.com/GreptimeTeam/greptimedb/releases">
+<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=*-nightly-*&label=nightly&color=orange" alt="Nightly"/>
+</a>
+
+<sub><b>stable</b> for production &nbsp;·&nbsp; <b>latest</b> includes pre-releases &nbsp;·&nbsp; <b>nightly</b> is a weekly snapshot of <code>main</code></sub>
+
 <a href="https://hub.docker.com/r/greptime/greptimedb/">
 <img src="https://img.shields.io/docker/pulls/greptime/greptimedb.svg" alt="Docker Pulls"/>
 </a>

--- a/README.md
+++ b/README.md
@@ -215,14 +215,6 @@ Read the [v1.0 highlights](https://greptime.com/blogs/2025-11-05-greptimedb-v1-h
 
 If GreptimeDB is useful to you, please star the repo.
 
-<a href="https://www.star-history.com/?repos=GreptimeTeam%2FGreptimeDB&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=GreptimeTeam/GreptimeDB&type=date&theme=dark&legend=top-left&sealed_token=1kD9cyZVPnWvxbpbPPTWo_r7W351gDAhGx9_55zfD1vSIfHsdTRfH6NAtdPVX_M2ac8sjNxiuw7-0Vk4WvbyXmOuufxlAoU3QF7z4onyltr0o0c9xVfUnPKltz7llUc3nEDW7l_r2fHBBMtJGf1-jsitNozdAUpb8eb7OJp9N1LqEnMQK78ESp2zgjyr" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=GreptimeTeam/GreptimeDB&type=date&legend=top-left&sealed_token=1kD9cyZVPnWvxbpbPPTWo_r7W351gDAhGx9_55zfD1vSIfHsdTRfH6NAtdPVX_M2ac8sjNxiuw7-0Vk4WvbyXmOuufxlAoU3QF7z4onyltr0o0c9xVfUnPKltz7llUc3nEDW7l_r2fHBBMtJGf1-jsitNozdAUpb8eb7OJp9N1LqEnMQK78ESp2zgjyr" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=GreptimeTeam/GreptimeDB&type=date&legend=top-left&sealed_token=1kD9cyZVPnWvxbpbPPTWo_r7W351gDAhGx9_55zfD1vSIfHsdTRfH6NAtdPVX_M2ac8sjNxiuw7-0Vk4WvbyXmOuufxlAoU3QF7z4onyltr0o0c9xVfUnPKltz7llUc3nEDW7l_r2fHBBMtJGf1-jsitNozdAUpb8eb7OJp9N1LqEnMQK78ESp2zgjyr" />
- </picture>
-</a>
-
 <img alt="Known Users" src="https://greptime.com/logo/img/users.png"/>
 
 ## Community


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Two README changes.

### 1. Split the release badge into three channels

The README carried a single `github/v/release` badge. It renders whatever GitHub considers the newest release, so right now it shows `v1.2.0-beta.1` — a pre-release — as if it were the version to install. The recommended stable version is `v1.1.4`, and the weekly nightly build is invisible.

| Channel | shields.io filter | Currently resolves to |
| --- | --- | --- |
| `stable` | `?filter=!*-*` | `v1.1.4` |
| `latest` | `?include_prereleases&filter=!*-*-*` | `v1.2.0-beta.1` |
| `nightly` | `?include_prereleases&filter=*-nightly-*` | `v1.2.0-nightly-20260706` |

The filters key off our existing tag naming, so no workflow or scripting changes are needed and the badges follow new releases on their own:

- formal releases have no hyphen (`v1.1.4`)
- pre-releases have one (`v1.2.0-beta.1`)
- nightly and dev builds have two or more (`v1.2.0-nightly-20260706`, `v1.2.0-d1e61a4ad-20260720-1784560249`)

A one-line caption below the badges says which channel to pick. All URLs were verified against shields.io before committing.

Two notes:

- The middle badge is labelled `latest`, not `latest (pre-release)`. Its filter means "newest release that is not a nightly or dev build", so once v1.2.0 GA ships it will correctly show `v1.2.0`. Labelling it `pre-release` would become wrong at that point. shields.io does not allow mixing positive and negative filter patterns, so "only pre-releases" cannot be expressed without hardcoding `*-beta*`, which would break on an `-rc` tag.
- The `release-date` badge is dropped. The three version badges already carry that signal and a fourth badge crowded the row.

### 2. Remove the star history chart

It embedded a large third-party image in the Project Status section, with a `sealed_token` repeated across three URLs, and said nothing the badges and case studies do not already cover. The "please star the repo" line stays.

### 3. Use `--grpc-bind-addr` in the quickstart

`--rpc-bind-addr` was renamed to `--grpc-bind-addr` (`src/cmd/src/standalone.rs:267`). The old spelling still parses as a hidden alias but no longer appears in `--help`, so the quickstart was teaching a name users cannot discover. The other flags in that snippet are unchanged.

---

Unrelated to this PR, but worth a look: the newest nightly release is `v1.2.0-nightly-20260706`, about a month old, while `release.yml` is scheduled weekly (`cron: '0 0 * * 1'`). The scheduled run may have been failing or skipped since then.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
