### PR TITLE
refactor!: move native histogram config and `prom_validation_mode` to prom_store

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -33,7 +33,6 @@
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
-| `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
 | `http.enable_api_server` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
@@ -80,6 +79,7 @@
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |
+| `prom_store.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `prom_store.pending_rows_flush_interval` | String | `0s` | Interval to flush pending rows batcher.<br/>Set to "0s" to disable batching mode in Prometheus Remote Write endpoint |
 | `prom_store.max_batch_rows` | Integer | `100000` | Max rows per pending batch before triggering a flush. |
 | `prom_store.max_concurrent_flushes` | Integer | `256` | Max number of concurrent batch flushes. |
@@ -262,7 +262,6 @@
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
 | `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
-| `http.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
 | `http.enable_api_server` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
@@ -321,6 +320,7 @@
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |
+| `prom_store.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `prom_store.pending_rows_flush_interval` | String | `0s` | Interval to flush pending rows batcher.<br/>Set to "0s" to disable batching mode in Prometheus Remote Write endpoint |
 | `prom_store.max_batch_rows` | Integer | `100000` | Max rows per pending batch before triggering a flush. |
 | `prom_store.max_concurrent_flushes` | Integer | `256` | Max number of concurrent batch flushes. |

--- a/config/config.md
+++ b/config/config.md
@@ -32,7 +32,6 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
-| `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
 | `http.enable_api_server` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
@@ -79,6 +78,7 @@
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |
+| `prom_store.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `prom_store.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `prom_store.pending_rows_flush_interval` | String | `0s` | Interval to flush pending rows batcher.<br/>Set to "0s" to disable batching mode in Prometheus Remote Write endpoint |
 | `prom_store.max_batch_rows` | Integer | `100000` | Max rows per pending batch before triggering a flush. |
@@ -261,7 +261,6 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>The following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.<br/>Set to 0 to disable limit. |
 | `http.enable_cors` | Bool | `true` | HTTP CORS support, it's turned on by default<br/>This allows browser to access http APIs without CORS restrictions |
 | `http.cors_allowed_origins` | Array | Unset | Customize allowed origins for HTTP CORS. |
-| `http.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `http.experimental_enable_explain_analyze_stream` | Bool | `true` | Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics. |
 | `http.enable_api_server` | Bool | `false` | Whether to start the dedicated public HTTP **API** server. This server serves<br/>only the `v1` interfaces plus the dashboard, and shares every other `[http]`<br/>option with the main server. It is disabled by default; set to `true` to enable. |
 | `http.api_server_addr` | String | `127.0.0.1:4006` | The address to bind the dedicated HTTP API server, in the same form as `addr`.<br/>Defaults to `127.0.0.1:4006`. |
@@ -320,6 +319,7 @@
 | `prom_store` | -- | -- | Prometheus remote storage options |
 | `prom_store.enable` | Bool | `true` | Whether to enable Prometheus remote write and read in HTTP API. |
 | `prom_store.with_metric_engine` | Bool | `true` | Whether to store the data from Prometheus remote write in metric engine. |
+| `prom_store.prom_validation_mode` | String | `strict` | Whether to enable validation for Prometheus remote write requests.<br/>Available options:<br/>- strict: deny invalid UTF-8 strings (default).<br/>- lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).<br/>- unchecked: do not valid strings. |
 | `prom_store.experimental_enable_prometheus_native_histogram` | Bool | `false` | Experimental: enable Prometheus remote write v2 native histogram ingestion. |
 | `prom_store.pending_rows_flush_interval` | String | `0s` | Interval to flush pending rows batcher.<br/>Set to "0s" to disable batching mode in Prometheus Remote Write endpoint |
 | `prom_store.max_batch_rows` | Integer | `100000` | Max rows per pending batch before triggering a flush. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -65,12 +65,6 @@ enable_cors = true
 ## Customize allowed origins for HTTP CORS.
 ## @toml2docs:none-default
 cors_allowed_origins = ["https://example.com"]
-## Whether to enable validation for Prometheus remote write requests.
-## Available options:
-## - strict: deny invalid UTF-8 strings (default).
-## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
-## - unchecked: do not valid strings.
-prom_validation_mode = "strict"
 ## Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics.
 experimental_enable_explain_analyze_stream = true
 
@@ -252,6 +246,12 @@ trace_ingest_chunk_size = 512
 enable = true
 ## Whether to store the data from Prometheus remote write in metric engine.
 with_metric_engine = true
+## Whether to enable validation for Prometheus remote write requests.
+## Available options:
+## - strict: deny invalid UTF-8 strings (default).
+## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
+## - unchecked: do not valid strings.
+prom_validation_mode = "strict"
 ## Experimental: enable Prometheus remote write v2 native histogram ingestion.
 experimental_enable_prometheus_native_histogram = false
 ## Interval to flush pending rows batcher.

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -71,8 +71,6 @@ cors_allowed_origins = ["https://example.com"]
 ## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
 ## - unchecked: do not valid strings.
 prom_validation_mode = "strict"
-## Experimental: enable Prometheus remote write v2 native histogram ingestion.
-experimental_enable_prometheus_native_histogram = false
 ## Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics.
 experimental_enable_explain_analyze_stream = true
 
@@ -254,6 +252,8 @@ trace_ingest_chunk_size = 512
 enable = true
 ## Whether to store the data from Prometheus remote write in metric engine.
 with_metric_engine = true
+## Experimental: enable Prometheus remote write v2 native histogram ingestion.
+experimental_enable_prometheus_native_histogram = false
 ## Interval to flush pending rows batcher.
 ## Set to "0s" to disable batching mode in Prometheus Remote Write endpoint
 #+pending_rows_flush_interval = "0s"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -79,12 +79,6 @@ enable_cors = true
 ## @toml2docs:none-default
 cors_allowed_origins = ["https://example.com"]
 
-## Whether to enable validation for Prometheus remote write requests.
-## Available options:
-## - strict: deny invalid UTF-8 strings (default).
-## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
-## - unchecked: do not valid strings.
-prom_validation_mode = "strict"
 ## Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics.
 experimental_enable_explain_analyze_stream = true
 
@@ -219,6 +213,12 @@ trace_ingest_chunk_size = 512
 enable = true
 ## Whether to store the data from Prometheus remote write in metric engine.
 with_metric_engine = true
+## Whether to enable validation for Prometheus remote write requests.
+## Available options:
+## - strict: deny invalid UTF-8 strings (default).
+## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
+## - unchecked: do not valid strings.
+prom_validation_mode = "strict"
 ## Experimental: enable Prometheus remote write v2 native histogram ingestion.
 experimental_enable_prometheus_native_histogram = false
 ## Interval to flush pending rows batcher.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -85,8 +85,6 @@ cors_allowed_origins = ["https://example.com"]
 ## - lossy: allow invalid UTF-8 strings, replace invalid characters with REPLACEMENT_CHARACTER(U+FFFD).
 ## - unchecked: do not valid strings.
 prom_validation_mode = "strict"
-## Experimental: enable Prometheus remote write v2 native histogram ingestion.
-experimental_enable_prometheus_native_histogram = false
 ## Experimental: enable POST /v1/sql/analyze/stream for streaming EXPLAIN ANALYZE VERBOSE metrics.
 experimental_enable_explain_analyze_stream = true
 
@@ -221,6 +219,8 @@ trace_ingest_chunk_size = 512
 enable = true
 ## Whether to store the data from Prometheus remote write in metric engine.
 with_metric_engine = true
+## Experimental: enable Prometheus remote write v2 native histogram ingestion.
+experimental_enable_prometheus_native_histogram = false
 ## Interval to flush pending rows batcher.
 ## Set to "0s" to disable batching mode in Prometheus Remote Write endpoint
 #+pending_rows_flush_interval = "0s"

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -149,7 +149,7 @@ where
                     self.instance.clone(),
                     Some(self.instance.clone()),
                     opts.prom_store.with_metric_engine,
-                    opts.http.prom_validation_mode,
+                    opts.prom_store.prom_validation_mode,
                     opts.prom_store
                         .experimental_enable_prometheus_native_histogram,
                     pending_rows_batcher,

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -150,6 +150,8 @@ where
                     Some(self.instance.clone()),
                     opts.prom_store.with_metric_engine,
                     opts.http.prom_validation_mode,
+                    opts.prom_store
+                        .experimental_enable_prometheus_native_histogram,
                     pending_rows_batcher,
                 )
                 .with_prometheus_handler(self.instance.clone());

--- a/src/frontend/src/service_config/prom_store.rs
+++ b/src/frontend/src/service_config/prom_store.rs
@@ -21,6 +21,9 @@ use serde::{Deserialize, Serialize};
 pub struct PromStoreOptions {
     pub enable: bool,
     pub with_metric_engine: bool,
+    /// Enables experimental Prometheus remote write v2 native histogram ingestion.
+    #[serde(default)]
+    pub experimental_enable_prometheus_native_histogram: bool,
     #[serde(default, with = "humantime_serde")]
     pub pending_rows_flush_interval: Duration,
     #[serde(default = "default_max_batch_rows")]
@@ -77,6 +80,7 @@ impl Default for PromStoreOptions {
         Self {
             enable: true,
             with_metric_engine: true,
+            experimental_enable_prometheus_native_histogram: false,
             pending_rows_flush_interval: Duration::ZERO,
             max_batch_rows: default_max_batch_rows(),
             max_concurrent_flushes: default_max_concurrent_flushes(),
@@ -103,6 +107,7 @@ mod tests {
         let default = PromStoreOptions::default();
         assert!(default.enable);
         assert!(default.with_metric_engine);
+        assert!(!default.experimental_enable_prometheus_native_histogram);
         assert_eq!(default.pending_rows_flush_interval, Duration::ZERO);
         assert_eq!(default.max_batch_rows, default_max_batch_rows());
         assert_eq!(

--- a/src/frontend/src/service_config/prom_store.rs
+++ b/src/frontend/src/service_config/prom_store.rs
@@ -16,11 +16,15 @@ use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use servers::prom_remote_write::validation::PromValidationMode;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PromStoreOptions {
     pub enable: bool,
     pub with_metric_engine: bool,
+    /// Validation mode while decoding Prometheus remote write requests.
+    #[serde(default)]
+    pub prom_validation_mode: PromValidationMode,
     /// Enables experimental Prometheus remote write v2 native histogram ingestion.
     #[serde(default)]
     pub experimental_enable_prometheus_native_histogram: bool,
@@ -80,6 +84,7 @@ impl Default for PromStoreOptions {
         Self {
             enable: true,
             with_metric_engine: true,
+            prom_validation_mode: PromValidationMode::Strict,
             experimental_enable_prometheus_native_histogram: false,
             pending_rows_flush_interval: Duration::ZERO,
             max_batch_rows: default_max_batch_rows(),
@@ -95,7 +100,7 @@ impl Default for PromStoreOptions {
 mod tests {
     use std::time::Duration;
 
-    use super::PromStoreOptions;
+    use super::{PromStoreOptions, PromValidationMode};
     use crate::service_config::prom_store::{
         default_flow_notification_queue_capacity, default_max_batch_rows,
         default_max_concurrent_flushes, default_max_inflight_requests,
@@ -107,6 +112,7 @@ mod tests {
         let default = PromStoreOptions::default();
         assert!(default.enable);
         assert!(default.with_metric_engine);
+        assert_eq!(default.prom_validation_mode, PromValidationMode::Strict);
         assert!(!default.experimental_enable_prometheus_native_histogram);
         assert_eq!(default.pending_rows_flush_interval, Duration::ZERO);
         assert_eq!(default.max_batch_rows, default_max_batch_rows());

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -251,9 +251,6 @@ pub struct HttpOptions {
     /// Validation mode while decoding Prometheus remote write requests.
     pub prom_validation_mode: PromValidationMode,
 
-    /// Enables experimental Prometheus remote write v2 native histogram ingestion.
-    pub experimental_enable_prometheus_native_histogram: bool,
-
     pub cors_allowed_origins: Vec<String>,
 
     pub enable_cors: bool,
@@ -280,7 +277,6 @@ impl Default for HttpOptions {
             cors_allowed_origins: Vec::new(),
             enable_cors: true,
             prom_validation_mode: PromValidationMode::Strict,
-            experimental_enable_prometheus_native_histogram: false,
             experimental_enable_explain_analyze_stream: true,
             enable_api_server: false,
             api_server_addr: format!("127.0.0.1:{}", DEFAULT_HTTP_API_ADDR_PORT),
@@ -697,6 +693,7 @@ impl HttpServerBuilder {
         pipeline_handler: Option<PipelineHandlerRef>,
         prom_store_with_metric_engine: bool,
         prom_validation_mode: PromValidationMode,
+        experimental_enable_prometheus_native_histogram: bool,
         pending_rows_batcher: Option<Arc<PendingRowsBatcher>>,
     ) -> Self {
         let state = PromStoreState {
@@ -704,9 +701,7 @@ impl HttpServerBuilder {
             pipeline_handler,
             prom_store_with_metric_engine,
             prom_validation_mode,
-            experimental_enable_prometheus_native_histogram: self
-                .options
-                .experimental_enable_prometheus_native_histogram,
+            experimental_enable_prometheus_native_histogram,
             pending_rows_batcher,
         };
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -248,9 +248,6 @@ pub struct HttpOptions {
 
     pub body_limit: ReadableSize,
 
-    /// Validation mode while decoding Prometheus remote write requests.
-    pub prom_validation_mode: PromValidationMode,
-
     pub cors_allowed_origins: Vec<String>,
 
     pub enable_cors: bool,
@@ -276,7 +273,6 @@ impl Default for HttpOptions {
             body_limit: DEFAULT_BODY_LIMIT,
             cors_allowed_origins: Vec::new(),
             enable_cors: true,
-            prom_validation_mode: PromValidationMode::Strict,
             experimental_enable_explain_analyze_stream: true,
             enable_api_server: false,
             api_server_addr: format!("127.0.0.1:{}", DEFAULT_HTTP_API_ADDR_PORT),

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -240,7 +240,7 @@ async fn remote_write_v2(
     if !experimental_enable_prometheus_native_histogram && request_has_native_histograms(&request) {
         return Ok(remote_write_v2_error_response(
             error::InvalidPromRemoteRequestSnafu {
-                msg: "prometheus remote write v2 native histogram ingestion is experimental; set http.experimental_enable_prometheus_native_histogram = true to enable it"
+                msg: "prometheus remote write v2 native histogram ingestion is experimental; set prom_store.experimental_enable_prometheus_native_histogram = true to enable it"
                     .to_string(),
             }
             .build(),

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -231,7 +231,6 @@ fn make_test_app_with_write_failure_inner(
 ) -> Router {
     let http_opts = HttpOptions {
         addr: format!("127.0.0.1:{}", ports::get_port()),
-        experimental_enable_prometheus_native_histogram,
         ..Default::default()
     };
 
@@ -243,7 +242,14 @@ fn make_test_app_with_write_failure_inner(
     });
     let server = HttpServerBuilder::new(http_opts)
         .with_sql_handler(instance.clone())
-        .with_prom_handler(instance, None, true, PromValidationMode::Unchecked, None)
+        .with_prom_handler(
+            instance,
+            None,
+            true,
+            PromValidationMode::Unchecked,
+            experimental_enable_prometheus_native_histogram,
+            None,
+        )
         .build();
     server.build(server.make_app()).unwrap()
 }
@@ -707,7 +713,7 @@ async fn test_prometheus_remote_write_v2_rejects_native_histogram_when_disabled(
         result
             .text()
             .await
-            .contains("native histogram ingestion is experimental")
+            .contains("prom_store.experimental_enable_prometheus_native_histogram")
     );
     assert!(write_rx.try_recv().is_err());
 }

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -643,7 +643,6 @@ async fn setup_test_prom_app_with_frontend_inner(
 
     let http_opts = HttpOptions {
         addr: format!("127.0.0.1:{}", ports::get_port()),
-        experimental_enable_prometheus_native_histogram,
         ..Default::default()
     };
     let frontend_ref = instance.fe_instance().clone();
@@ -675,6 +674,7 @@ async fn setup_test_prom_app_with_frontend_inner(
             Some(frontend_ref.clone()),
             true,
             PromValidationMode::Strict,
+            experimental_enable_prometheus_native_histogram,
             pending_rows_batcher,
         )
         .with_prometheus_handler(frontend_ref)

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2080,7 +2080,6 @@ addr = "127.0.0.1:4000"
 timeout = "0s"
 body_limit = "64MiB"
 prom_validation_mode = "strict"
-experimental_enable_prometheus_native_histogram = false
 cors_allowed_origins = []
 enable_cors = true
 experimental_enable_explain_analyze_stream = true
@@ -2144,6 +2143,7 @@ enable = true
 [prom_store]
 enable = true
 with_metric_engine = true
+experimental_enable_prometheus_native_histogram = false
 pending_rows_flush_interval = "0s"
 max_batch_rows = 100000
 max_concurrent_flushes = 256

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2079,7 +2079,6 @@ heartbeat_env_vars = []
 addr = "127.0.0.1:4000"
 timeout = "0s"
 body_limit = "64MiB"
-prom_validation_mode = "strict"
 cors_allowed_origins = []
 enable_cors = true
 experimental_enable_explain_analyze_stream = true
@@ -2143,6 +2142,7 @@ enable = true
 [prom_store]
 enable = true
 with_metric_engine = true
+prom_validation_mode = "strict"
 experimental_enable_prometheus_native_histogram = false
 pending_rows_flush_interval = "0s"
 max_batch_rows = 100000


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request updates the experimental Prometheus native histogram setting so it is owned by `[prom_store]` instead of the general `[http]` section.

It wires the relocated option into the Prometheus HTTP handler and updates the error guidance, example configurations, generated config reference, and serialization expectations. The default remains `false`; configurations using the experimental option must move it to `prom_store.experimental_enable_prometheus_native_histogram`, with no legacy `[http]` alias retained.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
