### PR TITLE
fix(operator): invalidate local cache after dropping view

### DIFF
--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -1246,6 +1246,7 @@ impl StatementExecutor {
         );
 
         let view_id = view_info.table_id();
+        let view_name = TableName::new(&catalog, &schema, &view);
 
         let task = DropViewTask {
             catalog,
@@ -1256,6 +1257,18 @@ impl StatementExecutor {
         };
 
         self.drop_view_procedure(task, query_context).await?;
+
+        // Invalidates local cache ASAP.
+        self.cache_invalidator
+            .invalidate(
+                &Context::default(),
+                &[
+                    CacheIdent::TableId(view_id),
+                    CacheIdent::TableName(view_name),
+                ],
+            )
+            .await
+            .context(error::InvalidateTableCacheSnafu)?;
 
         Ok(Output::new_with_affected_rows(0))
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

None

## What's changed and what's your intention?

This fixes a distributed read-after-DDL race for `DROP VIEW`.

After the DropView procedure succeeds, the originating frontend now immediately invalidates its local cache entries for the view's table ID and table name, matching the existing `DROP TABLE` behavior. Other frontends continue to receive invalidation through the metasrv broadcast path.

Without this local invalidation, an immediate query after `DROP VIEW` could resolve the stale cached view before the frontend processes the asynchronous heartbeat invalidation.

The existing distributed SQLness view-create case exercises the drop-then-query sequence. No API, schema, or persisted-data format is changed.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
