### PR TITLE
chore: bump version to 1.3.0 on default branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -942,7 +942,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1658,7 +1658,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -1993,7 +1993,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -2084,7 +2084,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.6",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.3.0",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "common-base"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "anymap2",
@@ -2305,14 +2305,14 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "const_format",
 ]
 
 [[package]]
 name = "common-config"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-macro",
  "http 1.3.1",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "common-base",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "greptime-proto",
  "once_cell",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "common-memory-manager"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-base",
  "common-grpc",
@@ -2701,11 +2701,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "1.2.0"
+version = "1.3.0"
 
 [[package]]
 name = "common-pprof"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-stream",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "serde",
  "strum 0.27.1",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "common-sql"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "common-stat"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-base",
  "common-runtime",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "backtrace",
  "common-base",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "client",
  "common-grpc",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "cargo-manifest",
  "const_format",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "common-telemetry",
  "serde",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -4525,7 +4525,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "datatypes"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-array 58.3.0",
@@ -5262,7 +5262,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-engine"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -5393,7 +5393,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -5463,7 +5463,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 1.2.0",
+ "substrait 1.3.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -5546,7 +5546,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -7970,7 +7970,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-query"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -7982,7 +7982,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8307,7 +8307,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8439,7 +8439,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -8540,7 +8540,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "bytes",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -9355,7 +9355,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9926,7 +9926,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -9985,7 +9985,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.3.0",
  "table",
  "tokio",
  "tokio-util",
@@ -10270,7 +10270,7 @@ checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
 
 [[package]]
 name = "partition"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "async-trait",
@@ -10664,7 +10664,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10821,7 +10821,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "auth",
  "catalog",
@@ -11161,7 +11161,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -11514,7 +11514,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -11576,7 +11576,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -11647,7 +11647,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.3.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -13267,7 +13267,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13407,7 +13407,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13760,7 +13760,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arrow-buffer 58.3.0",
@@ -13821,7 +13821,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -14103,7 +14103,7 @@ dependencies = [
 
 [[package]]
 name = "standalone"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "catalog",
@@ -14149,7 +14149,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-api"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -14342,7 +14342,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -14464,7 +14464,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -14747,7 +14747,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests-fuzz"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -14795,7 +14795,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -14877,7 +14877,7 @@ dependencies = [
  "sqlx",
  "standalone",
  "store-api",
- "substrait 1.2.0",
+ "substrait 1.3.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Start new release cycle

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
