### PR TITLE
chore: check enterprise-gated files are listed in both license configs

### DIFF
--- a/.agents/architecture-invariants.md
+++ b/.agents/architecture-invariants.md
@@ -103,6 +103,33 @@ So:
 - Upgrading DataFusion means bumping the version in `[workspace.dependencies]`
   **and** the rev in `[patch.crates-io]` together, for all of them.
 
+## 7. Enterprise-gated code is licensed differently from the rest
+
+A few sources in this repo are governed by the GreptimeDB Enterprise License
+(`LICENSE-ENTERPRISE`) rather than Apache-2.0. They are compiled only with the
+`enterprise` feature, and the license boundary is drawn at **file** granularity —
+so how you gate a change decides which license applies to it.
+
+- A whole feature that only exists in the enterprise build goes into its own
+  module file (e.g. `src/sql/src/statements/drop/trigger.rs`), pulled in by
+  `#[cfg(feature = "enterprise")] pub mod trigger;`. That file carries the
+  enterprise header, and must be listed in `licenserc-enterprise.toml`
+  (`includes`) **and** in `licenserc.toml` (`excludes`) so the Apache-2.0 check
+  skips it. Submodules of such a module inherit all of this.
+- A branch on a shared path — an extra enum variant, a match arm, an `if` — stays
+  inline behind `#[cfg(feature = "enterprise")]` in the shared file (e.g. the
+  trigger variants in `src/sql/src/statements/statement.rs`). The file keeps its
+  Apache-2.0 header. Do not split a file just to gate three lines.
+- The `enterprise` feature must be forwarded down every dependency edge that
+  needs it (`enterprise = ["sql/enterprise", ...]`). A crate that gates code on a
+  feature its dependents never enable silently compiles the OSS path.
+
+`make check-enterprise-license` verifies the bookkeeping half of this: every file
+behind an enterprise-gated `mod` appears in both configs, and neither config has
+stale entries. It runs in CI. Deciding what belongs in a separate file is still
+yours — hawkeye alone cannot catch a miss, because a wrongly Apache-headered
+enterprise file passes the default check exactly by not being excluded from it.
+
 ## Maintenance contract
 
 Update this file when a new repo-wide invariant emerges (a new persisted format,

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,6 +48,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Check enterprise license lists
+        run: make check-enterprise-license
       - uses: korandoru/hawkeye@v5
       - name: Check enterprise license header
         uses: korandoru/hawkeye@v5
@@ -74,6 +76,8 @@ jobs:
           version: "latest"
       - name: Run check-version script tests
         run: uv run --no-project python .github/scripts/check-version-test.py
+      - name: Run enterprise license check tests
+        run: python3 scripts/check-enterprise-license-test.py
       - name: Run fuzz orchestration script tests
         run: .github/scripts/run-fuzz-targets-test.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,12 @@ change-coupling points, and gotchas:
    and commit the regenerated `config/config.md`.
 6. If you changed a persisted or wire format, add a compatibility test case (see
    `.agents/architecture-invariants.md`).
-7. Use a conventional-commit title, sign off commits (`git commit -s`), and sign
+7. If you added or gated an enterprise-only file, give it the enterprise license
+   header, list it in `licenserc-enterprise.toml` (`includes`) and
+   `licenserc.toml` (`excludes`), and run `make check-enterprise-license`.
+8. Use a conventional-commit title, sign off commits (`git commit -s`), and sign
    the CLA.
-8. When creating or updating a pull request, follow
+9. When creating or updating a pull request, follow
    [`.github/pull_request_template.md`](.github/pull_request_template.md): include
    the CLA statement, fill the change-intention section with enough detail, and
    update checklist items accurately.

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,10 @@ fmt-check: ## Check code format.
 	python3 scripts/check-snafu.py
 	python3 scripts/check-super-imports.py
 
+.PHONY: check-enterprise-license
+check-enterprise-license: ## Check enterprise-gated files are listed in both license configs.
+	python3 scripts/check-enterprise-license.py
+
 .PHONY: start-etcd
 start-etcd: ## Start single node etcd for testing purpose.
 	docker run --rm -d --network=host -p 2379-2380:2379-2380 ${ETCD_IMAGE}

--- a/licenserc-enterprise.toml
+++ b/licenserc-enterprise.toml
@@ -10,8 +10,10 @@
 
 headerPath = "licenses/enterprise-header.txt"
 
-# Only the enterprise-gated sources. Keep this list in sync with the
-# "# enterprise" block in `licenserc.toml`'s `excludes`.
+# Only the enterprise-gated sources: every file reachable solely through
+# `#[cfg(feature = "enterprise")] mod ...;` belongs here. Keep this list in sync
+# with the "# enterprise" block in `licenserc.toml`'s `excludes` — both are
+# enforced by `make check-enterprise-license`.
 includes = [
     "src/common/meta/src/rpc/ddl/trigger.rs",
     "src/operator/src/expr_helper/trigger.rs",

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -30,6 +30,7 @@ excludes = [
     # the GreptimeDB Enterprise License and checked via `licenserc-enterprise.toml`.
     # Keep this list in sync with that file's `includes`; enforced by
     # `make check-enterprise-license`.
+    # enterprise:start
     "src/common/meta/src/rpc/ddl/trigger.rs",
     "src/operator/src/expr_helper/trigger.rs",
     "src/sql/src/statements/alter/trigger.rs",
@@ -40,6 +41,7 @@ excludes = [
     "src/sql/src/parsers/create_parser/trigger.rs",
     "src/sql/src/parsers/show_parser/trigger.rs",
     "src/mito2/src/extension.rs",
+    # enterprise:end
 ]
 
 [properties]

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -28,7 +28,8 @@ excludes = [
     "src/servers/src/http/test_helpers.rs",
     # enterprise: Apache-2.0 header is NOT applied to these. They are governed by
     # the GreptimeDB Enterprise License and checked via `licenserc-enterprise.toml`.
-    # Keep this list in sync with that file's `includes`.
+    # Keep this list in sync with that file's `includes`; enforced by
+    # `make check-enterprise-license`.
     "src/common/meta/src/rpc/ddl/trigger.rs",
     "src/operator/src/expr_helper/trigger.rs",
     "src/sql/src/statements/alter/trigger.rs",

--- a/scripts/check-enterprise-license-test.py
+++ b/scripts/check-enterprise-license-test.py
@@ -1,0 +1,187 @@
+# Copyright 2023 Greptime Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent / "check-enterprise-license.py"
+
+spec = importlib.util.spec_from_file_location("check_enterprise_license", SCRIPT_PATH)
+checker = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(checker)
+
+
+def write(root: Path, relative: str, source: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+    return path
+
+
+class ParseModDeclsTest(unittest.TestCase):
+    def parse(self, source: str) -> dict[str, bool]:
+        return dict(checker.parse_mod_decls(textwrap.dedent(source)))
+
+    def test_gate_applies_only_to_the_next_declaration(self):
+        self.assertEqual(
+            self.parse(
+                """
+                #[cfg(feature = "enterprise")]
+                pub mod trigger;
+                mod plain;
+                """
+            ),
+            {"trigger": True, "plain": False},
+        )
+
+    def test_test_only_gate_counts_as_enterprise(self):
+        self.assertEqual(
+            self.parse(
+                """
+                #[cfg(all(test, feature = "enterprise"))]
+                mod recycle_bin_test;
+                """
+            ),
+            {"recycle_bin_test": True},
+        )
+
+    def test_doc_comment_between_attribute_and_declaration(self):
+        self.assertEqual(
+            self.parse(
+                """
+                #[cfg(feature = "enterprise")]
+                /// Enterprise only.
+                pub(crate) mod gated;
+                """
+            ),
+            {"gated": True},
+        )
+
+    def test_attribute_on_the_same_line(self):
+        self.assertEqual(
+            self.parse('#[cfg(feature = "enterprise")] mod gated;\n'),
+            {"gated": True},
+        )
+
+    def test_attribute_consumed_by_another_item_does_not_leak(self):
+        self.assertEqual(
+            self.parse(
+                """
+                #[cfg(feature = "enterprise")]
+                use crate::gated::Thing;
+                mod plain;
+                """
+            ),
+            {"plain": False},
+        )
+
+    def test_other_features_are_not_enterprise(self):
+        self.assertEqual(
+            self.parse(
+                """
+                #[cfg(feature = "testing")]
+                mod helper;
+                """
+            ),
+            {"helper": False},
+        )
+
+    def test_inline_module_is_ignored(self):
+        self.assertEqual(
+            self.parse(
+                """
+                #[cfg(feature = "enterprise")]
+                mod inline {
+                    pub const A: u8 = 1;
+                }
+                """
+            ),
+            {},
+        )
+
+
+class CollectGatedFilesTest(unittest.TestCase):
+    def collect(self, root: Path):
+        rust_files = sorted(root.rglob("*.rs"))
+        return checker.collect_gated_files(rust_files)
+
+    def test_descendants_of_a_gated_module_are_gated(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write(
+                root,
+                "src/lib.rs",
+                """
+                #[cfg(feature = "enterprise")]
+                pub mod gated;
+                pub mod plain;
+                """,
+            )
+            write(root, "src/gated.rs", "pub mod nested;\n")
+            write(root, "src/gated/nested.rs", "pub const A: u8 = 1;\n")
+            write(root, "src/plain.rs", "pub const B: u8 = 2;\n")
+
+            gated, unresolved = self.collect(root)
+
+            self.assertEqual(
+                gated,
+                {root / "src/gated.rs", root / "src/gated/nested.rs"},
+            )
+            self.assertEqual(unresolved, [])
+
+    def test_module_declared_as_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            write(
+                root,
+                "src/lib.rs",
+                """
+                #[cfg(feature = "enterprise")]
+                mod gated;
+                """,
+            )
+            write(root, "src/gated/mod.rs", "mod leaf;\n")
+            write(root, "src/gated/leaf.rs", "pub const A: u8 = 1;\n")
+
+            gated, unresolved = self.collect(root)
+
+            self.assertEqual(
+                gated,
+                {root / "src/gated/mod.rs", root / "src/gated/leaf.rs"},
+            )
+            self.assertEqual(unresolved, [])
+
+    def test_missing_file_is_reported(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            declaring = write(
+                root,
+                "src/lib.rs",
+                """
+                #[cfg(feature = "enterprise")]
+                mod elsewhere;
+                """,
+            )
+
+            gated, unresolved = self.collect(root)
+
+            self.assertEqual(gated, set())
+            self.assertEqual(unresolved, [(declaring, "elsewhere")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check-enterprise-license-test.py
+++ b/scripts/check-enterprise-license-test.py
@@ -59,6 +59,19 @@ class ParseModDeclsTest(unittest.TestCase):
             {"recycle_bin_test": True},
         )
 
+    def test_non_gating_enterprise_attributes_are_ignored(self):
+        self.assertEqual(
+            self.parse(
+                """
+                #[cfg(any(test, feature = "enterprise"))]
+                mod shared_test;
+                #[cfg_attr(feature = "enterprise", allow(dead_code))]
+                mod shared;
+                """
+            ),
+            {"shared_test": False, "shared": False},
+        )
+
     def test_doc_comment_between_attribute_and_declaration(self):
         self.assertEqual(
             self.parse(
@@ -181,6 +194,32 @@ class CollectGatedFilesTest(unittest.TestCase):
 
             self.assertEqual(gated, set())
             self.assertEqual(unresolved, [(declaring, "elsewhere")])
+
+
+class ConfigSyncTest(unittest.TestCase):
+    def test_load_marked_paths(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = write(
+                Path(temp_dir),
+                "licenserc.toml",
+                """
+                excludes = [
+                    "copied.rs",
+                    # enterprise:start
+                    "gated.rs",
+                    # enterprise:end
+                ]
+                """,
+            )
+
+            self.assertEqual(
+                checker.load_marked_paths(
+                    config,
+                    checker.ENTERPRISE_EXCLUDES_START,
+                    checker.ENTERPRISE_EXCLUDES_END,
+                ),
+                {"gated.rs"},
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/check-enterprise-license.py
+++ b/scripts/check-enterprise-license.py
@@ -32,11 +32,35 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 APACHE_CONFIG = "licenserc.toml"
 ENTERPRISE_CONFIG = "licenserc-enterprise.toml"
+ENTERPRISE_EXCLUDES_START = "# enterprise:start"
+ENTERPRISE_EXCLUDES_END = "# enterprise:end"
 
 ATTRIBUTE = re.compile(r"#\[[^\]]*\]")
-ENTERPRISE_FEATURE = re.compile(r'feature\s*=\s*"enterprise"')
-MOD_DECL = re.compile(r"^\s*(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;")
+MOD_DECL = re.compile(
+    r"^\s*(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;"
+)
 MODULE_ROOTS = {"mod.rs", "lib.rs", "main.rs"}
+CFG_ATTRIBUTE = re.compile(r"#\[\s*cfg\s*\((.*)\)\s*\]")
+ENTERPRISE_FEATURE = re.compile(r'feature\s*=\s*"enterprise"')
+
+
+def cfg_requires_enterprise(attribute):
+    """Whether `attribute` prevents the item from compiling without enterprise."""
+    match = CFG_ATTRIBUTE.fullmatch(attribute)
+    if not match:
+        return False
+    predicate = match.group(1).strip()
+    if not ENTERPRISE_FEATURE.search(predicate):
+        return False
+    if ENTERPRISE_FEATURE.fullmatch(predicate):
+        return True
+
+    all_match = re.fullmatch(r"all\((.*)\)", predicate)
+    if all_match:
+        terms = [term.strip() for term in all_match.group(1).split(",")]
+        return any(ENTERPRISE_FEATURE.fullmatch(term) for term in terms)
+
+    return False
 
 
 def parse_mod_decls(source):
@@ -46,12 +70,17 @@ def parse_mod_decls(source):
     """
     attributes = []
     for line in source.splitlines():
-        attributes.extend(ATTRIBUTE.findall(line))
-        rest = ATTRIBUTE.sub("", line)
+        rest = line.lstrip()
+        while rest.startswith("#["):
+            attribute = ATTRIBUTE.match(rest)
+            if not attribute:
+                break
+            attributes.append(attribute.group())
+            rest = rest[attribute.end() :].lstrip()
 
         match = MOD_DECL.match(rest)
         if match:
-            gated = any(ENTERPRISE_FEATURE.search(attr) for attr in attributes)
+            gated = any(cfg_requires_enterprise(attr) for attr in attributes)
             yield match.group(1), gated
             attributes = []
             continue
@@ -124,6 +153,18 @@ def load_paths(config_path, key):
         return set(tomllib.load(config).get(key, []))
 
 
+def load_marked_paths(config_path, start_marker, end_marker):
+    """Load a TOML array fragment delimited by comment markers."""
+    source = config_path.read_text(encoding="utf-8")
+    try:
+        fragment = source.split(start_marker, 1)[1].split(end_marker, 1)[0]
+    except IndexError as error:
+        raise ValueError(
+            f"Missing {start_marker!r} or {end_marker!r} in {config_path}"
+        ) from error
+    return set(tomllib.loads(f"paths = [{fragment}]")["paths"])
+
+
 def report(title, paths):
     print(f"\n{title}:")
     for path in sorted(paths):
@@ -136,13 +177,23 @@ def main():
     gated = {path.relative_to(REPO_ROOT).as_posix() for path in gated_files}
 
     enterprise_includes = load_paths(REPO_ROOT / ENTERPRISE_CONFIG, "includes")
-    apache_excludes = load_paths(REPO_ROOT / APACHE_CONFIG, "excludes")
-
+    enterprise_excludes = load_marked_paths(
+        REPO_ROOT / APACHE_CONFIG,
+        ENTERPRISE_EXCLUDES_START,
+        ENTERPRISE_EXCLUDES_END,
+    )
     missing_includes = gated - enterprise_includes
-    missing_excludes = (gated | enterprise_includes) - apache_excludes
-    stale = enterprise_includes - gated
+    missing_excludes = gated - enterprise_excludes
+    stale_includes = enterprise_includes - gated
+    stale_excludes = enterprise_excludes - gated
 
-    if not (missing_includes or missing_excludes or stale or unresolved):
+    if not (
+        missing_includes
+        or missing_excludes
+        or stale_includes
+        or stale_excludes
+        or unresolved
+    ):
         print(f"Enterprise license lists are in sync ({len(gated)} gated files).")
         return
 
@@ -157,11 +208,17 @@ def main():
             "(the Apache-2.0 header must not be applied to them)",
             missing_excludes,
         )
-    if stale:
+    if stale_includes:
         report(
             f"Stale `includes` in {ENTERPRISE_CONFIG} (file is gone, or is no "
-            "longer behind `#[cfg(feature = \"enterprise\")]`)",
-            stale,
+            'longer behind `#[cfg(feature = "enterprise")]`)',
+            stale_includes,
+        )
+    if stale_excludes:
+        report(
+            f"Stale enterprise `excludes` in {APACHE_CONFIG} (file is gone, or "
+            "is no longer enterprise-gated)",
+            stale_excludes,
         )
     if unresolved:
         print("\nEnterprise-gated modules whose file could not be located:")

--- a/scripts/check-enterprise-license.py
+++ b/scripts/check-enterprise-license.py
@@ -1,0 +1,180 @@
+# Copyright 2023 Greptime Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keep the two license configs in sync with the enterprise feature gate.
+
+A Rust file reachable only through `#[cfg(feature = "enterprise")] mod ...;` is
+governed by the GreptimeDB Enterprise License, so it must be listed in the
+`includes` of `licenserc-enterprise.toml` and in the `excludes` of
+`licenserc.toml`.
+
+hawkeye cannot catch a miss here: such a file that still carries the Apache-2.0
+header passes the default check precisely because it was never excluded from it.
+"""
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APACHE_CONFIG = "licenserc.toml"
+ENTERPRISE_CONFIG = "licenserc-enterprise.toml"
+
+ATTRIBUTE = re.compile(r"#\[[^\]]*\]")
+ENTERPRISE_FEATURE = re.compile(r'feature\s*=\s*"enterprise"')
+MOD_DECL = re.compile(r"^\s*(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;")
+MODULE_ROOTS = {"mod.rs", "lib.rs", "main.rs"}
+
+
+def parse_mod_decls(source):
+    """Yield `(module_name, enterprise_gated)` for each `mod <name>;` declaration.
+
+    Inline `mod <name> { ... }` is skipped: it has no file of its own.
+    """
+    attributes = []
+    for line in source.splitlines():
+        attributes.extend(ATTRIBUTE.findall(line))
+        rest = ATTRIBUTE.sub("", line)
+
+        match = MOD_DECL.match(rest)
+        if match:
+            gated = any(ENTERPRISE_FEATURE.search(attr) for attr in attributes)
+            yield match.group(1), gated
+            attributes = []
+            continue
+
+        stripped = rest.strip()
+        if stripped and not stripped.startswith("//"):
+            attributes = []
+
+
+def child_module_dir(path):
+    """Directory holding the submodules declared by `path`."""
+    return path.parent if path.name in MODULE_ROOTS else path.parent / path.stem
+
+
+def resolve_module(parent, name):
+    directory = child_module_dir(parent)
+    for candidate in (directory / f"{name}.rs", directory / name / "mod.rs"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def collect_gated_files(rust_files):
+    """Return the files behind every enterprise-gated module, plus unresolved declarations.
+
+    Submodules of a gated module are gated too, so the walk keeps descending.
+    """
+    pending = [
+        (path, name)
+        for path in rust_files
+        for name, gated in parse_mod_decls(path.read_text(encoding="utf-8"))
+        if gated
+    ]
+
+    gated_files = set()
+    unresolved = []
+    while pending:
+        parent, name = pending.pop()
+        target = resolve_module(parent, name)
+        if target is None:
+            unresolved.append((parent, name))
+            continue
+        if target in gated_files:
+            continue
+        gated_files.add(target)
+        source = target.read_text(encoding="utf-8")
+        pending.extend((target, child) for child, _ in parse_mod_decls(source))
+
+    return gated_files, unresolved
+
+
+def tracked_rust_files(repo_root):
+    """Rust files under version control.
+
+    Untracked files are left out on purpose: a scratch copy of a gated module
+    lying around a working tree would otherwise fail the check. Anything headed
+    for a PR is tracked by the time CI sees it.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "*.rs"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [repo_root / line for line in result.stdout.splitlines() if line]
+
+
+def load_paths(config_path, key):
+    with open(config_path, "rb") as config:
+        return set(tomllib.load(config).get(key, []))
+
+
+def report(title, paths):
+    print(f"\n{title}:")
+    for path in sorted(paths):
+        print(f'    "{path}",')
+
+
+def main():
+    rust_files = tracked_rust_files(REPO_ROOT)
+    gated_files, unresolved = collect_gated_files(rust_files)
+    gated = {path.relative_to(REPO_ROOT).as_posix() for path in gated_files}
+
+    enterprise_includes = load_paths(REPO_ROOT / ENTERPRISE_CONFIG, "includes")
+    apache_excludes = load_paths(REPO_ROOT / APACHE_CONFIG, "excludes")
+
+    missing_includes = gated - enterprise_includes
+    missing_excludes = (gated | enterprise_includes) - apache_excludes
+    stale = enterprise_includes - gated
+
+    if not (missing_includes or missing_excludes or stale or unresolved):
+        print(f"Enterprise license lists are in sync ({len(gated)} gated files).")
+        return
+
+    if missing_includes:
+        report(
+            f"Enterprise-gated files missing from `includes` in {ENTERPRISE_CONFIG}",
+            missing_includes,
+        )
+    if missing_excludes:
+        report(
+            f"Enterprise files missing from `excludes` in {APACHE_CONFIG} "
+            "(the Apache-2.0 header must not be applied to them)",
+            missing_excludes,
+        )
+    if stale:
+        report(
+            f"Stale `includes` in {ENTERPRISE_CONFIG} (file is gone, or is no "
+            "longer behind `#[cfg(feature = \"enterprise\")]`)",
+            stale,
+        )
+    if unresolved:
+        print("\nEnterprise-gated modules whose file could not be located:")
+        for parent, name in sorted(unresolved):
+            print(f"    mod {name}; declared in {parent.relative_to(REPO_ROOT)}")
+
+    print(
+        "\nAn enterprise-gated file carries the enterprise header instead of the "
+        "Apache-2.0 one. After fixing both lists, run:"
+        "\n    hawkeye format --config licenserc-enterprise.toml"
+    )
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#8747

## What's changed and what's your intention?

Add `make check-enterprise-license` to keep enterprise-gated Rust files in sync with both license configs. The check:

- follows enterprise-gated `mod` declarations and their submodules;
- requires those files in `licenserc-enterprise.toml` and the enterprise block of `licenserc.toml`;
- reports missing files, stale entries, and unresolved modules.

It runs before hawkeye in the license CI job. This PR also adds unit tests and documents the repository invariant.

Verified on `main`: 10 enterprise-gated files, with both lists in sync.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
