### PR TITLE
fix(meta): release region guards after drop rollback

### DIFF
--- a/src/common/meta/src/ddl/drop_table.rs
+++ b/src/common/meta/src/ddl/drop_table.rs
@@ -410,7 +410,10 @@ impl Procedure for DropTableProcedure {
                 &self.data.region_wal_options,
             )
             .await
-            .map_err(ProcedureError::external)
+            .map_err(ProcedureError::external)?;
+
+        self.dropping_regions.clear();
+        Ok(())
     }
 }
 

--- a/src/common/meta/src/ddl/tests/drop_table.rs
+++ b/src/common/meta/src/ddl/tests/drop_table.rs
@@ -2566,6 +2566,18 @@ async fn test_on_rollback() {
         procedure.on_delete_metadata().await.unwrap();
         assert!(procedure.rollback_supported());
         procedure.rollback(&ctx).await.unwrap();
+        assert!(procedure.dropping_regions.is_empty());
+        assert_eq!(ddl_context.memory_region_keeper.len(), 0);
+
+        // The physical table can be dropped again after the metadata rollback.
+        let retry_task = new_drop_table_task("phy_table", physical_table_id, false);
+        let mut retry = DropTableProcedure::new(retry_task, ddl_context.clone());
+        retry.on_prepare().await.unwrap();
+        retry.on_delete_metadata().await.unwrap();
+        retry.rollback(&ctx).await.unwrap();
+        assert!(retry.dropping_regions.is_empty());
+        assert_eq!(ddl_context.memory_region_keeper.len(), 0);
+
         // Rollback again
         assert!(procedure.rollback_supported());
         procedure.rollback(&ctx).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

None.

## What's changed and what's your intention?

Release the in-memory dropping-region guards after a metric physical table drop procedure successfully restores its metadata during rollback.

The drop procedure acquires these guards before deleting metadata to prevent concurrent operations on the same region. Previously, a failed metric physical table drop restored its metadata but retained the guards, causing a subsequent operation on that region to fail with `RegionOperatingRace`.

Add unit coverage that verifies the guards are released and that a new physical table drop procedure can start immediately after rollback.

This change has no API, schema, or persisted-data compatibility impact.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
