### PR TITLE
fix(object-store): fix unused import on Windows after #8735

### DIFF
--- a/src/object-store/src/secure_fs.rs
+++ b/src/object-store/src/secure_fs.rs
@@ -625,11 +625,11 @@ mod tests {
     // On Windows, `std::fs::DirEntry` is a snapshot taken by
     // `FindFirstFileW`: `file_type()` and `metadata()` keep returning the
     // cached data even after the file is removed, so `read_list_entry`
-    // cannot observe the deletion and returns `Some` instead of `None`.
-    // This test only applies to platforms where metadata is fetched from
-    // the live filesystem (e.g. Unix `lstat` returns `ENOENT` after
-    // removal, which `read_list_entry` turns into `None`).
-    #[cfg(not(windows))]
+    // may return `Some` with the stale entry. On platforms where metadata
+    // is fetched from the live filesystem (e.g. Unix `lstat` returns
+    // `ENOENT` after removal), `read_list_entry` returns `None` instead.
+    // The strong assertion is Unix-specific; the portable part still
+    // verifies the call succeeds and yields the expected path.
     #[test]
     fn test_lister_skips_entry_removed_during_iteration() {
         let temp_dir = create_temp_dir("secure_fs_lister_removed_entry");
@@ -640,7 +640,14 @@ mod tests {
         let entry = read_dir.next().unwrap().unwrap();
         std::fs::remove_file(path).unwrap();
 
-        assert!(read_list_entry(entry, "").unwrap().is_none());
+        let result = read_list_entry(entry, "").unwrap();
+
+        if let Some(entry) = &result {
+            assert_eq!("removed", entry.path());
+        }
+
+        #[cfg(not(windows))]
+        assert!(result.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes nightly CI failure tracked in #8731; follows up #8735.

## What's changed and what's your intention?

#8735 gated the whole `test_lister_skips_entry_removed_during_iteration` test with `#[cfg(not(windows))]`. On Windows that leaves `read_list_entry` unused in the test module, so `cargo test --no-run` fails with `-D warnings`:

```
error: unused import: `read_list_entry`
 --> src/object-store/src/secure_fs.rs:546:65
```

PR CI does not catch this because Windows jobs only run in the nightly workflow (which failed: nightly run 695).

This PR makes the test portable instead of excluding it: it keeps the cross-platform assertions (call succeeds, path is `"removed"`) on all platforms and gates only the Unix-specific strong assertion (`result.is_none()`), which also keeps the `read_list_entry` reference alive on Windows.

Verified on Linux: `cargo nextest run -p object-store --lib -E 'test(test_lister_skips_entry_removed_during_iteration)'` → 1 passed.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (comment updated to describe the portable/Unix-specific split)
- [x] I have added the necessary unit tests and integration tests. (verified on Linux)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
