### PR TITLE
docs: align wal.sync_period documented default with actual fallback (5s)

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -96,7 +96,7 @@
 | `wal.sync_write` | Bool | `false` | Whether to use sync write.<br/>**It's only used when the provider is `raft_engine`**. |
 | `wal.enable_log_recycle` | Bool | `true` | Whether to reuse logically truncated log files.<br/>**It's only used when the provider is `raft_engine`**. |
 | `wal.prefill_log_files` | Bool | `false` | Whether to pre-create log files on start up.<br/>**It's only used when the provider is `raft_engine`**. |
-| `wal.sync_period` | String | `10s` | Duration for fsyncing log files.<br/>**It's only used when the provider is `raft_engine`**. |
+| `wal.sync_period` | String | `5s` | Duration for fsyncing log files.<br/>**It's only used when the provider is `raft_engine`**. |
 | `wal.recovery_parallelism` | Integer | `2` | Parallelism during WAL recovery. |
 | `wal.broker_endpoints` | Array | -- | The Kafka broker endpoints.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.connect_timeout` | String | `3s` | The connect timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
@@ -529,7 +529,7 @@
 | `wal.sync_write` | Bool | `false` | Whether to use sync write.<br/>**It's only used when the provider is `raft_engine`**. |
 | `wal.enable_log_recycle` | Bool | `true` | Whether to reuse logically truncated log files.<br/>**It's only used when the provider is `raft_engine`**. |
 | `wal.prefill_log_files` | Bool | `false` | Whether to pre-create log files on start up.<br/>**It's only used when the provider is `raft_engine`**. |
-| `wal.sync_period` | String | `10s` | Duration for fsyncing log files.<br/>**It's only used when the provider is `raft_engine`**. |
+| `wal.sync_period` | String | `5s` | Duration for fsyncing log files.<br/>**It's only used when the provider is `raft_engine`**. |
 | `wal.recovery_parallelism` | Integer | `2` | Parallelism during WAL recovery. |
 | `wal.broker_endpoints` | Array | -- | The Kafka broker endpoints.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.connect_timeout` | String | `3s` | The connect timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -161,7 +161,7 @@ prefill_log_files = false
 
 ## Duration for fsyncing log files.
 ## **It's only used when the provider is `raft_engine`**.
-sync_period = "10s"
+sync_period = "5s"
 
 ## Parallelism during WAL recovery.
 recovery_parallelism = 2

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -277,7 +277,7 @@ prefill_log_files = false
 
 ## Duration for fsyncing log files.
 ## **It's only used when the provider is `raft_engine`**.
-sync_period = "10s"
+sync_period = "5s"
 
 ## Parallelism during WAL recovery.
 recovery_parallelism = 2

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -103,7 +103,7 @@ fn test_load_datanode_example_config() {
             }),
             wal: DatanodeWalConfig::RaftEngine(RaftEngineConfig {
                 dir: Some(format!("{}/{}", DEFAULT_DATA_HOME, WAL_DIR)),
-                sync_period: Some(Duration::from_secs(10)),
+                sync_period: Some(Duration::from_secs(5)),
                 recovery_parallelism: 2,
                 ..Default::default()
             }),
@@ -341,7 +341,7 @@ fn test_load_standalone_example_config() {
             auto_create_table: true,
             wal: DatanodeWalConfig::RaftEngine(RaftEngineConfig {
                 dir: Some(format!("{}/{}", DEFAULT_DATA_HOME, WAL_DIR)),
-                sync_period: Some(Duration::from_secs(10)),
+                sync_period: Some(Duration::from_secs(5)),
                 recovery_parallelism: 2,
                 ..Default::default()
             }),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

The divergence was introduced in #5677.

## What's changed and what's your intention?

The example TOMLs and the generated `config/config.md` document the default of `wal.sync_period` as `10s`, but since #5677 moved the WAL sync to a background `RepeatedTask`, an unset `sync_period` actually falls back to **5s** in `RaftEngineLogStore` (`config.sync_period.unwrap_or(Duration::from_secs(5))`). As a result, the effective fsync period depended on the deployment path: deployments based on the example configs ran with 10s, while bare configs without the option ran with 5s.

This PR aligns the documentation with the actual code behavior (5s) rather than changing the code fallback to 10s, so that no existing deployment silently gets a larger data-loss window on unexpected host shutdown:

- `config/datanode.example.toml`, `config/standalone.example.toml`: `sync_period` `10s` -> `5s`
- `config/config.md`: regenerated via `make config-docs`
- `src/cmd/tests/load_config_test.rs`: updated the two assertions accordingly

No runtime behavior changes for users who leave the option unset. Users deploying from the example configs will fsync slightly more often (5s instead of 10s), which is the more conservative direction.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.