### PR TITLE
fix(servers): bound HTTP query-result buffering to prevent memory exhaustion

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -189,6 +189,18 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Query result is too large: {} rows, exceeds the maximum of {} rows",
+        rows,
+        limit
+    ))]
+    ResultTooLarge {
+        limit: usize,
+        rows: usize,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Invalid query: {}", reason))]
     InvalidQuery {
         reason: String,
@@ -814,6 +826,8 @@ impl ErrorExt for Error {
 
             TooManyConcurrentRequests { .. } => StatusCode::RuntimeResourcesExhausted,
 
+            ResultTooLarge { .. } => StatusCode::RuntimeResourcesExhausted,
+
             ParsePromQL { source, .. } => source.status_code(),
             Other { source, .. } => source.status_code(),
 
@@ -889,6 +903,8 @@ impl ErrorExt for Error {
             CollectRecordbatch { source, .. } => source.retry_hint(),
 
             TooManyConcurrentRequests { .. } => RetryHint::Retryable,
+
+            ResultTooLarge { .. } => RetryHint::NonRetryable,
 
             _ => RetryHint::NonRetryable,
         }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -158,6 +158,9 @@ impl ExtraHttpRouterProviders {
 const DEFAULT_BODY_LIMIT: ReadableSize = ReadableSize::mb(64);
 /// Default address port for the public HTTP API server.
 const DEFAULT_HTTP_API_ADDR_PORT: u16 = 4006;
+/// Default maximum rows of a single query result the HTTP API will materialize
+/// before refusing to buffer the whole result in memory. `0` disables the limit.
+pub const DEFAULT_MAX_RESULT_ROWS: usize = 1_000_000;
 
 /// Authorization header
 pub const AUTHORIZATION_HEADER: &str = "x-greptime-auth";
@@ -248,6 +251,11 @@ pub struct HttpOptions {
 
     pub body_limit: ReadableSize,
 
+    /// Maximum rows of a single query result the HTTP API will materialize
+    /// before returning an error. This converts unbounded buffering of large
+    /// query results (memory DoS) into a clean error. Set to 0 to disable.
+    pub max_result_rows: usize,
+
     pub cors_allowed_origins: Vec<String>,
 
     pub enable_cors: bool,
@@ -273,6 +281,8 @@ impl Default for HttpOptions {
             body_limit: DEFAULT_BODY_LIMIT,
             cors_allowed_origins: Vec::new(),
             enable_cors: true,
+            max_result_rows: DEFAULT_MAX_RESULT_ROWS,
+
             experimental_enable_explain_analyze_stream: true,
             enable_api_server: false,
             api_server_addr: format!("127.0.0.1:{}", DEFAULT_HTTP_API_ADDR_PORT),
@@ -601,6 +611,9 @@ impl From<NullResponse> for HttpResponse {
 pub struct ApiState {
     pub sql_handler: ServerSqlQueryHandlerRef,
     pub experimental_enable_explain_analyze_stream: bool,
+    /// Maximum rows of a single query result the HTTP API will materialize.
+    /// `0` disables the limit.
+    pub max_result_rows: usize,
 }
 
 #[derive(Clone)]
@@ -642,6 +655,7 @@ impl HttpServerBuilder {
             experimental_enable_explain_analyze_stream: self
                 .options
                 .experimental_enable_explain_analyze_stream,
+            max_result_rows: self.options.max_result_rows,
         });
 
         Self {
@@ -1676,6 +1690,8 @@ mod test {
         // The API server is disabled by default.
         assert!(!opts.enable_api_server);
         assert_eq!(opts.api_server_addr, "127.0.0.1:4006");
+        // The query result row limit is enabled by default.
+        assert_eq!(opts.max_result_rows, DEFAULT_MAX_RESULT_ROWS);
     }
 
     #[tokio::test]
@@ -2028,7 +2044,7 @@ mod test {
         let recordbatches = RecordBatches::try_new(schema.clone(), vec![]).unwrap();
         let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
 
-        let json_resp = GreptimedbV1Response::from_output(outputs).await;
+        let json_resp = GreptimedbV1Response::from_output(outputs, DEFAULT_MAX_RESULT_ROWS).await;
         if let HttpResponse::GreptimedbV1(json_resp) = json_resp {
             let json_output = &json_resp.output[0];
             if let GreptimeQueryOutput::Records(r) = json_output {
@@ -2075,15 +2091,33 @@ mod test {
                 RecordBatches::try_new(schema.clone(), vec![recordbatch.clone()]).unwrap();
             let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
             let json_resp = match format {
-                ResponseFormat::Arrow => ArrowResponse::from_output(outputs, None).await,
-                ResponseFormat::Csv(with_names, with_types) => {
-                    CsvResponse::from_output(outputs, with_names, with_types).await
+                ResponseFormat::Arrow => {
+                    ArrowResponse::from_output(outputs, None, DEFAULT_MAX_RESULT_ROWS).await
                 }
-                ResponseFormat::Table => TableResponse::from_output(outputs).await,
-                ResponseFormat::GreptimedbV1 => GreptimedbV1Response::from_output(outputs).await,
-                ResponseFormat::InfluxdbV1 => InfluxdbV1Response::from_output(outputs, None).await,
-                ResponseFormat::Json => JsonResponse::from_output(outputs).await,
-                ResponseFormat::Null => NullResponse::from_output(outputs).await,
+                ResponseFormat::Csv(with_names, with_types) => {
+                    CsvResponse::from_output(
+                        outputs,
+                        with_names,
+                        with_types,
+                        DEFAULT_MAX_RESULT_ROWS,
+                    )
+                    .await
+                }
+                ResponseFormat::Table => {
+                    TableResponse::from_output(outputs, DEFAULT_MAX_RESULT_ROWS).await
+                }
+                ResponseFormat::GreptimedbV1 => {
+                    GreptimedbV1Response::from_output(outputs, DEFAULT_MAX_RESULT_ROWS).await
+                }
+                ResponseFormat::InfluxdbV1 => {
+                    InfluxdbV1Response::from_output(outputs, None, DEFAULT_MAX_RESULT_ROWS).await
+                }
+                ResponseFormat::Json => {
+                    JsonResponse::from_output(outputs, DEFAULT_MAX_RESULT_ROWS).await
+                }
+                ResponseFormat::Null => {
+                    NullResponse::from_output(outputs, DEFAULT_MAX_RESULT_ROWS).await
+                }
             };
 
             match json_resp {

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -1017,7 +1017,10 @@ pub(crate) async fn execute_log_context_req(
             .observe(exec_timer.elapsed().as_secs_f64());
     }
 
-    let response = GreptimedbV1Response::from_output(outputs)
+    // The outputs of a log ingestion request are `AffectedRows` results; the
+    // `max_result_rows` guard only applies to query record streams, so the
+    // default limit is used here.
+    let response = GreptimedbV1Response::from_output(outputs, crate::http::DEFAULT_MAX_RESULT_ROWS)
         .await
         .with_execution_time(exec_timer.elapsed().as_millis() as u64);
     Ok(response)

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -40,7 +40,7 @@ use sql::dialect::GreptimeDbDialect;
 use sql::parser::{ParseOptions, ParserContext};
 use sql::statements::statement::Statement;
 
-use crate::error::{FailedToParseQuerySnafu, InvalidQuerySnafu, Result};
+use crate::error::{FailedToParseQuerySnafu, InvalidQuerySnafu, Result, ResultTooLargeSnafu};
 use crate::http::header::collect_plan_metrics;
 use crate::http::result::arrow_result::ArrowResponse;
 use crate::http::result::csv_result::CsvResponse;
@@ -175,16 +175,21 @@ pub async fn sql(
 
     let mut resp = match format {
         ResponseFormat::Arrow => {
-            ArrowResponse::from_output(outputs, query_params.compression).await
+            ArrowResponse::from_output(outputs, query_params.compression, state.max_result_rows)
+                .await
         }
         ResponseFormat::Csv(with_names, with_types) => {
-            CsvResponse::from_output(outputs, with_names, with_types).await
+            CsvResponse::from_output(outputs, with_names, with_types, state.max_result_rows).await
         }
-        ResponseFormat::Table => TableResponse::from_output(outputs).await,
-        ResponseFormat::GreptimedbV1 => GreptimedbV1Response::from_output(outputs).await,
-        ResponseFormat::InfluxdbV1 => InfluxdbV1Response::from_output(outputs, epoch).await,
-        ResponseFormat::Json => JsonResponse::from_output(outputs).await,
-        ResponseFormat::Null => NullResponse::from_output(outputs).await,
+        ResponseFormat::Table => TableResponse::from_output(outputs, state.max_result_rows).await,
+        ResponseFormat::GreptimedbV1 => {
+            GreptimedbV1Response::from_output(outputs, state.max_result_rows).await
+        }
+        ResponseFormat::InfluxdbV1 => {
+            InfluxdbV1Response::from_output(outputs, epoch, state.max_result_rows).await
+        }
+        ResponseFormat::Json => JsonResponse::from_output(outputs, state.max_result_rows).await,
+        ResponseFormat::Null => NullResponse::from_output(outputs, state.max_result_rows).await,
     };
 
     if let Some(limit) = query_params.limit {
@@ -526,9 +531,65 @@ pub async fn sql_format(
     Json(SqlFormatResponse { formatted }).into_response()
 }
 
+/// Errors when the total number of rows in `batches` exceeds `max_result_rows`
+/// (`0` disables the limit). Used for results that are already materialized.
+pub(crate) fn check_max_result_rows<'a>(
+    batches: impl IntoIterator<Item = &'a RecordBatch>,
+    max_result_rows: usize,
+) -> std::result::Result<(), ErrorResponse> {
+    if max_result_rows == 0 {
+        return Ok(());
+    }
+    let total_rows = batches.into_iter().map(|b| b.num_rows()).sum::<usize>();
+    if total_rows > max_result_rows {
+        return Err(ErrorResponse::from_error(
+            ResultTooLargeSnafu {
+                limit: max_result_rows,
+                rows: total_rows,
+            }
+            .build(),
+        ));
+    }
+    Ok(())
+}
+
+/// Collects a record batch stream into a `Vec`, erroring as soon as the total
+/// number of rows exceeds `max_result_rows` (`0` disables the limit). This
+/// converts unbounded in-memory accumulation of query results (memory DoS)
+/// into a clean error while keeping the buffered result bounded.
+pub(crate) async fn collect_with_max_rows(
+    mut stream: SendableRecordBatchStream,
+    max_result_rows: usize,
+) -> std::result::Result<Vec<RecordBatch>, ErrorResponse> {
+    if max_result_rows == 0 {
+        return util::collect(stream)
+            .await
+            .map_err(|err| ErrorResponse::from_error(err));
+    }
+
+    let mut batches = Vec::new();
+    let mut total_rows = 0usize;
+    while let Some(batch) = stream.next().await {
+        let batch = batch.map_err(|err| ErrorResponse::from_error(err))?;
+        total_rows += batch.num_rows();
+        if total_rows > max_result_rows {
+            return Err(ErrorResponse::from_error(
+                ResultTooLargeSnafu {
+                    limit: max_result_rows,
+                    rows: total_rows,
+                }
+                .build(),
+            ));
+        }
+        batches.push(batch);
+    }
+    Ok(batches)
+}
+
 /// Create a response from query result
 pub async fn from_output(
     outputs: Vec<crate::error::Result<Output>>,
+    max_result_rows: usize,
 ) -> std::result::Result<(Vec<GreptimeQueryOutput>, HashMap<String, Value>), ErrorResponse> {
     // TODO(sunng87): this api response structure cannot represent error well.
     //  It hides successful execution results from error response
@@ -547,17 +608,18 @@ pub async fn from_output(
                 OutputData::Stream(stream) => {
                     let schema = stream.schema().clone();
                     // TODO(sunng87): streaming response
-                    let mut http_record_output = match util::collect(stream).await {
-                        Ok(rows) => match HttpRecordsOutput::try_new(schema, rows) {
-                            Ok(rows) => rows,
+                    let mut http_record_output =
+                        match collect_with_max_rows(stream, max_result_rows).await {
+                            Ok(rows) => match HttpRecordsOutput::try_new(schema, rows) {
+                                Ok(rows) => rows,
+                                Err(err) => {
+                                    return Err(ErrorResponse::from_error(err));
+                                }
+                            },
                             Err(err) => {
-                                return Err(ErrorResponse::from_error(err));
+                                return Err(err);
                             }
-                        },
-                        Err(err) => {
-                            return Err(ErrorResponse::from_error(err));
-                        }
-                    };
+                        };
                     if let Some(physical_plan) = o.meta.plan {
                         let mut result_map = HashMap::new();
 
@@ -572,7 +634,12 @@ pub async fn from_output(
                     results.push(GreptimeQueryOutput::Records(http_record_output))
                 }
                 OutputData::RecordBatches(rbs) => {
-                    match HttpRecordsOutput::try_new(rbs.schema(), rbs.take()) {
+                    let schema = rbs.schema();
+                    let batches = rbs.take();
+                    if let Err(err) = check_max_result_rows(&batches, max_result_rows) {
+                        return Err(err);
+                    }
+                    match HttpRecordsOutput::try_new(schema, batches) {
                         Ok(rows) => {
                             results.push(GreptimeQueryOutput::Records(rows));
                         }
@@ -682,15 +749,24 @@ pub async fn promql(
         let outputs = sql_handler.do_promql_query(&prom_query, query_ctx).await;
 
         match format {
-            ResponseFormat::Arrow => ArrowResponse::from_output(outputs, compression).await,
-            ResponseFormat::Csv(with_names, with_types) => {
-                CsvResponse::from_output(outputs, with_names, with_types).await
+            ResponseFormat::Arrow => {
+                ArrowResponse::from_output(outputs, compression, state.max_result_rows).await
             }
-            ResponseFormat::Table => TableResponse::from_output(outputs).await,
-            ResponseFormat::GreptimedbV1 => GreptimedbV1Response::from_output(outputs).await,
-            ResponseFormat::InfluxdbV1 => InfluxdbV1Response::from_output(outputs, epoch).await,
-            ResponseFormat::Json => JsonResponse::from_output(outputs).await,
-            ResponseFormat::Null => NullResponse::from_output(outputs).await,
+            ResponseFormat::Csv(with_names, with_types) => {
+                CsvResponse::from_output(outputs, with_names, with_types, state.max_result_rows)
+                    .await
+            }
+            ResponseFormat::Table => {
+                TableResponse::from_output(outputs, state.max_result_rows).await
+            }
+            ResponseFormat::GreptimedbV1 => {
+                GreptimedbV1Response::from_output(outputs, state.max_result_rows).await
+            }
+            ResponseFormat::InfluxdbV1 => {
+                InfluxdbV1Response::from_output(outputs, epoch, state.max_result_rows).await
+            }
+            ResponseFormat::Json => JsonResponse::from_output(outputs, state.max_result_rows).await,
+            ResponseFormat::Null => NullResponse::from_output(outputs, state.max_result_rows).await,
         }
     };
 
@@ -828,5 +904,51 @@ mod tests {
         let value: Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(value["state"], "error");
         assert_eq!(value["reason"], "conversion failed");
+    }
+
+    #[tokio::test]
+    async fn http_query_output_stream_respects_max_result_rows() {
+        use common_recordbatch::{RecordBatch, RecordBatches};
+        use datatypes::prelude::*;
+        use datatypes::schema::{ColumnSchema, Schema};
+        use datatypes::vectors::UInt32Vector;
+
+        let column_schemas = vec![ColumnSchema::new(
+            "numbers",
+            ConcreteDataType::uint32_datatype(),
+            false,
+        )];
+        let schema = Arc::new(Schema::new(column_schemas));
+        let recordbatch = RecordBatch::new(
+            schema.clone(),
+            [Arc::new(UInt32Vector::from_slice(vec![1, 2, 3, 4])) as _],
+        )
+        .unwrap();
+        let recordbatches = RecordBatches::try_new(schema, vec![recordbatch]).unwrap();
+
+        // A stream larger than the limit errors cleanly instead of being
+        // collected into memory in full.
+        let outputs = vec![Ok(Output::new(
+            OutputData::Stream(recordbatches.as_stream()),
+            Default::default(),
+        ))];
+        let result = from_output(outputs, 2).await;
+        let err = result.expect_err("must error when the result exceeds the limit");
+        assert_eq!(err.code(), StatusCode::RuntimeResourcesExhausted as u32);
+        assert!(err.error().contains("maximum of 2"));
+
+        // A stream within the limit is collected normally.
+        let outputs = vec![Ok(Output::new(
+            OutputData::Stream(recordbatches.as_stream()),
+            Default::default(),
+        ))];
+        let (output, _) = from_output(outputs, 4)
+            .await
+            .expect("must succeed when the result is within the limit");
+        let records = match output.first().unwrap() {
+            GreptimeQueryOutput::Records(records) => records,
+            _ => unreachable!(),
+        };
+        assert_eq!(records.num_rows(), 4);
     }
 }

--- a/src/servers/src/http/logs.rs
+++ b/src/servers/src/http/logs.rs
@@ -50,7 +50,10 @@ pub async fn logs(
         .start_timer();
 
     let output = handler.query(params, query_ctx).await;
-    let resp = GreptimedbV1Response::from_output(vec![output]).await;
+    // Bound the query result by the default `max_result_rows` limit so log
+    // queries cannot buffer unbounded results in memory.
+    let resp =
+        GreptimedbV1Response::from_output(vec![output], crate::http::DEFAULT_MAX_RESULT_ROWS).await;
 
     resp.with_execution_time(exec_start.elapsed().as_millis() as u64)
         .into_response()

--- a/src/servers/src/http/result/arrow_result.rs
+++ b/src/servers/src/http/result/arrow_result.rs
@@ -27,10 +27,10 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
-use crate::error::{self, Error};
+use crate::error::{self, Error, ResultTooLargeSnafu};
 use crate::http::header::{GREPTIME_DB_HEADER_EXECUTION_TIME, GREPTIME_DB_HEADER_FORMAT};
 use crate::http::result::error_result::ErrorResponse;
-use crate::http::{HttpResponse, ResponseFormat};
+use crate::http::{HttpResponse, ResponseFormat, handler};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ArrowResponse {
@@ -42,8 +42,10 @@ async fn write_arrow_bytes(
     mut recordbatches: Pin<Box<dyn RecordBatchStream + Send>>,
     schema: &Arc<Schema>,
     compression: Option<CompressionType>,
+    max_result_rows: usize,
 ) -> Result<Vec<u8>, Error> {
     let mut bytes = Vec::new();
+    let mut total_rows = 0usize;
     {
         let options = IpcWriteOptions::default()
             .try_with_compression(compression)
@@ -53,6 +55,14 @@ async fn write_arrow_bytes(
 
         while let Some(rb) = recordbatches.next().await {
             let rb = rb.context(error::CollectRecordbatchSnafu)?;
+            total_rows += rb.num_rows();
+            if max_result_rows > 0 && total_rows > max_result_rows {
+                return ResultTooLargeSnafu {
+                    limit: max_result_rows,
+                    rows: total_rows,
+                }
+                .fail();
+            }
             writer
                 .write(&rb.into_df_record_batch())
                 .context(error::ArrowSnafu)?;
@@ -79,6 +89,7 @@ impl ArrowResponse {
     pub async fn from_output(
         mut outputs: Vec<error::Result<Output>>,
         compression: Option<String>,
+        max_result_rows: usize,
     ) -> HttpResponse {
         if outputs.len() > 1 {
             return HttpResponse::Error(ErrorResponse::from_error_message(
@@ -101,8 +112,18 @@ impl ArrowResponse {
                 }),
                 OutputData::RecordBatches(batches) => {
                     let schema = batches.schema();
-                    match write_arrow_bytes(batches.as_stream(), schema.arrow_schema(), compression)
-                        .await
+                    if let Err(err) =
+                        handler::check_max_result_rows(batches.iter(), max_result_rows)
+                    {
+                        return HttpResponse::Error(err);
+                    }
+                    match write_arrow_bytes(
+                        batches.as_stream(),
+                        schema.arrow_schema(),
+                        compression,
+                        max_result_rows,
+                    )
+                    .await
                     {
                         Ok(payload) => HttpResponse::Arrow(ArrowResponse {
                             data: payload,
@@ -113,7 +134,14 @@ impl ArrowResponse {
                 }
                 OutputData::Stream(batches) => {
                     let schema = batches.schema();
-                    match write_arrow_bytes(batches, schema.arrow_schema(), compression).await {
+                    match write_arrow_bytes(
+                        batches,
+                        schema.arrow_schema(),
+                        compression,
+                        max_result_rows,
+                    )
+                    .await
+                    {
                         Ok(payload) => HttpResponse::Arrow(ArrowResponse {
                             data: payload,
                             execution_time_ms: 0,
@@ -196,7 +224,7 @@ mod test {
                 RecordBatches::try_new(schema.clone(), vec![recordbatch.clone()]).unwrap();
             let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
 
-            let http_resp = ArrowResponse::from_output(outputs, compression).await;
+            let http_resp = ArrowResponse::from_output(outputs, compression, usize::MAX).await;
             match http_resp {
                 HttpResponse::Arrow(resp) => {
                     let output = resp.data;
@@ -217,6 +245,62 @@ mod test {
                 }
                 _ => unreachable!(),
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn http_arrow_response_bounded() {
+        use common_error::status_code::StatusCode;
+
+        let column_schemas = vec![ColumnSchema::new(
+            "numbers",
+            ConcreteDataType::uint32_datatype(),
+            false,
+        )];
+        let schema = Arc::new(Schema::new(column_schemas));
+
+        // A result larger than the limit errors cleanly instead of being buffered whole.
+        let columns: Vec<VectorRef> = vec![Arc::new(UInt32Vector::from_slice(vec![1, 2, 3, 4]))];
+        let recordbatch = RecordBatch::new(schema.clone(), columns).unwrap();
+        let recordbatches = RecordBatches::try_new(schema.clone(), vec![recordbatch]).unwrap();
+        let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
+        match ArrowResponse::from_output(outputs, None, 2).await {
+            HttpResponse::Error(err) => {
+                assert_eq!(err.code(), StatusCode::RuntimeResourcesExhausted as u32);
+                assert!(err.error().contains("maximum of 2"));
+            }
+            _ => panic!("expected error response"),
+        }
+
+        // A result within the limit still works.
+        let columns: Vec<VectorRef> = vec![Arc::new(UInt32Vector::from_slice(vec![1, 2, 3, 4]))];
+        let recordbatch = RecordBatch::new(schema.clone(), columns).unwrap();
+        let recordbatches = RecordBatches::try_new(schema.clone(), vec![recordbatch]).unwrap();
+        let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
+        match ArrowResponse::from_output(outputs, None, 4).await {
+            HttpResponse::Arrow(resp) => {
+                let mut reader = StreamReader::try_new(Cursor::new(resp.data), None)
+                    .expect("Arrow reader error");
+                let rb = reader.next().unwrap().expect("read record batch failed");
+                assert_eq!(rb.num_rows(), 4);
+            }
+            _ => panic!("expected arrow response"),
+        }
+
+        // A stream that overflows the limit is also rejected.
+        let columns: Vec<VectorRef> = vec![Arc::new(UInt32Vector::from_slice(vec![5, 6, 7, 8]))];
+        let recordbatch = RecordBatch::new(schema.clone(), columns).unwrap();
+        let recordbatches = RecordBatches::try_new(schema, vec![recordbatch]).unwrap();
+        let outputs = vec![Ok(Output::new(
+            OutputData::Stream(recordbatches.as_stream()),
+            Default::default(),
+        ))];
+        match ArrowResponse::from_output(outputs, None, 3).await {
+            HttpResponse::Error(err) => {
+                assert_eq!(err.code(), StatusCode::RuntimeResourcesExhausted as u32);
+                assert!(err.error().contains("maximum of 3"));
+            }
+            _ => panic!("expected error response"),
         }
     }
 }

--- a/src/servers/src/http/result/csv_result.rs
+++ b/src/servers/src/http/result/csv_result.rs
@@ -37,8 +37,9 @@ impl CsvResponse {
         outputs: Vec<crate::error::Result<Output>>,
         with_names: bool,
         with_types: bool,
+        max_result_rows: usize,
     ) -> HttpResponse {
-        match handler::from_output(outputs).await {
+        match handler::from_output(outputs, max_result_rows).await {
             Err(err) => HttpResponse::Error(err),
             Ok((output, _)) => {
                 if output.len() > 1 {
@@ -284,7 +285,7 @@ mod tests {
         let output = Output::new_with_record_batches(recordbatches);
         let outputs = vec![Ok(output)];
 
-        let resp = CsvResponse::from_output(outputs, with_names, with_types)
+        let resp = CsvResponse::from_output(outputs, with_names, with_types, usize::MAX)
             .await
             .into_response();
         let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();

--- a/src/servers/src/http/result/greptime_result_v1.rs
+++ b/src/servers/src/http/result/greptime_result_v1.rs
@@ -39,8 +39,11 @@ pub struct GreptimedbV1Response {
 }
 
 impl GreptimedbV1Response {
-    pub async fn from_output(outputs: Vec<crate::error::Result<Output>>) -> HttpResponse {
-        match handler::from_output(outputs).await {
+    pub async fn from_output(
+        outputs: Vec<crate::error::Result<Output>>,
+        max_result_rows: usize,
+    ) -> HttpResponse {
+        match handler::from_output(outputs, max_result_rows).await {
             Ok((output, resp_metrics)) => HttpResponse::GreptimedbV1(Self {
                 output,
                 execution_time_ms: 0,

--- a/src/servers/src/http/result/influxdb_result_v1.rs
+++ b/src/servers/src/http/result/influxdb_result_v1.rs
@@ -16,7 +16,7 @@ use axum::Json;
 use axum::http::HeaderValue;
 use axum::response::{IntoResponse, Response};
 use common_query::{Output, OutputData};
-use common_recordbatch::{RecordBatch, util};
+use common_recordbatch::RecordBatch;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -136,6 +136,7 @@ impl InfluxdbV1Response {
     pub async fn from_output(
         outputs: Vec<crate::error::Result<Output>>,
         epoch: Option<Epoch>,
+        max_result_rows: usize,
     ) -> HttpResponse {
         // TODO(sunng87): this api response structure cannot represent error well.
         //  It hides successful execution results from error response
@@ -153,7 +154,12 @@ impl InfluxdbV1Response {
                         }
                         OutputData::Stream(stream) => {
                             // TODO(sunng87): streaming response
-                            match util::collect(stream).await {
+                            match crate::http::handler::collect_with_max_rows(
+                                stream,
+                                max_result_rows,
+                            )
+                            .await
+                            {
                                 Ok(rows) => match InfluxdbRecordsOutput::try_from((epoch, rows)) {
                                     Ok(rows) => {
                                         results.push(InfluxdbOutput {
@@ -166,12 +172,19 @@ impl InfluxdbV1Response {
                                     }
                                 },
                                 Err(err) => {
-                                    return HttpResponse::Error(ErrorResponse::from_error(err));
+                                    return HttpResponse::Error(err);
                                 }
                             }
                         }
                         OutputData::RecordBatches(rbs) => {
-                            match InfluxdbRecordsOutput::try_from((epoch, rbs.take())) {
+                            let batches = rbs.take();
+                            if let Err(err) = crate::http::handler::check_max_result_rows(
+                                &batches,
+                                max_result_rows,
+                            ) {
+                                return HttpResponse::Error(err);
+                            }
+                            match InfluxdbRecordsOutput::try_from((epoch, batches)) {
                                 Ok(rows) => {
                                     results.push(InfluxdbOutput {
                                         statement_id,

--- a/src/servers/src/http/result/json_result.rs
+++ b/src/servers/src/http/result/json_result.rs
@@ -31,10 +31,12 @@ pub struct JsonResponse {
     output: Vec<GreptimeQueryOutput>,
     execution_time_ms: u64,
 }
-
 impl JsonResponse {
-    pub async fn from_output(outputs: Vec<crate::error::Result<Output>>) -> HttpResponse {
-        match handler::from_output(outputs).await {
+    pub async fn from_output(
+        outputs: Vec<crate::error::Result<Output>>,
+        max_result_rows: usize,
+    ) -> HttpResponse {
+        match handler::from_output(outputs, max_result_rows).await {
             Err(err) => HttpResponse::Error(err),
             Ok((output, _)) => {
                 if output.len() > 1 {
@@ -131,5 +133,59 @@ impl IntoResponse for JsonResponse {
             payload,
         )
             .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::status_code::StatusCode;
+    use common_query::Output;
+    use common_recordbatch::{RecordBatch, RecordBatches};
+    use datatypes::prelude::*;
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::{UInt32Vector, VectorRef};
+
+    use super::*;
+
+    fn numbers_recordbatches() -> RecordBatches {
+        let column_schemas = vec![ColumnSchema::new(
+            "numbers",
+            ConcreteDataType::uint32_datatype(),
+            false,
+        )];
+        let schema = Arc::new(Schema::new(column_schemas));
+        let columns: Vec<VectorRef> = vec![Arc::new(UInt32Vector::from_slice(vec![1, 2, 3, 4]))];
+        let recordbatch = RecordBatch::new(schema.clone(), columns).unwrap();
+        RecordBatches::try_new(schema, vec![recordbatch]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn http_json_response_respects_max_result_rows() {
+        // A result larger than the limit errors cleanly instead of being buffered whole.
+        let recordbatches = numbers_recordbatches();
+        let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
+        match JsonResponse::from_output(outputs, 2).await {
+            HttpResponse::Error(err) => {
+                assert_eq!(err.code(), StatusCode::RuntimeResourcesExhausted as u32);
+                assert!(err.error().contains("maximum of 2"));
+            }
+            _ => panic!("expected error response"),
+        }
+
+        // A result within the limit still works.
+        let recordbatches = numbers_recordbatches();
+        let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
+        match JsonResponse::from_output(outputs, 4).await {
+            HttpResponse::Json(resp) => {
+                let records = match resp.output().first().unwrap() {
+                    GreptimeQueryOutput::Records(records) => records,
+                    _ => unreachable!(),
+                };
+                assert_eq!(records.num_rows(), 4);
+            }
+            _ => panic!("expected json response"),
+        }
     }
 }

--- a/src/servers/src/http/result/null_result.rs
+++ b/src/servers/src/http/result/null_result.rs
@@ -39,8 +39,11 @@ pub struct NullResponse {
 }
 
 impl NullResponse {
-    pub async fn from_output(outputs: Vec<crate::error::Result<Output>>) -> HttpResponse {
-        match handler::from_output(outputs).await {
+    pub async fn from_output(
+        outputs: Vec<crate::error::Result<Output>>,
+        max_result_rows: usize,
+    ) -> HttpResponse {
+        match handler::from_output(outputs, max_result_rows).await {
             Err(err) => HttpResponse::Error(err),
             Ok((mut output, _)) => {
                 if output.len() > 1 {

--- a/src/servers/src/http/result/table_result.rs
+++ b/src/servers/src/http/result/table_result.rs
@@ -34,8 +34,11 @@ pub struct TableResponse {
 }
 
 impl TableResponse {
-    pub async fn from_output(outputs: Vec<crate::error::Result<Output>>) -> HttpResponse {
-        match handler::from_output(outputs).await {
+    pub async fn from_output(
+        outputs: Vec<crate::error::Result<Output>>,
+        max_result_rows: usize,
+    ) -> HttpResponse {
+        match handler::from_output(outputs, max_result_rows).await {
             Err(err) => HttpResponse::Error(err),
             Ok((output, _)) => {
                 if output.len() > 1 {

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -24,6 +24,7 @@ use axum::extract::{Json, Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
+use common_error::status_code::StatusCode as ErrorStatusCode;
 use common_query::{Output, OutputData};
 use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, SendableRecordBatchStream};
@@ -163,6 +164,7 @@ async fn test_sql_not_provided() {
     let api_state = ApiState {
         sql_handler,
         experimental_enable_explain_analyze_stream: false,
+        max_result_rows: HttpOptions::default().max_result_rows,
     };
 
     for format in ["greptimedb_v1", "influxdb_v1", "csv", "table"] {
@@ -197,6 +199,7 @@ async fn test_sql_output_rows() {
     let api_state = ApiState {
         sql_handler,
         experimental_enable_explain_analyze_stream: false,
+        max_result_rows: HttpOptions::default().max_result_rows,
     };
 
     let query_sql = "select sum(uint32s) from numbers limit 20";
@@ -305,6 +308,7 @@ async fn test_dashboard_sql_limit() {
     let api_state = ApiState {
         sql_handler,
         experimental_enable_explain_analyze_stream: false,
+        max_result_rows: HttpOptions::default().max_result_rows,
     };
     for format in ["greptimedb_v1", "csv", "table"] {
         let query = create_query(format, "select * from numbers", Some(1000));
@@ -351,6 +355,7 @@ async fn test_sql_form() {
     let api_state = ApiState {
         sql_handler,
         experimental_enable_explain_analyze_stream: false,
+        max_result_rows: HttpOptions::default().max_result_rows,
     };
 
     for format in ["greptimedb_v1", "influxdb_v1", "csv", "table", "null"] {
@@ -731,4 +736,74 @@ async fn get_body(response: Response) -> Bytes {
     axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap()
+}
+
+#[tokio::test]
+async fn test_http_query_result_respects_max_result_rows() {
+    common_telemetry::init_default_ut_logging();
+
+    let sql_handler = create_testing_sql_query_handler(MemTable::specified_numbers_table(2000));
+    let ctx = QueryContext::with_db_name(None);
+    ctx.set_current_user(auth::userinfo_by_name(None));
+    let api_state = ApiState {
+        sql_handler,
+        experimental_enable_explain_analyze_stream: false,
+        max_result_rows: 100,
+    };
+
+    // A query returning more rows than the limit errors cleanly.
+    for format in [
+        "greptimedb_v1",
+        "json",
+        "csv",
+        "table",
+        "influxdb_v1",
+        "arrow",
+    ] {
+        let query = create_query(format, "select * from numbers", None);
+        let resp = http_handler::sql(
+            State(api_state.clone()),
+            query,
+            axum::Extension(ctx.clone()),
+            Form(http_handler::SqlQuery::default()),
+        )
+        .await;
+        let HttpResponse::Error(err) = resp else {
+            panic!("expected error response for format {format}");
+        };
+        assert_eq!(
+            err.code(),
+            ErrorStatusCode::RuntimeResourcesExhausted as u32,
+            "format {format}"
+        );
+        assert!(err.error().contains("maximum of 100"), "format {format}");
+    }
+
+    // A query within the limit still works.
+    let api_state = ApiState {
+        sql_handler: create_testing_sql_query_handler(MemTable::specified_numbers_table(50)),
+        experimental_enable_explain_analyze_stream: false,
+        max_result_rows: 100,
+    };
+    for format in ["greptimedb_v1", "json"] {
+        let query = create_query(format, "select * from numbers", None);
+        let resp = http_handler::sql(
+            State(api_state.clone()),
+            query,
+            axum::Extension(ctx.clone()),
+            Form(http_handler::SqlQuery::default()),
+        )
+        .await;
+        match resp {
+            HttpResponse::GreptimedbV1(resp) => match resp.output().first().unwrap() {
+                Records(records) => assert_eq!(records.num_rows(), 50),
+                _ => unreachable!(),
+            },
+            HttpResponse::Json(resp) => match resp.output().first().unwrap() {
+                Records(records) => assert_eq!(records.num_rows(), 50),
+                _ => unreachable!(),
+            },
+            _ => panic!("expected success response for format {format}"),
+        }
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

Fixes unbounded query-result buffering in the HTTP response paths: JSON/Arrow/CSV/influxdb handlers collected the entire result set in memory before returning, so a large result (or many concurrent large queries) could exhaust server memory (memory DoS).

Adds `HttpOptions.max_result_rows` (default 1,000,000; 0 = unlimited), enforced at every unbounded accumulation point (JSON stream collect, influxdb_v1 collect, Arrow `write_arrow_bytes`/RecordBatches). Oversized results return a clean `ResultTooLarge` error (`StatusCode::RuntimeResourcesExhausted`) instead of exhausting memory.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
