### PR TITLE
feat(promql): define native histogram semantics

### DIFF
--- a/docs/rfcs/2026-08-04-native-histograms.md
+++ b/docs/rfcs/2026-08-04-native-histograms.md
@@ -153,7 +153,7 @@ The rejected alternative is Prometheus's direct-sum/Kahan-compensation design
 with an overflow-triggered mode change. It offers closer rounding parity but
 requires additional state and substantially more merge logic.
 
-## Equality and changes
+## Equality, changes, and resets
 
 Equality follows Prometheus's represented-layout semantics. Histograms compare
 equal only when their represented bucket-index sequences and bucket value bit
@@ -165,6 +165,9 @@ and reset hints and start timestamps remain excluded.
 Custom bucket bounds use ordinary floating-point equality rather than bitwise
 equality, matching Prometheus's `CustomBucketBoundsMatch`. Histogram payload
 values continue to use bitwise equality so NaN payloads behave deterministically.
+
+`resets()` counts ordinary counter resets and, unlike Prometheus, also counts
+each transition between gauge and non-gauge native histograms as one reset.
 
 ## Annotations
 

--- a/docs/rfcs/2026-08-04-native-histograms.md
+++ b/docs/rfcs/2026-08-04-native-histograms.md
@@ -1,0 +1,225 @@
+---
+Feature Name: Native Histogram Support and Compatibility Decisions
+Tracking Issue: TBD
+Date: 2026-08-04
+Author: TBD
+---
+
+# Summary
+
+GreptimeDB stores a Prometheus native histogram in one Struct-valued field and
+evaluates it as a first-class PromQL sample. This document records the supported
+protocols, the storage invariant, and the compatibility decisions needed to make
+that path predictable.
+
+Native histograms are experimental. Prometheus Remote Write 2.0 is the only
+supported native-histogram ingestion protocol. Remote Write 1.0 histogram
+payloads are rejected instead of being acknowledged and dropped.
+Native-histogram Remote Read is deferred; the existing Remote Read path
+continues to return scalar samples only.
+
+# Goals
+
+1. Prevent silent native-histogram data loss at protocol boundaries.
+2. Keep one stable persisted representation for integer, float, exponential,
+   and custom-bucket native histograms.
+3. Match Prometheus query behavior where it is observable and practical.
+4. State intentional limitations explicitly so incomplete behavior is not
+   mistaken for support.
+
+# Non-Goals
+
+- Supporting native histograms in Remote Write 1.0.
+- Returning native histograms through Prometheus Remote Read.
+- Persisting Remote Write metric metadata.
+- Ingesting OTLP exponential histograms.
+- Persisting exemplars.
+- Removing mixed float/histogram handling from PromQL expressions.
+- Propagating PromQL annotations produced on datanodes back to the frontend.
+
+# Data Model and Invariants
+
+Each native histogram is stored in the configured native-histogram field
+(`greptime_native_histogram` by default), a Struct whose children preserve the
+wire-level schema, zero threshold, sum, reset hint, start timestamp, custom
+bounds, spans, and either the integer or float count family.
+Integer bucket deltas are converted to absolute integer counts for storage;
+float bucket counts are already absolute. No separate sample-kind discriminator
+is stored because the populated count family identifies it.
+
+Within one resolved catalog, schema, and physical-table routing context, a
+metric name has exactly one persisted sample kind:
+
+- a float metric uses `greptime_value`;
+- a native-histogram metric uses the configured native-histogram field.
+
+Labels do not change that choice. Remote Write 2.0 rejects a request when two
+label sets use different sample kinds for the same metric, and the existing
+table schema rejects kind changes across requests. Prometheus metadata type is
+not used for this decision: a classic histogram family is described as a
+histogram but is represented by float-valued `_bucket`, `_sum`, and `_count`
+series.
+
+The storage invariant does not remove the need for mixed-sample PromQL support.
+An expression can combine different metrics or branches, for example with
+`or`, and therefore produce a vector containing float samples and histogram
+samples from different series.
+
+# Protocol Decisions
+
+## Remote Write 1.0
+
+Remote Write 1.0 scalar samples remain supported. Any `TimeSeries.histograms`
+field causes the complete request to fail with an invalid-arguments response.
+Rejecting at protobuf decode time prevents both histogram-only data loss and
+partial ingestion of a request that mixes scalar and histogram series. Clients
+that send native histograms must use Remote Write 2.0.
+
+## Remote Write 2.0
+
+Remote Write 2.0 accepts integer and float native histograms while
+`http.experimental_enable_prometheus_native_histogram` is enabled. Supported
+exponential schemas are `-4` through `8`; schema `-53` represents native
+histograms with custom buckets.
+
+Exponential spans may end at the schema's overflow bucket but must not continue
+beyond it. The overflow index is `(1024 << schema) + 1` for non-negative schemas
+and `(1024 >> -schema) + 1` for negative schemas. Inputs beyond that index are
+rejected rather than clamped or merged into infinity.
+
+Exemplars and declared metric metadata are accepted on the wire but are not
+persisted by this feature.
+
+## Remote Read
+
+Native-histogram Remote Read is deferred. GreptimeDB's existing Remote Read path
+continues to negotiate `SAMPLES` responses and serialize scalar samples only.
+
+A follow-up can map the stored Struct into `TimeSeries.histograms`. It must
+preserve integer counts without passing through `f64`, retain the stored
+histogram fields, and decide sampled versus streamed response coverage. The
+sampled protobuf has no start-timestamp field, so that omission must remain
+explicit if sampled responses are implemented.
+
+## OTLP
+
+OTLP exponential histograms are not converted in this version. The ingestion
+branch intentionally remains deferred until it can map temporality, scale,
+reset behavior, attributes, and rejected-point reporting into the canonical
+native-histogram path. The code carries an explicit TODO rather than a partial
+encoder.
+
+# PromQL Compatibility Decisions
+
+## Staleness
+
+A native histogram is stale only when its `sum` has Prometheus's stale-NaN bit
+pattern. Ordinary NaN sums remain samples. Range selectors remove stale markers
+before range functions run. Instant selectors treat the marker as the end of
+the series for lookback purposes and do not resurrect an older sample.
+
+## Start timestamps
+
+Reset detection already uses consecutive start timestamps in addition to
+bucket and count monotonicity. Counter `rate` and `increase` also use the first
+histogram's start timestamp as a synthetic zero when it is nonzero and strictly
+inside the query window before the first sample. This permits the same
+single-sample calculation as Prometheus and prevents left extrapolation past the
+known start.
+
+This behavior is native-histogram-only. GreptimeDB does not persist start
+timestamps for float samples, so float `rate` and `increase` still require two
+samples. Warnings for overlapping start timestamps are deferred.
+
+## Arithmetic and averages
+
+Histogram addition and subtraction always reconcile layouts, including empty
+histograms. Mixing exponential and custom layouts fails; custom layouts are
+reconciled according to their shared bounds. The only layout bypass is local to
+counter rate: when the first-to-second pair is a reset, the first sample's
+layout is irrelevant and the second sample starts the accumulated segment.
+
+`avg` and `avg_over_time` use a mergeable weighted running mean. This prevents a
+finite mean from becoming infinity solely because the intermediate sum
+overflowed. Native-histogram aggregates are not currently split into datanode
+partial aggregation and frontend state merging, so this state does not cross
+nodes or versions. If distributed stepping is added later, its state must be
+versioned before rolling upgrades can safely mix implementations.
+
+The rejected alternative is Prometheus's direct-sum/Kahan-compensation design
+with an overflow-triggered mode change. It offers closer rounding parity but
+requires additional state and substantially more merge logic.
+
+## Equality and changes
+
+Equality follows Prometheus's represented-layout semantics. Histograms compare
+equal only when their represented bucket-index sequences and bucket value bit
+patterns match. An explicitly represented zero bucket therefore differs from an
+omitted bucket, and `changes()` observes that layout change. Redundant
+zero-length span encodings are normalized, malformed layouts compare unequal,
+and reset hints and start timestamps remain excluded.
+
+Custom bucket bounds use ordinary floating-point equality rather than bitwise
+equality, matching Prometheus's `CustomBucketBoundsMatch`. Histogram payload
+values continue to use bitwise equality so NaN payloads behave deterministically.
+
+## Annotations
+
+Warnings and infos produced by frontend-executed PromQL functions are returned
+through the corresponding Prometheus JSON response fields. Annotations produced
+while a pushed-down plan executes on a datanode are not yet transported back to
+the frontend. The sample-dropping behavior is unchanged, but those remote
+annotations remain silent until a query-result transport is defined for them.
+
+## Standard deviation and bucket bounds
+
+Custom-bucket standard deviation and variance use the arithmetic midpoint
+`(lower + upper) / 2` for every bucket. Underflow and overflow buckets therefore
+naturally produce infinite or NaN estimates. Exponential buckets retain the
+signed geometric midpoint, with zero used for a bucket spanning zero.
+
+Boundary calculation returns the last finite boundary as `f64::MAX`, the
+overflow boundary as positive infinity, and rejects indices beyond the
+overflow bucket. Widened integer arithmetic prevents large negative-schema
+indices from wrapping into an unrelated finite boundary.
+
+# Metric Metadata
+
+The Prometheus `/metadata` endpoint currently derives metric names from logical
+table names and reads type and unit from semantic table options stamped at table
+creation. Native-histogram tables without a declared type fall back to
+`histogram`. Help is always empty, and unit is absent for tables without a
+semantic unit option.
+
+Persisting declared Remote Write metadata is separate work. Reusing table
+options alone is insufficient because metadata-only writes, later updates, and
+existing tables do not pass through auto-create. An in-memory registry would
+lose data on restart. The recommended follow-up is a persistent registry keyed
+by catalog, schema, and metric family, populated by Remote Write 1.0 metadata-only
+requests and Remote Write 2.0 per-series metadata. This follows the update
+boundary already recorded in
+[Table Semantic Layer](2026-05-28-table-semantic-layer.md).
+
+# Testing and Compatibility
+
+Compatibility coverage includes protocol rejection, kind exclusivity,
+stale-marker selector semantics, synthetic-zero rates, incompatible empty
+layouts, overflow-safe averages, layout-sensitive equality, infinite custom
+midpoints, and exponential overflow indices for schemas `-4`, `0`, and `8`.
+Behavioral coverage also verifies frontend PromQL warning and info responses.
+
+This work does not change GreptimeDB's persisted Struct, protobuf dependencies,
+or public configuration. Existing native-histogram data remains readable.
+
+# Future Work
+
+- Native-histogram Remote Read, including exact integer round-trips and streamed
+  chunks with start timestamps.
+- OTLP exponential-histogram conversion with partial-success reporting.
+- Persistent Remote Write metadata and accurate help/unit updates.
+- Native-histogram exemplars and exemplar query APIs.
+- Start-timestamp overlap annotations.
+- Datanode-to-frontend PromQL annotation propagation.
+- Versioned two-phase native-histogram aggregation state.
+- Exact Prometheus summation compensation if measured precision differences
+  justify the extra aggregate state.

--- a/docs/rfcs/2026-08-04-native-histograms.md
+++ b/docs/rfcs/2026-08-04-native-histograms.md
@@ -125,7 +125,10 @@ bucket and count monotonicity. Counter `rate` and `increase` also use the first
 histogram's start timestamp as a synthetic zero when it is nonzero and strictly
 inside the query window before the first sample. This permits the same
 single-sample calculation as Prometheus and prevents left extrapolation past the
-known start.
+known start. When no usable start timestamp exists, a positive histogram-count
+increase lets counter extrapolation infer a zero point from the first count to
+cap left extrapolation; a synthetic zero uses its known timestamp instead of
+that heuristic.
 
 This behavior is native-histogram-only. GreptimeDB does not persist start
 timestamps for float samples, so float `rate` and `increase` still require two

--- a/docs/rfcs/2026-08-04-native-histograms.md
+++ b/docs/rfcs/2026-08-04-native-histograms.md
@@ -2,7 +2,7 @@
 Feature Name: Native Histogram Support and Compatibility Decisions
 Tracking Issue: TBD
 Date: 2026-08-04
-Author: TBD
+Author: codex
 ---
 
 # Summary

--- a/src/common/query/src/native_histogram.rs
+++ b/src/common/query/src/native_histogram.rs
@@ -306,17 +306,6 @@ impl NativeHistogram {
     /// Returns `None` when the layouts are invalid or cannot be reconciled.
     pub fn add(&self, other: &Self) -> Option<Self> {
         let reset_hint = add_reset_hint(self.reset_hint, other.reset_hint);
-        if self.is_empty_payload() {
-            let mut result = other.clone();
-            result.reset_hint = reset_hint;
-            return result.compact();
-        }
-        if other.is_empty_payload() {
-            let mut result = self.clone();
-            result.reset_hint = reset_hint;
-            return result.compact();
-        }
-
         let (left, right) = self.reconcile(other)?;
         left.combine_exact(&right, reset_hint, |left, right| left + right)?
             .compact()
@@ -326,13 +315,6 @@ impl NativeHistogram {
     ///
     /// Returns `None` when the layouts are invalid or cannot be reconciled.
     pub fn sub(&self, other: &Self) -> Option<Self> {
-        if self.is_empty_payload() {
-            return other.clone().negated().compact();
-        }
-        if other.is_empty_payload() {
-            return self.clone().into_gauge().compact();
-        }
-
         let (left, right) = self.reconcile(other)?;
         left.combine_exact(&right, CounterResetHint::Gauge, |left, right| left - right)?
             .compact()
@@ -372,7 +354,7 @@ impl NativeHistogram {
 
     /// Compares PromQL-visible payload values by their exact bit patterns.
     ///
-    /// Reset hints, start timestamps, and sparse zero placement are ignored.
+    /// Reset hints and start timestamps are ignored.
     pub fn promql_eq(&self, other: &Self) -> bool {
         self.schema == other.schema
             && self.zero_threshold == other.zero_threshold
@@ -380,13 +362,13 @@ impl NativeHistogram {
             && self.count.to_bits() == other.count.to_bits()
             && self.zero_count.to_bits() == other.zero_count.to_bits()
             && self.sum.to_bits() == other.sum.to_bits()
-            && side_counts_equal(
+            && side_layout_equal(
                 &self.positive_spans,
                 &self.positive_buckets,
                 &other.positive_spans,
                 &other.positive_buckets,
             )
-            && side_counts_equal(
+            && side_layout_equal(
                 &self.negative_spans,
                 &self.negative_buckets,
                 &other.negative_spans,
@@ -792,17 +774,11 @@ impl NativeHistogram {
     }
 
     fn bucket_midpoint(&self, bucket: &Bucket) -> f64 {
-        if bucket.lower == f64::NEG_INFINITY && bucket.upper == f64::INFINITY {
-            return 0.0;
-        }
-        if bucket.lower == f64::NEG_INFINITY {
-            return bucket.upper;
-        }
-        if bucket.upper == f64::INFINITY {
-            return bucket.lower;
-        }
-        if self.uses_custom_buckets() || (bucket.lower <= 0.0 && bucket.upper >= 0.0) {
+        if self.uses_custom_buckets() {
             return (bucket.lower + bucket.upper) / 2.0;
+        }
+        if bucket.lower <= 0.0 && bucket.upper >= 0.0 {
+            return 0.0;
         }
         if bucket.upper < 0.0 {
             -((bucket.lower.abs() * bucket.upper.abs()).sqrt())
@@ -845,14 +821,6 @@ impl NativeHistogram {
             (false, false) => reconcile_exponential(self, other),
             _ => None,
         }
-    }
-
-    fn is_empty_payload(&self) -> bool {
-        self.count == 0.0
-            && self.zero_count == 0.0
-            && self.sum == 0.0
-            && self.positive_buckets.iter().all(|count| *count == 0.0)
-            && self.negative_buckets.iter().all(|count| *count == 0.0)
     }
 }
 
@@ -1011,7 +979,10 @@ fn side_bucket_indices(spans: &[Span]) -> Option<Vec<i32>> {
     let mut indices = Vec::new();
     let mut current_index = 0i32;
     let mut first = true;
-    for span in spans {
+    for (span_index, span) in spans.iter().enumerate() {
+        if span_index > 0 && span.offset < 0 {
+            return None;
+        }
         if first {
             current_index = span.offset;
             first = false;
@@ -1024,6 +995,12 @@ fn side_bucket_indices(spans: &[Span]) -> Option<Vec<i32>> {
         }
     }
     Some(indices)
+}
+
+fn span_bucket_len(spans: &[Span]) -> Option<usize> {
+    spans
+        .iter()
+        .try_fold(0usize, |sum, span| sum.checked_add(span.length as usize))
 }
 
 fn spans_from_indices_counts(values: Vec<(i32, f64)>) -> Option<(Vec<Span>, Vec<f64>)> {
@@ -1069,27 +1046,28 @@ fn side_counts(spans: &[Span], buckets: &[f64]) -> Option<BTreeMap<i32, f64>> {
     Some(values)
 }
 
-fn side_counts_equal(
+fn side_layout_equal(
     left_spans: &[Span],
     left_buckets: &[f64],
     right_spans: &[Span],
     right_buckets: &[f64],
 ) -> bool {
-    match (
-        side_counts(left_spans, left_buckets),
-        side_counts(right_spans, right_buckets),
-    ) {
-        (Some(left), Some(right)) => {
-            left.len() == right.len()
-                && left.iter().all(|(idx, count)| {
-                    right
-                        .get(idx)
-                        .is_some_and(|other| count.to_bits() == other.to_bits())
-                })
-        }
-        (None, None) => true,
-        _ => false,
+    if span_bucket_len(left_spans) != Some(left_buckets.len())
+        || span_bucket_len(right_spans) != Some(right_buckets.len())
+    {
+        return false;
     }
+    let Some(left_indices) = side_bucket_indices(left_spans) else {
+        return false;
+    };
+    let Some(right_indices) = side_bucket_indices(right_spans) else {
+        return false;
+    };
+    left_indices == right_indices
+        && left_buckets
+            .iter()
+            .zip(right_buckets)
+            .all(|(left, right)| left.to_bits() == right.to_bits())
 }
 
 fn merge_side(
@@ -1194,6 +1172,19 @@ fn ceil_div(value: i32, divisor: i32) -> i32 {
     value.div_euclid(divisor) + i32::from(value.rem_euclid(divisor) != 0)
 }
 
+/// Returns the index of the exponential bucket containing positive infinity.
+pub fn exponential_overflow_bucket_index(schema: i32) -> Option<i32> {
+    if !(MIN_EXPONENTIAL_SCHEMA..=MAX_EXPONENTIAL_SCHEMA).contains(&schema) {
+        return None;
+    }
+    let last_finite = if schema >= 0 {
+        1024_i64.checked_shl(schema as u32)?
+    } else {
+        1024_i64.checked_shr((-schema) as u32)?
+    };
+    i32::try_from(last_finite.checked_add(1)?).ok()
+}
+
 fn get_bound(idx: i32, schema: i32, custom_values: &[f64]) -> Option<f64> {
     if schema == CUSTOM_BUCKETS_SCHEMA {
         return match idx {
@@ -1206,23 +1197,25 @@ fn get_bound(idx: i32, schema: i32, custom_values: &[f64]) -> Option<f64> {
         };
     }
 
-    if !(MIN_EXPONENTIAL_SCHEMA..=MAX_EXPONENTIAL_SCHEMA).contains(&schema) {
+    let overflow_index = exponential_overflow_bucket_index(schema)?;
+    if idx > overflow_index {
         return None;
     }
+    if idx == overflow_index {
+        return Some(f64::INFINITY);
+    }
+    if idx == overflow_index - 1 {
+        return Some(f64::MAX);
+    }
     if schema < 0 {
-        let exponent = idx.checked_shl((-schema) as u32)?;
-        return Some(if exponent == f64::MAX_EXP {
-            f64::MAX
-        } else {
-            2.0_f64.powi(exponent)
-        });
+        let exponent = i64::from(idx).checked_shl((-schema) as u32)?;
+        let Ok(exponent) = i32::try_from(exponent) else {
+            return Some(0.0);
+        };
+        return Some(2.0_f64.powi(exponent));
     }
     let exponent = idx as f64 / (1u32 << schema) as f64;
-    Some(if exponent == f64::MAX_EXP as f64 {
-        f64::MAX
-    } else {
-        2.0_f64.powf(exponent)
-    })
+    Some(2.0_f64.powf(exponent))
 }
 
 /// Returns the Arrow type for a complete native histogram value.
@@ -1336,12 +1329,9 @@ fn read_spans(offsets: Vec<i32>, lengths: Vec<u32>, name: &str) -> DfResult<Vec<
 }
 
 fn check_span_bucket_count(spans: &[Span], buckets: usize, name: &str) -> DfResult<()> {
-    let span_len = spans
-        .iter()
-        .try_fold(0usize, |sum, span| sum.checked_add(span.length as usize))
-        .ok_or_else(|| {
-            DataFusionError::Execution(format!("native histogram {name} spans overflow"))
-        })?;
+    let span_len = span_bucket_len(spans).ok_or_else(|| {
+        DataFusionError::Execution(format!("native histogram {name} spans overflow"))
+    })?;
     if span_len != buckets {
         return Err(DataFusionError::Execution(format!(
             "native histogram {name} spans describe {span_len} buckets, found {buckets}"
@@ -1719,7 +1709,7 @@ mod tests {
     }
 
     #[test]
-    fn add_combines_reset_hints_for_empty_payloads() {
+    fn add_combines_reset_hints_for_compatible_empty_payloads() {
         let mut empty = histogram(Vec::new(), Vec::new());
         empty.reset_hint = CounterResetHint::Gauge;
         let mut populated = histogram(
@@ -1739,6 +1729,45 @@ mod tests {
             populated.add(&empty).unwrap().reset_hint,
             CounterResetHint::Gauge
         );
+    }
+
+    #[test]
+    fn empty_arithmetic_rejects_incompatible_schemas() {
+        let exponential = histogram(Vec::new(), Vec::new());
+        let mut custom = histogram(
+            vec![Span {
+                offset: 0,
+                length: 1,
+            }],
+            vec![2.0],
+        );
+        custom.schema = CUSTOM_BUCKETS_SCHEMA;
+        custom.custom_values = vec![1.0];
+
+        assert!(exponential.add(&custom).is_none());
+        assert!(custom.add(&exponential).is_none());
+        assert!(exponential.sub(&custom).is_none());
+        assert!(custom.sub(&exponential).is_none());
+    }
+
+    #[test]
+    fn empty_custom_histogram_still_reconciles_bounds() {
+        let mut empty = histogram(Vec::new(), Vec::new());
+        empty.schema = CUSTOM_BUCKETS_SCHEMA;
+        empty.custom_values = vec![1.0];
+        let mut populated = histogram(
+            vec![Span {
+                offset: 0,
+                length: 1,
+            }],
+            vec![2.0],
+        );
+        populated.schema = CUSTOM_BUCKETS_SCHEMA;
+        populated.custom_values = vec![2.0];
+
+        let result = empty.add(&populated).unwrap();
+        assert!(result.custom_values.is_empty());
+        assert_eq!(result.positive_buckets, vec![2.0]);
     }
 
     #[test]
@@ -1805,7 +1834,7 @@ mod tests {
     }
 
     #[test]
-    fn promql_eq_ignores_reset_hint_start_timestamp_and_sparse_zeros() {
+    fn promql_eq_ignores_metadata_but_compares_sparse_layout() {
         let mut left = histogram(
             vec![Span {
                 offset: 0,
@@ -1826,6 +1855,27 @@ mod tests {
         right.reset_hint = CounterResetHint::NotCounterReset;
         right.start_timestamp = Some(2000);
 
+        assert!(!left.promql_eq(&right));
+
+        right.positive_spans = vec![
+            Span {
+                offset: 0,
+                length: 0,
+            },
+            Span {
+                offset: 0,
+                length: 1,
+            },
+            Span {
+                offset: 42,
+                length: 0,
+            },
+        ];
+        left.positive_spans = vec![Span {
+            offset: 0,
+            length: 1,
+        }];
+        left.positive_buckets = vec![1.0];
         assert!(left.promql_eq(&right));
     }
 
@@ -1875,7 +1925,33 @@ mod tests {
             }],
             vec![1.0],
         );
-        assert!(undecodable.promql_eq(&undecodable.clone()));
+        assert!(!undecodable.promql_eq(&undecodable.clone()));
+
+        let mut mismatched = histogram(
+            vec![Span {
+                offset: 0,
+                length: 2,
+            }],
+            vec![1.0],
+        );
+        mismatched.count = 1.0;
+        mismatched.sum = 1.0;
+        assert!(!mismatched.promql_eq(&mismatched.clone()));
+
+        let invalid_offset = histogram(
+            vec![
+                Span {
+                    offset: 0,
+                    length: 1,
+                },
+                Span {
+                    offset: -1,
+                    length: 1,
+                },
+            ],
+            vec![1.0, 1.0],
+        );
+        assert!(!invalid_offset.promql_eq(&invalid_offset.clone()));
     }
 
     #[test]
@@ -1944,11 +2020,51 @@ mod tests {
     }
 
     #[test]
-    fn terminal_exponential_bucket_uses_max_finite_bound() {
-        for (schema, index) in [(-1, 512), (0, 1024), (2, 4096)] {
-            assert_eq!(get_bound(index, schema, &[]), Some(f64::MAX));
-            assert_eq!(get_bound(index + 1, schema, &[]), Some(f64::INFINITY));
+    fn exponential_bucket_bounds_stop_after_overflow_bucket() {
+        for schema in [-4, 0, 8] {
+            let overflow = exponential_overflow_bucket_index(schema).unwrap();
+            assert_eq!(get_bound(overflow - 1, schema, &[]), Some(f64::MAX));
+            assert_eq!(get_bound(overflow, schema, &[]), Some(f64::INFINITY));
+            assert_eq!(get_bound(overflow + 1, schema, &[]), None);
         }
+        assert_eq!(exponential_overflow_bucket_index(-5), None);
+        assert_eq!(exponential_overflow_bucket_index(9), None);
+        assert_eq!(get_bound(i32::MIN, -4, &[]), Some(0.0));
+    }
+
+    #[test]
+    fn custom_bucket_midpoints_preserve_infinite_bounds() {
+        let mut histogram = histogram(Vec::new(), Vec::new());
+        histogram.schema = CUSTOM_BUCKETS_SCHEMA;
+
+        assert_eq!(
+            histogram.bucket_midpoint(&Bucket {
+                lower: f64::NEG_INFINITY,
+                upper: -1.0,
+                count: 1.0,
+                boundary_rule: BoundaryRule::OpenLeft,
+            }),
+            f64::NEG_INFINITY
+        );
+        assert_eq!(
+            histogram.bucket_midpoint(&Bucket {
+                lower: 1.0,
+                upper: f64::INFINITY,
+                count: 1.0,
+                boundary_rule: BoundaryRule::OpenLeft,
+            }),
+            f64::INFINITY
+        );
+        assert!(
+            histogram
+                .bucket_midpoint(&Bucket {
+                    lower: f64::NEG_INFINITY,
+                    upper: f64::INFINITY,
+                    count: 1.0,
+                    boundary_rule: BoundaryRule::OpenLeft,
+                })
+                .is_nan()
+        );
     }
 
     #[test]
@@ -1989,7 +2105,25 @@ mod tests {
     }
 
     #[test]
-    fn subtraction_treats_empty_left_as_zero() {
+    fn subtraction_treats_compatible_empty_left_as_zero() {
+        let left = histogram(vec![], vec![]);
+        let right = histogram(
+            vec![Span {
+                offset: 0,
+                length: 1,
+            }],
+            vec![2.0],
+        );
+
+        let result = left.sub(&right).unwrap();
+        assert_eq!(result.reset_hint, CounterResetHint::Gauge);
+        assert_eq!(result.count, -2.0);
+        assert_eq!(result.sum, -2.0);
+        assert_eq!(result.positive_buckets, vec![-2.0]);
+    }
+
+    #[test]
+    fn subtraction_rejects_incompatible_empty_left() {
         let left = histogram(vec![], vec![]);
         let mut right = histogram(
             vec![Span {
@@ -2001,13 +2135,7 @@ mod tests {
         right.schema = CUSTOM_BUCKETS_SCHEMA;
         right.custom_values = vec![1.0];
 
-        let result = left.sub(&right).unwrap();
-
-        assert_eq!(result.schema, CUSTOM_BUCKETS_SCHEMA);
-        assert_eq!(result.reset_hint, CounterResetHint::Gauge);
-        assert_eq!(result.count, -2.0);
-        assert_eq!(result.sum, -2.0);
-        assert_eq!(result.positive_buckets, vec![-2.0]);
+        assert!(left.sub(&right).is_none());
     }
 }
 

--- a/src/promql/src/extension_plan.rs
+++ b/src/promql/src/extension_plan.rs
@@ -26,9 +26,13 @@ mod test_util;
 mod union_distinct_on;
 
 pub use absent::{Absent, AbsentExec, AbsentStream};
+use common_query::native_histogram::{SUM_FIELD, native_histogram_value_type};
+use common_query::prometheus::is_prometheus_stale_nan;
+use datafusion::arrow::array::{Array, Float64Array, StructArray};
 use datafusion::arrow::datatypes::{ArrowPrimitiveType, TimestampMillisecondType};
 use datafusion::common::DFSchemaRef;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datatypes::data_type::DataType as _;
 pub use empty_metric::{EmptyMetric, EmptyMetricExec, EmptyMetricStream, build_special_time_expr};
 pub use histogram_fold::{HistogramFold, HistogramFoldExec, HistogramFoldStream};
 pub use instant_manipulate::{InstantManipulate, InstantManipulateExec, InstantManipulateStream};
@@ -42,6 +46,26 @@ pub use union_distinct_on::{UnionDistinctOn, UnionDistinctOnExec, UnionDistinctO
 pub type Millisecond = <TimestampMillisecondType as ArrowPrimitiveType>::Native;
 
 const METRIC_NUM_SERIES: &str = "num_series";
+
+fn prometheus_stale_sample_column(column: &dyn Array) -> Option<(&dyn Array, &Float64Array)> {
+    let values = if let Some(values) = column.as_any().downcast_ref::<Float64Array>() {
+        values
+    } else {
+        let histograms = column.as_any().downcast_ref::<StructArray>()?;
+        if histograms.data_type() != &native_histogram_value_type().as_arrow_type() {
+            return None;
+        }
+        histograms
+            .column_by_name(SUM_FIELD)?
+            .as_any()
+            .downcast_ref::<Float64Array>()?
+    };
+    Some((column, values))
+}
+
+fn is_prometheus_stale_sample((column, values): (&dyn Array, &Float64Array), row: usize) -> bool {
+    column.is_valid(row) && values.is_valid(row) && is_prometheus_stale_nan(values.value(row))
+}
 
 /// Utilities for handling unfix logic in extension plans
 /// Convert column name to index for serialization

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -18,8 +18,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use common_query::prometheus::is_prometheus_stale_nan;
-use datafusion::arrow::array::{Array, Float64Array, TimestampMillisecondArray, UInt64Array};
+use datafusion::arrow::array::{Array, TimestampMillisecondArray, UInt64Array};
 use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::stats::Precision;
@@ -46,7 +45,8 @@ use snafu::ResultExt;
 use crate::error::{DeserializeSnafu, Result};
 use crate::extension_plan::series_divide::SeriesDivide;
 use crate::extension_plan::{
-    METRIC_NUM_SERIES, Millisecond, resolve_column_name, serialize_column_index,
+    METRIC_NUM_SERIES, Millisecond, is_prometheus_stale_sample, prometheus_stale_sample_column,
+    resolve_column_name, serialize_column_index,
 };
 use crate::metrics::PROMQL_SERIES_COUNT;
 
@@ -531,10 +531,11 @@ impl InstantManipulateStream {
             return Ok(input);
         }
 
-        // field column for staleness check
-        let field_column = self
+        // Field column for staleness checks, classified once per batch.
+        let stale_sample_column = self
             .field_index
-            .and_then(|index| input.column(index).as_any().downcast_ref::<Float64Array>());
+            .map(|index| input.column(index).as_ref())
+            .and_then(prometheus_stale_sample_column);
 
         // Optimize iteration range based on actual data bounds
         let first_ts = ts_column.value(0);
@@ -579,9 +580,8 @@ impl InstantManipulateStream {
                 let curr = ts_column.value(cursor);
                 match curr.cmp(&expected_ts) {
                     Ordering::Equal => {
-                        if let Some(field_column) = &field_column
-                            && field_column.is_valid(cursor)
-                            && is_prometheus_stale_nan(field_column.value(cursor))
+                        if stale_sample_column
+                            .is_some_and(|column| is_prometheus_stale_sample(column, cursor))
                         {
                             // Ignore the stale marker.
                         } else {
@@ -614,9 +614,8 @@ impl InstantManipulateStream {
                     let prev_ts = ts_column.value(prev_cursor);
                     if prev_ts + self.lookback_delta > expected_ts {
                         // only use the point in the time range
-                        if let Some(field_column) = &field_column
-                            && field_column.is_valid(prev_cursor)
-                            && is_prometheus_stale_nan(field_column.value(prev_cursor))
+                        if stale_sample_column
+                            .is_some_and(|column| is_prometheus_stale_sample(column, prev_cursor))
                         {
                             // Do not use a stale marker as the newest value.
                             continue;
@@ -626,9 +625,8 @@ impl InstantManipulateStream {
                         aligned_ts.push(expected_ts);
                     }
                 }
-            } else if let Some(field_column) = &field_column
-                && field_column.is_valid(cursor)
-                && is_prometheus_stale_nan(field_column.value(cursor))
+            } else if stale_sample_column
+                .is_some_and(|column| is_prometheus_stale_sample(column, cursor))
             {
                 // Do not use a stale marker as the newest value.
             } else {
@@ -692,6 +690,9 @@ fn reuse_constant_column(array: &Arc<dyn Array>, len: usize) -> DataFusionResult
 
 #[cfg(test)]
 mod test {
+    use common_query::native_histogram::build_histogram_array;
+    use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
+    use datafusion::arrow::array::Float64Array;
     use datafusion::arrow::buffer::NullBuffer;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::common::ToDFSchema;
@@ -702,7 +703,7 @@ mod test {
 
     use super::*;
     use crate::extension_plan::test_util::{
-        TIME_INDEX_COLUMN, prepare_test_data, prepare_test_data_with_stale_marker,
+        TIME_INDEX_COLUMN, native_histogram, prepare_test_data, prepare_test_data_with_stale_marker,
     };
 
     async fn do_normalize_test(
@@ -1432,6 +1433,51 @@ mod test {
             "the stale marker must suppress both the exact and lookback selections rather than \
              falling back to 42.0"
         );
+    }
+
+    #[tokio::test]
+    async fn native_histogram_stale_nan_suppresses_exact_and_lookback() {
+        let histograms = build_histogram_array(&[
+            Some(native_histogram(42.0)),
+            Some(native_histogram(f64::from_bits(PROMETHEUS_STALE_NAN_BITS))),
+        ]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                TIME_INDEX_COLUMN,
+                DataType::Timestamp(datafusion::arrow::datatypes::TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("value", histograms.data_type().clone(), true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![500, 1_000])),
+                histograms,
+            ],
+        )
+        .unwrap();
+        let input = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap(),
+        )));
+        let exec = Arc::new(InstantManipulateExec {
+            start: 1_000,
+            end: 1_500,
+            lookback_delta: 1_001,
+            interval: 500,
+            time_index_column: TIME_INDEX_COLUMN.to_string(),
+            field_column: Some("value".to_string()),
+            reuse_tsid_column: false,
+            input,
+            metric: ExecutionPlanMetricsSet::new(),
+        });
+
+        let context = SessionContext::default();
+        let batches = datafusion::physical_plan::collect(exec, context.task_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0);
     }
 
     #[tokio::test]

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -510,11 +510,12 @@ impl Stream for InstantManipulateStream {
 }
 
 impl InstantManipulateStream {
-    // Refer to Prometheus `vectorSelectorSingle` / lookback semantics.
-    //
-    // Prometheus `v3.9.1` uses a start-exclusive lookback window:
-    //   (eval_ts - lookback_delta, eval_ts]
-    // i.e. a sample at exactly `eval_ts - lookback_delta` is considered too old.
+    /// Manipulates one complete series sorted by timestamp. The planner enforces
+    /// this input contract with a sort followed by [`SeriesDivide`].
+    ///
+    /// Prometheus `v3.9.1`'s `vectorSelectorSingle` uses a start-exclusive
+    /// lookback window `(eval_ts - lookback_delta, eval_ts]`; a sample at exactly
+    /// `eval_ts - lookback_delta` is too old.
     pub fn manipulate(&self, input: RecordBatch) -> DataFusionResult<RecordBatch> {
         let ts_column = input
             .column(self.time_index)
@@ -1387,7 +1388,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn prometheus_stale_nan_suppresses_exact_and_lookback() {
+    async fn prometheus_stale_nan_selects_before_and_suppresses_after_marker() {
         let schema = Arc::new(Schema::new(vec![
             Field::new(
                 TIME_INDEX_COLUMN,
@@ -1411,10 +1412,10 @@ mod test {
             MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap(),
         )));
         let exec = Arc::new(InstantManipulateExec {
-            start: 1_000,
+            start: 750,
             end: 1_500,
             lookback_delta: 1_001,
-            interval: 500,
+            interval: 250,
             time_index_column: TIME_INDEX_COLUMN.to_string(),
             field_column: Some("value".to_string()),
             reuse_tsid_column: false,
@@ -1427,11 +1428,24 @@ mod test {
             .await
             .unwrap();
 
+        let row_count = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        let batch = batches.iter().find(|batch| batch.num_rows() > 0).unwrap();
+        let timestamp = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .unwrap()
+            .value(0);
+        let value = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .value(0);
         assert_eq!(
-            batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
-            0,
-            "the stale marker must suppress both the exact and lookback selections rather than \
-             falling back to 42.0"
+            (row_count, timestamp, value),
+            (1, 750, 42.0),
+            "only the evaluation before the stale marker should select 42.0"
         );
     }
 

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -17,7 +17,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use datafusion::arrow::array::{Array, BooleanArray};
+use common_query::native_histogram::{START_TIMESTAMP_FIELD, native_histogram_arrow_type};
+use datafusion::arrow::array::{Array, BooleanArray, StructArray};
 use datafusion::arrow::compute;
 use datafusion::common::{DFSchema, DFSchemaRef, Result as DataFusionResult, Statistics};
 use datafusion::error::DataFusionError;
@@ -33,7 +34,7 @@ use datafusion::physical_plan::{
 };
 use datafusion_expr::col;
 use datatypes::arrow::array::TimestampMillisecondArray;
-use datatypes::arrow::datatypes::SchemaRef;
+use datatypes::arrow::datatypes::{SchemaRef, TimestampMillisecondType};
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::{Stream, StreamExt, ready};
 use greptime_proto::substrait_extension as pb;
@@ -51,7 +52,7 @@ use crate::metrics::PROMQL_SERIES_COUNT;
 /// the input batch only contains sample points from one time series.
 ///
 /// Roughly speaking, this method does these things:
-/// - bias sample's timestamp by offset
+/// - bias sample and native histogram start timestamps by offset
 /// - sort the record batch based on timestamp column
 /// - remove Prometheus stale markers (optional)
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd)]
@@ -397,16 +398,61 @@ impl SeriesNormalizeStream {
                 )
             })?;
 
+        let bias_timestamp = |timestamp: i64| {
+            timestamp.checked_add(self.offset).ok_or_else(|| {
+                DataFusionError::Execution("SeriesNormalize: timestamp offset overflow".into())
+            })
+        };
+
         // bias the timestamp column by offset
         let ts_column_biased = if self.offset == 0 {
             Arc::new(ts_column.clone()) as _
         } else {
-            Arc::new(TimestampMillisecondArray::from_iter(
-                ts_column.iter().map(|ts| ts.map(|ts| ts + self.offset)),
-            ))
+            Arc::new(ts_column.try_unary::<_, TimestampMillisecondType, _>(&bias_timestamp)?)
         };
         let mut columns = input.columns().to_vec();
         columns[self.time_index] = ts_column_biased;
+
+        // Offset selectors move samples into the evaluation timeline. Keep native histogram
+        // start timestamps on the same timeline for rate and reset calculations.
+        if self.offset != 0 {
+            let native_histogram_type = native_histogram_arrow_type();
+            for column in &mut columns {
+                let Some((histograms, start_timestamp_index, start_timestamps)) = column
+                    .as_any()
+                    .downcast_ref::<StructArray>()
+                    .filter(|histograms| histograms.data_type() == &native_histogram_type)
+                    .and_then(|histograms| {
+                        let (index, _) = histograms.fields().find(START_TIMESTAMP_FIELD)?;
+                        let timestamps = histograms
+                            .column(index)
+                            .as_any()
+                            .downcast_ref::<TimestampMillisecondArray>()?;
+                        Some((histograms, index, timestamps))
+                    })
+                else {
+                    continue;
+                };
+                let start_timestamps = start_timestamps
+                    .try_unary::<_, TimestampMillisecondType, _>(|timestamp| {
+                        // Prometheus uses zero to mean that the start timestamp is unknown.
+                        if timestamp == 0 {
+                            Ok(0)
+                        } else {
+                            bias_timestamp(timestamp)
+                        }
+                    })?;
+                // Replace only the start timestamp child to preserve the histogram payload and
+                // null bitmap.
+                let mut children = histograms.columns().to_vec();
+                children[start_timestamp_index] = Arc::new(start_timestamps);
+                *column = Arc::new(StructArray::new(
+                    histograms.fields().clone(),
+                    children,
+                    histograms.nulls().cloned(),
+                ));
+            }
+        }
 
         let result_batch = RecordBatch::try_new(input.schema(), columns)?;
         if !self.filter_stale_markers {
@@ -664,11 +710,15 @@ mod test {
     }
 
     #[tokio::test]
-    async fn filters_native_histogram_stale_markers() {
+    async fn offsets_native_histogram_timestamps_and_filters_stale_markers() {
+        let mut regular = native_histogram(42.0);
+        regular.start_timestamp = Some(500);
+        let mut ordinary_nan = native_histogram(f64::NAN);
+        ordinary_nan.start_timestamp = Some(0);
         let histograms = build_histogram_array(&[
-            Some(native_histogram(42.0)),
+            Some(regular),
             Some(native_histogram(f64::from_bits(PROMETHEUS_STALE_NAN_BITS))),
-            Some(native_histogram(f64::NAN)),
+            Some(ordinary_nan),
             None,
         ]);
         let schema = Arc::new(Schema::new(vec![
@@ -693,7 +743,7 @@ mod test {
             MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap(),
         )));
         let exec = Arc::new(SeriesNormalizeExec {
-            offset: 0,
+            offset: 1_000,
             time_index_column_name: TIME_INDEX_COLUMN.to_string(),
             filter_stale_markers: true,
             tag_columns: Vec::new(),
@@ -712,8 +762,17 @@ mod test {
             .downcast_ref::<datafusion::arrow::array::StructArray>()
             .unwrap();
 
-        assert_eq!(read_histogram(values, 0).unwrap().unwrap().sum, 42.0);
-        assert!(read_histogram(values, 1).unwrap().unwrap().sum.is_nan());
+        let timestamps = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .unwrap();
+        assert_eq!(timestamps.values(), &[2_000, 4_000, 5_000]);
+        let regular = read_histogram(values, 0).unwrap().unwrap();
+        assert_eq!((regular.sum, regular.start_timestamp), (42.0, Some(1_500)));
+        let ordinary_nan = read_histogram(values, 1).unwrap().unwrap();
+        assert!(ordinary_nan.sum.is_nan());
+        assert_eq!(ordinary_nan.start_timestamp, Some(0));
         assert!(read_histogram(values, 2).unwrap().is_none());
     }
 }

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -17,8 +17,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use common_query::prometheus::is_prometheus_stale_nan;
-use datafusion::arrow::array::{Array, BooleanArray, Float64Array};
+use datafusion::arrow::array::{Array, BooleanArray};
 use datafusion::arrow::compute;
 use datafusion::common::{DFSchema, DFSchemaRef, Result as DataFusionResult, Statistics};
 use datafusion::error::DataFusionError;
@@ -43,7 +42,8 @@ use snafu::ResultExt;
 
 use crate::error::{DeserializeSnafu, Result};
 use crate::extension_plan::{
-    METRIC_NUM_SERIES, Millisecond, resolve_column_name, serialize_column_index,
+    METRIC_NUM_SERIES, Millisecond, is_prometheus_stale_sample, prometheus_stale_sample_column,
+    resolve_column_name, serialize_column_index,
 };
 use crate::metrics::PROMQL_SERIES_COUNT;
 
@@ -416,11 +416,12 @@ impl SeriesNormalizeStream {
         // Filter out Prometheus stale markers.
         let mut stale_marker_filter = vec![true; input.num_rows()];
         for column in result_batch.columns() {
-            if let Some(float_column) = column.as_any().downcast_ref::<Float64Array>() {
-                for (i, flag) in stale_marker_filter.iter_mut().enumerate() {
-                    if float_column.is_valid(i) && is_prometheus_stale_nan(float_column.value(i)) {
-                        *flag = false;
-                    }
+            let Some(stale_sample_column) = prometheus_stale_sample_column(column.as_ref()) else {
+                continue;
+            };
+            for (i, flag) in stale_marker_filter.iter_mut().enumerate() {
+                if is_prometheus_stale_sample(stale_sample_column, i) {
+                    *flag = false;
                 }
             }
         }
@@ -462,6 +463,8 @@ impl Stream for SeriesNormalizeStream {
 
 #[cfg(test)]
 mod test {
+    use common_query::native_histogram::{build_histogram_array, read_histogram};
+    use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
     use datafusion::arrow::array::Float64Array;
     use datafusion::arrow::buffer::NullBuffer;
     use datafusion::arrow::datatypes::{
@@ -476,6 +479,7 @@ mod test {
     use datatypes::arrow_array::StringArray;
 
     use super::*;
+    use crate::extension_plan::test_util::native_histogram;
 
     const TIME_INDEX_COLUMN: &str = "timestamp";
 
@@ -657,5 +661,59 @@ mod test {
         assert_eq!(value.value(0), 42.0);
         assert_eq!(auxiliary.value(0).to_bits(), 0x7ff8_0000_0000_0000);
         assert!(!value.is_valid(1));
+    }
+
+    #[tokio::test]
+    async fn filters_native_histogram_stale_markers() {
+        let histograms = build_histogram_array(&[
+            Some(native_histogram(42.0)),
+            Some(native_histogram(f64::from_bits(PROMETHEUS_STALE_NAN_BITS))),
+            Some(native_histogram(f64::NAN)),
+            None,
+        ]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                TIME_INDEX_COLUMN,
+                TimestampMillisecondType::DATA_TYPE,
+                false,
+            ),
+            Field::new("value", histograms.data_type().clone(), true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![
+                    1_000, 2_000, 3_000, 4_000,
+                ])),
+                histograms,
+            ],
+        )
+        .unwrap();
+        let input = Arc::new(DataSourceExec::new(Arc::new(
+            MemorySourceConfig::try_new(&[vec![batch]], schema, None).unwrap(),
+        )));
+        let exec = Arc::new(SeriesNormalizeExec {
+            offset: 0,
+            time_index_column_name: TIME_INDEX_COLUMN.to_string(),
+            filter_stale_markers: true,
+            tag_columns: Vec::new(),
+            input,
+            metric: ExecutionPlanMetricsSet::new(),
+        });
+
+        let context = SessionContext::default();
+        let batches = datafusion::physical_plan::collect(exec, context.task_ctx())
+            .await
+            .unwrap();
+        let batch = batches.iter().find(|batch| batch.num_rows() == 3).unwrap();
+        let values = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StructArray>()
+            .unwrap();
+
+        assert_eq!(read_histogram(values, 0).unwrap().unwrap().sum, 42.0);
+        assert!(read_histogram(values, 1).unwrap().unwrap().sum.is_nan());
+        assert!(read_histogram(values, 2).unwrap().is_none());
     }
 }

--- a/src/promql/src/extension_plan/test_util.rs
+++ b/src/promql/src/extension_plan/test_util.rs
@@ -16,6 +16,7 @@
 
 use std::sync::Arc;
 
+use common_query::native_histogram::{NativeHistogram, Span, UNKNOWN_COUNTER_RESET_HINT};
 use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
 use common_recordbatch::DfRecordBatch as RecordBatch;
 use datafusion::arrow::array::Float64Array;
@@ -28,6 +29,26 @@ use datatypes::arrow::array::TimestampMillisecondArray;
 use datatypes::arrow_array::StringArray;
 
 pub(crate) const TIME_INDEX_COLUMN: &str = "timestamp";
+
+pub(crate) fn native_histogram(sum: f64) -> NativeHistogram {
+    NativeHistogram {
+        schema: 0,
+        zero_threshold: 0.0,
+        sum,
+        reset_hint: UNKNOWN_COUNTER_RESET_HINT,
+        start_timestamp: None,
+        custom_values: Vec::new(),
+        positive_spans: vec![Span {
+            offset: 0,
+            length: 1,
+        }],
+        negative_spans: Vec::new(),
+        count: 1.0,
+        zero_count: 0.0,
+        positive_buckets: vec![1.0],
+        negative_buckets: Vec::new(),
+    }
+}
 
 pub(crate) fn prepare_test_data() -> DataSourceExec {
     let schema = Arc::new(Schema::new(vec![

--- a/src/promql/src/functions/native_histogram.rs
+++ b/src/promql/src/functions/native_histogram.rs
@@ -1462,24 +1462,25 @@ fn histogram_delta(
             .map(NativeHistogram::into_gauge);
     }
 
-    let mut result = samples.first()?.zero_like();
-    let mut segment_start = samples.first()?;
-    for (sample_pair, ts_pair) in samples.windows(2).zip(timestamps.windows(2)) {
-        let previous_ts = ts_pair[0];
-        let current_ts = ts_pair[1];
-        let previous = &sample_pair[0];
-        let current = &sample_pair[1];
-        if current.detect_counter_reset(previous, previous_ts, current_ts) {
-            result = result.add(&previous.sub(segment_start)?)?;
-            result = result.add(current)?;
-            segment_start = current;
+    let first_reset = samples[1].detect_counter_reset(&samples[0], timestamps[0], timestamps[1]);
+    let (initial, reset_scan_start) = if first_reset {
+        // The first sample is irrelevant after an immediate reset. Adopt the
+        // second sample's layout so an incompatible pre-reset layout is ignored.
+        (samples[1].zero_like(), 2)
+    } else {
+        (samples[0].clone(), 1)
+    };
+    let mut result = samples.last()?.sub(&initial)?;
+    for index in reset_scan_start..samples.len() {
+        if samples[index].detect_counter_reset(
+            &samples[index - 1],
+            timestamps[index - 1],
+            timestamps[index],
+        ) {
+            result = result.add(&samples[index - 1])?;
         }
     }
-    Some(
-        result
-            .add(&samples.last()?.sub(segment_start)?)?
-            .into_gauge(),
-    )
+    Some(result.into_gauge())
 }
 
 fn idelta_value(
@@ -1569,7 +1570,7 @@ fn native_extrapolated_rate<const IS_COUNTER: bool, const IS_RATE: bool>(
         let (raw_offset, raw_length) = unpack(keys[index]);
         let offset = raw_offset as usize;
         let length = raw_length as usize;
-        if length < 2 {
+        if length == 0 {
             result.push(None);
             continue;
         }
@@ -1584,6 +1585,20 @@ fn native_extrapolated_rate<const IS_COUNTER: bool, const IS_RATE: bool>(
             samples.push(histogram);
         }
         if has_null {
+            result.push(None);
+            continue;
+        }
+
+        let first_ts = all_timestamps[offset];
+        let last_ts = all_timestamps[offset + length - 1];
+        let range_end = eval_ts.value(index);
+        let range_start = range_end - range_length;
+        let synthetic_zero_timestamp = IS_COUNTER
+            .then_some(samples[0].start_timestamp)
+            .flatten()
+            .filter(|start| *start != 0 && range_start < *start && *start < first_ts);
+        let synthetic_zero_start = synthetic_zero_timestamp.is_some();
+        if length < 2 && !synthetic_zero_start {
             result.push(None);
             continue;
         }
@@ -1608,7 +1623,11 @@ fn native_extrapolated_rate<const IS_COUNTER: bool, const IS_RATE: bool>(
         for pair in samples.windows(2) {
             record_custom_reconciliation(&collector, func_name, &pair[0], &pair[1]);
         }
-        let Some(mut histogram) = histogram_delta(&samples, timestamps, IS_COUNTER) else {
+        let mut histogram = if length == 1 {
+            samples[0].clone()
+        } else if let Some(histogram) = histogram_delta(&samples, timestamps, IS_COUNTER) {
+            histogram
+        } else {
             record_warning(
                 &collector,
                 format!("{func_name}: dropped native histogram range with incompatible schemas"),
@@ -1616,21 +1635,41 @@ fn native_extrapolated_rate<const IS_COUNTER: bool, const IS_RATE: bool>(
             result.push(None);
             continue;
         };
+        if synthetic_zero_start && length > 1 {
+            let Some(with_synthetic_zero) = histogram.add(&samples[0]) else {
+                record_warning(
+                    &collector,
+                    format!(
+                        "{func_name}: dropped native histogram range with incompatible schemas"
+                    ),
+                );
+                result.push(None);
+                continue;
+            };
+            histogram = with_synthetic_zero;
+        }
 
-        let first_ts = all_timestamps[offset];
-        let last_ts = all_timestamps[offset + length - 1];
-        let range_end = eval_ts.value(index);
-        let range_start = range_end - range_length;
-        let sampled_interval_ms = (last_ts - first_ts) as f64;
+        let real_sampled_interval_ms = (last_ts - first_ts) as f64;
+        let sampled_interval_ms = synthetic_zero_timestamp
+            .map(|start| (last_ts - start) as f64)
+            .unwrap_or(real_sampled_interval_ms);
         if sampled_interval_ms <= 0.0 {
             result.push(None);
             continue;
         }
-        let average_interval_ms = sampled_interval_ms / (length - 1) as f64;
-        let mut duration_to_start_ms = (first_ts - range_start) as f64;
+        let average_interval_ms = if length > 1 {
+            real_sampled_interval_ms / (length - 1) as f64
+        } else {
+            0.0
+        };
+        let mut duration_to_start_ms = if synthetic_zero_start {
+            0.0
+        } else {
+            (first_ts - range_start) as f64
+        };
         let duration_to_end_ms = (range_end - last_ts) as f64;
 
-        if IS_COUNTER && histogram.count > 0.0 && samples[0].count >= 0.0 {
+        if IS_COUNTER && !synthetic_zero_start && histogram.count > 0.0 && samples[0].count >= 0.0 {
             let duration_to_zero = sampled_interval_ms * (samples[0].count / histogram.count);
             if duration_to_zero < duration_to_start_ms {
                 duration_to_start_ms = duration_to_zero;
@@ -2010,14 +2049,47 @@ mod tests {
         histograms: Vec<NativeHistogram>,
     ) -> NativeHistogram {
         let range_length = histograms.len() as i64 * 1000;
-        let mut input = histogram_range_input(histograms.into_iter().map(Some).collect::<Vec<_>>());
+        let timestamps = (0..histograms.len())
+            .map(|idx| (idx as i64 + 1) * 1000)
+            .collect();
+        extrapolated_histogram_result(udf, timestamps, histograms, range_length, range_length)
+            .unwrap()
+    }
+
+    fn extrapolated_histogram_result(
+        udf: ScalarUDF,
+        timestamps: Vec<i64>,
+        histograms: Vec<NativeHistogram>,
+        range_end: i64,
+        range_length: i64,
+    ) -> Option<NativeHistogram> {
+        assert_eq!(timestamps.len(), histograms.len());
+        let range = [(0, u32::try_from(histograms.len()).unwrap())];
+        let timestamps = Arc::new(TimestampMillisecondArray::from(timestamps));
+        let histograms =
+            build_histogram_array(&histograms.into_iter().map(Some).collect::<Vec<_>>());
+        let mut input = vec![
+            ColumnarValue::Array(Arc::new(
+                RangeArray::from_ranges(timestamps, range)
+                    .unwrap()
+                    .into_dict(),
+            )),
+            ColumnarValue::Array(Arc::new(
+                RangeArray::from_ranges(histograms, range)
+                    .unwrap()
+                    .into_dict(),
+            )),
+        ];
         input.push(ColumnarValue::Array(Arc::new(
-            TimestampMillisecondArray::from(vec![range_length]),
+            TimestampMillisecondArray::from(vec![range_end]),
         )));
         input.push(ColumnarValue::Array(Arc::new(Int64Array::from(vec![
             range_length,
         ]))));
-        run_histogram_udf(udf, input)
+        let result = run_udf(udf, input, native_histogram_arrow_type());
+        let result = extract_array(&result).unwrap();
+        let result = result.as_any().downcast_ref::<StructArray>().unwrap();
+        read_histogram(result, 0).unwrap()
     }
 
     fn collected_warnings(collector: &PromqlAnnotationCollector) -> Vec<String> {
@@ -2051,7 +2123,7 @@ mod tests {
     }
 
     #[test]
-    fn comparison_uses_promql_histogram_equality() {
+    fn comparison_observes_explicit_sparse_zero_buckets() {
         let mut left = sample_histogram(1.0, 1.0, vec![1.0, 0.0]);
         left.reset_hint = COUNTER_RESET_HINT;
         left.start_timestamp = Some(1000);
@@ -2069,7 +2141,7 @@ mod tests {
         );
         let values = extract_array(&result).unwrap();
         let values = values.as_any().downcast_ref::<BooleanArray>().unwrap();
-        assert!(values.value(0));
+        assert!(!values.value(0));
     }
 
     #[test]
@@ -2396,5 +2468,133 @@ mod tests {
         let idelta = idelta_value(&[first, last], true, 1000, 2000, 1.0).unwrap();
         assert_eq!(idelta.count, 7.0);
         assert_eq!(idelta.sum, 12.0);
+    }
+
+    #[test]
+    fn extrapolated_rate_uses_start_timestamp_synthetic_zero() {
+        let mut single = sample_histogram(1.0, 1.0, vec![1.0]);
+        single.start_timestamp = Some(1_000);
+
+        let rate = extrapolated_histogram_result(
+            NativeHistogramRate::scalar_udf(),
+            vec![2_000],
+            vec![single.clone()],
+            3_000,
+            3_000,
+        )
+        .unwrap();
+        assert_eq!(rate.count, 1.0 / 3.0);
+        assert_eq!(rate.sum, 1.0 / 3.0);
+
+        let increase = extrapolated_histogram_result(
+            NativeHistogramIncrease::scalar_udf(),
+            vec![2_000],
+            vec![single],
+            3_000,
+            3_000,
+        )
+        .unwrap();
+        assert_eq!(increase.count, 1.0);
+        assert_eq!(increase.sum, 1.0);
+
+        let mut first = sample_histogram(2.0, 2.0, vec![2.0]);
+        first.start_timestamp = Some(1_000);
+        let last = sample_histogram(4.0, 4.0, vec![4.0]);
+        let increase = extrapolated_histogram_result(
+            NativeHistogramIncrease::scalar_udf(),
+            vec![2_000, 3_000],
+            vec![first, last],
+            3_000,
+            3_000,
+        )
+        .unwrap();
+        assert_eq!(increase.count, 4.0);
+        assert_eq!(increase.sum, 4.0);
+    }
+
+    #[test]
+    fn extrapolated_rate_requires_strictly_in_range_start_timestamp() {
+        for (start_timestamp, range_end, range_length) in [
+            (0, 3_000, 3_000),
+            (500, 3_000, 2_000),
+            (1_000, 3_000, 2_000),
+            (2_000, 3_000, 3_000),
+            (2_500, 3_000, 3_000),
+        ] {
+            let mut sample = sample_histogram(1.0, 1.0, vec![1.0]);
+            sample.start_timestamp = Some(start_timestamp);
+            assert!(
+                extrapolated_histogram_result(
+                    NativeHistogramRate::scalar_udf(),
+                    vec![2_000],
+                    vec![sample],
+                    range_end,
+                    range_length,
+                )
+                .is_none(),
+                "start_timestamp={start_timestamp}"
+            );
+        }
+
+        let mut gauge = sample_histogram(1.0, 1.0, vec![1.0]);
+        gauge.start_timestamp = Some(1_000);
+        gauge.reset_hint = GAUGE_RESET_HINT;
+        assert!(
+            extrapolated_histogram_result(
+                NativeHistogramDelta::scalar_udf(),
+                vec![2_000],
+                vec![gauge],
+                3_000,
+                3_000,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn first_reset_ignores_incompatible_pre_reset_layout() {
+        let first = sample_histogram(10.0, 10.0, vec![10.0]);
+        let second = NativeHistogram {
+            schema: CUSTOM_BUCKETS_SCHEMA,
+            zero_threshold: 0.0,
+            sum: 2.0,
+            reset_hint: COUNTER_RESET_HINT,
+            start_timestamp: None,
+            custom_values: vec![1.0],
+            positive_spans: vec![Span {
+                offset: 0,
+                length: 1,
+            }],
+            negative_spans: Vec::new(),
+            count: 2.0,
+            zero_count: 0.0,
+            positive_buckets: vec![2.0],
+            negative_buckets: Vec::new(),
+        };
+
+        let delta = histogram_delta(&[first, second], &[1_000, 2_000], true).unwrap();
+        assert_eq!(delta.schema, CUSTOM_BUCKETS_SCHEMA);
+        assert_eq!(delta.count, 2.0);
+        assert_eq!(delta.sum, 2.0);
+        assert_eq!(delta.positive_buckets, vec![2.0]);
+    }
+
+    #[test]
+    fn counter_delta_handles_reset_segment_boundaries() {
+        let first = sample_histogram(5.0, 5.0, vec![5.0]);
+        let second = sample_histogram(7.0, 7.0, vec![7.0]);
+        let mut reset = sample_histogram(2.0, 2.0, vec![2.0]);
+        reset.reset_hint = COUNTER_RESET_HINT;
+        let last = sample_histogram(4.0, 4.0, vec![4.0]);
+
+        let delta = histogram_delta(
+            &[first, second, reset, last],
+            &[1_000, 2_000, 3_000, 4_000],
+            true,
+        )
+        .unwrap();
+        assert_eq!(delta.count, 6.0);
+        assert_eq!(delta.sum, 6.0);
+        assert_eq!(delta.positive_buckets, vec![6.0]);
     }
 }

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -6779,9 +6779,32 @@ mod test {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn single_timestamp() {
-        do_single_instant_function_call("timestamp", "").await;
+    async fn single_timestamp_plan_preserves_source_value() {
+        let eval_stmt = build_eval_stmt(r#"timestamp(some_metric{tag_0!="bar"})"#);
+        let table_provider = build_test_table_provider(
+            &[(DEFAULT_SCHEMA_NAME.to_string(), "some_metric".to_string())],
+            1,
+            1,
+        )
+        .await;
+        let plan =
+            PromPlanner::stmt_to_plan(table_provider, &eval_stmt, &build_query_engine_state())
+                .await
+                .unwrap();
+
+        let expected = String::from(
+            "Filter: value IS NOT NULL [timestamp:Timestamp(ms), value:Float64, tag_0:Utf8]\
+            \n  Projection: some_metric.timestamp, value AS value, some_metric.tag_0 [timestamp:Timestamp(ms), value:Float64, tag_0:Utf8]\
+            \n    Projection: some_metric.timestamp, __promql_timestamp_value_ AS value, some_metric.tag_0 [timestamp:Timestamp(ms), value:Float64, tag_0:Utf8]\
+            \n      PromInstantManipulate: range=[0..100000000], lookback=[1000], interval=[5000], time index=[timestamp] [tag_0:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, __promql_timestamp_value_:Float64]\
+            \n        Projection: some_metric.tag_0, some_metric.timestamp, some_metric.field_0, CAST(CAST(some_metric.timestamp AS Int64) AS Float64) / Float64(1000) AS __promql_timestamp_value_ [tag_0:Utf8, timestamp:Timestamp(ms), field_0:Float64;N, __promql_timestamp_value_:Float64]\
+            \n          PromSeriesDivide: tags=[\"tag_0\"] [tag_0:Utf8, timestamp:Timestamp(ms), field_0:Float64;N]\
+            \n            Sort: some_metric.tag_0 ASC NULLS FIRST, some_metric.timestamp ASC NULLS FIRST [tag_0:Utf8, timestamp:Timestamp(ms), field_0:Float64;N]\
+            \n              Filter: some_metric.tag_0 != Utf8(\"bar\") AND some_metric.timestamp >= TimestampMillisecond(-999, None) AND some_metric.timestamp <= TimestampMillisecond(100000000, None) [tag_0:Utf8, timestamp:Timestamp(ms), field_0:Float64;N]\
+            \n                TableScan: some_metric [tag_0:Utf8, timestamp:Timestamp(ms), field_0:Float64;N]",
+        );
+
+        assert_eq!(plan.display_indent_schema().to_string(), expected);
     }
 
     #[tokio::test]

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -140,6 +140,7 @@ const DB_COLUMN_MATCHER: &str = "__database__";
 const BINARY_ISLAND_LEAF_ALIAS_PREFIX: &str = "__prom_v";
 const OR_FLOAT_FIELD_PREFIX: &str = "__promql_or_float_";
 const OR_HISTOGRAM_FIELD_PREFIX: &str = "__promql_or_histogram_";
+const TIMESTAMP_VALUE_PREFIX: &str = "__promql_timestamp_value_";
 
 /// Threshold for scatter scan mode
 const MAX_SCATTER_POINTS: i64 = 400;
@@ -1516,42 +1517,77 @@ impl PromPlanner {
         let normalize = self
             .selector_to_series_normalize_plan(offset, matchers, false)
             .await?;
+        let time_index_column =
+            self.ctx
+                .time_index_column
+                .clone()
+                .with_context(|| TimeIndexNotFoundSnafu {
+                    table: self.ctx.table_name.clone().unwrap_or_default(),
+                })?;
 
-        let normalize = if timestamp_fn {
-            // If evaluating the PromQL `timestamp()` function, project the time index column as the value column
-            // before wrapping with [`InstantManipulate`], so the output matches PromQL's `timestamp()` semantics.
-            self.create_timestamp_func_plan(normalize)?
+        let (normalize, timestamp_value_column) = if timestamp_fn {
+            // Keep the original sample for stale-marker detection while carrying
+            // its timestamp through InstantManipulate in a private value column.
+            let occupied = normalize
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<HashSet<_>>();
+            let mut timestamp_value_column = TIMESTAMP_VALUE_PREFIX.to_string();
+            while occupied.contains(timestamp_value_column.as_str()) {
+                timestamp_value_column.push('_');
+            }
+            let mut project_exprs = normalize
+                .schema()
+                .iter()
+                .map(|(qualifier, field)| {
+                    DfExpr::Column(Column::new(qualifier.cloned(), field.name().clone()))
+                })
+                .collect::<Vec<_>>();
+            project_exprs
+                .push(build_special_time_expr(&time_index_column).alias(&timestamp_value_column));
+            let normalize = LogicalPlanBuilder::from(normalize)
+                .project(project_exprs)
+                .context(DataFusionPlanningSnafu)?
+                .build()
+                .context(DataFusionPlanningSnafu)?;
+            (normalize, Some(timestamp_value_column))
         } else {
-            normalize
+            (normalize, None)
         };
 
+        let field_column = self.ctx.field_columns.first().cloned();
         let manipulate = InstantManipulate::new(
             self.ctx.start,
             self.ctx.end,
             self.ctx.lookback_delta,
             self.ctx.interval,
-            self.ctx
-                .time_index_column
-                .clone()
-                .expect("time index should be set in `setup_context`"),
+            time_index_column,
             if self.ctx.use_tsid {
                 vec![DATA_SCHEMA_TSID_COLUMN_NAME.to_string()]
             } else {
                 self.ctx.tag_columns.clone()
             },
-            self.ctx.field_columns.first().cloned(),
+            field_column,
             normalize,
         );
-        Ok(LogicalPlan::Extension(Extension {
+        let manipulate = LogicalPlan::Extension(Extension {
             node: Arc::new(manipulate),
-        }))
+        });
+        if let Some(timestamp_value_column) = timestamp_value_column {
+            self.create_timestamp_func_plan(manipulate, &timestamp_value_column)
+        } else {
+            Ok(manipulate)
+        }
     }
 
     /// Builds a projection plan for the PromQL `timestamp()` function.
     /// Projects the time index column as the value column for each row.
     ///
     /// # Arguments
-    /// * `normalize` - Input [`LogicalPlan`] for the normalized series.
+    /// * `input` - Input [`LogicalPlan`] after instant-vector selection.
+    /// * `timestamp_value_column` - Private column containing each selected sample's timestamp.
     ///
     /// # Returns
     /// Returns a [`Result<LogicalPlan>`] where the resulting logical plan projects the timestamp
@@ -1568,16 +1604,19 @@ impl PromPlanner {
     /// # Side Effects
     /// Updates the planner context's field columns to the timestamp column name.
     ///
-    fn create_timestamp_func_plan(&mut self, normalize: LogicalPlan) -> Result<LogicalPlan> {
-        let time_expr = build_special_time_expr(self.ctx.time_index_column.as_ref().unwrap())
-            .alias(DEFAULT_FIELD_COLUMN);
+    fn create_timestamp_func_plan(
+        &mut self,
+        input: LogicalPlan,
+        timestamp_value_column: &str,
+    ) -> Result<LogicalPlan> {
+        let time_expr = col(timestamp_value_column).alias(DEFAULT_FIELD_COLUMN);
         self.ctx.field_columns = vec![time_expr.schema_name().to_string()];
         let mut project_exprs = Vec::with_capacity(self.ctx.tag_columns.len() + 2);
         project_exprs.push(self.create_time_index_column_expr()?);
         project_exprs.push(time_expr);
         project_exprs.extend(self.create_tag_column_exprs()?);
 
-        LogicalPlanBuilder::from(normalize)
+        LogicalPlanBuilder::from(input)
             .project(project_exprs)
             .context(DataFusionPlanningSnafu)?
             .build()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This is the 1st PR of (hopefully) the final 6 PRs of native histogram.

This pull request adds Prometheus-compatible semantics for native histogram samples across PromQL selection, arithmetic, comparison, and counter range functions. It handles histogram stale markers, layout reconciliation, sparse-layout equality, start-timestamp synthetic zeros for `rate()` and `increase()`, and overflow-safe bucket bounds. It also documents the storage, protocol, and query contract without changing the persisted Struct, protobuf dependencies, or public configuration.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
