### PR TITLE
fix(mito2): select last rows for instant evaluations (follow-up of #8561)

### DIFF
--- a/src/mito2/src/engine/row_selector_test.rs
+++ b/src/mito2/src/engine/row_selector_test.rs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 use api::v1::Rows;
+use api::v1::helper::row;
+use api::v1::value::ValueData;
 use common_base::readable_size::ReadableSize;
 use common_recordbatch::RecordBatches;
+use datafusion_common::ScalarValue;
 use datafusion_expr::{col, lit};
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::RegionRequest;
@@ -24,7 +27,8 @@ use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
 use crate::test_util::batch_util::sort_batches_and_print;
 use crate::test_util::{
-    CreateRequestBuilder, TestEnv, build_rows_for_key, flush_region, put_rows, rows_schema,
+    CreateRequestBuilder, TestEnv, build_delete_rows_for_key, build_rows_for_key, delete_rows,
+    delete_rows_schema, flush_region, put_rows, rows_schema,
 };
 
 async fn test_last_row(append_mode: bool, flat_format: bool) {
@@ -131,6 +135,24 @@ async fn scan_last_row(
     sort_batches_and_print(&batches, &["tag_0", "ts"])
 }
 
+/// Build rows with a NaN (stale marker) field for `key` in `[start, end)`.
+fn build_stale_rows_for_key(key: &str, start: usize, end: usize) -> Vec<api::v1::Row> {
+    (start..end)
+        .map(|ts| {
+            row(vec![
+                ValueData::StringValue(key.to_string()),
+                ValueData::F64Value(f64::NAN),
+                ValueData::TimestampMillisecondValue(ts as i64 * 1000),
+            ])
+        })
+        .collect()
+}
+
+/// Helper to create a timestamp millisecond literal.
+fn ts_millis_lit(val: i64) -> datafusion_expr::Expr {
+    lit(ScalarValue::TimestampMillisecond(Some(val), None))
+}
+
 #[tokio::test]
 async fn test_last_row_append_mode_disabled() {
     test_last_row(false, false).await;
@@ -214,5 +236,213 @@ async fn test_last_row_flat_format_prefilter_does_not_poison_selector_cache() {
 | b     | 12.0    | 1970-01-01T00:00:02 |
 +-------+---------+---------------------+",
         unfiltered
+    );
+}
+
+#[tokio::test]
+async fn test_last_row_same_timestamp_across_ssts_prefers_newer_sequence() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // SST 1: key a, ts 0..3 (values 0, 1, 2).
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 3, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id, None).await;
+    // SST 2 (newer sequence): key a, ts 1..3 (values 10, 11). The maximum
+    // timestamp 2 exists in both SSTs, so the row with the higher sequence
+    // must win after the last-row scan.
+    let rows = Rows {
+        schema: column_schemas,
+        rows: build_rows_for_key("a", 1, 3, 10),
+    };
+    put_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id, None).await;
+
+    let result = scan_last_row(&engine, region_id, vec![]).await;
+    assert_eq!(
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| a     | 11.0    | 1970-01-01T00:00:02 |
++-------+---------+---------------------+",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_last_row_returns_stale_marker_row() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Normal values at ts 0..3.
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 3, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id, None).await;
+    // Stale markers (NaN) overwrite ts 2 and add ts 3. The storage layer must
+    // return the stale row as the last row; staleness is judged upstream by
+    // InstantManipulate.
+    let rows = Rows {
+        schema: column_schemas,
+        rows: build_stale_rows_for_key("a", 2, 4),
+    };
+    put_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id, None).await;
+
+    let result = scan_last_row(&engine, region_id, vec![]).await;
+    assert_eq!(
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| a     | NaN     | 1970-01-01T00:00:03 |
++-------+---------+---------------------+",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_last_row_after_delete_returns_nothing() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = rows_schema(&request);
+    let delete_schema = delete_rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Put rows at ts 0..3, then delete the whole series.
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 3, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id, None).await;
+
+    let rows = Rows {
+        schema: delete_schema,
+        rows: build_delete_rows_for_key("a", 0, 3),
+    };
+    delete_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id, None).await;
+
+    let result = scan_last_row(&engine, region_id, vec![]).await;
+    assert_eq!(
+        "\
++-------+---------+----+
+| tag_0 | field_0 | ts |
++-------+---------+----+
++-------+---------+----+",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_last_row_respects_lookback_left_boundary() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    let request = CreateRequestBuilder::new().build();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // key a, ts 0..5 (values 0..4).
+    let rows = Rows {
+        schema: column_schemas,
+        rows: build_rows_for_key("a", 0, 5, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id, None).await;
+
+    // An instant evaluation at 4s with a 2s lookback reads [2s, 4s]; samples
+    // before the left boundary must not match even though they are the last
+    // rows of the series overall.
+    let result = scan_last_row(
+        &engine,
+        region_id,
+        vec![
+            col("ts").gt_eq(ts_millis_lit(2000)),
+            col("ts").lt_eq(ts_millis_lit(4000)),
+        ],
+    )
+    .await;
+    assert_eq!(
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| a     | 4.0     | 1970-01-01T00:00:04 |
++-------+---------+---------------------+",
+        result
     );
 }

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -117,10 +117,10 @@ impl FlatCompatBatch {
         }
 
         let expect_schema = mapper.batch_schema();
-        if expect_schema == actual_schema
-            && actual.primary_key == mapper.metadata().primary_key
-            && actual.primary_key_encoding == mapper.metadata().primary_key_encoding
-        {
+        let primary_key_matches = mapper.metadata().primary_key_encoding
+            == actual.primary_key_encoding
+            && is_primary_key_same(mapper.metadata(), actual)?;
+        if expect_schema == actual_schema && primary_key_matches {
             // Although the SST has a different schema, but the schema after projection is the same
             // as expected schema.
             return Ok(None);
@@ -655,13 +655,13 @@ mod tests {
 
     use api::v1::{OpType, SemanticType};
     use datatypes::arrow::array::{
-        ArrayRef, BinaryArray, BinaryDictionaryBuilder, Int64Array, StringDictionaryBuilder,
-        TimestampMillisecondArray, UInt8Array, UInt64Array,
+        ArrayRef, BinaryArray, BinaryDictionaryBuilder, Int64Array, StringArray,
+        StringDictionaryBuilder, TimestampMillisecondArray, UInt8Array, UInt64Array,
     };
     use datatypes::arrow::datatypes::UInt32Type;
     use datatypes::arrow::record_batch::RecordBatch;
     use datatypes::prelude::ConcreteDataType;
-    use datatypes::schema::ColumnSchema;
+    use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema};
     use datatypes::value::ValueRef;
     use mito_codec::row_converter::{
         DensePrimaryKeyCodec, PrimaryKeyCodecExt, SparsePrimaryKeyCodec,
@@ -671,10 +671,12 @@ mod tests {
     use store_api::storage::RegionId;
 
     use super::*;
+    use crate::cache::CacheStrategy;
     use crate::read::flat_projection::FlatProjectionMapper;
     use crate::read::read_columns::ReadColumns;
     use crate::sst::parquet::flat_format::FlatReadFormat;
     use crate::sst::{FlatSchemaOptions, to_flat_sst_arrow_schema};
+    use crate::test_util::sst_util::{new_sparse_primary_key, sst_region_metadata_with_encoding};
 
     /// Creates a new [RegionMetadata].
     fn new_metadata(
@@ -921,6 +923,77 @@ mod tests {
         let expected_batch = RecordBatch::try_new(expected_schema, expected_columns).unwrap();
 
         assert_eq!(expected_batch, result);
+    }
+
+    #[test]
+    fn test_flat_compat_rewrites_key_before_deferred_tag_decode() {
+        let actual_metadata = Arc::new(sst_region_metadata_with_encoding(
+            PrimaryKeyEncoding::Sparse,
+        ));
+        let mut expected_builder = RegionMetadataBuilder::from_existing((*actual_metadata).clone());
+        let mut expected_primary_key = actual_metadata.primary_key.clone();
+        expected_primary_key.push(4);
+        expected_builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new("host", ConcreteDataType::string_datatype(), true)
+                    .with_default_constraint(Some(ColumnDefaultConstraint::Value(Value::from(""))))
+                    .unwrap(),
+                semantic_type: SemanticType::Tag,
+                column_id: 4,
+            })
+            .primary_key(expected_primary_key);
+        let expected_metadata = Arc::new(expected_builder.build().unwrap());
+        let host_index = expected_metadata.column_index_by_id(4).unwrap();
+
+        // The focused path reads the field and encoded key, then materializes host
+        // only after LastRow selection.
+        let mapper = FlatProjectionMapper::new_with_deferred_tags(
+            &expected_metadata,
+            vec![host_index],
+            ReadColumns::from_deduped_column_ids([2]),
+            None,
+            &[4],
+        )
+        .unwrap();
+        let read_format = FlatReadFormat::new(
+            actual_metadata.clone(),
+            ReadColumns::from_deduped_column_ids([2]),
+            None,
+            "test",
+            false,
+        )
+        .unwrap();
+
+        let compat_batch = FlatCompatBatch::try_new(&mapper, &read_format, false)
+            .unwrap()
+            .expect("primary key evolution requires compatibility");
+        let old_key = new_sparse_primary_key(&["tag0", "tag1"], &actual_metadata, 1, 100);
+        let input_schema = read_format.arrow_schema().clone();
+        let input_batch = RecordBatch::try_new(
+            input_schema,
+            vec![
+                Arc::new(UInt64Array::from(vec![100, 200])),
+                Arc::new(TimestampMillisecondArray::from_iter_values([1000, 2000])),
+                build_flat_test_pk_array(&[&old_key, &old_key]),
+                Arc::new(UInt64Array::from_iter_values([1, 2])),
+                Arc::new(UInt8Array::from_iter_values([
+                    OpType::Put as u8,
+                    OpType::Put as u8,
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let compatible = compat_batch.compat(input_batch).unwrap();
+        let output = mapper
+            .convert(&compatible, &CacheStrategy::Disabled)
+            .unwrap();
+        let tag = output
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(["", ""], [tag.value(0), tag.value(1)]);
     }
 
     #[test]

--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -14,6 +14,7 @@
 
 //! Utilities for projection on flat format.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -33,6 +34,7 @@ use datatypes::types::json_type::JsonNativeType;
 use datatypes::value::Value;
 use datatypes::vectors::Helper;
 use datatypes::vectors::json::array::JsonArray;
+use mito_codec::row_converter::build_primary_key_codec;
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
 use store_api::storage::ColumnId;
@@ -41,7 +43,7 @@ use crate::cache::CacheStrategy;
 use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
 use crate::read::read_columns::ReadColumns;
-use crate::sst::parquet::flat_format::sst_column_id_indices;
+use crate::sst::parquet::flat_format::{FlatConvertFormat, sst_column_id_indices};
 use crate::sst::parquet::format::FormatProjection;
 use crate::sst::{
     FlatSchemaOptions, internal_fields, tag_maybe_to_dictionary_field, to_flat_sst_arrow_schema,
@@ -71,6 +73,8 @@ pub struct FlatProjectionMapper {
     is_empty_projection: bool,
     /// The index in flat format [RecordBatch] for each column in the output [RecordBatch].
     batch_indices: Vec<usize>,
+    /// Existing flat-format decoder reused for projected tags deferred by LastRow scans.
+    deferred_tag_format: Option<FlatConvertFormat>,
     /// Precomputed Arrow schema for input batches.
     input_arrow_schema: datatypes::arrow::datatypes::SchemaRef,
 }
@@ -96,6 +100,16 @@ impl FlatProjectionMapper {
         projection: Vec<usize>,
         read_cols: ReadColumns,
         json_type_hint: Option<&HashMap<String, JsonNativeType>>,
+    ) -> Result<Self> {
+        Self::new_with_deferred_tags(metadata, projection, read_cols, json_type_hint, &[])
+    }
+
+    pub(crate) fn new_with_deferred_tags(
+        metadata: &RegionMetadataRef,
+        projection: Vec<usize>,
+        read_cols: ReadColumns,
+        json_type_hint: Option<&HashMap<String, JsonNativeType>>,
+        deferred_tags: &[ColumnId],
     ) -> Result<Self> {
         // If the original projection is empty.
         let is_empty_projection = projection.is_empty();
@@ -162,17 +176,28 @@ impl FlatProjectionMapper {
             Arc::new(Schema::new(col_schemas))
         };
 
+        let deferred_indices = metadata
+            .primary_key
+            .iter()
+            .filter(|id| deferred_tags.contains(id))
+            .enumerate()
+            .map(|(index, id)| (*id, index))
+            .collect::<HashMap<_, _>>();
         let batch_indices = if is_empty_projection {
             vec![]
         } else {
             output_col_ids
                 .iter()
                 .map(|id| {
+                    if let Some(index) = deferred_indices.get(id) {
+                        return Ok(*index);
+                    }
                     // Safety: The map is computed from the read projection.
                     format_projection
                         .column_id_to_projected_index
                         .get(id)
                         .copied()
+                        .map(|index| index + deferred_indices.len())
                         .with_context(|| {
                             let name = metadata
                                 .column_by_id(*id)
@@ -189,6 +214,21 @@ impl FlatProjectionMapper {
                 })
                 .collect::<Result<Vec<_>>>()?
         };
+        let deferred_tag_format = if deferred_tags.is_empty() {
+            None
+        } else {
+            let read_cols = ReadColumns::from_deduped_column_ids(deferred_tags.iter().copied());
+            let projection = FormatProjection::compute_format_projection(
+                &id_to_index,
+                metadata.column_metadatas.len() + 3,
+                read_cols,
+            );
+            FlatConvertFormat::new(
+                metadata.clone(),
+                &projection,
+                build_primary_key_codec(metadata),
+            )
+        };
 
         Ok(FlatProjectionMapper {
             metadata: metadata.clone(),
@@ -197,6 +237,7 @@ impl FlatProjectionMapper {
             batch_schema,
             is_empty_projection,
             batch_indices,
+            deferred_tag_format,
             input_arrow_schema,
         })
     }
@@ -319,6 +360,7 @@ impl FlatProjectionMapper {
         }
         // Construct output record batch directly from Arrow arrays to avoid
         // Arrow -> Vector -> Arrow roundtrips in the hot path.
+        let batch = self.with_deferred_tags(batch)?;
         let mut arrays = Vec::with_capacity(self.output_schema.num_columns());
         for (output_idx, index) in self.batch_indices.iter().enumerate() {
             let mut array = batch.column(*index).clone();
@@ -381,6 +423,7 @@ impl FlatProjectionMapper {
         &self,
         batch: &datatypes::arrow::record_batch::RecordBatch,
     ) -> common_recordbatch::error::Result<Vec<datatypes::vectors::VectorRef>> {
+        let batch = self.with_deferred_tags(batch)?;
         let mut columns = Vec::with_capacity(self.output_schema.num_columns());
         for index in &self.batch_indices {
             let mut array = batch.column(*index).clone();
@@ -398,6 +441,21 @@ impl FlatProjectionMapper {
             columns.push(vector);
         }
         Ok(columns)
+    }
+
+    fn with_deferred_tags<'a>(
+        &self,
+        batch: &'a datatypes::arrow::record_batch::RecordBatch,
+    ) -> common_recordbatch::error::Result<Cow<'a, datatypes::arrow::record_batch::RecordBatch>>
+    {
+        match &self.deferred_tag_format {
+            Some(format) => format
+                .convert(batch.clone())
+                .map_err(BoxedError::new)
+                .context(ExternalSnafu)
+                .map(Cow::Owned),
+            None => Ok(Cow::Borrowed(batch)),
+        }
     }
 }
 
@@ -616,12 +674,20 @@ impl DfBatchAssembler {
 
 #[cfg(test)]
 mod tests {
+    use api::v1::OpType;
+    use datatypes::arrow::array::{
+        ArrayRef, BinaryDictionaryBuilder, StringArray, TimestampMillisecondArray, UInt8Array,
+        UInt64Array,
+    };
+    use datatypes::arrow::datatypes::UInt32Type;
     use datatypes::schema::ColumnSchema;
     use datatypes::types::json_type::JsonObjectType;
+    use store_api::codec::PrimaryKeyEncoding;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
 
     use super::*;
+    use crate::test_util::sst_util::{new_sparse_primary_key, sst_region_metadata_with_encoding};
 
     fn metadata_with_legacy_json() -> RegionMetadataRef {
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1024, 0));
@@ -706,5 +772,49 @@ mod tests {
             mapper.batch_schema()[0],
             (0, ConcreteDataType::json_datatype())
         );
+    }
+
+    #[test]
+    fn test_deferred_sparse_tag_projection() {
+        let metadata = Arc::new(sst_region_metadata_with_encoding(
+            PrimaryKeyEncoding::Sparse,
+        ));
+        let schema = to_flat_sst_arrow_schema(
+            &metadata,
+            &FlatSchemaOptions::from_encoding(PrimaryKeyEncoding::Sparse),
+        );
+        let key = new_sparse_primary_key(&["a", "x"], &metadata, 1, 100);
+        let mut keys = BinaryDictionaryBuilder::<UInt32Type>::new();
+        keys.append(&key).unwrap();
+        keys.append(&key).unwrap();
+        let batch = datatypes::arrow::record_batch::RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(UInt64Array::from(vec![10, 11])) as ArrayRef,
+                Arc::new(TimestampMillisecondArray::from(vec![1, 2])) as ArrayRef,
+                Arc::new(keys.finish()) as ArrayRef,
+                Arc::new(UInt64Array::from_value(1, 2)) as ArrayRef,
+                Arc::new(UInt8Array::from_value(OpType::Put as u8, 2)) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let mapper = FlatProjectionMapper::new_with_deferred_tags(
+            &metadata,
+            vec![2, 4, 5],
+            ReadColumns::from_deduped_column_ids([2, 3]),
+            None,
+            &[0],
+        )
+        .unwrap();
+
+        let output = mapper.convert(&batch, &CacheStrategy::Disabled).unwrap();
+        let tags = output
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(["a", "a"], [tags.value(0), tags.value(1)]);
+        assert_eq!(2, output.num_rows());
+        assert_eq!(3, output.num_columns());
     }
 }

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -519,6 +519,12 @@ fn build_range_cache_key_inner(
     part_range: &PartitionRange,
     stage: Option<RangeScanStage>,
 ) -> Option<RangeScanCacheKey> {
+    // Focused LastRow pruning depends on query-local coverage accumulated while
+    // scanning newer files, which is not represented by a partition cache key.
+    if stream_ctx.input.is_focused_last_row() {
+        return None;
+    }
+
     if !stream_ctx.input.cache_strategy.has_range_result_cache() {
         return None;
     }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -42,7 +42,9 @@ use itertools::Itertools;
 use partition::expr::PartitionExpr;
 use smallvec::SmallVec;
 use snafu::{OptionExt, ResultExt};
+use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
+use store_api::metric_engine_consts::is_metric_engine_internal_column;
 use store_api::region_engine::{PartitionRange, RegionScannerRef};
 use store_api::storage::{
     ColumnId, NestedPath, RegionId, ScanRequest, SequenceNumber, SequenceRange,
@@ -83,6 +85,7 @@ use crate::sst::index::inverted_index::applier::builder::InvertedIndexApplierBui
 #[cfg(feature = "vector_index")]
 use crate::sst::index::vector_index::applier::{VectorIndexApplier, VectorIndexApplierRef};
 use crate::sst::parquet::file_range::PreFilterMode;
+use crate::sst::parquet::prefilter::{LastRowCoverage, LastRowCoverageFilter};
 use crate::sst::parquet::reader::ReaderMetrics;
 
 #[cfg(feature = "vector_index")]
@@ -417,6 +420,13 @@ impl ScanRegion {
         let sst_min_sequence = self.request.sst_min_sequence.and_then(NonZeroU64::new);
         let time_range = self.build_time_range_predicate();
         let predicate = PredicateGroup::new(metadata, &self.request.filters)?;
+        // The mapper always computes projected column ids as the schema of SSTs may change.
+        let projection = self
+            .request
+            .projection
+            .clone()
+            .unwrap_or_else(|| (0..metadata.column_metadatas.len()).collect());
+        let deferred_tags = self.focused_last_row_tags(&predicate, &projection);
 
         let read_col_ids =
             self.build_read_col_ids(self.request.projection.as_deref(), &predicate)?;
@@ -432,18 +442,18 @@ impl ScanRegion {
             .fields()
             .iter()
             .any(is_json2_extension_type);
-        let read_cols = if has_structured_json {
+        let mut read_cols = if has_structured_json {
             self.read_columns_with_json_type_hint(&read_col_ids)
         } else {
             ReadColumns::from_deduped_column_ids(read_col_ids.iter().copied())
         };
+        if let Some(deferred_tags) = &deferred_tags {
+            read_cols
+                .cols
+                .retain(|column| !deferred_tags.contains(&column.column_id));
+        }
+        let read_col_ids = read_cols.column_ids();
 
-        // The mapper always computes projected column ids as the schema of SSTs may change.
-        let projection = self
-            .request
-            .projection
-            .clone()
-            .unwrap_or_else(|| (0..metadata.column_metadatas.len()).collect());
         let json_type_hint = has_structured_json
             .then_some(&self.request.json_type_hint)
             .inspect(|json_type_hint| {
@@ -455,11 +465,12 @@ impl ScanRegion {
                         .join(", ")
                 );
             });
-        let mapper = FlatProjectionMapper::new_with_read_columns(
+        let mapper = FlatProjectionMapper::new_with_deferred_tags(
             metadata,
             projection,
             read_cols,
             json_type_hint,
+            deferred_tags.as_deref().unwrap_or_default(),
         )?;
         let mapper = if self.request.preserve_pk_dictionary_encoding {
             mapper.with_pk_dictionary_encoding()
@@ -578,6 +589,7 @@ impl ScanRegion {
             .with_filter_deleted(self.filter_deleted)
             .with_merge_mode(self.version.options.merge_mode())
             .with_series_row_selector(self.request.series_row_selector)
+            .with_last_row_coverage(deferred_tags.is_some().then(LastRowCoverage::default))
             .with_distribution(self.request.distribution)
             .with_explain_flat_format(
                 self.version.options.sst_format == Some(crate::sst::FormatType::Flat),
@@ -866,6 +878,48 @@ impl ScanRegion {
 
         Some(Arc::new(applier))
     }
+
+    /// Returns projected tags that can be reconstructed after focused LastRow selection.
+    /// `Some` also marks the complete focused path when the projection has no tags.
+    fn focused_last_row_tags(
+        &self,
+        predicate: &PredicateGroup,
+        projection: &[usize],
+    ) -> Option<Vec<ColumnId>> {
+        let metadata = &self.version.metadata;
+        let supported = !self.version.options.append_mode
+            && self.version.options.merge_mode() == MergeMode::LastRow
+            && self.request.series_row_selector == Some(TimeSeriesRowSelector::LastRow)
+            && metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse
+            && predicate.region_partition_expr.is_none()
+            && predicate
+                .predicate_without_region()
+                .is_none_or(|predicate| {
+                    predicate.dyn_filters().is_empty()
+                        && predicate.exprs().iter().all(|expr| {
+                            SimpleFilterEvaluator::try_new(expr)
+                                .and_then(|filter| metadata.column_by_name(filter.column_name()))
+                                .is_some_and(|column| {
+                                    matches!(
+                                        column.semantic_type,
+                                        SemanticType::Tag | SemanticType::Timestamp
+                                    )
+                                })
+                        })
+                });
+        supported.then(|| {
+            projection
+                .iter()
+                .filter_map(|index| metadata.column_metadatas.get(*index))
+                .filter(|column| {
+                    column.semantic_type == SemanticType::Tag
+                        && metadata.primary_key.contains(&column.column_id)
+                        && !is_metric_engine_internal_column(&column.column_schema.name)
+                })
+                .map(|column| column.column_id)
+                .collect()
+        })
+    }
 }
 
 /// Returns true if the time range of a SST `file` matches the `predicate`.
@@ -927,6 +981,8 @@ pub struct ScanInput {
     pub(crate) merge_mode: MergeMode,
     /// Hint to select rows from time series.
     pub(crate) series_row_selector: Option<TimeSeriesRowSelector>,
+    /// Newer-file timestamps observed by this explicit LastRow scan.
+    last_row_coverage: Option<LastRowCoverage>,
     /// Hint for the required distribution of the scanner.
     pub(crate) distribution: Option<TimeSeriesDistribution>,
     /// Whether the region's configured SST format is flat.
@@ -970,6 +1026,7 @@ impl ScanInput {
             filter_deleted: true,
             merge_mode: MergeMode::default(),
             series_row_selector: None,
+            last_row_coverage: None,
             distribution: None,
             explain_flat_format: false,
             snapshot_sequence: None,
@@ -1157,6 +1214,16 @@ impl ScanInput {
     }
 
     #[must_use]
+    fn with_last_row_coverage(mut self, coverage: Option<LastRowCoverage>) -> Self {
+        self.last_row_coverage = coverage;
+        self
+    }
+
+    pub(crate) fn is_focused_last_row(&self) -> bool {
+        self.last_row_coverage.is_some()
+    }
+
+    #[must_use]
     pub(crate) fn with_snapshot_sequence(
         mut self,
         snapshot_sequence: Option<SequenceNumber>,
@@ -1217,6 +1284,19 @@ impl ScanInput {
             max_scalar: timestamp_to_scalar_value(time_index_unit, Some(max_ts.value())),
             time_index_col_name: time_index.column_schema.name.clone(),
         })
+    }
+
+    fn last_row_coverage_for_file(&self, file: &FileHandle) -> Option<LastRowCoverageFilter> {
+        let coverage = self.last_row_coverage.as_ref()?;
+        let unit = self
+            .region_metadata()
+            .time_index_column()
+            .column_schema
+            .data_type
+            .as_timestamp()?
+            .unit();
+        let file_max = file.time_range().1.convert_to_ceil(unit)?;
+        Some(coverage.for_file(file_max.value()))
     }
 
     /// Checks whether a file can be definitively pruned using only its manifest-level
@@ -1321,6 +1401,7 @@ impl ScanInput {
             .compaction(self.compaction)
             .pre_filter_mode(pre_filter_mode)
             .decode_primary_key_values(decode_pk_values)
+            .last_row_coverage(self.last_row_coverage_for_file(file))
             .build_reader_input(reader_metrics)
             .await;
         let read_input = match res {
@@ -1954,6 +2035,9 @@ impl StreamContext {
         self: &Arc<Self>,
         filter_exprs: Vec<Arc<dyn datafusion::physical_plan::PhysicalExpr>>,
     ) -> Vec<bool> {
+        if self.input.is_focused_last_row() {
+            return vec![false; filter_exprs.len()];
+        }
         let mut supported = Vec::with_capacity(filter_exprs.len());
         let filter_expr = filter_exprs
             .into_iter()

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -26,10 +26,11 @@ use common_telemetry::tracing;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, Time};
 use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::timestamp::timestamp_array_to_primitive;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use prometheus::IntGauge;
 use smallvec::SmallVec;
 use store_api::storage::RegionId;
+use tokio::sync::mpsc;
 
 use crate::error::Result;
 use crate::memtable::MemScanMetrics;
@@ -1514,6 +1515,36 @@ pub fn build_flat_file_range_scan_stream(
     mut per_file_metrics: Option<HashMap<RegionFileId, FileScanMetrics>>,
 ) -> impl Stream<Item = Result<RecordBatch>> {
     try_stream! {
+        if stream_ctx.input.is_focused_last_row() && ranges.len() > 1 {
+            const PREFETCH_WINDOW: usize = 8;
+            if let Some(file_metrics) = per_file_metrics.as_ref() {
+                part_metrics.merge_reader_metrics(&ReaderMetrics::default(), Some(file_metrics));
+            }
+
+            let mut ranges = ranges.into_iter();
+            let spawn = |range| {
+                spawn_last_row_range(
+                    stream_ctx.clone(),
+                    range,
+                    part_metrics.clone(),
+                    read_type,
+                )
+            };
+            let mut receivers = VecDeque::with_capacity(PREFETCH_WINDOW);
+            for range in ranges.by_ref().take(PREFETCH_WINDOW) {
+                receivers.push_back(spawn(range));
+            }
+            while let Some(mut receiver) = receivers.pop_front() {
+                while let Some(batch) = receiver.recv().await {
+                    yield batch?;
+                }
+                if let Some(range) = ranges.next() {
+                    receivers.push_back(spawn(range));
+                }
+            }
+            return;
+        }
+
         let fetch_metrics = if part_metrics.explain_verbose() {
             Some(Arc::new(ParquetFetchMetrics::default()))
         } else {
@@ -1579,6 +1610,30 @@ pub fn build_flat_file_range_scan_stream(
         reader_metrics.filter_metrics.observe();
         part_metrics.merge_reader_metrics(reader_metrics, per_file_metrics.as_ref());
     }
+}
+
+fn spawn_last_row_range(
+    stream_ctx: Arc<StreamContext>,
+    range: FileRange,
+    part_metrics: PartitionMetrics,
+    read_type: &'static str,
+) -> mpsc::Receiver<Result<RecordBatch>> {
+    let (sender, receiver) = mpsc::channel(2);
+    common_runtime::spawn_query(async move {
+        let mut stream: BoxedRecordBatchStream = Box::pin(build_flat_file_range_scan_stream(
+            stream_ctx,
+            part_metrics,
+            read_type,
+            std::iter::once(range).collect(),
+            Some(HashMap::new()),
+        ));
+        while let Some(batch) = stream.next().await {
+            if sender.send(batch).await.is_err() {
+                break;
+            }
+        }
+    });
+    receiver
 }
 
 /// Build the stream of scanning the extension range in flat format denoted by the [`RowGroupIndex`].

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -654,28 +654,47 @@ pub(crate) async fn build_flat_sources(
         return Ok(None);
     }
 
-    let split_batch_size = should_split_flat_batches_for_merge(stream_ctx, range_meta);
+    let optimize_last_row = !compaction && stream_ctx.input.is_focused_last_row();
+    let split_batch_size = if optimize_last_row {
+        None
+    } else {
+        should_split_flat_batches_for_merge(stream_ctx, range_meta)
+    };
     let should_split = split_batch_size.is_some();
     sources.reserve(num_indices);
     let mut ordered_sources = Vec::with_capacity(num_indices);
     ordered_sources.resize_with(num_indices, || None);
     let mut file_scan_tasks = Vec::new();
     let pre_filter_mode = stream_ctx.range_pre_filter_mode(part_range);
+    let mut source_order = range_meta
+        .row_group_indices
+        .iter()
+        .copied()
+        .enumerate()
+        .collect::<Vec<_>>();
+    if optimize_last_row {
+        source_order.sort_by_key(|(position, index)| {
+            let file_max = stream_ctx.is_file_range_index(*index).then(|| {
+                std::cmp::Reverse(stream_ctx.input.file_from_index(*index).time_range().1)
+            });
+            (file_max.is_some(), file_max, *position)
+        });
+    }
 
-    for (position, index) in range_meta.row_group_indices.iter().enumerate() {
-        if stream_ctx.is_mem_range_index(*index) {
+    for &(position, index) in &source_order {
+        if stream_ctx.is_mem_range_index(index) {
             let stream = scan_flat_mem_ranges(
                 stream_ctx.clone(),
                 part_metrics.clone(),
-                *index,
+                index,
                 range_meta.time_range,
             );
             ordered_sources[position] = Some(Box::pin(stream) as _);
-        } else if stream_ctx.is_file_range_index(*index) {
+        } else if stream_ctx.is_file_range_index(index) {
             // Common manifest-level fast-skip shared by SeqScan and UnorderedScan.
             // Compaction should keep reading its selected input ranges completely.
             if !compaction
-                && partition_pruner.try_skip_manifest_pruned_file_range(*index, part_metrics)
+                && partition_pruner.try_skip_manifest_pruned_file_range(index, part_metrics)
             {
                 continue;
             }
@@ -685,7 +704,7 @@ pub(crate) async fn build_flat_sources(
                 let part_metrics = part_metrics.clone();
                 let partition_pruner = partition_pruner.clone();
                 let semaphore = Arc::clone(semaphore_ref);
-                let row_group_index = *index;
+                let row_group_index = index;
                 file_scan_tasks.push(async move {
                     let _permit = semaphore.acquire().await.unwrap();
                     let stream = scan_flat_file_ranges(
@@ -703,7 +722,7 @@ pub(crate) async fn build_flat_sources(
                 let stream = scan_flat_file_ranges(
                     stream_ctx.clone(),
                     part_metrics.clone(),
-                    *index,
+                    index,
                     read_type,
                     partition_pruner.clone(),
                 )
@@ -713,7 +732,7 @@ pub(crate) async fn build_flat_sources(
         } else {
             let stream = scan_util::maybe_scan_flat_other_ranges(
                 stream_ctx,
-                *index,
+                index,
                 part_metrics,
                 pre_filter_mode,
             )
@@ -729,7 +748,10 @@ pub(crate) async fn build_flat_sources(
         }
     }
 
-    for stream in ordered_sources.into_iter().flatten() {
+    for (position, _) in source_order {
+        let Some(stream) = ordered_sources[position].take() else {
+            continue;
+        };
         if should_split {
             sources.push(Box::pin(SplitRecordBatchStream::new(stream)));
         } else {

--- a/src/mito2/src/read/series_scan.rs
+++ b/src/mito2/src/read/series_scan.rs
@@ -53,6 +53,7 @@ use crate::read::scan_util::{
 };
 use crate::read::seq_scan::SeqScan;
 use crate::read::stream::{ConvertBatchStream, ScanBatch, ScanBatchStream};
+use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 use crate::sst::parquet::flat_format::primary_key_column_index;
 use crate::sst::parquet::format::PrimaryKeyArray;
 
@@ -227,7 +228,8 @@ impl SeriesScan {
             return;
         }
 
-        let (senders, receivers) = new_channel_list(self.properties.num_partitions());
+        let channel_size = 1 + usize::from(self.stream_ctx.input.is_focused_last_row());
+        let (senders, receivers) = new_channel_list(self.properties.num_partitions(), channel_size);
         let mut distributor = SeriesDistributor {
             stream_ctx: self.stream_ctx.clone(),
             range_semaphore: Some(Arc::new(Semaphore::new(self.properties.num_partitions()))),
@@ -319,10 +321,10 @@ impl SeriesScan {
     }
 }
 
-fn new_channel_list(num_partitions: usize) -> (SenderList, ReceiverList) {
+fn new_channel_list(num_partitions: usize, channel_size: usize) -> (SenderList, ReceiverList) {
     let (senders, receivers): (Vec<_>, Vec<_>) = (0..num_partitions)
         .map(|_| {
-            let (sender, receiver) = mpsc::channel(1);
+            let (sender, receiver) = mpsc::channel(channel_size);
             (Some(sender), Some(receiver))
         })
         .unzip();
@@ -557,6 +559,9 @@ impl SeriesDistributor {
         let mut metrics = SeriesDistributorMetrics::default();
 
         let mut divider = FlatSeriesBatchDivider::default();
+        let balance_last_rows = self.stream_ctx.input.is_focused_last_row();
+        let last_row_batch_size =
+            DEFAULT_READ_BATCH_SIZE.div_ceil(self.senders.senders.len().max(1));
         while let Some(record_batch) = reader.try_next().await? {
             metrics.scan_cost += fetch_start.elapsed();
             metrics.num_batches += 1;
@@ -568,9 +573,36 @@ impl SeriesDistributor {
                 continue;
             }
 
-            // Use divider to split series
+            if balance_last_rows {
+                for offset in (0..record_batch.num_rows()).step_by(last_row_batch_size) {
+                    let mut batch = FlatSeriesBatch::default();
+                    batch.batches.push(record_batch.slice(
+                        offset,
+                        last_row_batch_size.min(record_batch.num_rows() - offset),
+                    ));
+                    let yield_start = Instant::now();
+                    self.senders.send_batch(SeriesBatch::Flat(batch)).await?;
+                    metrics.yield_cost += yield_start.elapsed();
+                }
+            } else {
+                let divider_start = Instant::now();
+                let series_batch = divider.push(record_batch);
+                metrics.divider_cost += divider_start.elapsed();
+                if let Some(series_batch) = series_batch {
+                    let yield_start = Instant::now();
+                    self.senders
+                        .send_batch(SeriesBatch::Flat(series_batch))
+                        .await?;
+                    metrics.yield_cost += yield_start.elapsed();
+                }
+            }
+            fetch_start = Instant::now();
+        }
+
+        // Send any remaining batch in the divider
+        if !balance_last_rows {
             let divider_start = Instant::now();
-            let series_batch = divider.push(record_batch);
+            let series_batch = divider.finish();
             metrics.divider_cost += divider_start.elapsed();
             if let Some(series_batch) = series_batch {
                 let yield_start = Instant::now();
@@ -579,19 +611,6 @@ impl SeriesDistributor {
                     .await?;
                 metrics.yield_cost += yield_start.elapsed();
             }
-            fetch_start = Instant::now();
-        }
-
-        // Send any remaining batch in the divider
-        let divider_start = Instant::now();
-        let series_batch = divider.finish();
-        metrics.divider_cost += divider_start.elapsed();
-        if let Some(series_batch) = series_batch {
-            let yield_start = Instant::now();
-            self.senders
-                .send_batch(SeriesBatch::Flat(series_batch))
-                .await?;
-            metrics.yield_cost += yield_start.elapsed();
         }
 
         metrics.scan_cost += fetch_start.elapsed();

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -24,10 +24,12 @@ use std::sync::Arc;
 
 use api::v1::SemanticType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
+use dashmap::DashMap;
 use datatypes::arrow::array::{Array, BinaryArray, BooleanArray, BooleanBufferBuilder};
 use datatypes::arrow::buffer::BooleanBuffer;
 use datatypes::arrow::datatypes::SchemaRef;
 use datatypes::arrow::record_batch::RecordBatch;
+use datatypes::timestamp::timestamp_array_to_primitive;
 use futures::StreamExt;
 use mito_codec::row_converter::{PrimaryKeyCodec, PrimaryKeyFilter, build_primary_key_codec};
 use parquet::arrow::ProjectionMask;
@@ -51,6 +53,31 @@ use crate::sst::parquet::reader::{
     MaybeFilter, PhysicalFilterContext, RowGroupBuildContext, RowGroupReaderBuilder,
     SimpleFilterContext,
 };
+
+/// Timestamps already found by newer SST work in one explicit LastRow scan.
+#[derive(Clone, Default)]
+pub(crate) struct LastRowCoverage(Arc<DashMap<Vec<u8>, i64>>);
+
+impl LastRowCoverage {
+    pub(crate) fn for_file(&self, max_timestamp: i64) -> LastRowCoverageFilter {
+        LastRowCoverageFilter {
+            observed: self.0.clone(),
+            max_timestamp,
+        }
+    }
+}
+
+/// A file-specific view of query-local LastRow coverage.
+#[derive(Clone)]
+pub(crate) struct LastRowCoverageFilter {
+    observed: Arc<DashMap<Vec<u8>, i64>>,
+    max_timestamp: i64,
+}
+
+struct LastRowRun {
+    key: Vec<u8>,
+    rows: usize,
+}
 
 pub(crate) fn matching_row_ranges_by_primary_key(
     input: &RecordBatch,
@@ -122,7 +149,6 @@ fn matching_row_ranges_from_dict(
         while end < key_values.len() && key_values[end] == key {
             end += 1;
         }
-
         push_matched_range(
             &mut matched_row_ranges,
             pk_filter,
@@ -159,7 +185,6 @@ fn matching_row_ranges_from_binary(
         while end < pk_array.len() && pk_array.value(end) == value {
             end += 1;
         }
-
         push_matched_range(&mut matched_row_ranges, pk_filter, value, start, end)?;
 
         start = end;
@@ -519,6 +544,12 @@ pub(crate) struct PrefilterContext {
     pk_filter_expr_strs: Option<SmallVec<[String; 1]>>,
     /// Arrow schema used to build narrowed prefilter projections.
     arrow_schema: SchemaRef,
+    /// Name of the time index in the Parquet schema.
+    time_index_name: String,
+    /// Matching keys already covered by newer files in this query.
+    last_row_coverage: Option<LastRowCoverageFilter>,
+    /// Matching PK runs carried from the first stage into timestamp selection.
+    last_row_runs: Vec<LastRowRun>,
 }
 
 /// Pre-built state for constructing [PrefilterContext] per row group.
@@ -535,6 +566,7 @@ pub(crate) struct PrefilterContextBuilder {
     metadata: RegionMetadataRef,
     schema_version: u64,
     arrow_schema: SchemaRef,
+    last_row_coverage: Option<LastRowCoverageFilter>,
 }
 
 impl PrefilterContextBuilder {
@@ -607,7 +639,12 @@ impl PrefilterContextBuilder {
             metadata: metadata.clone(),
             schema_version,
             arrow_schema: read_format.arrow_schema().clone(),
+            last_row_coverage: None,
         })
+    }
+
+    pub(crate) fn set_last_row_coverage(&mut self, coverage: LastRowCoverageFilter) {
+        self.last_row_coverage = Some(coverage);
     }
 
     /// Builds a [PrefilterContext] for a specific row group.
@@ -622,6 +659,9 @@ impl PrefilterContextBuilder {
             schema_version: self.schema_version,
             pk_filter_expr_strs: self.pk_filter_expr_strs.clone(),
             arrow_schema: self.arrow_schema.clone(),
+            time_index_name: self.metadata.time_index_column().column_schema.name.clone(),
+            last_row_coverage: self.last_row_coverage.clone(),
+            last_row_runs: Vec::new(),
         }
     }
 
@@ -704,6 +744,12 @@ pub(crate) async fn execute_prefilter(
     reader_builder: &RowGroupReaderBuilder,
     build_ctx: &RowGroupBuildContext<'_>,
 ) -> Result<PrefilterResult> {
+    // LastRow selection depends on the complete row-group ordering and must not
+    // be stored in the predicate-result cache.
+    if prefilter_ctx.last_row_coverage.is_some() {
+        return execute_last_row_prefilter(prefilter_ctx, reader_builder, build_ctx).await;
+    }
+
     let entries = build_prefilter_cache_entries(prefilter_ctx, reader_builder, build_ctx);
 
     if entries.is_empty() {
@@ -712,6 +758,52 @@ pub(crate) async fn execute_prefilter(
     }
 
     execute_prefilter_with_result_cache(prefilter_ctx, reader_builder, build_ctx, entries).await
+}
+
+/// Runs encoded-primary-key filters before timestamp filtering and LastRow
+/// selection. Sparse metric scans can discard unrelated series before decoding
+/// the timestamp column, while the second stage still returns one candidate per
+/// matching key for the ordinary projected read.
+async fn execute_last_row_prefilter(
+    prefilter_ctx: &mut PrefilterContext,
+    reader_builder: &RowGroupReaderBuilder,
+    build_ctx: &RowGroupBuildContext<'_>,
+) -> Result<PrefilterResult> {
+    let (pk_entries, remaining): (Vec<_>, Vec<_>) = all_prefilter_entries(prefilter_ctx)
+        .into_iter()
+        .partition(|entry| matches!(entry.kind, PrefilterEntryKind::PkGroup));
+    if pk_entries.is_empty() {
+        return execute_prefilter_by_reading_columns(prefilter_ctx, reader_builder, build_ctx)
+            .await;
+    }
+
+    let pk_result =
+        build_prefilter_masks(prefilter_ctx, reader_builder, build_ctx, &pk_entries, false).await;
+    let (pk_mask, rows_before_filter) = pk_result?;
+    let pk_mask = pk_mask.unwrap_or_else(|| BooleanBuffer::new_set(rows_before_filter));
+    let pk_selection = refined_selection_from_mask(&pk_mask, &build_ctx.row_selection);
+
+    let second_stage = RowGroupBuildContext {
+        row_group_idx: build_ctx.row_group_idx,
+        row_selection: Some(pk_selection),
+        fetch_metrics: build_ctx.fetch_metrics,
+    };
+    let (last_row_mask, selected_pk_rows) = build_prefilter_masks(
+        prefilter_ctx,
+        reader_builder,
+        &second_stage,
+        &remaining,
+        true,
+    )
+    .await?;
+    let last_row_mask = last_row_mask.unwrap_or_else(|| BooleanBuffer::new_set(selected_pk_rows));
+    let refined_selection =
+        refined_selection_from_mask(&last_row_mask, &second_stage.row_selection);
+    let filtered_rows = rows_before_filter.saturating_sub(refined_selection.row_count());
+    Ok(PrefilterResult {
+        refined_selection,
+        filtered_rows,
+    })
 }
 
 async fn execute_prefilter_with_result_cache(
@@ -758,8 +850,14 @@ async fn execute_prefilter_with_result_cache(
             .copied()
             .map(|idx| PrefilterEntry::without_cache(PrefilterEntryKind::Physical(idx))),
     );
-    let (uncached_mask, read_rows) =
-        build_prefilter_masks(prefilter_ctx, reader_builder, build_ctx, &uncached_entries).await?;
+    let (uncached_mask, read_rows) = build_prefilter_masks(
+        prefilter_ctx,
+        reader_builder,
+        build_ctx,
+        &uncached_entries,
+        false,
+    )
+    .await?;
 
     let final_mask = match (hit_mask, uncached_mask) {
         (Some(hit_mask), Some(uncached_mask)) => hit_mask.bitand(&uncached_mask),
@@ -792,8 +890,12 @@ async fn build_prefilter_masks(
     reader_builder: &RowGroupReaderBuilder,
     build_ctx: &RowGroupBuildContext<'_>,
     entries: &[PrefilterEntry],
+    select_last_row: bool,
 ) -> Result<(Option<BooleanBuffer>, usize)> {
-    let prefilter_column_names = prefilter_column_names_for_entries(prefilter_ctx, entries);
+    let mut prefilter_column_names = prefilter_column_names_for_entries(prefilter_ctx, entries);
+    if select_last_row {
+        prefilter_column_names.insert(prefilter_ctx.time_index_name.clone());
+    }
     let parquet_schema = reader_builder
         .parquet_metadata()
         .file_metadata()
@@ -818,6 +920,8 @@ async fn build_prefilter_masks(
         .map(|entry| entry.key.is_some().then(|| BooleanBufferBuilder::new(0)))
         .collect::<Vec<_>>();
     let mut combined_builder = (!entries.is_empty()).then(|| BooleanBufferBuilder::new(0));
+    let mut last_row_timestamps = Vec::new();
+    let mut last_row_predicate = BooleanBufferBuilder::new(0);
     let mut rows_before_filter = 0usize;
 
     while let Some(batch_result) = stream.next().await {
@@ -841,7 +945,21 @@ async fn build_prefilter_masks(
                 builder.append_buffer(&mask);
             }
         }
-        if let Some(builder) = &mut combined_builder {
+        if select_last_row {
+            let (timestamp_index, _) = batch
+                .schema()
+                .column_with_name(&prefilter_ctx.time_index_name)
+                .context(UnexpectedSnafu {
+                    reason: "Timestamp is missing from LastRow prefilter",
+                })?;
+            let (array, _) = timestamp_array_to_primitive(batch.column(timestamp_index)).context(
+                UnexpectedSnafu {
+                    reason: "Invalid timestamp in LastRow prefilter",
+                },
+            )?;
+            last_row_timestamps.extend_from_slice(array.values());
+            last_row_predicate.append_buffer(&batch_mask);
+        } else if let Some(builder) = &mut combined_builder {
             builder.append_buffer(&batch_mask);
         }
     }
@@ -854,10 +972,23 @@ async fn build_prefilter_masks(
         }
     }
 
-    Ok((
-        combined_builder.map(|mut builder| builder.finish()),
-        rows_before_filter,
-    ))
+    let combined_mask = if select_last_row {
+        let coverage = prefilter_ctx
+            .last_row_coverage
+            .as_ref()
+            .context(UnexpectedSnafu {
+                reason: "LastRow selection requires coverage",
+            })?;
+        Some(select_last_rows(
+            &last_row_timestamps,
+            &last_row_predicate.finish(),
+            &prefilter_ctx.last_row_runs,
+            coverage,
+        )?)
+    } else {
+        combined_builder.map(|mut builder| builder.finish())
+    };
+    Ok((combined_mask, rows_before_filter))
 }
 
 fn prefilter_column_names_for_entries(
@@ -887,6 +1018,105 @@ fn prefilter_column_names_for_entries(
     prefilter_column_names
 }
 
+enum PrimaryKeys<'a> {
+    Dictionary(&'a PrimaryKeyArray, &'a BinaryArray),
+    Binary(&'a BinaryArray),
+}
+
+impl<'a> PrimaryKeys<'a> {
+    fn try_new(batch: &'a RecordBatch, index: usize) -> Result<Self> {
+        let column = batch.column(index);
+        if let Some(keys) = column.as_any().downcast_ref::<PrimaryKeyArray>() {
+            let values = keys
+                .values()
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .context(UnexpectedSnafu {
+                    reason: "Primary key dictionary values are not binary",
+                })?;
+            return Ok(Self::Dictionary(keys, values));
+        }
+        column
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .map(Self::Binary)
+            .with_context(|| UnexpectedSnafu {
+                reason: format!("Unsupported primary key array: {:?}", column.data_type()),
+            })
+    }
+
+    fn value(&self, row: usize) -> &'a [u8] {
+        match self {
+            Self::Dictionary(keys, values) => values.value(keys.keys().value(row) as usize),
+            Self::Binary(keys) => keys.value(row),
+        }
+    }
+}
+
+fn matching_primary_key_runs<'a>(
+    batch: &'a RecordBatch,
+    index: usize,
+    filter: &mut dyn PrimaryKeyFilter,
+) -> Result<Vec<(Range<usize>, &'a [u8])>> {
+    let keys = PrimaryKeys::try_new(batch, index)?;
+    let mut runs = Vec::new();
+    let mut start = 0;
+    while start < batch.num_rows() {
+        let key = keys.value(start);
+        let mut end = start + 1;
+        while end < batch.num_rows() && keys.value(end) == key {
+            end += 1;
+        }
+        if filter.matches(key).context(DecodeSnafu)? {
+            runs.push((start..end, key));
+        }
+        start = end;
+    }
+    Ok(runs)
+}
+
+/// Narrows a timestamp predicate mask to the maximum matching timestamp of each
+/// PK run carried from the first prefilter stage. Equal timestamps are retained
+/// for the ordinary sequence/delete deduplication.
+fn select_last_rows(
+    timestamps: &[i64],
+    predicate: &BooleanBuffer,
+    runs: &[LastRowRun],
+    coverage: &LastRowCoverageFilter,
+) -> Result<BooleanBuffer> {
+    let total_rows = timestamps.len();
+    if runs.iter().map(|run| run.rows).sum::<usize>() != total_rows {
+        return UnexpectedSnafu {
+            reason: "LastRow PK runs and timestamp rows have different lengths",
+        }
+        .fail();
+    }
+    let mut output = BooleanBufferBuilder::new(total_rows);
+    output.append_n(total_rows, false);
+    let mut start = 0;
+    for run in runs {
+        let end = start + run.rows;
+        if let Some(last) = (start..end).rev().find(|row| predicate.value(*row)) {
+            let timestamp = timestamps[last];
+            for row in (start..=last)
+                .rev()
+                .take_while(|row| timestamps[*row] == timestamp)
+                .filter(|row| predicate.value(*row))
+            {
+                output.set_bit(row, true);
+            }
+            coverage
+                .observed
+                .entry(run.key.clone())
+                .and_modify(|current| *current = (*current).max(timestamp))
+                .or_insert(timestamp);
+        }
+        start = end;
+    }
+
+    Ok(output.finish())
+}
+
 async fn execute_prefilter_by_reading_columns(
     prefilter_ctx: &mut PrefilterContext,
     reader_builder: &RowGroupReaderBuilder,
@@ -894,7 +1124,7 @@ async fn execute_prefilter_by_reading_columns(
 ) -> Result<PrefilterResult> {
     let entries = all_prefilter_entries(prefilter_ctx);
     let (mask, rows_before_filter) =
-        build_prefilter_masks(prefilter_ctx, reader_builder, build_ctx, &entries).await?;
+        build_prefilter_masks(prefilter_ctx, reader_builder, build_ctx, &entries, false).await?;
 
     let final_mask = mask.unwrap_or_else(|| BooleanBuffer::new_set(rows_before_filter));
     let rows_selected = final_mask.count_set_bits();
@@ -1040,6 +1270,7 @@ fn eval_entry_mask(
     kind: PrefilterEntryKind,
     file_path: &str,
 ) -> Result<BooleanBuffer> {
+    let last_row_coverage = prefilter_ctx.last_row_coverage.clone();
     match kind {
         PrefilterEntryKind::Simple(idx) => {
             eval_simple_filter_mask(batch, &prefilter_ctx.filters[idx], file_path)
@@ -1051,7 +1282,20 @@ fn eval_entry_mask(
             let pk_filter = prefilter_ctx.pk_filter.as_mut().context(UnexpectedSnafu {
                 reason: "Missing primary key filter for prefilter cache entry",
             })?;
-            primary_key_filter_mask(batch, pk_filter.as_mut())
+            let Some(coverage) = last_row_coverage.as_ref() else {
+                return primary_key_filter_mask(batch, pk_filter.as_mut());
+            };
+            let (mask, runs) = eval_last_row_pk_mask(batch, pk_filter.as_mut(), coverage)?;
+            for run in runs {
+                if let Some(previous) = prefilter_ctx.last_row_runs.last_mut()
+                    && previous.key == run.key
+                {
+                    previous.rows += run.rows;
+                } else {
+                    prefilter_ctx.last_row_runs.push(run);
+                }
+            }
+            Ok(mask)
         }
     }
 }
@@ -1061,12 +1305,7 @@ pub(crate) fn primary_key_filter_mask(
     batch: &RecordBatch,
     pk_filter: &mut dyn PrimaryKeyFilter,
 ) -> Result<BooleanBuffer> {
-    let (pk_column_index, _) = batch
-        .schema()
-        .column_with_name(PRIMARY_KEY_COLUMN_NAME)
-        .context(UnexpectedSnafu {
-            reason: "Primary key column not found in prefilter batch",
-        })?;
+    let pk_column_index = primary_key_column_index(batch)?;
     let matched_row_ranges = matching_row_ranges_by_primary_key(batch, pk_column_index, pk_filter)?;
     let mut builder = BooleanBufferBuilder::new(batch.num_rows());
     builder.append_n(batch.num_rows(), false);
@@ -1076,6 +1315,45 @@ pub(crate) fn primary_key_filter_mask(
         }
     }
     Ok(builder.finish())
+}
+
+fn eval_last_row_pk_mask(
+    batch: &RecordBatch,
+    pk_filter: &mut dyn PrimaryKeyFilter,
+    coverage: &LastRowCoverageFilter,
+) -> Result<(BooleanBuffer, Vec<LastRowRun>)> {
+    let pk_column_index = primary_key_column_index(batch)?;
+    let matched = matching_primary_key_runs(batch, pk_column_index, pk_filter)?;
+    let mut builder = BooleanBufferBuilder::new(batch.num_rows());
+    builder.append_n(batch.num_rows(), false);
+    let mut selected_runs = Vec::new();
+    for (range, key) in matched {
+        if coverage
+            .observed
+            .get(key)
+            .is_some_and(|timestamp| *timestamp > coverage.max_timestamp)
+        {
+            continue;
+        }
+        selected_runs.push(LastRowRun {
+            key: key.to_vec(),
+            rows: range.len(),
+        });
+        for row in range {
+            builder.set_bit(row, true);
+        }
+    }
+    Ok((builder.finish(), selected_runs))
+}
+
+fn primary_key_column_index(batch: &RecordBatch) -> Result<usize> {
+    batch
+        .schema()
+        .column_with_name(PRIMARY_KEY_COLUMN_NAME)
+        .map(|(index, _)| index)
+        .context(UnexpectedSnafu {
+            reason: "Primary key column not found in prefilter batch",
+        })
 }
 
 fn eval_simple_filter_mask(
@@ -1200,6 +1478,47 @@ mod tests {
         );
 
         assert_eq!(hits.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn test_select_last_rows_after_predicate() {
+        let k1 = new_primary_key(&["a", "x"]);
+        let k2 = new_primary_key(&["b", "x"]);
+        let predicate = BooleanBuffer::collect_bool(5, |row| [true, true, true, true, false][row]);
+
+        let runs = [
+            LastRowRun { key: k1, rows: 3 },
+            LastRowRun { key: k2, rows: 2 },
+        ];
+        let coverage = LastRowCoverage::default().for_file(i64::MAX);
+        let selected = select_last_rows(&[0, 2, 2, 3, 4], &predicate, &runs, &coverage).unwrap();
+
+        assert_eq!(selected.count_set_bits(), 3);
+        assert!(selected.value(1));
+        assert!(selected.value(2));
+        assert!(selected.value(3));
+    }
+
+    #[test]
+    fn test_last_row_coverage_requires_strictly_newer_timestamp() {
+        let metadata = Arc::new(sst_region_metadata());
+        let filters = Arc::new(new_test_filters(&[col("tag_0").eq(lit("a"))]));
+        let mut pk_filter =
+            build_primary_key_codec(metadata.as_ref()).primary_key_filter(&metadata, filters);
+        let key = new_primary_key(&["a", "x"]);
+        let batch = new_prefilter_batch(&[key.as_slice(), key.as_slice()], &[9, 10]);
+        let coverage = LastRowCoverage::default();
+        coverage.0.insert(key, 10);
+
+        let (equal_mask, equal_runs) =
+            eval_last_row_pk_mask(&batch, pk_filter.as_mut(), &coverage.for_file(10)).unwrap();
+        assert_eq!(equal_mask.count_set_bits(), 2);
+        assert_eq!(equal_runs.len(), 1);
+
+        let (older_mask, older_runs) =
+            eval_last_row_pk_mask(&batch, pk_filter.as_mut(), &coverage.for_file(9)).unwrap();
+        assert_eq!(older_mask.count_set_bits(), 0);
+        assert!(older_runs.is_empty());
     }
 
     fn new_test_filters(exprs: &[datafusion_expr::Expr]) -> Vec<SimpleFilterEvaluator> {

--- a/src/mito2/src/sst/parquet/prefilter.rs
+++ b/src/mito2/src/sst/parquet/prefilter.rs
@@ -769,12 +769,17 @@ async fn execute_last_row_prefilter(
     reader_builder: &RowGroupReaderBuilder,
     build_ctx: &RowGroupBuildContext<'_>,
 ) -> Result<PrefilterResult> {
-    let (pk_entries, remaining): (Vec<_>, Vec<_>) = all_prefilter_entries(prefilter_ctx)
+    let (mut pk_entries, remaining): (Vec<_>, Vec<_>) = all_prefilter_entries(prefilter_ctx)
         .into_iter()
         .partition(|entry| matches!(entry.kind, PrefilterEntryKind::PkGroup));
     if pk_entries.is_empty() {
-        return execute_prefilter_by_reading_columns(prefilter_ctx, reader_builder, build_ctx)
-            .await;
+        // No PK matcher (e.g. a bare instant query with only a time predicate):
+        // keep the focused two-stage LastRow prefilter by treating the whole
+        // encoded PK column as one run stream grouped by key, so per-series
+        // last-row selection and coverage pruning still apply.
+        pk_entries.push(PrefilterEntry::without_cache(
+            PrefilterEntryKind::PkGroupAll,
+        ));
     }
 
     let pk_result =
@@ -1010,7 +1015,7 @@ fn prefilter_column_names_for_entries(
                         .to_string(),
                 );
             }
-            PrefilterEntryKind::PkGroup => {
+            PrefilterEntryKind::PkGroup | PrefilterEntryKind::PkGroupAll => {
                 prefilter_column_names.insert(PRIMARY_KEY_COLUMN_NAME.to_string());
             }
         }
@@ -1164,6 +1169,8 @@ enum PrefilterEntryKind {
     Simple(usize),
     Physical(usize),
     PkGroup,
+    /// The whole encoded PK column treated as one run stream (no PK matcher).
+    PkGroupAll,
 }
 
 struct PrefilterEntry {
@@ -1285,17 +1292,32 @@ fn eval_entry_mask(
             let Some(coverage) = last_row_coverage.as_ref() else {
                 return primary_key_filter_mask(batch, pk_filter.as_mut());
             };
-            let (mask, runs) = eval_last_row_pk_mask(batch, pk_filter.as_mut(), coverage)?;
-            for run in runs {
-                if let Some(previous) = prefilter_ctx.last_row_runs.last_mut()
-                    && previous.key == run.key
-                {
-                    previous.rows += run.rows;
-                } else {
-                    prefilter_ctx.last_row_runs.push(run);
-                }
-            }
+            let (mask, runs) = eval_last_row_pk_mask(batch, Some(pk_filter.as_mut()), coverage)?;
+            record_last_row_runs(prefilter_ctx, runs);
             Ok(mask)
+        }
+        PrefilterEntryKind::PkGroupAll => {
+            let Some(coverage) = last_row_coverage.as_ref() else {
+                // Without coverage there is nothing to prune: select every row.
+                return Ok(BooleanBuffer::new_set(batch.num_rows()));
+            };
+            let (mask, runs) = eval_last_row_pk_mask(batch, None, coverage)?;
+            record_last_row_runs(prefilter_ctx, runs);
+            Ok(mask)
+        }
+    }
+}
+
+/// Coalesces adjacent `LastRowRun`s with the same key, mirroring the row order
+/// of the batches they were produced from.
+fn record_last_row_runs(prefilter_ctx: &mut PrefilterContext, runs: Vec<LastRowRun>) {
+    for run in runs {
+        if let Some(previous) = prefilter_ctx.last_row_runs.last_mut()
+            && previous.key == run.key
+        {
+            previous.rows += run.rows;
+        } else {
+            prefilter_ctx.last_row_runs.push(run);
         }
     }
 }
@@ -1319,11 +1341,29 @@ pub(crate) fn primary_key_filter_mask(
 
 fn eval_last_row_pk_mask(
     batch: &RecordBatch,
-    pk_filter: &mut dyn PrimaryKeyFilter,
+    pk_filter: Option<&mut dyn PrimaryKeyFilter>,
     coverage: &LastRowCoverageFilter,
 ) -> Result<(BooleanBuffer, Vec<LastRowRun>)> {
     let pk_column_index = primary_key_column_index(batch)?;
-    let matched = matching_primary_key_runs(batch, pk_column_index, pk_filter)?;
+    let matched = match pk_filter {
+        Some(filter) => matching_primary_key_runs(batch, pk_column_index, filter)?,
+        // No PK matcher: treat the whole PK column as one run stream grouped by key.
+        None => {
+            let keys = PrimaryKeys::try_new(batch, pk_column_index)?;
+            let mut runs = Vec::new();
+            let mut start = 0;
+            while start < batch.num_rows() {
+                let key = keys.value(start);
+                let mut end = start + 1;
+                while end < batch.num_rows() && keys.value(end) == key {
+                    end += 1;
+                }
+                runs.push((start..end, key));
+                start = end;
+            }
+            runs
+        }
+    };
     let mut builder = BooleanBufferBuilder::new(batch.num_rows());
     builder.append_n(batch.num_rows(), false);
     let mut selected_runs = Vec::new();
@@ -1511,14 +1551,40 @@ mod tests {
         coverage.0.insert(key, 10);
 
         let (equal_mask, equal_runs) =
-            eval_last_row_pk_mask(&batch, pk_filter.as_mut(), &coverage.for_file(10)).unwrap();
+            eval_last_row_pk_mask(&batch, Some(pk_filter.as_mut()), &coverage.for_file(10))
+                .unwrap();
         assert_eq!(equal_mask.count_set_bits(), 2);
         assert_eq!(equal_runs.len(), 1);
 
         let (older_mask, older_runs) =
-            eval_last_row_pk_mask(&batch, pk_filter.as_mut(), &coverage.for_file(9)).unwrap();
+            eval_last_row_pk_mask(&batch, Some(pk_filter.as_mut()), &coverage.for_file(9)).unwrap();
         assert_eq!(older_mask.count_set_bits(), 0);
         assert!(older_runs.is_empty());
+    }
+
+    #[test]
+    fn test_last_row_pk_mask_without_pk_filter() {
+        let key = new_primary_key(&["a", "x"]);
+        let other = new_primary_key(&["b", "x"]);
+        let batch = new_prefilter_batch(
+            &[key.as_slice(), key.as_slice(), other.as_slice()],
+            &[9, 10, 11],
+        );
+        let coverage = LastRowCoverage::default();
+        coverage.0.insert(key, 10);
+
+        // The strict `>` coverage comparison still prunes runs already covered
+        // by a newer file when there is no PK matcher.
+        let (equal_mask, equal_runs) =
+            eval_last_row_pk_mask(&batch, None, &coverage.for_file(10)).unwrap();
+        assert_eq!(equal_mask.count_set_bits(), 3);
+        assert_eq!(equal_runs.len(), 2);
+
+        let (older_mask, older_runs) =
+            eval_last_row_pk_mask(&batch, None, &coverage.for_file(9)).unwrap();
+        assert_eq!(older_mask.count_set_bits(), 1);
+        assert_eq!(older_runs.len(), 1);
+        assert_eq!(older_runs[0].key, other);
     }
 
     fn new_test_filters(exprs: &[datafusion_expr::Expr]) -> Vec<SimpleFilterEvaluator> {

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -85,7 +85,8 @@ use crate::sst::parquet::format::{INTERNAL_COLUMN_NUM, need_override_sequence};
 use crate::sst::parquet::json_align::{NestedSchemaAligner, ProjectedRecordBatchStream};
 use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::prefilter::{
-    CachedPrimaryKeyFilter, PrefilterContextBuilder, build_reader_filter_plan, execute_prefilter,
+    CachedPrimaryKeyFilter, LastRowCoverageFilter, PrefilterContextBuilder, build_reader_filter_plan,
+    execute_prefilter,
 };
 use crate::sst::parquet::push_decoder::{
     SstParquetRangeFetcher, build_sst_parquet_record_batch_stream,
@@ -185,6 +186,8 @@ pub struct ParquetReaderBuilder {
     pre_filter_mode: PreFilterMode,
     /// Whether to decode primary key values eagerly when reading primary key format SSTs.
     decode_primary_key_values: bool,
+    /// Query-local LastRow coverage for this file.
+    last_row_coverage: Option<LastRowCoverageFilter>,
     page_index_policy: PageIndexPolicy,
     defer_optional_page_index: bool,
     /// Scan-wide hint for rows in a decoded batch.
@@ -218,6 +221,7 @@ impl ParquetReaderBuilder {
             compaction: false,
             pre_filter_mode: PreFilterMode::All,
             decode_primary_key_values: false,
+            last_row_coverage: None,
             page_index_policy: Default::default(),
             defer_optional_page_index: false,
             batch_size: DEFAULT_READ_BATCH_SIZE,
@@ -322,6 +326,11 @@ impl ParquetReaderBuilder {
     #[must_use]
     pub(crate) fn decode_primary_key_values(mut self, decode: bool) -> Self {
         self.decode_primary_key_values = decode;
+        self
+    }
+
+    pub(crate) fn last_row_coverage(mut self, coverage: Option<LastRowCoverageFilter>) -> Self {
+        self.last_row_coverage = coverage;
         self
     }
 
@@ -493,13 +502,18 @@ impl ParquetReaderBuilder {
 
         let codec = build_primary_key_codec(read_format.metadata());
 
-        let filter_plan = build_reader_filter_plan(
+        let mut filter_plan = build_reader_filter_plan(
             self.predicate.as_ref(),
             self.expected_metadata.as_deref(),
             self.pre_filter_mode,
             &read_format,
             &codec,
         );
+        if let (Some(coverage), Some(builder)) =
+            (&self.last_row_coverage, &mut filter_plan.prefilter_builder)
+        {
+            builder.set_last_row_coverage(coverage.clone());
+        }
 
         if self.defer_optional_page_index
             && self.page_index_policy == PageIndexPolicy::Optional

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -79,14 +79,15 @@ use crate::sst::index::vector_index::applier::VectorIndexApplierRef;
 use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
 use crate::sst::parquet::file_range::{
     FileRangeContext, FileRangeContextRef, PartitionFilterContext, PreFilterMode, RangeBase,
+    row_group_contains_delete,
 };
 use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
 use crate::sst::parquet::format::{INTERNAL_COLUMN_NUM, need_override_sequence};
 use crate::sst::parquet::json_align::{NestedSchemaAligner, ProjectedRecordBatchStream};
 use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::prefilter::{
-    CachedPrimaryKeyFilter, LastRowCoverageFilter, PrefilterContextBuilder, build_reader_filter_plan,
-    execute_prefilter,
+    CachedPrimaryKeyFilter, LastRowCoverageFilter, PrefilterContextBuilder,
+    build_reader_filter_plan, execute_prefilter,
 };
 use crate::sst::parquet::push_decoder::{
     SstParquetRangeFetcher, build_sst_parquet_record_batch_stream,
@@ -509,8 +510,15 @@ impl ParquetReaderBuilder {
             &read_format,
             &codec,
         );
+        let last_row_coverage = self.last_row_coverage.as_ref().filter(|_| {
+            selection.iter().all(|(row_group, _)| {
+                row_group_contains_delete(&parquet_meta, *row_group, &file_path)
+                    .map(|contains_delete| !contains_delete)
+                    .unwrap_or(false)
+            })
+        });
         if let (Some(coverage), Some(builder)) =
-            (&self.last_row_coverage, &mut filter_plan.prefilter_builder)
+            (last_row_coverage, &mut filter_plan.prefilter_builder)
         {
             builder.set_last_row_coverage(coverage.clone());
         }

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -223,6 +223,11 @@ impl InstantManipulate {
         "InstantManipulate"
     }
 
+    /// Returns whether this plan evaluates exactly one timestamp.
+    pub fn is_single_evaluation(&self) -> bool {
+        self.start == self.end
+    }
+
     fn resolve_tag_columns(input: &LogicalPlan, tag_columns: &[String]) -> Vec<String> {
         if !tag_columns.is_empty() {
             return tag_columns.to_vec();

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -286,6 +286,19 @@ impl DummyTableProvider {
         self.scan_request.lock().unwrap().series_row_selector = Some(selector);
     }
 
+    /// Creates a copy of this provider with an independent scan request, so
+    /// hints can be applied per TableScan node without leaking to sibling
+    /// scans that share the same region provider.
+    pub(crate) fn fork(&self) -> Self {
+        Self {
+            region_id: self.region_id,
+            engine: self.engine.clone(),
+            metadata: self.metadata.clone(),
+            scan_request: Arc::new(Mutex::new(self.scan_request.lock().unwrap().clone())),
+            query_ctx: self.query_ctx.clone(),
+        }
+    }
+
     pub fn with_vector_search_hint(&self, hint: VectorSearchRequest) {
         self.scan_request.lock().unwrap().vector_search = Some(hint);
     }

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -105,6 +105,9 @@ impl ScanHintRule {
                         if visitor
                             .instant_last_row_scans
                             .contains(&(adapter as *const DummyTableProvider as usize))
+                            && !visitor
+                                .non_instant_scans
+                                .contains(&(adapter as *const DummyTableProvider as usize))
                         {
                             adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
                         }
@@ -247,6 +250,8 @@ struct ScanHintVisitor {
     instant_selector_depth: usize,
     /// Dummy providers scanned under a single-evaluation instant selector.
     instant_last_row_scans: HashSet<usize>,
+    /// Dummy providers also scanned outside a single-evaluation instant selector.
+    non_instant_scans: HashSet<usize>,
     #[cfg(feature = "vector_index")]
     vector_search: VectorSearchState,
 }
@@ -368,8 +373,7 @@ impl TreeNodeVisitor<'_> for ScanHintVisitor {
             }
         }
 
-        if self.instant_selector_depth > 0
-            && let LogicalPlan::TableScan(table_scan) = node
+        if let LogicalPlan::TableScan(table_scan) = node
             && let Some(source) = table_scan
                 .source
                 .as_any()
@@ -379,8 +383,12 @@ impl TreeNodeVisitor<'_> for ScanHintVisitor {
                 .as_any()
                 .downcast_ref::<DummyTableProvider>()
         {
-            self.instant_last_row_scans
-                .insert(adapter as *const DummyTableProvider as usize);
+            let provider = adapter as *const DummyTableProvider as usize;
+            if self.instant_selector_depth > 0 {
+                self.instant_last_row_scans.insert(provider);
+            } else {
+                self.non_instant_scans.insert(provider);
+            }
         }
 
         #[cfg(feature = "vector_index")]
@@ -624,6 +632,55 @@ mod test {
             single_request.distribution
         );
         assert_eq!(None, range_provider.scan_request().series_row_selector);
+    }
+
+    #[test]
+    fn shared_provider_is_not_hinted_for_mixed_instant_and_range_scans() {
+        let provider = Arc::new(mock_table_provider_with_tsid(RegionId::new(1, 1)));
+        let source = Arc::new(DefaultTableSource::new(provider.clone()));
+        let instant_input = LogicalPlanBuilder::scan("instant", source.clone(), None)
+            .unwrap()
+            .build()
+            .unwrap();
+        let instant = LogicalPlan::Extension(datafusion_expr::logical_plan::Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                1000,
+                300_000,
+                5_000,
+                "ts".to_string(),
+                vec![DATA_SCHEMA_TSID_COLUMN_NAME.to_string()],
+                Some("v0".to_string()),
+                instant_input,
+            )),
+        });
+        let range_input = LogicalPlanBuilder::scan("range", source, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        let range = LogicalPlan::Extension(datafusion_expr::logical_plan::Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                2000,
+                300_000,
+                5_000,
+                "ts".to_string(),
+                vec![DATA_SCHEMA_TSID_COLUMN_NAME.to_string()],
+                Some("v0".to_string()),
+                range_input,
+            )),
+        });
+        let plan = LogicalPlanBuilder::from(instant)
+            .union(range)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap();
+
+        assert_eq!(None, provider.scan_request().series_row_selector);
     }
 
     #[test]

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -24,6 +24,7 @@ use datafusion_common::{Column, Result};
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{Expr, LogicalPlan, utils};
 use datafusion_optimizer::{OptimizerConfig, OptimizerRule};
+use promql::extension_plan::InstantManipulate;
 use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
 use store_api::storage::{TimeSeriesDistribution, TimeSeriesRowSelector};
 
@@ -99,6 +100,13 @@ impl ScanHintRule {
                                 group_by_cols,
                                 order_by_col,
                             );
+                        }
+
+                        if visitor
+                            .instant_last_row_scans
+                            .contains(&(adapter as *const DummyTableProvider as usize))
+                        {
+                            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
                         }
 
                         #[cfg(feature = "vector_index")]
@@ -235,6 +243,10 @@ struct ScanHintVisitor {
     /// This field stores saved `group_by` columns when all aggregate functions are `last_value`
     /// and the `order_by` column which should be time index.
     ts_row_selector: Option<(HashSet<Column>, Column)>,
+    /// Nesting depth of single-evaluation PromQL instant selectors.
+    instant_selector_depth: usize,
+    /// Dummy providers scanned under a single-evaluation instant selector.
+    instant_last_row_scans: HashSet<usize>,
     #[cfg(feature = "vector_index")]
     vector_search: VectorSearchState,
 }
@@ -243,6 +255,13 @@ impl TreeNodeVisitor<'_> for ScanHintVisitor {
     type Node = LogicalPlan;
 
     fn f_down(&mut self, node: &Self::Node) -> Result<TreeNodeRecursion> {
+        if let LogicalPlan::Extension(extension) = node
+            && let Some(instant) = extension.node.as_any().downcast_ref::<InstantManipulate>()
+            && instant.is_single_evaluation()
+        {
+            self.instant_selector_depth += 1;
+        }
+
         #[cfg(feature = "vector_index")]
         if let LogicalPlan::Limit(limit) = node {
             // Track LIMIT so vector hint k can be derived within the same input chain.
@@ -349,6 +368,21 @@ impl TreeNodeVisitor<'_> for ScanHintVisitor {
             }
         }
 
+        if self.instant_selector_depth > 0
+            && let LogicalPlan::TableScan(table_scan) = node
+            && let Some(source) = table_scan
+                .source
+                .as_any()
+                .downcast_ref::<DefaultTableSource>()
+            && let Some(adapter) = source
+                .table_provider
+                .as_any()
+                .downcast_ref::<DummyTableProvider>()
+        {
+            self.instant_last_row_scans
+                .insert(adapter as *const DummyTableProvider as usize);
+        }
+
         #[cfg(feature = "vector_index")]
         if let LogicalPlan::Filter(filter) = node {
             self.vector_search.on_filter_enter(&filter.predicate);
@@ -364,6 +398,13 @@ impl TreeNodeVisitor<'_> for ScanHintVisitor {
     }
 
     fn f_up(&mut self, _node: &Self::Node) -> Result<TreeNodeRecursion> {
+        if let LogicalPlan::Extension(extension) = _node
+            && let Some(instant) = extension.node.as_any().downcast_ref::<InstantManipulate>()
+            && instant.is_single_evaluation()
+        {
+            self.instant_selector_depth -= 1;
+        }
+
         #[cfg(feature = "vector_index")]
         match _node {
             LogicalPlan::Limit(_) => {
@@ -392,7 +433,9 @@ impl TreeNodeVisitor<'_> for ScanHintVisitor {
 
 impl ScanHintVisitor {
     fn need_rewrite(&self) -> bool {
-        let base = self.order_expr.is_some() || self.ts_row_selector.is_some();
+        let base = self.order_expr.is_some()
+            || self.ts_row_selector.is_some()
+            || !self.instant_last_row_scans.is_empty();
         #[cfg(feature = "vector_index")]
         {
             base || self.vector_search.need_rewrite()
@@ -517,6 +560,70 @@ mod test {
 
         let scan_req = provider.scan_request();
         let _ = scan_req.series_row_selector.unwrap();
+    }
+
+    #[test]
+    fn single_evaluation_uses_last_row_only_for_instant_selector() {
+        let single_provider = Arc::new(mock_table_provider_with_tsid(RegionId::new(1, 1)));
+        let single_source = Arc::new(DefaultTableSource::new(single_provider.clone()));
+        let single_input = LogicalPlanBuilder::scan("single", single_source, None)
+            .unwrap()
+            .sort(vec![
+                col(DATA_SCHEMA_TSID_COLUMN_NAME).sort(true, true),
+                col("ts").sort(true, true),
+            ])
+            .unwrap()
+            .build()
+            .unwrap();
+        let single = LogicalPlan::Extension(datafusion_expr::logical_plan::Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                1000,
+                300_000,
+                5_000,
+                "ts".to_string(),
+                vec![DATA_SCHEMA_TSID_COLUMN_NAME.to_string()],
+                Some("v0".to_string()),
+                single_input,
+            )),
+        });
+
+        let range_provider = Arc::new(mock_table_provider(RegionId::new(2, 1)));
+        let range_source = Arc::new(DefaultTableSource::new(range_provider.clone()));
+        let range_input = LogicalPlanBuilder::scan("range", range_source, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        let range = LogicalPlan::Extension(datafusion_expr::logical_plan::Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                2000,
+                300_000,
+                5_000,
+                "ts".to_string(),
+                vec!["k0".to_string()],
+                Some("v0".to_string()),
+                range_input,
+            )),
+        });
+
+        ScanHintRule
+            .rewrite(single, &OptimizerContext::default())
+            .unwrap();
+        ScanHintRule
+            .rewrite(range, &OptimizerContext::default())
+            .unwrap();
+
+        let single_request = single_provider.scan_request();
+        assert_eq!(
+            Some(TimeSeriesRowSelector::LastRow),
+            single_request.series_row_selector
+        );
+        assert_eq!(
+            Some(TimeSeriesDistribution::PerSeries),
+            single_request.distribution
+        );
+        assert_eq!(None, range_provider.scan_request().series_row_selector);
     }
 
     #[test]

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use api::v1::SemanticType;
 use arrow_schema::SortOptions;
@@ -22,6 +23,7 @@ use datafusion::datasource::DefaultTableSource;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion, TreeNodeVisitor};
 use datafusion_common::{Column, Result};
 use datafusion_expr::expr::Sort;
+use datafusion_expr::logical_plan::TableScan;
 use datafusion_expr::{Expr, LogicalPlan, utils};
 use datafusion_optimizer::{OptimizerConfig, OptimizerRule};
 use promql::extension_plan::InstantManipulate;
@@ -64,6 +66,10 @@ impl ScanHintRule {
         let _ = plan.visit(&mut visitor)?;
 
         if visitor.need_rewrite() {
+            // The hint-setting pass walks the plan in the same order as the
+            // visitor pass, so restart the per-node sequence to make the
+            // lookups in `set_hints` match the ids recorded by `f_down`.
+            visitor.table_scan_seq = 0;
             plan.transform_down(&mut |plan| Self::set_hints(plan, &mut visitor))
         } else {
             Ok(Transformed::no(plan))
@@ -74,8 +80,10 @@ impl ScanHintRule {
         plan: LogicalPlan,
         visitor: &mut ScanHintVisitor,
     ) -> Result<Transformed<LogicalPlan>> {
-        match &plan {
-            LogicalPlan::TableScan(table_scan) => {
+        match plan {
+            LogicalPlan::TableScan(mut table_scan) => {
+                let node_id = visitor.table_scan_seq;
+                visitor.table_scan_seq += 1;
                 let mut transformed = false;
                 if let Some(source) = table_scan
                     .source
@@ -88,47 +96,67 @@ impl ScanHintRule {
                         .as_any()
                         .downcast_ref::<DummyTableProvider>()
                     {
-                        // set order_hint
-                        if let Some(order_expr) = &visitor.order_expr {
-                            Self::set_order_hint(adapter, order_expr);
-                        }
-
-                        // set time series selector hint
-                        if let Some((group_by_cols, order_by_col)) = &visitor.ts_row_selector {
-                            Self::set_time_series_row_selector_hint(
-                                adapter,
-                                group_by_cols,
-                                order_by_col,
-                            );
-                        }
-
-                        if visitor
-                            .instant_last_row_scans
-                            .contains(&(adapter as *const DummyTableProvider as usize))
-                            && !visitor
-                                .non_instant_scans
-                                .contains(&(adapter as *const DummyTableProvider as usize))
-                        {
-                            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
-                        }
-
-                        #[cfg(feature = "vector_index")]
-                        if let Some(vector_request) = visitor
-                            .vector_search
-                            .take_vector_request_from_dummy(adapter, &table_scan.table_name)
-                        {
-                            adapter.with_vector_search_hint(vector_request);
+                        let provider = adapter as *const DummyTableProvider as usize;
+                        // The LastRow hint is qualified per TableScan node: it is only valid
+                        // when this node is scanned under a single-evaluation instant selector
+                        // and is never scanned outside one. When several TableScan nodes share
+                        // the same provider (e.g. the same table on both sides of a join/binary
+                        // expression or a reused `with` subquery), the per-node decision must
+                        // not leak into the shared provider, so hints are applied to a per-node
+                        // fork instead of mutating the shared provider.
+                        let last_row = visitor.instant_last_row_scans.contains(&node_id)
+                            && !visitor.non_instant_scans.contains(&node_id);
+                        let shared = visitor
+                            .provider_scan_nodes
+                            .get(&provider)
+                            .is_some_and(|nodes| nodes.len() > 1);
+                        if shared {
+                            let fork = adapter.fork();
+                            Self::apply_hints(&fork, &table_scan, last_row, visitor);
+                            table_scan.source = Arc::new(DefaultTableSource::new(Arc::new(fork)));
+                        } else {
+                            Self::apply_hints(adapter, &table_scan, last_row, visitor);
                         }
                         transformed = true;
                     }
                 }
                 if transformed {
-                    Ok(Transformed::yes(plan))
+                    Ok(Transformed::yes(LogicalPlan::TableScan(table_scan)))
                 } else {
-                    Ok(Transformed::no(plan))
+                    Ok(Transformed::no(LogicalPlan::TableScan(table_scan)))
                 }
             }
             _ => Ok(Transformed::no(plan)),
+        }
+    }
+
+    #[cfg_attr(not(feature = "vector_index"), allow(unused_variables))]
+    fn apply_hints(
+        adapter: &DummyTableProvider,
+        table_scan: &TableScan,
+        last_row: bool,
+        visitor: &mut ScanHintVisitor,
+    ) {
+        // set order_hint
+        if let Some(order_expr) = &visitor.order_expr {
+            Self::set_order_hint(adapter, order_expr);
+        }
+
+        // set time series selector hint
+        if let Some((group_by_cols, order_by_col)) = &visitor.ts_row_selector {
+            Self::set_time_series_row_selector_hint(adapter, group_by_cols, order_by_col);
+        }
+
+        if last_row {
+            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
+        }
+
+        #[cfg(feature = "vector_index")]
+        if let Some(vector_request) = visitor
+            .vector_search
+            .take_vector_request_from_dummy(adapter, &table_scan.table_name)
+        {
+            adapter.with_vector_search_hint(vector_request);
         }
     }
 
@@ -248,10 +276,18 @@ struct ScanHintVisitor {
     ts_row_selector: Option<(HashSet<Column>, Column)>,
     /// Nesting depth of single-evaluation PromQL instant selectors.
     instant_selector_depth: usize,
-    /// Dummy providers scanned under a single-evaluation instant selector.
+    /// TableScan nodes scanned under a single-evaluation instant selector,
+    /// identified by their plan node address.
     instant_last_row_scans: HashSet<usize>,
-    /// Dummy providers also scanned outside a single-evaluation instant selector.
+    /// TableScan nodes also scanned outside a single-evaluation instant selector.
     non_instant_scans: HashSet<usize>,
+    /// Distinct TableScan nodes per provider, to detect providers shared by
+    /// several scans that need per-node hint state.
+    provider_scan_nodes: HashMap<usize, HashSet<usize>>,
+    /// Traversal-order sequence number for TableScan nodes. Both the visitor
+    /// pass and the hint-setting pass walk the plan in the same order, so the
+    /// sequence is a stable per-node identity.
+    table_scan_seq: usize,
     #[cfg(feature = "vector_index")]
     vector_search: VectorSearchState,
 }
@@ -373,21 +409,28 @@ impl TreeNodeVisitor<'_> for ScanHintVisitor {
             }
         }
 
-        if let LogicalPlan::TableScan(table_scan) = node
-            && let Some(source) = table_scan
+        if let LogicalPlan::TableScan(table_scan) = node {
+            let node_id = self.table_scan_seq;
+            self.table_scan_seq += 1;
+            if let Some(source) = table_scan
                 .source
                 .as_any()
                 .downcast_ref::<DefaultTableSource>()
-            && let Some(adapter) = source
-                .table_provider
-                .as_any()
-                .downcast_ref::<DummyTableProvider>()
-        {
-            let provider = adapter as *const DummyTableProvider as usize;
-            if self.instant_selector_depth > 0 {
-                self.instant_last_row_scans.insert(provider);
-            } else {
-                self.non_instant_scans.insert(provider);
+                && let Some(adapter) = source
+                    .table_provider
+                    .as_any()
+                    .downcast_ref::<DummyTableProvider>()
+            {
+                let provider = adapter as *const DummyTableProvider as usize;
+                if self.instant_selector_depth > 0 {
+                    self.instant_last_row_scans.insert(node_id);
+                } else {
+                    self.non_instant_scans.insert(node_id);
+                }
+                self.provider_scan_nodes
+                    .entry(provider)
+                    .or_default()
+                    .insert(node_id);
             }
         }
 
@@ -494,6 +537,7 @@ fn has_non_inlineable_ops(plan: &LogicalPlan) -> bool {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use datafusion::functions_aggregate::first_last::last_value_udaf;
@@ -635,7 +679,7 @@ mod test {
     }
 
     #[test]
-    fn shared_provider_is_not_hinted_for_mixed_instant_and_range_scans() {
+    fn shared_provider_hints_last_row_per_scan_node() {
         let provider = Arc::new(mock_table_provider_with_tsid(RegionId::new(1, 1)));
         let source = Arc::new(DefaultTableSource::new(provider.clone()));
         let instant_input = LogicalPlanBuilder::scan("instant", source.clone(), None)
@@ -676,11 +720,43 @@ mod test {
             .build()
             .unwrap();
 
-        ScanHintRule
+        let rewritten = ScanHintRule
             .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        // The shared provider itself is left untouched: the per-node decision is
+        // applied to a fork per TableScan node instead.
+        assert_eq!(None, provider.scan_request().series_row_selector);
+
+        let mut selectors = HashMap::new();
+        rewritten
+            .apply(|node| {
+                if let LogicalPlan::TableScan(table_scan) = node
+                    && let Some(source) = table_scan
+                        .source
+                        .as_any()
+                        .downcast_ref::<DefaultTableSource>()
+                    && let Some(adapter) = source
+                        .table_provider
+                        .as_any()
+                        .downcast_ref::<DummyTableProvider>()
+                {
+                    selectors.insert(
+                        table_scan.table_name.to_string(),
+                        adapter.scan_request().series_row_selector,
+                    );
+                }
+                Ok(TreeNodeRecursion::Continue)
+            })
             .unwrap();
 
-        assert_eq!(None, provider.scan_request().series_row_selector);
+        // The instant node keeps the LastRow hint while the range node does not.
+        assert_eq!(
+            Some(TimeSeriesRowSelector::LastRow),
+            selectors.get("instant").copied().flatten()
+        );
+        assert_eq!(None, selectors.get("range").copied().flatten());
     }
 
     #[test]

--- a/tests/cases/distributed/explain/step_aggr_advance.result
+++ b/tests/cases/distributed/explain/step_aggr_advance.result
@@ -409,7 +409,7 @@ tql analyze sum(aggr_optimize_not);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@4 as greptime_timestamp, greptime_value@5 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a", "b", "c", "d"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=FinalPartitioned, gby=[greptime_timestamp@0 as greptime_timestamp], aggr=[__sum_state(aggr_optimize_not.greptime_value)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
@@ -417,7 +417,7 @@ tql analyze sum(aggr_optimize_not);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@4 as greptime_timestamp, greptime_value@5 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a", "b", "c", "d"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/promql/regex.result
+++ b/tests/cases/standalone/common/promql/regex.result
@@ -75,7 +75,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host=~".*"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+
@@ -99,7 +99,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host=~".+"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host != Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host != Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+
@@ -145,7 +145,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host!~".+"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host = Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host = Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.result
@@ -296,7 +296,7 @@ TQL ANALYZE sum(test2);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@0 as greptime_timestamp, greptime_value@1 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["shard"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=FinalPartitioned, gby=[greptime_timestamp@0 as greptime_timestamp], aggr=[__sum_state(test2.greptime_value)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
@@ -304,7 +304,7 @@ TQL ANALYZE sum(test2);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@0 as greptime_timestamp, greptime_value@1 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["shard"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up of closed PR #8561 (perf: select last rows for instant evaluations). The core approach of #8561 was verified correct by an independent review; this PR fixes its three P2 findings and reopens the optimization.

## What's changed and what's your intention?

### Summary

Single-evaluation PromQL instant queries (`start == end`) now push down `TimeSeriesRowSelector::LastRow` to storage, so each series only emits its last row within the lookback window instead of scanning/decoding/merging every candidate sample.

### How it works

Planner side (`src/query/src/optimizer/scan_hint.rs`):
- `ScanHintRule` detects single-evaluation `InstantManipulate` (`start == end`) and adds the `LastRow` hint to the TableScan nodes beneath it. This mirrors the existing `last_value(...)` aggregate path that already derives the same selector.
- Distributed path is unaffected: the hint is applied on the datanode side where the provider is rebuilt, matching how the `last_value` selector is already applied.

Storage side (`src/mito2/src/`):
- Focused last-row prefilter (`src/mito2/src/sst/parquet/prefilter.rs`): two-stage filtering — first match encoded-PK groups, then keep only the max-timestamp row per PK run (same-timestamp rows are retained and resolved by sequence during dedup).
- Cross-file `LastRowCoverage` pruning with strict `>` timestamp comparison, plus file reads ordered newest-first (`src/mito2/src/read/seq_scan.rs`, `src/mito2/src/read/scan_util.rs`).
- `InstantManipulate` remains in charge of stale-marker detection and lookback semantics after the storage layer returns the last rows.

### P2 fixes from the review of #8561

1. **Bare instant queries without a PK matcher** (only a time predicate, e.g. `up`): previously fell back to a full read; now the whole encoded PK column is treated as one run stream (`PkGroupAll`) so per-series last-row selection and coverage pruning still apply (`src/mito2/src/sst/parquet/prefilter.rs`).
2. **Shared `DummyTableProvider`** used by several TableScan nodes (join/binary/`with` reuse): previously the provider pointer was the unit of qualification, so any non-instant sibling disabled `LastRow` for the whole provider. Now qualification is per TableScan node, and shared providers are forked per node with independent hint state (`src/query/src/optimizer/scan_hint.rs`, `src/query/src/dummy_catalog.rs`).
3. **Cross-SST integration tests** added (`src/mito2/src/engine/row_selector_test.rs`): same PK/same timestamp across two SSTs picks the higher sequence; a stale-marker row is returned as the last row; Delete suppresses the last row; empty-table expectation fixed.

### Limitations

- The `LastRow` hint is only derived for single-evaluation (`start == end`) instant selectors; range queries and multi-evaluation instant queries are unaffected.
- Focused last-row prefilter currently bypasses the predicate-result cache (performance only, correctness verified by review).
- SQL `last_value(...)` behavior is unchanged; the new tests cover the shared-provider and cross-SST cases.

### Compatibility

No API or data compatibility impact: the change adds optimizer hints and storage read-path optimizations only; no schema, wire format, or persisted format changes.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.