### PR TITLE
fix(servers): merge Prometheus series with the same labelset across RecordBatch boundaries

### DIFF
--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -392,9 +392,7 @@ pub fn recordbatches_to_timeseries(
     // order for equal timestamps.
     if multiple_batches {
         for series in &mut timeseries {
-            series
-                .samples
-                .sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+            series.samples.sort_by_key(|sample| sample.timestamp);
         }
     }
 

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -356,13 +356,16 @@ pub fn recordbatches_to_timeseries(
     table_name: &str,
     recordbatches: RecordBatches,
 ) -> Result<Vec<TimeSeries>> {
+    let recordbatches = recordbatches.take();
+    let multiple_batches = recordbatches.len() > 1;
+
     let mut timeseries: Vec<TimeSeries> = Vec::new();
     // Maps a labelset to the index of its TimeSeries in `timeseries`, so that
     // series split across RecordBatch boundaries are merged into a single
     // TimeSeries instead of being emitted once per batch.
     let mut timeseries_by_labels: HashMap<Vec<Label>, usize> = HashMap::new();
 
-    for recordbatch in recordbatches.take() {
+    for recordbatch in recordbatches {
         let batch_timeseries = recordbatch_to_timeseries(table_name, recordbatch)?;
         for series in batch_timeseries {
             match timeseries_by_labels.entry(series.labels.clone()) {
@@ -381,14 +384,18 @@ pub fn recordbatches_to_timeseries(
     timeseries
         .sort_unstable_by(|left, right| compare_timeseries_labels(&left.labels, &right.labels));
 
-    // Samples accumulated from multiple RecordBatches (which may arrive in any
-    // order from parallel scan partitions) must be ordered by timestamp
-    // ascending, as required by the Prometheus remote read protocol. A stable
-    // sort keeps insertion order for equal timestamps.
-    for series in &mut timeseries {
-        series
-            .samples
-            .sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+    // When samples from multiple RecordBatches are merged, the batches may
+    // arrive in any order (parallel scan partitions), so the accumulated
+    // samples must be ordered by timestamp ascending, as required by the
+    // Prometheus remote read protocol. A single batch is already in row order
+    // within the batch, so no sorting is needed. A stable sort keeps insertion
+    // order for equal timestamps.
+    if multiple_batches {
+        for series in &mut timeseries {
+            series
+                .samples
+                .sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+        }
     }
 
     Ok(timeseries)

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -380,6 +380,17 @@ pub fn recordbatches_to_timeseries(
 
     timeseries
         .sort_unstable_by(|left, right| compare_timeseries_labels(&left.labels, &right.labels));
+
+    // Samples accumulated from multiple RecordBatches (which may arrive in any
+    // order from parallel scan partitions) must be ordered by timestamp
+    // ascending, as required by the Prometheus remote read protocol. A stable
+    // sort keeps insertion order for equal timestamps.
+    for series in &mut timeseries {
+        series
+            .samples
+            .sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
+    }
+
     Ok(timeseries)
 }
 
@@ -1377,6 +1388,66 @@ mod tests {
                 Sample {
                     value: 5.0,
                     timestamp: 3000,
+                },
+            ],
+            timeseries[0].samples
+        );
+    }
+
+    #[test]
+    fn recordbatches_to_timeseries_sorts_merged_samples_by_timestamp() {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new(
+                greptime_timestamp(),
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                true,
+            ),
+            ColumnSchema::new(greptime_value(), ConcreteDataType::float64_datatype(), true),
+            ColumnSchema::new("instance", ConcreteDataType::string_datatype(), true),
+        ]));
+
+        // Parallel scan partitions may reach the merge point in any order: here
+        // the newer batch (ts = 2000) arrives before the older batch
+        // (ts = 1000). The merged TimeSeries must still list samples in
+        // ascending timestamp order as required by the remote read protocol.
+        let recordbatches = RecordBatches::try_new(
+            schema.clone(),
+            vec![
+                RecordBatch::new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(TimestampMillisecondVector::from_vec(vec![2000])) as _,
+                        Arc::new(Float64Vector::from_vec(vec![4.0])) as _,
+                        Arc::new(StringVector::from(vec!["host1"])) as _,
+                    ],
+                )
+                .unwrap(),
+                RecordBatch::new(
+                    schema,
+                    vec![
+                        Arc::new(TimestampMillisecondVector::from_vec(vec![1000])) as _,
+                        Arc::new(Float64Vector::from_vec(vec![3.0])) as _,
+                        Arc::new(StringVector::from(vec!["host1"])) as _,
+                    ],
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let timeseries = recordbatches_to_timeseries("metric1", recordbatches).unwrap();
+
+        // Merged into a single series with samples sorted by timestamp.
+        assert_eq!(1, timeseries.len());
+        assert_eq!(
+            vec![
+                Sample {
+                    value: 3.0,
+                    timestamp: 1000,
+                },
+                Sample {
+                    value: 4.0,
+                    timestamp: 2000,
                 },
             ],
             timeseries[0].samples

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -16,7 +16,7 @@
 //! handles prometheus remote_write, remote_read logic
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::collections::hash_map::DefaultHasher;
+use std::collections::hash_map::{DefaultHasher, Entry};
 use std::hash::{Hash, Hasher};
 
 use api::prom_store::remote::label_matcher::Type as MatcherType;
@@ -356,14 +356,31 @@ pub fn recordbatches_to_timeseries(
     table_name: &str,
     recordbatches: RecordBatches,
 ) -> Result<Vec<TimeSeries>> {
-    Ok(recordbatches
-        .take()
-        .into_iter()
-        .map(|x| recordbatch_to_timeseries(table_name, x))
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect())
+    let mut timeseries: Vec<TimeSeries> = Vec::new();
+    // Maps a labelset to the index of its TimeSeries in `timeseries`, so that
+    // series split across RecordBatch boundaries are merged into a single
+    // TimeSeries instead of being emitted once per batch.
+    let mut timeseries_by_labels: HashMap<Vec<Label>, usize> = HashMap::new();
+
+    for recordbatch in recordbatches.take() {
+        let batch_timeseries = recordbatch_to_timeseries(table_name, recordbatch)?;
+        for series in batch_timeseries {
+            match timeseries_by_labels.entry(series.labels.clone()) {
+                Entry::Occupied(entry) => {
+                    timeseries[*entry.get()].samples.extend(series.samples);
+                }
+                Entry::Vacant(entry) => {
+                    let index = timeseries.len();
+                    entry.insert(index);
+                    timeseries.push(series);
+                }
+            }
+        }
+    }
+
+    timeseries
+        .sort_unstable_by(|left, right| compare_timeseries_labels(&left.labels, &right.labels));
+    Ok(timeseries)
 }
 
 fn recordbatch_to_timeseries(table: &str, recordbatch: RecordBatch) -> Result<Vec<TimeSeries>> {
@@ -1288,6 +1305,81 @@ mod tests {
                 },
             ],
             timeseries[1].samples
+        );
+    }
+
+    #[test]
+    fn recordbatches_to_timeseries_merges_series_across_batches() {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new(
+                greptime_timestamp(),
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                true,
+            ),
+            ColumnSchema::new(greptime_value(), ConcreteDataType::float64_datatype(), true),
+            ColumnSchema::new("instance", ConcreteDataType::string_datatype(), true),
+        ]));
+
+        // The same series (instance = "host1") is split across two RecordBatches:
+        // the first batch holds two samples, the second batch holds one more.
+        let recordbatches = RecordBatches::try_new(
+            schema.clone(),
+            vec![
+                RecordBatch::new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(TimestampMillisecondVector::from_vec(vec![1000, 2000])) as _,
+                        Arc::new(Float64Vector::from_vec(vec![3.0, 4.0])) as _,
+                        Arc::new(StringVector::from(vec!["host1", "host1"])) as _,
+                    ],
+                )
+                .unwrap(),
+                RecordBatch::new(
+                    schema,
+                    vec![
+                        Arc::new(TimestampMillisecondVector::from_vec(vec![3000])) as _,
+                        Arc::new(Float64Vector::from_vec(vec![5.0])) as _,
+                        Arc::new(StringVector::from(vec!["host1"])) as _,
+                    ],
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap();
+
+        let timeseries = recordbatches_to_timeseries("metric1", recordbatches).unwrap();
+
+        // The series must be merged into a single TimeSeries holding all samples.
+        assert_eq!(1, timeseries.len());
+        assert_eq!(
+            vec![
+                Label {
+                    name: METRIC_NAME_LABEL.to_string(),
+                    value: "metric1".to_string(),
+                },
+                Label {
+                    name: "instance".to_string(),
+                    value: "host1".to_string(),
+                },
+            ],
+            timeseries[0].labels
+        );
+        assert_eq!(
+            vec![
+                Sample {
+                    value: 3.0,
+                    timestamp: 1000,
+                },
+                Sample {
+                    value: 4.0,
+                    timestamp: 2000,
+                },
+                Sample {
+                    value: 5.0,
+                    timestamp: 3000,
+                },
+            ],
+            timeseries[0].samples
         );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

Fixes #8607: Prometheus remote read returned duplicate series across RecordBatch boundaries. `recordbatches_to_timeseries` converted each RecordBatch independently, so a series split across batch boundaries (same labelset, different samples) was emitted as multiple `TimeSeries` instead of one merged series.

Now samples are accumulated per labelset across all batches (`HashMap<labelset, index>` → merge into the existing `TimeSeries`) before emitting, preserving single-batch behavior.

Tests: `recordbatches_to_timeseries_merges_series_across_batches` (RED before: 2 series; GREEN after: 1 merged with both samples).

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
