### PR TITLE
refactor(mito2): prioritize file count in TWCS picker

### DIFF
--- a/src/mito2/benches/bench_compaction_picker.rs
+++ b/src/mito2/benches/bench_compaction_picker.rs
@@ -17,7 +17,6 @@ use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
 use mito2::compaction::run::{
     Item, Ranged, SortedRun, find_overlapping_items, find_sorted_runs, find_sorted_runs_original,
-    merge_seq_files, reduce_runs,
 };
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -47,20 +46,6 @@ impl Item for MockFile {
     fn size(&self) -> usize {
         self.size
     }
-}
-
-fn generate_test_files(n: usize) -> Vec<MockFile> {
-    let mut files = Vec::with_capacity(n);
-    for _ in 0..n {
-        // Create slightly overlapping ranges to force multiple sorted runs
-        files.push(MockFile {
-            start: 0,
-            end: 10,
-            pk: 0,
-            size: 10,
-        });
-    }
-    files
 }
 
 fn generate_same_timestamp_files(total_files: usize, files_per_timestamp: usize) -> Vec<MockFile> {
@@ -107,21 +92,6 @@ fn bench_find_sorted_runs(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_reduce_runs(c: &mut Criterion) {
-    let mut group = c.benchmark_group("reduce_runs");
-
-    for size in [10, 100, 1000].iter() {
-        group.bench_function(format!("size_{}", size), |b| {
-            let mut files = generate_test_files(*size);
-            let runs = find_sorted_runs(&mut files);
-            b.iter(|| {
-                reduce_runs(black_box(runs.clone()));
-            });
-        });
-    }
-    group.finish();
-}
-
 fn bench_find_overlapping_items(c: &mut Criterion) {
     let mut group = c.benchmark_group("find_overlapping_items");
 
@@ -158,45 +128,9 @@ fn bench_find_overlapping_items(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_merge_seq_files(c: &mut Criterion) {
-    let mut group = c.benchmark_group("merge_seq_files");
-
-    for size in [10, 100, 1000].iter() {
-        group.bench_function(format!("size_{}", size), |b| {
-            // Create a set of files with varying sizes
-            let mut files = Vec::with_capacity(*size);
-
-            for i in 0..*size {
-                // Create files with different sizes to test the scoring algorithm
-                let file_size = if i % 3 == 0 {
-                    5
-                } else if i % 3 == 1 {
-                    10
-                } else {
-                    15
-                };
-
-                files.push(MockFile {
-                    start: i as i64,
-                    end: (i + 1) as i64,
-                    pk: 0,
-                    size: file_size,
-                });
-            }
-
-            b.iter(|| {
-                merge_seq_files(black_box(&files), black_box(Some(50)));
-            });
-        });
-    }
-    group.finish();
-}
-
 criterion_group!(
     benches,
     bench_find_sorted_runs,
-    bench_reduce_runs,
     bench_find_overlapping_items,
-    bench_merge_seq_files
 );
 criterion_main!(benches);

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -20,14 +20,10 @@ use std::collections::BinaryHeap;
 
 use bytes::{Buf, Bytes};
 use common_base::BitVec;
-use common_base::readable_size::ReadableSize;
 use common_time::Timestamp;
 use smallvec::{SmallVec, smallvec};
 
 use crate::sst::file::{FileHandle, RegionFileId};
-
-/// Default max compaction output file size when not specified.
-const DEFAULT_MAX_OUTPUT_SIZE: u64 = ReadableSize::gb(2).as_bytes();
 
 /// Trait for any items with specific range (both boundaries are inclusive).
 pub trait Ranged {
@@ -553,124 +549,8 @@ where
     runs.into_iter().map(|x| x.run).collect()
 }
 
-/// Finds a set of files with minimum penalty to merge that can reduce the total num of runs.
-/// The penalty of merging is defined as the size of all overlapping files between two runs.
-pub fn reduce_runs<T: Item>(mut runs: Vec<SortedRun<T>>) -> Vec<T> {
-    assert!(runs.len() > 1);
-    // sort runs by size
-    runs.sort_unstable_by_key(|a| a.size);
-    // limit max probe runs to 100
-    let probe_end = runs.len().min(100);
-    let mut min_penalty = usize::MAX;
-    let mut files = vec![];
-    let mut temp_files = vec![];
-    for i in 0..probe_end {
-        for j in i + 1..probe_end {
-            let (a, b) = runs.split_at_mut(j);
-            find_overlapping_items(&mut a[i], &mut b[0], &mut temp_files);
-            let penalty = temp_files.iter().map(|e| e.size()).sum();
-            if penalty < min_penalty {
-                min_penalty = penalty;
-                files.clear();
-                files.extend_from_slice(&temp_files);
-            }
-        }
-    }
-    files
-}
-
-/// Finds the optimal set of adjacent files to merge based on a scoring system.
-///
-/// This function evaluates all possible contiguous subsets of files to find the best
-/// candidates for merging, considering:
-///
-/// 1. File reduction - prioritizes merging more files to reduce the total count
-/// 2. Write amplification - minimizes the ratio of largest file to total size
-/// 3. Size efficiency - prefers merges that utilize available space effectively
-///
-/// When multiple merge candidates have the same score, older files (those with lower indices)
-/// are preferred.
-///
-/// # Arguments
-/// * `input_files` - Slice of files to consider for merging
-/// * `max_file_size` - Optional maximum size constraint for the merged file.
-///   If None, uses 1.5 times the average file size.
-///
-/// # Returns
-/// A vector containing the best set of adjacent files to merge.
-/// Returns an empty vector if input is empty or contains only one file.
-pub fn merge_seq_files<T: Item>(input_files: &[T], max_file_size: Option<u64>) -> Vec<T> {
-    if input_files.is_empty() || input_files.len() == 1 {
-        return vec![];
-    }
-
-    // Limit the number of files to process to 100 to control time complexity
-    let files_to_process = if input_files.len() > 100 {
-        &input_files[0..100]
-    } else {
-        input_files
-    };
-
-    // Calculate target size based on max_file_size or average file size
-    let target_size = match max_file_size {
-        Some(size) => size as usize,
-        None => {
-            // Calculate 1.5*average_file_size if max_file_size is not provided and clamp to 2GB
-            let total_size: usize = files_to_process.iter().map(|f| f.size()).sum();
-            ((((total_size as f64) / (files_to_process.len() as f64)) * 1.5) as usize)
-                .min(DEFAULT_MAX_OUTPUT_SIZE as usize)
-        }
-    };
-
-    // Find the best group of adjacent files to merge
-    let mut best_group = Vec::new();
-    let mut best_score = f64::NEG_INFINITY;
-
-    // Try different starting positions - iterate from end to start to prefer older files
-    for start_idx in (0..files_to_process.len()).rev() {
-        // Try different ending positions - also iterate from end to start
-        for end_idx in (start_idx + 1..files_to_process.len()).rev() {
-            let group = &files_to_process[start_idx..=end_idx];
-            let total_size: usize = group.iter().map(|f| f.size()).sum();
-
-            // Skip if total size exceeds target size
-            if total_size > target_size {
-                continue; // Use continue instead of break to check smaller ranges
-            }
-
-            // Calculate amplification factor (largest file size / total size)
-            let largest_file_size = group.iter().map(|f| f.size()).max().unwrap_or(0);
-            let amplification_factor = largest_file_size as f64 / total_size as f64;
-
-            // Calculate file reduction (number of files that will be reduced)
-            let file_reduction = group.len() - 1;
-
-            // Calculate score based on multiple factors:
-            // 1. File reduction (higher is better)
-            // 2. Amplification factor (lower is better)
-            // 3. Size efficiency (how close to target size)
-            let file_reduction_score = file_reduction as f64 / files_to_process.len() as f64;
-            let amp_factor_score = (1.0 - amplification_factor) * 1.5; // Lower amplification is better
-            let size_efficiency = (total_size as f64 / target_size as f64).min(1.0); // Reward using available space
-
-            let score = file_reduction_score + amp_factor_score + size_efficiency;
-
-            // Check if this group is better than our current best
-            // Use >= instead of > to prefer older files (which we encounter first due to reverse iteration)
-            if score >= best_score {
-                best_score = score;
-                best_group = group.to_vec();
-            }
-        }
-    }
-
-    best_group
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use bytes::Bytes;
     use store_api::storage::FileId;
 
@@ -705,17 +585,6 @@ mod tests {
                 start: *start,
                 end: *end,
                 size: (*end - *start) as usize,
-            })
-            .collect()
-    }
-
-    fn build_items_with_size(items: &[(i64, i64, usize)]) -> Vec<MockFile> {
-        items
-            .iter()
-            .map(|(start, end, size)| MockFile {
-                start: *start,
-                end: *end,
-                size: *size,
             })
             .collect()
     }
@@ -842,99 +711,6 @@ mod tests {
         ] {
             check_find_sorted_runs_consistency(ranges);
         }
-    }
-
-    fn check_reduce_runs(
-        files: &[(i64, i64)],
-        expected_runs: &[Vec<(i64, i64)>],
-        expected: &[(i64, i64)],
-    ) {
-        let runs = check_sorted_runs(files, expected_runs);
-        if runs.len() <= 1 {
-            assert!(expected.is_empty());
-            return;
-        }
-        let files_to_merge = reduce_runs(runs);
-        let file_to_merge_timestamps = files_to_merge
-            .into_iter()
-            .map(|f| (f.start, f.end))
-            .collect::<HashSet<_>>();
-
-        let expected = expected.iter().cloned().collect::<HashSet<_>>();
-        assert_eq!(&expected, &file_to_merge_timestamps);
-    }
-
-    #[test]
-    fn test_reduce_runs() {
-        // [1..3]   [5..6]
-        //   [2..4]
-        check_reduce_runs(
-            &[(1, 3), (2, 4), (5, 6)],
-            &[vec![(1, 3), (5, 6)], vec![(2, 4)]],
-            &[(1, 3), (2, 4)],
-        );
-
-        // [1..2][3..5]
-        //         [4..6]
-        check_reduce_runs(
-            &[(1, 2), (3, 5), (4, 6)],
-            &[vec![(1, 2), (3, 5)], vec![(4, 6)]],
-            &[(3, 5), (4, 6)],
-        );
-
-        // [1..2][3..4]    [7..8]
-        //          [4..6]
-        check_reduce_runs(
-            &[(1, 2), (3, 4), (4, 6), (7, 8)],
-            &[vec![(1, 2), (3, 4), (4, 6), (7, 8)]],
-            &[],
-        );
-
-        // [1..2][3........6][7..8][8..9]
-        //       [3..4][5..6]
-        check_reduce_runs(
-            &[(1, 2), (3, 4), (5, 6), (3, 6), (7, 8), (8, 9)],
-            &[vec![(1, 2), (3, 6), (7, 8), (8, 9)], vec![(3, 4), (5, 6)]],
-            &[(5, 6), (3, 4), (3, 6)], // already satisfied
-        );
-
-        // [1..2][3........6][7..8][8..9]
-        //       [3..4][5..6]
-        check_reduce_runs(
-            &[(1, 2), (3, 4), (5, 6), (3, 6), (7, 8), (8, 9)],
-            &[vec![(1, 2), (3, 6), (7, 8), (8, 9)], vec![(3, 4), (5, 6)]],
-            &[(3, 4), (3, 6), (5, 6)],
-        );
-
-        // [10..20] [30..40] [50........80][80...100][100..110]
-        //                   [50..60]  [80..90]
-        //
-        check_reduce_runs(
-            &[
-                (10, 20),
-                (30, 40),
-                (50, 60),
-                (50, 80),
-                (80, 90),
-                (80, 100),
-                (100, 110),
-            ],
-            &[
-                vec![(10, 20), (30, 40), (50, 80), (80, 100), (100, 110)],
-                vec![(50, 60), (80, 90)],
-            ],
-            &[(50, 80), (80, 100), (50, 60), (80, 90)],
-        );
-
-        // [0..10]
-        // [0...11]
-        // [0....12]
-        // [0.....13]
-        check_reduce_runs(
-            &[(0, 10), (0, 11), (0, 12), (0, 13)],
-            &[vec![(0, 13)], vec![(0, 12)], vec![(0, 11)], vec![(0, 10)]],
-            &[(0, 10), (0, 11)],
-        );
     }
 
     #[test]
@@ -1186,79 +962,5 @@ mod tests {
             ));
 
         assert!(!lhs.overlap(&rhs));
-    }
-
-    #[test]
-    fn test_merge_seq_files() {
-        // Test empty input
-        let files = Vec::<MockFile>::new();
-        assert_eq!(merge_seq_files(&files, None), Vec::<MockFile>::new());
-
-        // Test single file input (should return empty vec as no merge needed)
-        let files = build_items(&[(1, 5)]);
-        assert_eq!(merge_seq_files(&files, None), Vec::<MockFile>::new());
-
-        // Test the example case: [10, 1, 1, 1] - should merge the last three files
-        let files = build_items_with_size(&[(1, 2, 10), (3, 4, 1), (5, 6, 1), (7, 8, 1)]);
-        let result = merge_seq_files(&files, None);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].size, 1);
-        assert_eq!(result[1].size, 1);
-        assert_eq!(result[2].size, 1);
-
-        // Test with files of equal size - should merge as many as possible
-        let files = build_items_with_size(&[(1, 2, 5), (3, 4, 5), (5, 6, 5), (7, 8, 5)]);
-        let result = merge_seq_files(&files, Some(20));
-        assert_eq!(result.len(), 4); // Should merge all 4 files as total size is 20
-
-        // Test with max_file_size constraint
-        let files = build_items_with_size(&[(1, 2, 5), (3, 4, 5), (5, 6, 5), (7, 8, 5)]);
-        let result = merge_seq_files(&files, Some(10));
-        assert_eq!(result.len(), 2); // Should merge only 2 files as max size is 10
-
-        // Test with uneven file sizes - should prioritize reducing file count
-        let files = build_items_with_size(&[(1, 2, 2), (3, 4, 3), (5, 6, 4), (7, 8, 10)]);
-        let result = merge_seq_files(&files, Some(10));
-        assert_eq!(result.len(), 3); // Should merge the first 3 files (total size 9)
-
-        // Test amplification factor prioritization
-        // Two possible merges: [5, 5] (amp factor 0.5) vs [10, 1, 1] (amp factor 0.83)
-        let files =
-            build_items_with_size(&[(1, 2, 5), (3, 4, 5), (5, 6, 10), (7, 8, 1), (9, 10, 1)]);
-        let result = merge_seq_files(&files, Some(12));
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].size, 5);
-        assert_eq!(result[1].size, 5);
-
-        // Test with large file preventing merges
-        let files = build_items_with_size(&[(1, 2, 100), (3, 4, 1), (5, 6, 1), (7, 8, 1)]);
-        let result = merge_seq_files(&files, Some(10));
-        assert_eq!(result.len(), 3); // Should merge the last 3 small files
-        assert_eq!(result[0].size, 1);
-        assert_eq!(result[1].size, 1);
-        assert_eq!(result[2].size, 1);
-
-        let files = build_items_with_size(&[(1, 2, 100), (3, 4, 20), (5, 6, 20), (7, 8, 20)]);
-        let result = merge_seq_files(&files, Some(200));
-        assert_eq!(result.len(), 4);
-
-        let files = build_items_with_size(&[(1, 2, 160), (3, 4, 20), (5, 6, 20), (7, 8, 20)]);
-        let result = merge_seq_files(&files, None);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].size, 20);
-        assert_eq!(result[1].size, 20);
-        assert_eq!(result[2].size, 20);
-
-        let files = build_items_with_size(&[(1, 2, 100), (3, 4, 1)]);
-        let result = merge_seq_files(&files, Some(200));
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].size, 100);
-        assert_eq!(result[1].size, 1);
-
-        let files = build_items_with_size(&[(1, 2, 20), (3, 4, 20), (5, 6, 20), (7, 8, 20)]);
-        let result = merge_seq_files(&files, Some(40));
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].start, 1);
-        assert_eq!(result[1].start, 3);
     }
 }

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -21,9 +21,8 @@ use std::collections::BinaryHeap;
 use bytes::{Buf, Bytes};
 use common_base::BitVec;
 use common_time::Timestamp;
-use smallvec::{SmallVec, smallvec};
 
-use crate::sst::file::{FileHandle, RegionFileId};
+use crate::sst::file::FileHandle;
 
 /// Trait for any items with specific range (both boundaries are inclusive).
 pub trait Ranged {
@@ -148,71 +147,11 @@ pub trait Item: Ranged + Clone {
     fn size(&self) -> usize;
 }
 
-/// A group of files that are created by the same compaction task.
-#[derive(Debug, Clone)]
-pub struct FileGroup {
-    files: SmallVec<[FileHandle; 2]>,
-    size: usize,
-    num_rows: usize,
-    min_timestamp: Timestamp,
-    max_timestamp: Timestamp,
-    primary_key_range: Option<(Bytes, Bytes)>,
-}
-
-impl FileGroup {
-    pub(crate) fn new_with_file(file: FileHandle) -> Self {
-        let size = file.size() as usize;
-        let (min_timestamp, max_timestamp) = file.time_range();
-        let num_rows = file.num_rows();
-        let primary_key_range = file.primary_key_range();
-        Self {
-            files: smallvec![file],
-            size,
-            num_rows,
-            min_timestamp,
-            max_timestamp,
-            primary_key_range,
-        }
-    }
-
-    pub(crate) fn num_rows(&self) -> usize {
-        self.num_rows
-    }
-
-    pub(crate) fn add_file(&mut self, file: FileHandle) {
-        self.size += file.size() as usize;
-        self.num_rows += file.num_rows();
-        let (min_timestamp, max_timestamp) = file.time_range();
-        self.min_timestamp = self.min_timestamp.min(min_timestamp);
-        self.max_timestamp = self.max_timestamp.max(max_timestamp);
-        self.primary_key_range =
-            merge_primary_key_ranges(self.primary_key_range.take(), file.primary_key_range());
-        self.files.push(file);
-    }
-
-    pub(crate) fn num_files(&self) -> usize {
-        self.files.len()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn files(&self) -> &[FileHandle] {
-        &self.files[..]
-    }
-
-    pub(crate) fn file_ids(&self) -> SmallVec<[RegionFileId; 2]> {
-        SmallVec::from_iter(self.files.iter().map(|f| f.file_id()))
-    }
-
-    pub(crate) fn into_files(self) -> impl Iterator<Item = FileHandle> {
-        self.files.into_iter()
-    }
-}
-
-impl Ranged for FileGroup {
+impl Ranged for FileHandle {
     type BoundType = Timestamp;
 
     fn range(&self) -> (Self::BoundType, Self::BoundType) {
-        (self.min_timestamp, self.max_timestamp)
+        self.time_range()
     }
 
     fn overlap(&self, other: &Self) -> bool {
@@ -222,7 +161,7 @@ impl Ranged for FileGroup {
             return false;
         }
 
-        match (&self.primary_key_range, &other.primary_key_range) {
+        match (&self.primary_key_range(), &other.primary_key_range()) {
             (Some(lhs), Some(rhs)) => primary_key_ranges_overlap(lhs, rhs),
             _ => true,
         }
@@ -235,16 +174,16 @@ impl Ranged for FileGroup {
             return false;
         }
 
-        match (&self.primary_key_range, &other.primary_key_range) {
+        match (&self.primary_key_range(), &other.primary_key_range()) {
             (Some(lhs), Some(rhs)) => primary_key_ranges_overlap(lhs, rhs),
             _ => true,
         }
     }
 }
 
-impl Item for FileGroup {
+impl Item for FileHandle {
     fn size(&self) -> usize {
-        self.size
+        self.size() as usize
     }
 }
 
@@ -814,27 +753,25 @@ mod tests {
     }
 
     #[test]
-    fn test_file_group_overlap_time_overlap_pk_disjoint() {
-        let lhs =
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
-                FileId::random(),
-                0,
-                100,
-                0,
-                1,
-                10,
-                pk_range(b"a", b"f"),
-            ));
-        let rhs =
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
-                FileId::random(),
-                50,
-                150,
-                0,
-                2,
-                10,
-                pk_range(b"x", b"z"),
-            ));
+    fn test_file_overlap_time_overlap_pk_disjoint() {
+        let lhs = new_file_handle_with_size_sequence_and_primary_key_range(
+            FileId::random(),
+            0,
+            100,
+            0,
+            1,
+            10,
+            pk_range(b"a", b"f"),
+        );
+        let rhs = new_file_handle_with_size_sequence_and_primary_key_range(
+            FileId::random(),
+            50,
+            150,
+            0,
+            2,
+            10,
+            pk_range(b"x", b"z"),
+        );
 
         assert!(!lhs.overlap(&rhs));
     }
@@ -842,7 +779,7 @@ mod tests {
     #[test]
     fn test_find_sorted_runs_collapses_pk_disjoint_files_into_one_run() {
         let mut files = vec![
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
+            new_file_handle_with_size_sequence_and_primary_key_range(
                 FileId::random(),
                 0,
                 100,
@@ -850,8 +787,8 @@ mod tests {
                 1,
                 10,
                 pk_range(b"a", b"f"),
-            )),
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
+            ),
+            new_file_handle_with_size_sequence_and_primary_key_range(
                 FileId::random(),
                 50,
                 150,
@@ -859,7 +796,7 @@ mod tests {
                 2,
                 10,
                 pk_range(b"x", b"z"),
-            )),
+            ),
         ];
 
         let runs = find_sorted_runs(&mut files);
@@ -871,7 +808,7 @@ mod tests {
     #[test]
     fn test_find_sorted_runs_handles_2d_transitivity_break() {
         let mut files = vec![
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
+            new_file_handle_with_size_sequence_and_primary_key_range(
                 FileId::random(),
                 0,
                 100,
@@ -879,8 +816,8 @@ mod tests {
                 1,
                 10,
                 pk_range(b"a", b"f"),
-            )),
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
+            ),
+            new_file_handle_with_size_sequence_and_primary_key_range(
                 FileId::random(),
                 50,
                 150,
@@ -888,8 +825,8 @@ mod tests {
                 2,
                 10,
                 pk_range(b"x", b"z"),
-            )),
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
+            ),
+            new_file_handle_with_size_sequence_and_primary_key_range(
                 FileId::random(),
                 50,
                 150,
@@ -897,7 +834,7 @@ mod tests {
                 3,
                 10,
                 pk_range(b"a", b"f"),
-            )),
+            ),
         ];
 
         let runs = find_sorted_runs(&mut files);
@@ -909,7 +846,7 @@ mod tests {
 
     #[test]
     fn test_find_overlapping_items_skips_pk_disjoint_pairs() {
-        let mut left = SortedRun::from(vec![FileGroup::new_with_file(
+        let mut left = SortedRun::from(vec![
             new_file_handle_with_size_sequence_and_primary_key_range(
                 FileId::random(),
                 0,
@@ -919,8 +856,8 @@ mod tests {
                 10,
                 pk_range(b"a", b"f"),
             ),
-        )]);
-        let mut right = SortedRun::from(vec![FileGroup::new_with_file(
+        ]);
+        let mut right = SortedRun::from(vec![
             new_file_handle_with_size_sequence_and_primary_key_range(
                 FileId::random(),
                 50,
@@ -930,7 +867,7 @@ mod tests {
                 10,
                 pk_range(b"x", b"z"),
             ),
-        )]);
+        ]);
         let mut result = Vec::new();
 
         find_overlapping_items(&mut left, &mut right, &mut result);
@@ -939,27 +876,25 @@ mod tests {
     }
 
     #[test]
-    fn test_file_group_touching_time_boundary_with_same_pk_is_not_overlap() {
-        let lhs =
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
-                FileId::random(),
-                0,
-                100,
-                0,
-                1,
-                10,
-                pk_range(b"a", b"f"),
-            ));
-        let rhs =
-            FileGroup::new_with_file(new_file_handle_with_size_sequence_and_primary_key_range(
-                FileId::random(),
-                100,
-                150,
-                0,
-                2,
-                10,
-                pk_range(b"a", b"f"),
-            ));
+    fn test_file_touching_time_boundary_with_same_pk_is_not_overlap() {
+        let lhs = new_file_handle_with_size_sequence_and_primary_key_range(
+            FileId::random(),
+            0,
+            100,
+            0,
+            1,
+            10,
+            pk_range(b"a", b"f"),
+        );
+        let rhs = new_file_handle_with_size_sequence_and_primary_key_range(
+            FileId::random(),
+            100,
+            150,
+            0,
+            2,
+            10,
+            pk_range(b"a", b"f"),
+        );
 
         assert!(!lhs.overlap(&rhs));
     }

--- a/src/mito2/src/compaction/scheduler.rs
+++ b/src/mito2/src/compaction/scheduler.rs
@@ -264,9 +264,13 @@ impl CompactionScheduler {
     ///
     /// # Effects
     ///
-    /// Notifies waiters, schedules a pending manual or explicit automatic
-    /// follow-up, or removes the region status. The returned transition reports
-    /// a dispatched automatic follow-up or DDLs that are now safe to execute.
+    /// Notifies waiters, schedules a pending manual or automatic follow-up, or
+    /// removes the region status. A follow-up is scheduled whenever the cycle
+    /// latched an automatic trigger, or when `made_progress` is true (the
+    /// execution removed more files than it added): successful compaction keeps
+    /// draining the region until the picker returns no plan. The returned
+    /// transition reports a dispatched automatic follow-up or DDLs that are now
+    /// safe to execute.
     ///
     /// # Constraints
     ///
@@ -279,12 +283,18 @@ impl CompactionScheduler {
         execution: &CompactionExecution,
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
+        made_progress: bool,
     ) -> CompactionTransition {
         if !self.is_current_execution(region_id, execution) {
             return CompactionTransition::NoAction;
         }
-        self.on_compaction_finished(region_id, manifest_ctx, schema_metadata_manager)
-            .await
+        self.on_compaction_finished(
+            region_id,
+            manifest_ctx,
+            schema_metadata_manager,
+            made_progress,
+        )
+        .await
     }
 
     /// Completes a cooperatively canceled execution.
@@ -571,6 +581,7 @@ impl CompactionScheduler {
         region_id: RegionId,
         manifest_ctx: &ManifestContextRef,
         schema_metadata_manager: SchemaMetadataManagerRef,
+        made_progress: bool,
     ) -> CompactionTransition {
         if !self.region_status.contains_key(&region_id) {
             return CompactionTransition::NoAction;
@@ -605,7 +616,11 @@ impl CompactionScheduler {
             return CompactionTransition::DdlReady(pending_ddl_requests);
         }
 
-        if status.active.reset_automatic_followup()
+        // Keep draining when the cycle latched an automatic trigger, or when the
+        // execution reduced the file count. A no-progress rewrite stops here so a
+        // split-heavy output cannot loop forever; the next flush trigger resumes.
+        let should_continue = status.active.reset_automatic_followup() || made_progress;
+        if should_continue
             && self.schedule_automatic_followup(region_id, manifest_ctx, schema_metadata_manager)
         {
             return CompactionTransition::AutomaticFollowupScheduled;

--- a/src/mito2/src/compaction/scheduler_test.rs
+++ b/src/mito2/src/compaction/scheduler_test.rs
@@ -826,6 +826,7 @@ async fn test_stale_plan_execution_does_not_affect_replacement_status() {
             &stale_execution,
             &manifest_ctx,
             schema_metadata_manager,
+            true,
         )
         .await;
     assert!(pending_ddls.is_empty());
@@ -907,7 +908,7 @@ async fn test_schedule_compaction_skips_task_exceeding_memory_limit() {
 }
 
 #[tokio::test]
-async fn test_execution_finished_without_followup_removes_status() {
+async fn test_execution_finished_drains_until_no_plan() {
     common_telemetry::init_default_ut_logging();
     let job_scheduler = Arc::new(VecScheduler::default());
     let env = SchedulerEnv::new().await.scheduler(job_scheduler.clone());
@@ -975,10 +976,115 @@ async fn test_execution_finished_without_followup_removes_status() {
         &file_metas,
         purger.clone(),
     );
-    // A completed execution without an explicit follow-up removes its status.
-    scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
+    // A completed execution that reduced the file count chains another pick even
+    // without an explicit trigger, because the layout is still compactable.
+    let transition = scheduler
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            true,
+        )
         .await;
+    assert_matches!(transition, CompactionTransition::AutomaticFollowupScheduled);
+    assert!(scheduler.region_status.contains_key(&region_id));
+    let finished = recv_compaction_pick_finished(&mut rx).await;
+    scheduler
+        .handle_compaction_pick_finished(finished, &manifest_ctx, schema_metadata_manager.clone())
+        .await;
+    assert_eq!(2, job_scheduler.num_jobs());
+
+    // Replace the layout with a single file: the drain must stop once the picker
+    // finds nothing to do.
+    let data = version_control.current();
+    let file_metas: Vec<_> = data.version.ssts.levels()[0]
+        .files
+        .values()
+        .map(|file| file.meta_ref().clone())
+        .collect();
+    apply_edit(&version_control, &[(0, end)], &file_metas, purger.clone());
+    let transition = scheduler
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            true,
+        )
+        .await;
+    assert_matches!(transition, CompactionTransition::AutomaticFollowupScheduled);
+    let finished = recv_compaction_pick_finished(&mut rx).await;
+    let transition = scheduler
+        .handle_compaction_pick_finished(finished, &manifest_ctx, schema_metadata_manager.clone())
+        .await;
+    assert_matches!(transition, CompactionTransition::NoAction);
+    assert!(scheduler.region_status.is_empty());
+    assert_eq!(2, job_scheduler.num_jobs());
+}
+
+#[tokio::test]
+async fn test_execution_finished_without_progress_removes_status() {
+    common_telemetry::init_default_ut_logging();
+    let job_scheduler = Arc::new(VecScheduler::default());
+    let env = SchedulerEnv::new().await.scheduler(job_scheduler.clone());
+    let (tx, mut rx) = mpsc::channel(4);
+    let mut scheduler = env.mock_compaction_scheduler(tx);
+    let mut builder = VersionControlBuilder::new();
+    let region_id = builder.region_id();
+
+    let (schema_metadata_manager, kv_backend) = mock_schema_metadata_manager();
+    schema_metadata_manager
+        .register_region_table_info(
+            builder.region_id().table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            kv_backend,
+        )
+        .await;
+
+    // 5 files to compact.
+    let end = 1000 * 1000;
+    let version_control = Arc::new(
+        builder
+            .push_l0_file(0, end)
+            .push_l0_file(10, end)
+            .push_l0_file(50, end)
+            .push_l0_file(80, end)
+            .push_l0_file(90, end)
+            .build(),
+    );
+    let manifest_ctx = env
+        .mock_manifest_context(version_control.current().version.metadata.clone())
+        .await;
+    let scheduled = scheduler
+        .schedule_automatic_compaction(
+            compact_request::Options::Regular(Default::default()),
+            &version_control,
+            &env.access_layer,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+        )
+        .unwrap();
+    assert!(scheduled);
+    let finished = recv_compaction_pick_finished(&mut rx).await;
+    scheduler
+        .handle_compaction_pick_finished(finished, &manifest_ctx, schema_metadata_manager.clone())
+        .await;
+    assert_eq!(1, job_scheduler.num_jobs());
+
+    // The execution rewrote files without reducing the file count (e.g. its output
+    // was split into more files than its input). Chaining would loop without making
+    // progress, so the lifecycle ends here; the next flush trigger resumes compaction.
+    let transition = scheduler
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            false,
+        )
+        .await;
+    assert_matches!(transition, CompactionTransition::NoAction);
     assert!(scheduler.region_status.is_empty());
     assert_eq!(1, job_scheduler.num_jobs());
 }
@@ -1085,7 +1191,12 @@ async fn test_time_range_compaction_when_compaction_in_progress() {
 
     // On compaction finished and schedule next compaction.
     scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            true,
+        )
         .await;
     assert_eq!(1, scheduler.region_status.len());
     assert!(
@@ -1276,10 +1387,21 @@ async fn test_ranged_compaction_stops_without_followup() {
     assert_eq!(1, job_scheduler.num_jobs());
 
     scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            true,
+        )
         .await;
-    assert!(!scheduler.region_status.contains_key(&region_id));
-    assert_eq!(1, job_scheduler.num_jobs());
+    // The execution reduced the file count and the remaining window is still
+    // compactable, so the scheduler drains it with an unrestricted follow-up.
+    assert!(scheduler.region_status.contains_key(&region_id));
+    let followup = recv_compaction_pick_finished(&mut rx).await;
+    scheduler
+        .handle_compaction_pick_finished(followup, &manifest_ctx, schema_metadata_manager.clone())
+        .await;
+    assert_eq!(2, job_scheduler.num_jobs());
 }
 
 #[tokio::test]
@@ -1360,7 +1482,12 @@ async fn test_automatic_trigger_during_execution_clears_continuation_scope() {
     // Finishing the manual execution must chain an unrestricted follow-up instead of
     // continuing with the manual request's time range.
     scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            true,
+        )
         .await;
 
     let continuation = recv_compaction_pick_finished(&mut rx).await;
@@ -1927,7 +2054,7 @@ async fn test_on_compaction_finished_returns_pending_ddl_requests() {
     });
 
     let pending_ddls = scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager)
+        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager, true)
         .await;
 
     assert_eq!(pending_ddls.len(), 1);
@@ -1976,7 +2103,12 @@ async fn test_planning_terminal_prioritizes_pending_ddl_over_automatic_followup(
     assert!(result.is_ok());
 
     let pending_ddls = scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            true,
+        )
         .await;
 
     assert!(pending_ddls.is_empty());
@@ -2025,7 +2157,7 @@ async fn test_on_compaction_finished_dispatches_pending_ddl_before_chained_regul
     });
 
     let pending_ddls = scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager)
+        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager, true)
         .await;
 
     assert_eq!(pending_ddls.len(), 1);
@@ -2047,7 +2179,7 @@ async fn test_on_compaction_finished_returns_empty_when_region_absent() {
     let (schema_metadata_manager, _kv_backend) = mock_schema_metadata_manager();
 
     let pending_ddls = scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager)
+        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager, true)
         .await;
 
     assert!(pending_ddls.is_empty());
@@ -2102,7 +2234,12 @@ async fn test_on_compaction_finished_manual_schedule_error_cleans_status() {
     });
 
     let pending_ddls = scheduler
-        .on_compaction_finished(region_id, &manifest_ctx, schema_metadata_manager.clone())
+        .on_compaction_finished(
+            region_id,
+            &manifest_ctx,
+            schema_metadata_manager.clone(),
+            true,
+        )
         .await;
 
     assert!(pending_ddls.is_empty());

--- a/src/mito2/src/compaction/scheduler_test.rs
+++ b/src/mito2/src/compaction/scheduler_test.rs
@@ -1006,17 +1006,12 @@ async fn test_time_range_compaction_when_compaction_in_progress() {
         )
         .await;
 
-    // 5 files to compact.
+    // 40 files to compact. The first task picks 32, leaving 8 for the pending request.
     let end = 1000 * 1000;
-    let version_control = Arc::new(
-        builder
-            .push_l0_file(0, end)
-            .push_l0_file(10, end)
-            .push_l0_file(50, end)
-            .push_l0_file(80, end)
-            .push_l0_file(90, end)
-            .build(),
-    );
+    for offset in 0..40 {
+        builder.push_l0_file(offset * 10, end);
+    }
+    let version_control = Arc::new(builder.build());
     let manifest_ctx = env
         .mock_manifest_context(version_control.current().version.metadata.clone())
         .await;
@@ -1027,13 +1022,9 @@ async fn test_time_range_compaction_when_compaction_in_progress() {
         .map(|file| file.meta_ref().clone())
         .collect();
 
-    // 5 files for next compaction and removes old files.
-    apply_edit(
-        &version_control,
-        &[(0, end), (20, end), (40, end), (60, end), (80, end)],
-        &file_metas,
-        purger.clone(),
-    );
+    // Replaces the files before scheduling the first compaction.
+    let next_files = (0..40).map(|offset| (offset * 20, end)).collect::<Vec<_>>();
+    apply_edit(&version_control, &next_files, &file_metas, purger.clone());
 
     scheduler
         .schedule_automatic_compaction(

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -168,17 +168,9 @@ impl TwcsPicker {
         };
         let found_runs = sorted_runs.len();
         let inputs = pick_count_first(sorted_runs, self.trigger_file_num);
-        let mut filter_deleted = !self.append_mode
+        let filter_deleted = !self.append_mode
             && !window_has_overlap(files, windows)
             && !selected_overlaps_unselected(&inputs, files);
-
-        // The inputs are only a subset of the window: `reduce_runs` and `merge_seq_files` both
-        // narrow the selection down and the file num limit above narrows it further. A deletion
-        // marker may only be dropped when every file that can hold a row it masks is compacted
-        // along with it, so re-check the final selection against what stays in the window.
-        if filter_deleted && overlaps_files_left_behind(&inputs, &files_to_merge) {
-            filter_deleted = false;
-        }
 
         if inputs.len() > 1 {
             // If we have more than one group to compact.
@@ -195,20 +187,6 @@ impl TwcsPicker {
         }
         (inputs, filter_deleted)
     }
-}
-
-/// Returns whether any file group of `window_files` that is not part of `inputs` overlaps
-/// `inputs`. Such a group keeps rows a deletion marker in `inputs` masks, so the compaction
-/// must not filter deleted rows out.
-///
-/// Overlapping is inclusive on both boundaries here: two files that only share a boundary
-/// timestamp can still hold the same row.
-fn overlaps_files_left_behind(inputs: &[FileGroup], window_files: &[FileGroup]) -> bool {
-    let picked: HashSet<_> = inputs.iter().flat_map(|fg| fg.file_ids()).collect();
-    window_files
-        .iter()
-        .filter(|fg| !fg.file_ids().iter().any(|id| picked.contains(id)))
-        .any(|fg| inputs.iter().any(|input| input.overlap_inclusive(fg)))
 }
 
 #[derive(Debug)]

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -32,8 +32,8 @@ use crate::compaction::buckets::infer_time_bucket;
 use crate::compaction::compactor::CompactionRegion;
 use crate::compaction::picker::{Picker, PickerOutput, get_expired_ssts};
 use crate::compaction::run::{
-    FileGroup, Item, Ranged, find_sorted_runs, find_sorted_runs_by_time_range,
-    merge_primary_key_ranges, merge_seq_files, primary_key_ranges_overlap, reduce_runs,
+    FileGroup, Item, Ranged, SortedRun, find_sorted_runs, find_sorted_runs_by_time_range,
+    merge_primary_key_ranges, primary_key_ranges_overlap,
 };
 use crate::error::{JoinSnafu, Result};
 use crate::sst::file::{FileHandle, Level, overlaps};
@@ -167,48 +167,10 @@ impl TwcsPicker {
             find_sorted_runs_by_time_range(&mut files_to_merge)
         };
         let found_runs = sorted_runs.len();
-        // We only remove deletion markers if we found less than 2 runs and not in append mode.
-        // because after compaction there will be no overlapping files.
-        let filter_deleted =
-            found_runs <= 2 && !self.append_mode && !window_has_overlap(files, windows);
-        if found_runs == 0 {
-            return (vec![], filter_deleted);
-        }
-
-        let mut inputs = if found_runs > 1 {
-            reduce_runs(sorted_runs)
-        } else {
-            let run = sorted_runs.last().unwrap();
-            if run.items().len() < self.trigger_file_num {
-                return (vec![], filter_deleted);
-            }
-            // no overlapping files, try merge small files
-            merge_seq_files(run.items(), self.max_output_file_size)
-        };
-
-        // Limits the number of input files.
-        let total_input_files: usize = inputs.iter().map(|fg| fg.num_files()).sum();
-        if total_input_files > DEFAULT_MAX_INPUT_FILE_NUM {
-            // Sorts file groups by size first.
-            inputs.sort_unstable_by_key(|fg| fg.size());
-            let mut num_picked_files = 0;
-            inputs = inputs
-                .into_iter()
-                .take_while(|fg| {
-                    let current_group_file_num = fg.num_files();
-                    if current_group_file_num + num_picked_files <= DEFAULT_MAX_INPUT_FILE_NUM {
-                        num_picked_files += current_group_file_num;
-                        true
-                    } else {
-                        false
-                    }
-                })
-                .collect::<Vec<_>>();
-            info!(
-                "Compaction for region {} enforces max input file num limit: {}, current total: {}, input: {:?}",
-                region_id, DEFAULT_MAX_INPUT_FILE_NUM, total_input_files, inputs
-            );
-        }
+        let inputs = pick_count_first(sorted_runs, self.trigger_file_num);
+        let filter_deleted = !self.append_mode
+            && !window_has_overlap(files, windows)
+            && !selected_overlaps_unselected(&inputs, files);
 
         if inputs.len() > 1 {
             // If we have more than one group to compact.
@@ -225,6 +187,143 @@ impl TwcsPicker {
         }
         (inputs, filter_deleted)
     }
+}
+
+#[derive(Debug)]
+struct OrderedFileGroup<'a> {
+    group: &'a FileGroup,
+    run_id: usize,
+    position_in_run: usize,
+}
+
+#[derive(Debug)]
+struct CandidateScore {
+    num_files: usize,
+    overlap_participants: usize,
+    size: usize,
+}
+
+impl CandidateScore {
+    fn is_better_than(&self, other: &Self) -> bool {
+        self.num_files
+            .cmp(&other.num_files)
+            .then_with(|| self.overlap_participants.cmp(&other.overlap_participants))
+            .then_with(|| other.size.cmp(&self.size))
+            .is_gt()
+    }
+}
+
+fn pick_count_first(
+    sorted_runs: Vec<SortedRun<FileGroup>>,
+    trigger_file_num: usize,
+) -> Vec<FileGroup> {
+    let mut groups = sorted_runs
+        .iter()
+        .enumerate()
+        .flat_map(|(run_id, run)| {
+            run.items()
+                .iter()
+                .enumerate()
+                .map(move |(position_in_run, group)| OrderedFileGroup {
+                    group,
+                    run_id,
+                    position_in_run,
+                })
+        })
+        .collect::<Vec<_>>();
+    groups.sort_unstable_by(|lhs, rhs| {
+        let (lhs_start, lhs_end) = lhs.group.range();
+        let (rhs_start, rhs_end) = rhs.group.range();
+        lhs_start
+            .cmp(&rhs_start)
+            .then_with(|| rhs_end.cmp(&lhs_end))
+            .then_with(|| lhs.run_id.cmp(&rhs.run_id))
+            .then_with(|| lhs.position_in_run.cmp(&rhs.position_in_run))
+    });
+
+    let mut left = 0;
+    let mut num_files = 0;
+    let mut best = None;
+    for right in 0..groups.len() {
+        let group_file_num = groups[right].group.num_files();
+        if group_file_num > DEFAULT_MAX_INPUT_FILE_NUM {
+            left = right + 1;
+            num_files = 0;
+            continue;
+        }
+
+        num_files += group_file_num;
+        while num_files > DEFAULT_MAX_INPUT_FILE_NUM {
+            num_files -= groups[left].group.num_files();
+            left += 1;
+        }
+
+        if num_files < trigger_file_num || right + 1 - left < 2 {
+            continue;
+        }
+
+        let candidate = &groups[left..=right];
+        let score = CandidateScore {
+            num_files,
+            overlap_participants: count_overlap_participants(candidate),
+            size: candidate.iter().map(|group| group.group.size()).sum(),
+        };
+        if best
+            .as_ref()
+            .is_none_or(|(best_score, _, _)| score.is_better_than(best_score))
+        {
+            best = Some((score, left, right));
+        }
+    }
+
+    let Some((_, left, right)) = best else {
+        return vec![];
+    };
+    groups[left..=right]
+        .iter()
+        .map(|group| group.group.clone())
+        .collect()
+}
+
+fn count_overlap_participants(groups: &[OrderedFileGroup<'_>]) -> usize {
+    let mut participants = vec![false; groups.len()];
+    for lhs in 0..groups.len() {
+        for rhs in lhs + 1..groups.len() {
+            if groups[lhs].run_id != groups[rhs].run_id
+                && groups[lhs].group.overlap_inclusive(groups[rhs].group)
+            {
+                participants[lhs] = true;
+                participants[rhs] = true;
+            }
+        }
+    }
+
+    groups
+        .iter()
+        .zip(participants)
+        .filter(|(_, participant)| *participant)
+        .map(|(group, _)| group.group.num_files())
+        .sum()
+}
+
+fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool {
+    let selected_file_ids = selected
+        .iter()
+        .flat_map(FileGroup::file_ids)
+        .collect::<HashSet<_>>();
+    window
+        .files()
+        .filter(|group| {
+            !group
+                .file_ids()
+                .iter()
+                .all(|file_id| selected_file_ids.contains(file_id))
+        })
+        .any(|unselected| {
+            selected
+                .iter()
+                .any(|selected| selected.overlap_inclusive(unselected))
+        })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -966,7 +1065,7 @@ mod tests {
             let active_window =
                 find_latest_window_in_seconds(self.input_files.iter(), self.window_size);
             let output = TwcsPicker {
-                trigger_file_num: 4,
+                trigger_file_num: 2,
                 time_window_seconds: None,
                 max_output_file_size: None,
                 append_mode: false,
@@ -1053,7 +1152,7 @@ mod tests {
             .to_vec(),
             expected_outputs: vec![
                 ExpectedOutput {
-                    input_files: vec![2, 4],
+                    input_files: vec![2, 3, 4],
                     output_level: 1,
                 },
                 ExpectedOutput {
@@ -1169,7 +1268,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_output_multiple_windows_with_zero_runs() {
-        let file_ids = (0..6).map(|_| FileId::random()).collect::<Vec<_>>();
+        let file_ids = (0..7).map(|_| FileId::random()).collect::<Vec<_>>();
 
         let files = [
             // Window 0: Contains 3 files but not forming any runs (not enough files in sequence to reach trigger_file_num)
@@ -1180,6 +1279,7 @@ mod tests {
             new_file_handle_with_sequence(file_ids[3], 3000, 3999, 0, 4),
             new_file_handle_with_sequence(file_ids[4], 3000, 3999, 0, 5),
             new_file_handle_with_sequence(file_ids[5], 3000, 3999, 0, 6),
+            new_file_handle_with_sequence(file_ids[6], 3000, 3999, 0, 7),
         ];
 
         let windows = assign_to_windows(files.iter(), 3);
@@ -1409,7 +1509,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, output.len());
-        assert_eq!(output[0].inputs.len(), 2);
+        assert_eq!(output[0].inputs.len(), num_files);
     }
 
     #[tokio::test]
@@ -1553,6 +1653,237 @@ mod tests {
                 .iter()
                 .map(|file| file.file_id().file_id())
                 .collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn test_count_first_prefers_more_files_over_smaller_overlap() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 40, 50, 0, 3, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 5, 15, 0, 4, 10),
+        ];
+        let mut windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 2,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert_eq!(1, output.len());
+        assert_eq!(4, output[0].inputs.len());
+    }
+
+    #[test]
+    fn test_count_first_trigger_counts_actual_ssts() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
+        ];
+        let mut windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 3,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert_eq!(1, output.len());
+        assert_eq!(3, output[0].inputs.len());
+    }
+
+    #[test]
+    fn test_count_first_does_not_compact_overlap_below_trigger() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 20, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 10, 30, 0, 2, 10),
+        ];
+        let mut windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 3,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_filter_deleted_is_false_when_selected_files_overlap_unselected_file() {
+        let mut files = (0..32)
+            .map(|idx| {
+                new_file_handle_with_size_and_sequence(
+                    FileId::random(),
+                    idx * 10,
+                    idx * 10 + 9,
+                    0,
+                    idx as u64 + 1,
+                    10,
+                )
+            })
+            .collect::<Vec<_>>();
+        files.push(new_file_handle_with_size_and_sequence(
+            FileId::random(),
+            0,
+            320,
+            0,
+            33,
+            10,
+        ));
+        let mut windows = assign_to_windows(files.iter(), 1000);
+        let picker = TwcsPicker {
+            trigger_file_num: 2,
+            time_window_seconds: Some(1000),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert_eq!(1, output.len());
+        assert_eq!(DEFAULT_MAX_INPUT_FILE_NUM, output[0].inputs.len());
+        assert!(!output[0].filter_deleted);
+    }
+
+    fn new_file_group(
+        start: i64,
+        end: i64,
+        sequence: u64,
+        num_files: usize,
+        file_size: u64,
+    ) -> FileGroup {
+        let mut group = FileGroup::new_with_file(new_file_handle_with_size_and_sequence(
+            FileId::random(),
+            start,
+            end,
+            0,
+            sequence,
+            file_size,
+        ));
+        for _ in 1..num_files {
+            group.add_file(new_file_handle_with_size_and_sequence(
+                FileId::random(),
+                start,
+                end,
+                0,
+                sequence,
+                file_size,
+            ));
+        }
+        group
+    }
+
+    fn picked_ranges(groups: &[FileGroup]) -> Vec<(i64, i64)> {
+        groups
+            .iter()
+            .map(|group| {
+                let (start, end) = group.range();
+                (start.value(), end.value())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_count_first_prefers_overlap_participants_when_file_counts_match() {
+        let first = new_file_group(0, 9, 1, 16, 10);
+        let second = new_file_group(20, 39, 2, 16, 10);
+        let overlapping = new_file_group(30, 49, 3, 16, 10);
+
+        let picked = pick_count_first(
+            vec![
+                SortedRun::from(vec![first, second]),
+                SortedRun::from(vec![overlapping]),
+            ],
+            2,
+        );
+
+        assert_eq!(vec![(20, 39), (30, 49)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_prefers_smaller_bytes_when_file_counts_match() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 16, 10),
+                new_file_group(20, 29, 2, 16, 10),
+                new_file_group(40, 49, 3, 16, 1),
+            ])],
+            2,
+        );
+
+        assert_eq!(vec![(20, 29), (40, 49)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_prefers_earlier_time_on_exact_tie() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 16, 10),
+                new_file_group(20, 29, 2, 16, 10),
+                new_file_group(40, 49, 3, 16, 10),
+            ])],
+            2,
+        );
+
+        assert_eq!(vec![(0, 9), (20, 29)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_skips_oversized_atomic_file_group() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 33, 1),
+                new_file_group(20, 29, 2, 16, 1),
+                new_file_group(40, 49, 3, 16, 1),
+            ])],
+            2,
+        );
+
+        assert_eq!(
+            DEFAULT_MAX_INPUT_FILE_NUM,
+            picked.iter().map(FileGroup::num_files).sum::<usize>()
+        );
+        assert_eq!(vec![(20, 29), (40, 49)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_keeps_each_interleaved_run_contiguous() {
+        let picked = pick_count_first(
+            vec![
+                SortedRun::from(vec![
+                    new_file_group(0, 9, 1, 8, 1),
+                    new_file_group(20, 29, 2, 8, 1),
+                    new_file_group(40, 49, 3, 8, 1),
+                ]),
+                SortedRun::from(vec![
+                    new_file_group(10, 19, 4, 8, 1),
+                    new_file_group(30, 39, 5, 8, 1),
+                ]),
+            ],
+            2,
+        );
+
+        assert_eq!(
+            vec![(0, 9), (10, 19), (20, 29), (30, 39)],
+            picked_ranges(&picked)
         );
     }
 

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -15,7 +15,6 @@
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
-use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use common_base::readable_size::ReadableSize;
@@ -32,8 +31,8 @@ use crate::compaction::buckets::infer_time_bucket;
 use crate::compaction::compactor::CompactionRegion;
 use crate::compaction::picker::{Picker, PickerOutput, get_expired_ssts};
 use crate::compaction::run::{
-    FileGroup, Item, Ranged, SortedRun, find_sorted_runs, find_sorted_runs_by_time_range,
-    merge_primary_key_ranges, primary_key_ranges_overlap,
+    Ranged, SortedRun, find_sorted_runs, find_sorted_runs_by_time_range, merge_primary_key_ranges,
+    primary_key_ranges_overlap,
 };
 use crate::error::{JoinSnafu, Result};
 use crate::sst::file::{FileHandle, Level, overlaps};
@@ -41,14 +40,14 @@ use crate::sst::version::LevelMeta;
 
 const LEVEL_COMPACTED: Level = 1;
 
-/// Maximum number of logical FileGroups in one compaction input.
-const MAX_INPUT_FILE_GROUPS: usize = 32;
+/// Maximum number of input SST files in one compaction input.
+const MAX_INPUT_FILES: usize = 32;
 
 /// `TwcsPicker` picks files of which the max timestamp are in the same time window as compaction
 /// candidates.
 #[derive(Clone, Debug)]
 pub struct TwcsPicker {
-    /// Minimum eligible FileGroup num to trigger a compaction.
+    /// Minimum file num to trigger a compaction.
     pub trigger_file_num: usize,
     /// Compaction time window in seconds.
     pub time_window_seconds: Option<i64>,
@@ -113,7 +112,7 @@ impl TwcsPicker {
 
                 output.push(CompactionOutput {
                     output_level: LEVEL_COMPACTED, // always compact to l1
-                    inputs: inputs.into_iter().flat_map(|fg| fg.into_files()).collect(),
+                    inputs,
                     filter_deleted,
                     output_time_range: None, // we do not enforce output time range in twcs compactions.
                 });
@@ -138,7 +137,7 @@ impl TwcsPicker {
         active_window: Option<i64>,
         files: &Window,
         windows: &BTreeMap<i64, Window>,
-    ) -> (Vec<FileGroup>, bool) {
+    ) -> (Vec<FileHandle>, bool) {
         let window = &files.time_window;
         let mut files_to_merge: Vec<_> = files.files().cloned().collect();
 
@@ -148,7 +147,7 @@ impl TwcsPicker {
         {
             let (kept_files, ignored_files) = files_to_merge
                 .into_iter()
-                .partition(|fg| fg.size() <= max_size as usize);
+                .partition(|file| file.size() <= max_size);
             files_to_merge = kept_files;
             if !ignored_files.is_empty() {
                 info!(
@@ -173,7 +172,7 @@ impl TwcsPicker {
             && !selected_overlaps_unselected(&inputs, files);
 
         if inputs.len() > 1 {
-            // If we have more than one group to compact.
+            // If we have more than one file to compact.
             log_pick_result(
                 region_id,
                 *window,
@@ -190,114 +189,118 @@ impl TwcsPicker {
 }
 
 #[derive(Debug)]
-struct OrderedFileGroup<'a> {
-    group: &'a FileGroup,
+struct OrderedFile<'a> {
+    file: &'a FileHandle,
     run_id: usize,
     position_in_run: usize,
 }
 
+/// Score of a candidate compaction input. Higher is better: first by the number of SST files
+/// it removes, then by the number of files participating in an overlap (resolving overlap is
+/// what reduces sorted runs), then by smaller input bytes.
 #[derive(Debug)]
 struct CandidateScore {
-    num_file_groups: usize,
+    num_files: usize,
     overlap_participants: usize,
     size: usize,
 }
 
 impl CandidateScore {
     fn is_better_than(&self, other: &Self) -> bool {
-        self.num_file_groups
-            .cmp(&other.num_file_groups)
+        self.num_files
+            .cmp(&other.num_files)
             .then_with(|| self.overlap_participants.cmp(&other.overlap_participants))
             .then_with(|| other.size.cmp(&self.size))
             .is_gt()
     }
 }
 
+/// Picks a contiguous (in global time order) interval of files to compact.
+///
+/// The picker first reorders all files from all sorted runs by `(start asc, end desc)` and
+/// then enumerates every interval of at most [`MAX_INPUT_FILES`] files. An interval is
+/// eligible when it holds at least `trigger_file_num` files and at least 2 files, and when
+/// no single file dominates the interval (`largest <= sum of the others`), so a large
+/// historical file is only rewritten once its peers contribute at least the same amount of
+/// data. The best interval wins by [`CandidateScore`]; ties keep the earliest interval.
 fn pick_count_first(
-    sorted_runs: Vec<SortedRun<FileGroup>>,
+    sorted_runs: Vec<SortedRun<FileHandle>>,
     trigger_file_num: usize,
-) -> Vec<FileGroup> {
-    let mut groups = sorted_runs
+) -> Vec<FileHandle> {
+    let mut files = sorted_runs
         .iter()
         .enumerate()
         .flat_map(|(run_id, run)| {
             run.items()
                 .iter()
                 .enumerate()
-                .map(move |(position_in_run, group)| OrderedFileGroup {
-                    group,
+                .map(move |(position_in_run, file)| OrderedFile {
+                    file,
                     run_id,
                     position_in_run,
                 })
         })
         .collect::<Vec<_>>();
-    groups.sort_unstable_by(|lhs, rhs| {
-        let (lhs_start, lhs_end) = lhs.group.range();
-        let (rhs_start, rhs_end) = rhs.group.range();
+    files.sort_unstable_by(|lhs, rhs| {
+        let (lhs_start, lhs_end) = lhs.file.range();
+        let (rhs_start, rhs_end) = rhs.file.range();
         lhs_start
             .cmp(&rhs_start)
             .then_with(|| rhs_end.cmp(&lhs_end))
             .then_with(|| lhs.run_id.cmp(&rhs.run_id))
             .then_with(|| lhs.position_in_run.cmp(&rhs.position_in_run))
     });
-    // A multi-SST FileGroup is a compaction output that already exceeded the output size target
-    // and was split. Recompacting it cannot reduce physical files, so automatic TWCS treats it as
-    // stable. It remains in the original Window for tombstone overlap checks.
+
     let mut best = None;
-    for segment in groups
-        .split(|group| group.group.num_files() != 1)
-        .filter(|segment| !segment.is_empty())
-    {
-        for left in 0..segment.len() {
-            let mut total_size = 0;
-            let mut largest_group_size = 0;
-            let mut overlap_participants = 0;
-            let right_bound = (left + MAX_INPUT_FILE_GROUPS).min(segment.len());
-            let mut participants: Vec<bool> = Vec::with_capacity(right_bound - left);
-            for right in left..right_bound {
-                let right_group = &segment[right];
-                let group_size = right_group.group.size();
-                total_size += group_size;
-                largest_group_size = largest_group_size.max(group_size);
+    for left in 0..files.len() {
+        let mut total_size = 0;
+        let mut largest_file_size = 0;
+        let mut overlap_participants = 0;
+        let right_bound = (left + MAX_INPUT_FILES).min(files.len());
+        let mut participants: Vec<bool> = Vec::with_capacity(right_bound - left);
+        for right in left..right_bound {
+            let right_file = &files[right];
+            let file_size = right_file.file.size() as usize;
+            total_size += file_size;
+            largest_file_size = largest_file_size.max(file_size);
 
-                let mut right_participates = false;
-                for (offset, other) in segment[left..right].iter().enumerate() {
-                    if right_group.run_id != other.run_id
-                        && right_group.group.overlap_inclusive(other.group)
-                    {
-                        if !participants[offset] {
-                            participants[offset] = true;
-                            overlap_participants += 1;
-                        }
-                        right_participates = true;
-                    }
-                }
-                participants.push(right_participates);
-                if right_participates {
-                    overlap_participants += 1;
-                }
-
-                let num_file_groups = right + 1 - left;
-                if num_file_groups < trigger_file_num || num_file_groups < 2 {
-                    continue;
-                }
-                // A historical group is only rewritten after peers contribute at least the same
-                // amount of data, so every rewrite moves it into a larger size tier.
-                if largest_group_size > total_size - largest_group_size {
-                    continue;
-                }
-
-                let score = CandidateScore {
-                    num_file_groups,
-                    overlap_participants,
-                    size: total_size,
-                };
-                if best
-                    .as_ref()
-                    .is_none_or(|(best_score, _)| score.is_better_than(best_score))
+            let mut right_participates = false;
+            for (offset, other) in files[left..right].iter().enumerate() {
+                if right_file.run_id != other.run_id
+                    && right_file.file.overlap_inclusive(other.file)
                 {
-                    best = Some((score, &segment[left..=right]));
+                    if !participants[offset] {
+                        participants[offset] = true;
+                        overlap_participants += 1;
+                    }
+                    right_participates = true;
                 }
+            }
+            participants.push(right_participates);
+            if right_participates {
+                overlap_participants += 1;
+            }
+
+            let num_files = right + 1 - left;
+            if num_files < trigger_file_num || num_files < 2 {
+                continue;
+            }
+            // A historical file is only rewritten after peers contribute at least the same
+            // amount of data, so every rewrite moves it into a larger size tier.
+            if largest_file_size > total_size - largest_file_size {
+                continue;
+            }
+
+            let score = CandidateScore {
+                num_files,
+                overlap_participants,
+                size: total_size,
+            };
+            if best
+                .as_ref()
+                .is_none_or(|(best_score, _)| score.is_better_than(best_score))
+            {
+                best = Some((score, &files[left..=right]));
             }
         }
     }
@@ -305,12 +308,12 @@ fn pick_count_first(
     let Some((_, best)) = best else {
         return vec![];
     };
-    best.iter().map(|group| group.group.clone()).collect()
+    best.iter().map(|file| file.file.clone()).collect()
 }
 
-fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool {
-    // The overall time span of the selection: a group outside it cannot overlap any
-    // selected group (ranges are inclusive), so it needs no precise overlap check.
+fn selected_overlaps_unselected(selected: &[FileHandle], window: &Window) -> bool {
+    // The overall time span of the selection: a file outside it cannot overlap any
+    // selected file (ranges are inclusive), so it needs no precise overlap check.
     let Some((span_start, span_end)) = selected
         .iter()
         .map(Ranged::range)
@@ -320,20 +323,15 @@ fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool
     };
     let selected_file_ids = selected
         .iter()
-        .flat_map(FileGroup::file_ids)
+        .map(FileHandle::file_id)
         .collect::<HashSet<_>>();
     window
         .files()
-        .filter(|group| {
-            let (start, end) = group.range();
+        .filter(|file| {
+            let (start, end) = file.range();
             start <= span_end && span_start <= end
         })
-        .filter(|group| {
-            !group
-                .file_ids()
-                .iter()
-                .all(|file_id| selected_file_ids.contains(file_id))
-        })
+        .filter(|file| !selected_file_ids.contains(&file.file_id()))
         .any(|unselected| {
             selected
                 .iter()
@@ -350,7 +348,7 @@ fn log_pick_result(
     file_num: usize,
     max_output_file_size: Option<u64>,
     filter_deleted: bool,
-    inputs: &[FileGroup],
+    inputs: &[FileHandle],
 ) {
     let input_file_str: Vec<String> = inputs
         .iter()
@@ -360,11 +358,11 @@ fn log_pick_result(
             let end = range.1.to_iso8601_string();
             let num_rows = f.num_rows();
             format!(
-                "FileGroup{{id: {:?}, range: ({}, {}), size: {}, num rows: {} }}",
-                f.file_ids(),
+                "File{{id: {:?}, range: ({}, {}), size: {}, num rows: {} }}",
+                f.file_id(),
                 start,
                 end,
-                ReadableSize(f.size() as u64),
+                ReadableSize(f.size()),
                 num_rows
             )
         })
@@ -461,9 +459,7 @@ impl Picker for TwcsPicker {
 struct Window {
     start: Timestamp,
     end: Timestamp,
-    // Mapping from file sequence to file groups. Files with the same sequence is considered
-    // created from the same compaction task.
-    files: HashMap<Option<NonZeroU64>, FileGroup>,
+    files: Vec<FileHandle>,
     time_window: i64,
     primary_key_range: Option<(bytes::Bytes, bytes::Bytes)>,
 }
@@ -473,11 +469,10 @@ impl Window {
     fn new_with_file(file: FileHandle) -> Self {
         let (start, end) = file.time_range();
         let primary_key_range = file.primary_key_range();
-        let files = HashMap::from([(file.meta_ref().sequence, FileGroup::new_with_file(file))]);
         Self {
             start,
             end,
-            files,
+            files: vec![file],
             time_window: 0,
             primary_key_range,
         }
@@ -495,19 +490,11 @@ impl Window {
         self.end = self.end.max(end);
         self.primary_key_range =
             merge_primary_key_ranges(self.primary_key_range.take(), file.primary_key_range());
-
-        match self.files.entry(file.meta_ref().sequence) {
-            Entry::Occupied(mut o) => {
-                o.get_mut().add_file(file);
-            }
-            Entry::Vacant(v) => {
-                v.insert(FileGroup::new_with_file(file));
-            }
-        }
+        self.files.push(file);
     }
 
-    fn files(&self) -> impl Iterator<Item = &FileGroup> {
-        self.files.values()
+    fn files(&self) -> impl Iterator<Item = &FileHandle> {
+        self.files.iter()
     }
 }
 
@@ -756,8 +743,7 @@ mod tests {
             3,
         );
         let fgs = &windows.get(&0).unwrap().files;
-        assert_eq!(1, fgs.len());
-        assert_eq!(fgs.values().map(|f| f.files().len()).sum::<usize>(), 5);
+        assert_eq!(5, fgs.len());
 
         let files = [FileId::random(); 3];
         let windows = assign_to_windows(
@@ -771,26 +757,41 @@ mod tests {
         );
         assert_eq!(
             files[0],
-            windows.get(&0).unwrap().files().next().unwrap().files()[0]
+            windows
+                .get(&0)
+                .unwrap()
+                .files()
+                .next()
+                .unwrap()
                 .file_id()
                 .file_id()
         );
         assert_eq!(
             files[1],
-            windows.get(&3).unwrap().files().next().unwrap().files()[0]
+            windows
+                .get(&3)
+                .unwrap()
+                .files()
+                .next()
+                .unwrap()
                 .file_id()
                 .file_id()
         );
         assert_eq!(
             files[2],
-            windows.get(&12).unwrap().files().next().unwrap().files()[0]
+            windows
+                .get(&12)
+                .unwrap()
+                .files()
+                .next()
+                .unwrap()
                 .file_id()
                 .file_id()
         );
     }
 
     #[test]
-    fn test_assign_file_groups_to_windows() {
+    fn test_assign_files_to_windows() {
         let files = [
             FileId::random(),
             FileId::random(),
@@ -808,25 +809,14 @@ mod tests {
             3,
         );
         assert_eq!(windows.len(), 1);
-        let fgs = &windows.get(&0).unwrap().files;
-        assert_eq!(2, fgs.len());
+        let window_files = &windows.get(&0).unwrap().files;
+        assert_eq!(4, window_files.len());
         assert_eq!(
-            fgs.get(&NonZeroU64::new(1))
-                .unwrap()
-                .files()
+            window_files
                 .iter()
                 .map(|f| f.file_id().file_id())
                 .collect::<HashSet<_>>(),
-            [files[0], files[1]].into_iter().collect()
-        );
-        assert_eq!(
-            fgs.get(&NonZeroU64::new(2))
-                .unwrap()
-                .files()
-                .iter()
-                .map(|f| f.file_id().file_id())
-                .collect::<HashSet<_>>(),
-            [files[2], files[3]].into_iter().collect()
+            files.into_iter().collect()
         );
     }
 
@@ -843,11 +833,10 @@ mod tests {
         files[2].set_compacting(true);
         let mut windows = assign_to_windows(files.iter(), 3);
         let window0 = windows.remove(&0).unwrap();
-        assert_eq!(1, window0.files.len());
+        assert_eq!(3, window0.files.len());
         let candidates = window0
             .files
-            .into_values()
-            .flat_map(|fg| fg.into_files())
+            .iter()
             .map(|f| f.file_id().file_id())
             .collect::<HashSet<_>>();
         assert_eq!(candidates.len(), 3);
@@ -893,12 +882,10 @@ mod tests {
             assert_eq!(*overlapping, actual_overlapping);
             let mut file_ranges = actual_window
                 .files
-                .values()
-                .flat_map(|f| {
-                    f.files().iter().map(|f| {
-                        let (s, e) = f.time_range();
-                        (s.value(), e.value())
-                    })
+                .iter()
+                .map(|f| {
+                    let (s, e) = f.time_range();
+                    (s.value(), e.value())
                 })
                 .collect::<Vec<_>>();
             file_ranges.sort_unstable_by(|l, r| l.0.cmp(&r.0).then(l.1.cmp(&r.1)));
@@ -1181,8 +1168,8 @@ mod tests {
 
         // Case 3:
         // A compaction may split output into several files that have overlapping time ranges and
-        // the same sequence. We treat these files as one stable FileGroup and exclude it from
-        // automatic TWCS candidates.
+        // the same sequence. They are ordinary compaction candidates now: the picker merges the
+        // overlapping ones in the window that reaches the trigger.
         let file_ids = (0..6).map(|_| FileId::random()).collect::<Vec<_>>();
         CompactionPickerTestCase {
             window_size: 3,
@@ -1194,7 +1181,16 @@ mod tests {
                 new_file_handle_with_sequence(file_ids[4], 11, 2990, 0, 3),
             ]
             .to_vec(),
-            expected_outputs: vec![],
+            expected_outputs: vec![
+                ExpectedOutput {
+                    input_files: vec![2, 3],
+                    output_level: 1,
+                },
+                ExpectedOutput {
+                    input_files: vec![0, 1, 4],
+                    output_level: 1,
+                },
+            ],
         }
         .check()
         .await;
@@ -1250,30 +1246,24 @@ mod tests {
         let small_file_2 = new_file_handle_with_size_and_sequence(file_ids[2], 0, 999, 0, 3, 800);
         let large_file_2 = new_file_handle_with_size_and_sequence(file_ids[3], 0, 999, 0, 4, 2000);
 
-        // Create file groups (each file is in its own group due to different sequences)
-        let mut files_to_merge = vec![
-            FileGroup::new_with_file(small_file_1),
-            FileGroup::new_with_file(large_file_1),
-            FileGroup::new_with_file(small_file_2),
-            FileGroup::new_with_file(large_file_2),
-        ];
+        let mut files_to_merge = vec![small_file_1, large_file_1, small_file_2, large_file_2];
 
         // Test filtering logic directly
         let original_count = files_to_merge.len();
 
         // Apply append mode filtering
-        files_to_merge.retain(|fg| fg.size() <= max_output_file_size as usize);
+        files_to_merge.retain(|file| file.size() <= max_output_file_size);
 
         // Should have filtered out 2 large files, leaving 2 small files
         assert_eq!(files_to_merge.len(), 2);
         assert_eq!(original_count, 4);
 
         // Verify the remaining files are the small ones
-        for fg in &files_to_merge {
+        for file in &files_to_merge {
             assert!(
-                fg.size() <= max_output_file_size as usize,
+                file.size() <= max_output_file_size,
                 "File size {} should be <= {}",
-                fg.size(),
+                file.size(),
                 max_output_file_size
             );
         }
@@ -1790,7 +1780,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_count_first_trigger_counts_file_groups() {
+    async fn test_count_first_trigger_counts_physical_ssts() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
@@ -1811,7 +1801,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(output.is_empty());
+        assert_eq!(1, output.len());
+        assert_eq!(3, output[0].inputs.len());
     }
 
     #[tokio::test]
@@ -1876,191 +1867,32 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, output.len());
-        assert_eq!(MAX_INPUT_FILE_GROUPS, output[0].inputs.len());
+        assert_eq!(MAX_INPUT_FILES, output[0].inputs.len());
         assert!(!output[0].filter_deleted);
     }
 
-    #[tokio::test]
-    async fn test_filter_deleted_is_false_when_selected_overlaps_ignored_file_group() {
-        let files = [
-            new_file_handle_with_size_and_sequence(FileId::random(), 0, 100, 0, 1, 10),
-            new_file_handle_with_size_and_sequence(FileId::random(), 0, 100, 0, 1, 10),
-            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 2, 10),
-            new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 3, 10),
-            new_file_handle_with_size_and_sequence(FileId::random(), 40, 50, 0, 4, 10),
-            new_file_handle_with_size_and_sequence(FileId::random(), 60, 70, 0, 5, 10),
-        ];
-        let windows = assign_to_windows(files.iter(), 100);
-        let picker = TwcsPicker {
-            trigger_file_num: 4,
-            time_window_seconds: Some(100),
-            max_output_file_size: None,
-            append_mode: false,
-            max_background_tasks: None,
-            time_range: None,
-        };
-
-        let output = picker
-            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
-            .await
-            .unwrap();
-
-        assert_eq!(1, output.len());
-        assert_eq!(4, output[0].inputs.len());
-        assert!(!output[0].filter_deleted);
+    fn new_file(start: i64, end: i64, sequence: u64, file_size: u64) -> FileHandle {
+        new_file_handle_with_size_and_sequence(FileId::random(), start, end, 0, sequence, file_size)
     }
 
-    fn new_file_group(
-        start: i64,
-        end: i64,
-        sequence: u64,
-        num_files: usize,
-        file_size: u64,
-    ) -> FileGroup {
-        let mut group = FileGroup::new_with_file(new_file_handle_with_size_and_sequence(
-            FileId::random(),
-            start,
-            end,
-            0,
-            sequence,
-            file_size,
-        ));
-        for _ in 1..num_files {
-            group.add_file(new_file_handle_with_size_and_sequence(
-                FileId::random(),
-                start,
-                end,
-                0,
-                sequence,
-                file_size,
-            ));
-        }
-        group
-    }
-
-    fn picked_ranges(groups: &[FileGroup]) -> Vec<(i64, i64)> {
-        groups
+    fn picked_ranges(files: &[FileHandle]) -> Vec<(i64, i64)> {
+        files
             .iter()
-            .map(|group| {
-                let (start, end) = group.range();
+            .map(|file| {
+                let (start, end) = file.range();
                 (start.value(), end.value())
             })
             .collect()
     }
 
     #[test]
-    fn test_count_first_counts_file_groups_not_physical_ssts() {
+    fn test_count_first_rejects_dominant_historical_file() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 2, 10),
-                new_file_group(20, 29, 2, 1, 10),
-                new_file_group(40, 49, 3, 1, 10),
-            ])],
-            2,
-        );
-
-        assert_eq!(vec![(20, 29), (40, 49)], picked_ranges(&picked));
-    }
-
-    #[test]
-    fn test_count_first_does_not_cross_multi_sst_group() {
-        let picked = pick_count_first(
-            vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 1, 10),
-                new_file_group(10, 19, 2, 2, 10),
-                new_file_group(20, 29, 3, 1, 10),
-            ])],
-            2,
-        );
-
-        assert!(picked.is_empty());
-    }
-
-    #[test]
-    fn test_count_first_compares_candidates_on_each_side_of_barrier() {
-        let cases = [
-            ([1, 1, 2, 1, 1, 1], vec![(30, 39), (40, 49), (50, 59)]),
-            ([1, 1, 1, 2, 1, 1], vec![(0, 9), (10, 19), (20, 29)]),
-        ];
-
-        let (expected, actual): (Vec<_>, Vec<_>) = cases
-            .into_iter()
-            .map(|(groups, expected)| {
-                let groups: Vec<_> = groups
-                    .into_iter()
-                    .enumerate()
-                    .map(|(idx, num_files)| {
-                        let start = idx as i64 * 10;
-                        new_file_group(start, start + 9, idx as u64 + 1, num_files, 10)
-                    })
-                    .collect();
-                let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
-                (expected, picked_ranges(&picked))
-            })
-            .unzip();
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn test_count_first_multi_sst_barrier_boundaries() {
-        struct TestCase {
-            group_file_nums: &'static [usize],
-            expected_ranges: &'static [(i64, i64)],
-        }
-
-        let cases = [
-            TestCase {
-                group_file_nums: &[2, 1, 1],
-                expected_ranges: &[(10, 19), (20, 29)],
-            },
-            TestCase {
-                group_file_nums: &[1, 1, 2],
-                expected_ranges: &[(0, 9), (10, 19)],
-            },
-            TestCase {
-                group_file_nums: &[1, 2, 1, 2, 1],
-                expected_ranges: &[],
-            },
-        ];
-
-        for case in cases {
-            let groups: Vec<_> = case
-                .group_file_nums
-                .iter()
-                .enumerate()
-                .map(|(idx, &num_files)| {
-                    let start = idx as i64 * 10;
-                    new_file_group(start, start + 9, idx as u64 + 1, num_files, 10)
-                })
-                .collect();
-            let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
-
-            assert_eq!(case.expected_ranges, picked_ranges(&picked));
-        }
-    }
-
-    #[test]
-    fn test_count_first_returns_empty_for_only_multi_sst_groups() {
-        let picked = pick_count_first(
-            vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 2, 10),
-                new_file_group(20, 29, 2, 2, 10),
-            ])],
-            2,
-        );
-
-        assert!(picked.is_empty());
-    }
-
-    #[test]
-    fn test_count_first_rejects_dominant_historical_group() {
-        let picked = pick_count_first(
-            vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 1, 400),
-                new_file_group(20, 29, 2, 1, 100),
-                new_file_group(40, 49, 3, 1, 100),
-                new_file_group(60, 69, 4, 1, 100),
+                new_file(0, 9, 1, 400),
+                new_file(20, 29, 2, 100),
+                new_file(40, 49, 3, 100),
+                new_file(60, 69, 4, 100),
             ])],
             4,
         );
@@ -2069,14 +1901,14 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_accepts_balanced_historical_group() {
+    fn test_count_first_accepts_balanced_historical_file() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 1, 400),
-                new_file_group(20, 29, 2, 1, 100),
-                new_file_group(40, 49, 3, 1, 100),
-                new_file_group(60, 69, 4, 1, 100),
-                new_file_group(80, 89, 5, 1, 100),
+                new_file(0, 9, 1, 400),
+                new_file(20, 29, 2, 100),
+                new_file(40, 49, 3, 100),
+                new_file(60, 69, 4, 100),
+                new_file(80, 89, 5, 100),
             ])],
             4,
         );
@@ -2091,11 +1923,11 @@ mod tests {
     fn test_count_first_finds_smaller_balanced_interval_when_larger_one_is_unbalanced() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 1, 1000),
-                new_file_group(20, 29, 2, 1, 100),
-                new_file_group(40, 49, 3, 1, 100),
-                new_file_group(60, 69, 4, 1, 100),
-                new_file_group(80, 89, 5, 1, 100),
+                new_file(0, 9, 1, 1000),
+                new_file(20, 29, 2, 100),
+                new_file(40, 49, 3, 100),
+                new_file(60, 69, 4, 100),
+                new_file(80, 89, 5, 100),
             ])],
             4,
         );
@@ -2107,19 +1939,19 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_prefers_overlap_participants_when_file_group_counts_match() {
-        let first_run = (0..MAX_INPUT_FILE_GROUPS)
+    fn test_count_first_prefers_overlap_participants_when_file_counts_match() {
+        let first_run = (0..MAX_INPUT_FILES)
             .map(|idx| {
                 let start = idx as i64 * 20;
-                let end = if idx + 1 == MAX_INPUT_FILE_GROUPS {
+                let end = if idx + 1 == MAX_INPUT_FILES {
                     700
                 } else {
                     start + 9
                 };
-                new_file_group(start, end, idx as u64 + 1, 1, 10)
+                new_file(start, end, idx as u64 + 1, 10)
             })
             .collect::<Vec<_>>();
-        let overlapping = new_file_group(690, 710, 100, 1, 10);
+        let overlapping = new_file(690, 710, 100, 10);
 
         let picked = pick_count_first(
             vec![
@@ -2130,48 +1962,48 @@ mod tests {
         );
         let ranges = picked_ranges(&picked);
 
-        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert_eq!(MAX_INPUT_FILES, ranges.len());
         assert!(!ranges.contains(&(0, 9)));
         assert!(ranges.contains(&(690, 710)));
     }
 
     #[test]
-    fn test_count_first_prefers_smaller_bytes_when_file_group_counts_match() {
-        let groups = (0..=MAX_INPUT_FILE_GROUPS)
+    fn test_count_first_prefers_smaller_bytes_when_file_counts_match() {
+        let files = (0..=MAX_INPUT_FILES)
             .map(|idx| {
                 let start = idx as i64 * 20;
                 let size = if idx == 0 {
                     100
-                } else if idx == MAX_INPUT_FILE_GROUPS {
+                } else if idx == MAX_INPUT_FILES {
                     1
                 } else {
                     10
                 };
-                new_file_group(start, start + 9, idx as u64 + 1, 1, size)
+                new_file(start, start + 9, idx as u64 + 1, size)
             })
             .collect::<Vec<_>>();
 
-        let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+        let picked = pick_count_first(vec![SortedRun::from(files)], 2);
         let ranges = picked_ranges(&picked);
 
-        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert_eq!(MAX_INPUT_FILES, ranges.len());
         assert_eq!(Some(&(20, 29)), ranges.first());
         assert_eq!(Some(&(640, 649)), ranges.last());
     }
 
     #[test]
     fn test_count_first_prefers_earlier_time_on_exact_tie() {
-        let groups = (0..=MAX_INPUT_FILE_GROUPS)
+        let files = (0..=MAX_INPUT_FILES)
             .map(|idx| {
                 let start = idx as i64 * 20;
-                new_file_group(start, start + 9, idx as u64 + 1, 1, 10)
+                new_file(start, start + 9, idx as u64 + 1, 10)
             })
             .collect::<Vec<_>>();
 
-        let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+        let picked = pick_count_first(vec![SortedRun::from(files)], 2);
         let ranges = picked_ranges(&picked);
 
-        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert_eq!(MAX_INPUT_FILES, ranges.len());
         assert_eq!(Some(&(0, 9)), ranges.first());
         assert_eq!(Some(&(620, 629)), ranges.last());
     }
@@ -2181,14 +2013,11 @@ mod tests {
         let picked = pick_count_first(
             vec![
                 SortedRun::from(vec![
-                    new_file_group(0, 9, 1, 1, 1),
-                    new_file_group(20, 29, 2, 1, 1),
-                    new_file_group(40, 49, 3, 1, 1),
+                    new_file(0, 9, 1, 1),
+                    new_file(20, 29, 2, 1),
+                    new_file(40, 49, 3, 1),
                 ]),
-                SortedRun::from(vec![
-                    new_file_group(10, 19, 4, 1, 1),
-                    new_file_group(30, 39, 5, 1, 1),
-                ]),
+                SortedRun::from(vec![new_file(10, 19, 4, 1), new_file(30, 39, 5, 1)]),
             ],
             2,
         );
@@ -2200,4 +2029,86 @@ mod tests {
     }
 
     // TODO(hl): TTL tester that checks if get_expired_ssts function works as expected.
+
+    // Reproduces the leftover-small-files deadlock observed in the compaction bench:
+    // an "EngineFull" flush emits several SSTs sharing one sequence. They must be ordinary
+    // candidates so a contiguous candidate can span them instead of treating them as an
+    // indivisible block that fragments the timeline.
+    #[test]
+    fn test_count_first_candidate_spans_same_sequence_files() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file(0, 9, 1, 10),
+                // One EngineFull flush output: three SSTs with the same sequence.
+                new_file(10, 19, 2, 10),
+                new_file(10, 19, 2, 10),
+                new_file(10, 19, 2, 10),
+                new_file(20, 29, 3, 10),
+            ])],
+            2,
+        );
+
+        assert_eq!(
+            vec![(0, 9), (10, 19), (10, 19), (10, 19), (20, 29)],
+            picked_ranges(&picked)
+        );
+    }
+
+    // `trigger_file_num` is documented as "Minimum file num in every time window to
+    // trigger a compaction", so every physical SST counts toward the trigger.
+    #[test]
+    fn test_count_first_trigger_counts_same_sequence_files() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file(0, 9, 1, 10),
+                // Three SSTs with the same sequence: 1 + 3 = 4 actual SSTs >= trigger.
+                new_file(10, 19, 2, 10),
+                new_file(10, 19, 2, 10),
+                new_file(10, 19, 2, 10),
+            ])],
+            3,
+        );
+
+        assert_eq!(
+            vec![(0, 9), (10, 19), (10, 19), (10, 19)],
+            picked_ranges(&picked)
+        );
+    }
+
+    // End-to-end repro of the compaction-bench leftover files: a window where
+    // EngineFull flush groups (multiple SSTs sharing a sequence) sit between
+    // singleton flushes. The picker must be able to merge the whole contiguous
+    // range; otherwise these files can never be compacted once the active window
+    // moves on.
+    #[tokio::test]
+    async fn test_count_first_merges_window_with_interleaved_flush_groups() {
+        let files = [
+            // Singleton flush.
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 9, 0, 1, 10),
+            // EngineFull flush: three SSTs sharing sequence 2.
+            new_file_handle_with_size_and_sequence(FileId::random(), 10, 19, 0, 2, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 10, 19, 0, 2, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 10, 19, 0, 2, 10),
+            // Singleton flush.
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 29, 0, 3, 10),
+        ];
+        let windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 3,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
+
+        assert_eq!(1, output.len());
+        // All five SSTs of the window are merged in one compaction.
+        assert_eq!(5, output[0].inputs.len());
+    }
 }

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -155,6 +155,10 @@ impl TwcsPicker {
         files: &Window,
         windows: &BTreeMap<i64, Window>,
     ) -> (Vec<FileHandle>, bool) {
+        if files.files.len() < self.trigger_file_num {
+            return (vec![], false);
+        }
+
         let window = &files.time_window;
         let mut files_to_merge: Vec<_> = files.files().cloned().collect();
 
@@ -183,11 +187,7 @@ impl TwcsPicker {
             find_sorted_runs_by_time_range(&mut files_to_merge)
         };
         let found_runs = sorted_runs.len();
-        let inputs = pick_count_first(
-            sorted_runs,
-            self.trigger_file_num,
-            self.max_output_file_size,
-        );
+        let inputs = pick_count_first(sorted_runs, self.max_output_file_size);
         let filter_deleted = !self.append_mode
             && !window_has_overlap(files, windows)
             && !selected_overlaps_unselected(&inputs, files);
@@ -330,7 +330,7 @@ impl CandidateScore {
 /// enumerates every interval of at most [`MAX_INPUT_FILES`] files as a [`Candidate`].
 /// An interval is eligible when it
 ///
-/// - holds at least `trigger_file_num` files (and at least 2),
+/// - holds at least 2 files,
 /// - is balanced: no single file dominates it (`largest <= sum of the others`),
 /// - makes progress on at least one axis: it reduces the physical file count given
 ///   the output split threshold `max_output_file_size`, or it resolves at least one
@@ -339,11 +339,9 @@ impl CandidateScore {
 /// The best interval wins by [`CandidateScore`]; ties keep the earliest interval.
 fn pick_count_first(
     sorted_runs: Vec<SortedRun<FileHandle>>,
-    trigger_file_num: usize,
     max_output_file_size: Option<u64>,
 ) -> Vec<FileHandle> {
     let files = ordered_files(&sorted_runs);
-    let min_files = trigger_file_num.max(2);
 
     let mut best = None;
     for left in 0..files.len() {
@@ -352,7 +350,7 @@ fn pick_count_first(
         let mut participations: Vec<bool> = Vec::with_capacity(right_bound - left);
         for right in left..right_bound {
             candidate.absorb(&files[right], &files[left..right], &mut participations);
-            if candidate.num_files < min_files
+            if candidate.num_files < 2
                 || !candidate.is_balanced()
                 || !candidate.makes_progress(max_output_file_size)
             {
@@ -1621,7 +1619,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_limit_max_input_files() {
+    async fn test_window_trigger_can_exceed_input_limit() {
         common_telemetry::init_default_ut_logging();
 
         let num_files = 50;
@@ -1646,7 +1644,7 @@ mod tests {
         let windows = assign_to_windows(files.iter(), 3);
 
         let picker = TwcsPicker {
-            trigger_file_num: 4,
+            trigger_file_num: num_files,
             time_window_seconds: Some(3),
             max_output_file_size: None,
             append_mode: false,
@@ -1996,10 +1994,7 @@ mod tests {
             vec![SortedRun::from(vec![
                 new_file(0, 9, 1, 400),
                 new_file(20, 29, 2, 100),
-                new_file(40, 49, 3, 100),
-                new_file(60, 69, 4, 100),
             ])],
-            4,
             None,
         );
 
@@ -2016,7 +2011,6 @@ mod tests {
                 new_file(60, 69, 4, 100),
                 new_file(80, 89, 5, 100),
             ])],
-            4,
             None,
         );
 
@@ -2036,7 +2030,6 @@ mod tests {
                 new_file(60, 69, 4, 100),
                 new_file(80, 89, 5, 100),
             ])],
-            4,
             None,
         );
 
@@ -2066,7 +2059,6 @@ mod tests {
                 SortedRun::from(first_run),
                 SortedRun::from(vec![overlapping]),
             ],
-            2,
             None,
         );
         let ranges = picked_ranges(&picked);
@@ -2092,7 +2084,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let picked = pick_count_first(vec![SortedRun::from(files)], 2, None);
+        let picked = pick_count_first(vec![SortedRun::from(files)], None);
         let ranges = picked_ranges(&picked);
 
         assert_eq!(DEFAULT_MAX_INPUT_FILES, ranges.len());
@@ -2112,7 +2104,6 @@ mod tests {
                 new_file(40, 49, 3, 600),
                 new_file(60, 69, 4, 600),
             ])],
-            2,
             Some(512),
         );
 
@@ -2129,7 +2120,6 @@ mod tests {
                 SortedRun::from(vec![new_file(0, 19, 1, 600)]),
                 SortedRun::from(vec![new_file(10, 29, 2, 600)]),
             ],
-            2,
             Some(512),
         );
 
@@ -2150,7 +2140,6 @@ mod tests {
                 new_file(40, 49, 5, 10),
                 new_file(50, 59, 6, 10),
             ])],
-            2,
             Some(512),
         );
 
@@ -2166,7 +2155,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let picked = pick_count_first(vec![SortedRun::from(files)], 2, None);
+        let picked = pick_count_first(vec![SortedRun::from(files)], None);
         let ranges = picked_ranges(&picked);
 
         assert_eq!(DEFAULT_MAX_INPUT_FILES, ranges.len());
@@ -2185,7 +2174,6 @@ mod tests {
                 ]),
                 SortedRun::from(vec![new_file(10, 19, 4, 1), new_file(30, 39, 5, 1)]),
             ],
-            2,
             None,
         );
 
@@ -2212,34 +2200,11 @@ mod tests {
                 new_file(10, 19, 2, 10),
                 new_file(20, 29, 3, 10),
             ])],
-            2,
             None,
         );
 
         assert_eq!(
             vec![(0, 9), (10, 19), (10, 19), (10, 19), (20, 29)],
-            picked_ranges(&picked)
-        );
-    }
-
-    // `trigger_file_num` is documented as "Minimum file num in every time window to
-    // trigger a compaction", so every physical SST counts toward the trigger.
-    #[test]
-    fn test_count_first_trigger_counts_same_sequence_files() {
-        let picked = pick_count_first(
-            vec![SortedRun::from(vec![
-                new_file(0, 9, 1, 10),
-                // Three SSTs with the same sequence: 1 + 3 = 4 actual SSTs >= trigger.
-                new_file(10, 19, 2, 10),
-                new_file(10, 19, 2, 10),
-                new_file(10, 19, 2, 10),
-            ])],
-            3,
-            None,
-        );
-
-        assert_eq!(
-            vec![(0, 9), (10, 19), (10, 19), (10, 19)],
             picked_ranges(&picked)
         );
     }

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -1656,15 +1656,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_count_first_prefers_more_files_over_smaller_overlap() {
+    #[tokio::test]
+    async fn test_count_first_prefers_more_files_over_smaller_overlap() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 40, 50, 0, 3, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 5, 15, 0, 4, 10),
         ];
-        let mut windows = assign_to_windows(files.iter(), 100);
+        let windows = assign_to_windows(files.iter(), 100);
         let picker = TwcsPicker {
             trigger_file_num: 2,
             time_window_seconds: Some(100),
@@ -1674,20 +1674,23 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert_eq!(1, output.len());
         assert_eq!(4, output[0].inputs.len());
     }
 
-    #[test]
-    fn test_count_first_trigger_counts_actual_ssts() {
+    #[tokio::test]
+    async fn test_count_first_trigger_counts_actual_ssts() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
         ];
-        let mut windows = assign_to_windows(files.iter(), 100);
+        let windows = assign_to_windows(files.iter(), 100);
         let picker = TwcsPicker {
             trigger_file_num: 3,
             time_window_seconds: Some(100),
@@ -1697,19 +1700,22 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert_eq!(1, output.len());
         assert_eq!(3, output[0].inputs.len());
     }
 
-    #[test]
-    fn test_count_first_does_not_compact_overlap_below_trigger() {
+    #[tokio::test]
+    async fn test_count_first_does_not_compact_overlap_below_trigger() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 20, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 10, 30, 0, 2, 10),
         ];
-        let mut windows = assign_to_windows(files.iter(), 100);
+        let windows = assign_to_windows(files.iter(), 100);
         let picker = TwcsPicker {
             trigger_file_num: 3,
             time_window_seconds: Some(100),
@@ -1719,13 +1725,16 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert!(output.is_empty());
     }
 
-    #[test]
-    fn test_filter_deleted_is_false_when_selected_files_overlap_unselected_file() {
+    #[tokio::test]
+    async fn test_filter_deleted_is_false_when_selected_files_overlap_unselected_file() {
         let mut files = (0..32)
             .map(|idx| {
                 new_file_handle_with_size_and_sequence(
@@ -1746,7 +1755,7 @@ mod tests {
             33,
             10,
         ));
-        let mut windows = assign_to_windows(files.iter(), 1000);
+        let windows = assign_to_windows(files.iter(), 1000);
         let picker = TwcsPicker {
             trigger_file_num: 2,
             time_window_seconds: Some(1000),
@@ -1756,7 +1765,10 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert_eq!(1, output.len());
         assert_eq!(DEFAULT_MAX_INPUT_FILE_NUM, output[0].inputs.len());

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -309,12 +309,25 @@ fn pick_count_first(
 }
 
 fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool {
+    // The overall time span of the selection: a group outside it cannot overlap any
+    // selected group (ranges are inclusive), so it needs no precise overlap check.
+    let Some((span_start, span_end)) = selected
+        .iter()
+        .map(Ranged::range)
+        .reduce(|(start_a, end_a), (start_b, end_b)| (start_a.min(start_b), end_a.max(end_b)))
+    else {
+        return false;
+    };
     let selected_file_ids = selected
         .iter()
         .flat_map(FileGroup::file_ids)
         .collect::<HashSet<_>>();
     window
         .files()
+        .filter(|group| {
+            let (start, end) = group.range();
+            start <= span_end && span_start <= end
+        })
         .filter(|group| {
             !group
                 .file_ids()

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -1771,15 +1771,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_count_first_prefers_more_files_over_smaller_overlap() {
+    #[tokio::test]
+    async fn test_count_first_prefers_more_files_over_smaller_overlap() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 40, 50, 0, 3, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 5, 15, 0, 4, 10),
         ];
-        let mut windows = assign_to_windows(files.iter(), 100);
+        let windows = assign_to_windows(files.iter(), 100);
         let picker = TwcsPicker {
             trigger_file_num: 2,
             time_window_seconds: Some(100),
@@ -1789,20 +1789,23 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert_eq!(1, output.len());
         assert_eq!(4, output[0].inputs.len());
     }
 
-    #[test]
-    fn test_count_first_trigger_counts_actual_ssts() {
+    #[tokio::test]
+    async fn test_count_first_trigger_counts_actual_ssts() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
         ];
-        let mut windows = assign_to_windows(files.iter(), 100);
+        let windows = assign_to_windows(files.iter(), 100);
         let picker = TwcsPicker {
             trigger_file_num: 3,
             time_window_seconds: Some(100),
@@ -1812,19 +1815,22 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert_eq!(1, output.len());
         assert_eq!(3, output[0].inputs.len());
     }
 
-    #[test]
-    fn test_count_first_does_not_compact_overlap_below_trigger() {
+    #[tokio::test]
+    async fn test_count_first_does_not_compact_overlap_below_trigger() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 20, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 10, 30, 0, 2, 10),
         ];
-        let mut windows = assign_to_windows(files.iter(), 100);
+        let windows = assign_to_windows(files.iter(), 100);
         let picker = TwcsPicker {
             trigger_file_num: 3,
             time_window_seconds: Some(100),
@@ -1834,13 +1840,16 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert!(output.is_empty());
     }
 
-    #[test]
-    fn test_filter_deleted_is_false_when_selected_files_overlap_unselected_file() {
+    #[tokio::test]
+    async fn test_filter_deleted_is_false_when_selected_files_overlap_unselected_file() {
         let mut files = (0..32)
             .map(|idx| {
                 new_file_handle_with_size_and_sequence(
@@ -1861,7 +1870,7 @@ mod tests {
             33,
             10,
         ));
-        let mut windows = assign_to_windows(files.iter(), 1000);
+        let windows = assign_to_windows(files.iter(), 1000);
         let picker = TwcsPicker {
             trigger_file_num: 2,
             time_window_seconds: Some(1000),
@@ -1871,7 +1880,10 @@ mod tests {
             time_range: None,
         };
 
-        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
 
         assert_eq!(1, output.len());
         assert_eq!(DEFAULT_MAX_INPUT_FILE_NUM, output[0].inputs.len());

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -41,14 +41,14 @@ use crate::sst::version::LevelMeta;
 
 const LEVEL_COMPACTED: Level = 1;
 
-/// Default value for max compaction input file num.
-const DEFAULT_MAX_INPUT_FILE_NUM: usize = 32;
+/// Maximum number of logical FileGroups in one compaction input.
+const MAX_INPUT_FILE_GROUPS: usize = 32;
 
 /// `TwcsPicker` picks files of which the max timestamp are in the same time window as compaction
 /// candidates.
 #[derive(Clone, Debug)]
 pub struct TwcsPicker {
-    /// Minimum file num to trigger a compaction.
+    /// Minimum eligible FileGroup num to trigger a compaction.
     pub trigger_file_num: usize,
     /// Compaction time window in seconds.
     pub time_window_seconds: Option<i64>,
@@ -198,15 +198,15 @@ struct OrderedFileGroup<'a> {
 
 #[derive(Debug)]
 struct CandidateScore {
-    num_files: usize,
+    num_file_groups: usize,
     overlap_participants: usize,
     size: usize,
 }
 
 impl CandidateScore {
     fn is_better_than(&self, other: &Self) -> bool {
-        self.num_files
-            .cmp(&other.num_files)
+        self.num_file_groups
+            .cmp(&other.num_file_groups)
             .then_with(|| self.overlap_participants.cmp(&other.overlap_participants))
             .then_with(|| other.size.cmp(&self.size))
             .is_gt()
@@ -240,39 +240,62 @@ fn pick_count_first(
             .then_with(|| lhs.run_id.cmp(&rhs.run_id))
             .then_with(|| lhs.position_in_run.cmp(&rhs.position_in_run))
     });
+    // A multi-SST FileGroup is a compaction output that already exceeded the output size target
+    // and was split. Recompacting it cannot reduce physical files, so automatic TWCS treats it as
+    // stable. It remains in the original Window for tombstone overlap checks.
+    groups.retain(|group| group.group.num_files() == 1);
 
-    let mut left = 0;
-    let mut num_files = 0;
     let mut best = None;
-    for right in 0..groups.len() {
-        let group_file_num = groups[right].group.num_files();
-        if group_file_num > DEFAULT_MAX_INPUT_FILE_NUM {
-            left = right + 1;
-            num_files = 0;
-            continue;
-        }
+    for left in 0..groups.len() {
+        let mut total_size = 0;
+        let mut largest_group_size = 0;
+        let mut overlap_participants = 0;
+        let right_bound = (left + MAX_INPUT_FILE_GROUPS).min(groups.len());
+        let mut participants: Vec<bool> = Vec::with_capacity(right_bound - left);
+        for right in left..right_bound {
+            let right_group = &groups[right];
+            let group_size = right_group.group.size();
+            total_size += group_size;
+            largest_group_size = largest_group_size.max(group_size);
 
-        num_files += group_file_num;
-        while num_files > DEFAULT_MAX_INPUT_FILE_NUM {
-            num_files -= groups[left].group.num_files();
-            left += 1;
-        }
+            let mut right_participates = false;
+            for (offset, other) in groups[left..right].iter().enumerate() {
+                if right_group.run_id != other.run_id
+                    && right_group.group.overlap_inclusive(other.group)
+                {
+                    if !participants[offset] {
+                        participants[offset] = true;
+                        overlap_participants += 1;
+                    }
+                    right_participates = true;
+                }
+            }
+            participants.push(right_participates);
+            if right_participates {
+                overlap_participants += 1;
+            }
 
-        if num_files < trigger_file_num || right + 1 - left < 2 {
-            continue;
-        }
+            let num_file_groups = right + 1 - left;
+            if num_file_groups < trigger_file_num || num_file_groups < 2 {
+                continue;
+            }
+            // A historical group is only rewritten after peers contribute at least the same
+            // amount of data, so every rewrite moves it into a larger size tier.
+            if largest_group_size > total_size - largest_group_size {
+                continue;
+            }
 
-        let candidate = &groups[left..=right];
-        let score = CandidateScore {
-            num_files,
-            overlap_participants: count_overlap_participants(candidate),
-            size: candidate.iter().map(|group| group.group.size()).sum(),
-        };
-        if best
-            .as_ref()
-            .is_none_or(|(best_score, _, _)| score.is_better_than(best_score))
-        {
-            best = Some((score, left, right));
+            let score = CandidateScore {
+                num_file_groups,
+                overlap_participants,
+                size: total_size,
+            };
+            if best
+                .as_ref()
+                .is_none_or(|(best_score, _, _)| score.is_better_than(best_score))
+            {
+                best = Some((score, left, right));
+            }
         }
     }
 
@@ -283,27 +306,6 @@ fn pick_count_first(
         .iter()
         .map(|group| group.group.clone())
         .collect()
-}
-
-fn count_overlap_participants(groups: &[OrderedFileGroup<'_>]) -> usize {
-    let mut participants = vec![false; groups.len()];
-    for lhs in 0..groups.len() {
-        for rhs in lhs + 1..groups.len() {
-            if groups[lhs].run_id != groups[rhs].run_id
-                && groups[lhs].group.overlap_inclusive(groups[rhs].group)
-            {
-                participants[lhs] = true;
-                participants[rhs] = true;
-            }
-        }
-    }
-
-    groups
-        .iter()
-        .zip(participants)
-        .filter(|(_, participant)| *participant)
-        .map(|(group, _)| group.group.num_files())
-        .sum()
 }
 
 fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool {
@@ -1165,8 +1167,9 @@ mod tests {
         .await;
 
         // Case 3:
-        // A compaction may split output into several files that have overlapping time ranges and same sequence,
-        // we should treat these files as one FileGroup.
+        // A compaction may split output into several files that have overlapping time ranges and
+        // the same sequence. We treat these files as one stable FileGroup and exclude it from
+        // automatic TWCS candidates.
         let file_ids = (0..6).map(|_| FileId::random()).collect::<Vec<_>>();
         CompactionPickerTestCase {
             window_size: 3,
@@ -1178,10 +1181,7 @@ mod tests {
                 new_file_handle_with_sequence(file_ids[4], 11, 2990, 0, 3),
             ]
             .to_vec(),
-            expected_outputs: vec![ExpectedOutput {
-                input_files: vec![0, 1, 4],
-                output_level: 1,
-            }],
+            expected_outputs: vec![],
         }
         .check()
         .await;
@@ -1684,7 +1684,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_count_first_trigger_counts_actual_ssts() {
+    async fn test_count_first_trigger_counts_file_groups() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
@@ -1705,8 +1705,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, output.len());
-        assert_eq!(3, output[0].inputs.len());
+        assert!(output.is_empty());
     }
 
     #[tokio::test]
@@ -1771,7 +1770,37 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, output.len());
-        assert_eq!(DEFAULT_MAX_INPUT_FILE_NUM, output[0].inputs.len());
+        assert_eq!(MAX_INPUT_FILE_GROUPS, output[0].inputs.len());
+        assert!(!output[0].filter_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_filter_deleted_is_false_when_selected_overlaps_ignored_file_group() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 100, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 100, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 2, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 3, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 40, 50, 0, 4, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 60, 70, 0, 5, 10),
+        ];
+        let windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 4,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
+
+        assert_eq!(1, output.len());
+        assert_eq!(4, output[0].inputs.len());
         assert!(!output[0].filter_deleted);
     }
 
@@ -1814,29 +1843,12 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_prefers_overlap_participants_when_file_counts_match() {
-        let first = new_file_group(0, 9, 1, 16, 10);
-        let second = new_file_group(20, 39, 2, 16, 10);
-        let overlapping = new_file_group(30, 49, 3, 16, 10);
-
-        let picked = pick_count_first(
-            vec![
-                SortedRun::from(vec![first, second]),
-                SortedRun::from(vec![overlapping]),
-            ],
-            2,
-        );
-
-        assert_eq!(vec![(20, 39), (30, 49)], picked_ranges(&picked));
-    }
-
-    #[test]
-    fn test_count_first_prefers_smaller_bytes_when_file_counts_match() {
+    fn test_count_first_counts_file_groups_not_physical_ssts() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 16, 10),
-                new_file_group(20, 29, 2, 16, 10),
-                new_file_group(40, 49, 3, 16, 1),
+                new_file_group(0, 9, 1, 2, 10),
+                new_file_group(20, 29, 2, 1, 10),
+                new_file_group(40, 49, 3, 1, 10),
             ])],
             2,
         );
@@ -1845,12 +1857,12 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_prefers_earlier_time_on_exact_tie() {
+    fn test_count_first_ignores_multi_sst_groups_between_singletons() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 16, 10),
-                new_file_group(20, 29, 2, 16, 10),
-                new_file_group(40, 49, 3, 16, 10),
+                new_file_group(0, 9, 1, 1, 10),
+                new_file_group(10, 19, 2, 2, 10),
+                new_file_group(20, 29, 3, 1, 10),
             ])],
             2,
         );
@@ -1859,21 +1871,139 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_skips_oversized_atomic_file_group() {
+    fn test_count_first_returns_empty_for_only_multi_sst_groups() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 33, 1),
-                new_file_group(20, 29, 2, 16, 1),
-                new_file_group(40, 49, 3, 16, 1),
+                new_file_group(0, 9, 1, 2, 10),
+                new_file_group(20, 29, 2, 2, 10),
             ])],
             2,
         );
 
-        assert_eq!(
-            DEFAULT_MAX_INPUT_FILE_NUM,
-            picked.iter().map(FileGroup::num_files).sum::<usize>()
+        assert!(picked.is_empty());
+    }
+
+    #[test]
+    fn test_count_first_rejects_dominant_historical_group() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 1, 400),
+                new_file_group(20, 29, 2, 1, 100),
+                new_file_group(40, 49, 3, 1, 100),
+                new_file_group(60, 69, 4, 1, 100),
+            ])],
+            4,
         );
-        assert_eq!(vec![(20, 29), (40, 49)], picked_ranges(&picked));
+
+        assert!(picked.is_empty());
+    }
+
+    #[test]
+    fn test_count_first_accepts_balanced_historical_group() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 1, 400),
+                new_file_group(20, 29, 2, 1, 100),
+                new_file_group(40, 49, 3, 1, 100),
+                new_file_group(60, 69, 4, 1, 100),
+                new_file_group(80, 89, 5, 1, 100),
+            ])],
+            4,
+        );
+
+        assert_eq!(
+            vec![(0, 9), (20, 29), (40, 49), (60, 69), (80, 89)],
+            picked_ranges(&picked)
+        );
+    }
+
+    #[test]
+    fn test_count_first_finds_smaller_balanced_interval_when_larger_one_is_unbalanced() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 1, 1000),
+                new_file_group(20, 29, 2, 1, 100),
+                new_file_group(40, 49, 3, 1, 100),
+                new_file_group(60, 69, 4, 1, 100),
+                new_file_group(80, 89, 5, 1, 100),
+            ])],
+            4,
+        );
+
+        assert_eq!(
+            vec![(20, 29), (40, 49), (60, 69), (80, 89)],
+            picked_ranges(&picked)
+        );
+    }
+
+    #[test]
+    fn test_count_first_prefers_overlap_participants_when_file_group_counts_match() {
+        let first_run = (0..MAX_INPUT_FILE_GROUPS)
+            .map(|idx| {
+                let start = idx as i64 * 20;
+                let end = if idx + 1 == MAX_INPUT_FILE_GROUPS {
+                    700
+                } else {
+                    start + 9
+                };
+                new_file_group(start, end, idx as u64 + 1, 1, 10)
+            })
+            .collect::<Vec<_>>();
+        let overlapping = new_file_group(690, 710, 100, 1, 10);
+
+        let picked = pick_count_first(
+            vec![
+                SortedRun::from(first_run),
+                SortedRun::from(vec![overlapping]),
+            ],
+            2,
+        );
+        let ranges = picked_ranges(&picked);
+
+        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert!(!ranges.contains(&(0, 9)));
+        assert!(ranges.contains(&(690, 710)));
+    }
+
+    #[test]
+    fn test_count_first_prefers_smaller_bytes_when_file_group_counts_match() {
+        let groups = (0..=MAX_INPUT_FILE_GROUPS)
+            .map(|idx| {
+                let start = idx as i64 * 20;
+                let size = if idx == 0 {
+                    100
+                } else if idx == MAX_INPUT_FILE_GROUPS {
+                    1
+                } else {
+                    10
+                };
+                new_file_group(start, start + 9, idx as u64 + 1, 1, size)
+            })
+            .collect::<Vec<_>>();
+
+        let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+        let ranges = picked_ranges(&picked);
+
+        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert_eq!(Some(&(20, 29)), ranges.first());
+        assert_eq!(Some(&(640, 649)), ranges.last());
+    }
+
+    #[test]
+    fn test_count_first_prefers_earlier_time_on_exact_tie() {
+        let groups = (0..=MAX_INPUT_FILE_GROUPS)
+            .map(|idx| {
+                let start = idx as i64 * 20;
+                new_file_group(start, start + 9, idx as u64 + 1, 1, 10)
+            })
+            .collect::<Vec<_>>();
+
+        let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+        let ranges = picked_ranges(&picked);
+
+        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert_eq!(Some(&(0, 9)), ranges.first());
+        assert_eq!(Some(&(620, 629)), ranges.last());
     }
 
     #[test]
@@ -1881,20 +2011,20 @@ mod tests {
         let picked = pick_count_first(
             vec![
                 SortedRun::from(vec![
-                    new_file_group(0, 9, 1, 8, 1),
-                    new_file_group(20, 29, 2, 8, 1),
-                    new_file_group(40, 49, 3, 8, 1),
+                    new_file_group(0, 9, 1, 1, 1),
+                    new_file_group(20, 29, 2, 1, 1),
+                    new_file_group(40, 49, 3, 1, 1),
                 ]),
                 SortedRun::from(vec![
-                    new_file_group(10, 19, 4, 8, 1),
-                    new_file_group(30, 39, 5, 8, 1),
+                    new_file_group(10, 19, 4, 1, 1),
+                    new_file_group(30, 39, 5, 1, 1),
                 ]),
             ],
             2,
         );
 
         assert_eq!(
-            vec![(0, 9), (10, 19), (20, 29), (30, 39)],
+            vec![(0, 9), (10, 19), (20, 29), (30, 39), (40, 49)],
             picked_ranges(&picked)
         );
     }

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -51,7 +51,8 @@ pub struct TwcsPicker {
     pub trigger_file_num: usize,
     /// Compaction time window in seconds.
     pub time_window_seconds: Option<i64>,
-    /// Max allowed compaction output file size.
+    /// Max allowed compaction output file size. The picker also uses it to predict
+    /// output splits when scoring candidates.
     pub max_output_file_size: Option<u64>,
     /// Whether the target region is in append mode.
     pub append_mode: bool,
@@ -166,7 +167,11 @@ impl TwcsPicker {
             find_sorted_runs_by_time_range(&mut files_to_merge)
         };
         let found_runs = sorted_runs.len();
-        let inputs = pick_count_first(sorted_runs, self.trigger_file_num);
+        let inputs = pick_count_first(
+            sorted_runs,
+            self.trigger_file_num,
+            self.max_output_file_size,
+        );
         let filter_deleted = !self.append_mode
             && !window_has_overlap(files, windows)
             && !selected_overlaps_unselected(&inputs, files);
@@ -195,38 +200,168 @@ struct OrderedFile<'a> {
     position_in_run: usize,
 }
 
-/// Score of a candidate compaction input. Higher is better: first by the number of SST files
-/// it removes, then by the number of files participating in an overlap (resolving overlap is
-/// what reduces sorted runs), then by smaller input bytes.
+/// Metrics of a candidate compaction input, accumulated incrementally as the
+/// candidate interval expands one file at a time.
+#[derive(Debug, Default)]
+struct Candidate {
+    /// Number of files in the interval.
+    num_files: usize,
+    /// Total input bytes of the interval.
+    total_size: usize,
+    /// Size of the largest single file in the interval.
+    largest_file_size: usize,
+    /// Files in the interval that overlap another interval file from a different
+    /// sorted run. Resolving these overlaps is what reduces sorted runs.
+    overlap_participants: usize,
+}
+
+impl Candidate {
+    /// Absorbs `file` into the candidate. `preceding` holds the interval files added
+    /// before it and `participations` tracks which of them already participate in an
+    /// intra-interval overlap; both exist only for overlap accounting.
+    fn absorb(
+        &mut self,
+        file: &OrderedFile,
+        preceding: &[OrderedFile],
+        participations: &mut Vec<bool>,
+    ) {
+        self.num_files += 1;
+        let file_size = file.file.size() as usize;
+        self.total_size += file_size;
+        self.largest_file_size = self.largest_file_size.max(file_size);
+
+        let mut participates = false;
+        for (offset, other) in preceding.iter().enumerate() {
+            if file.run_id != other.run_id && file.file.overlap_inclusive(other.file) {
+                if !participations[offset] {
+                    participations[offset] = true;
+                    self.overlap_participants += 1;
+                }
+                participates = true;
+            }
+        }
+        participations.push(participates);
+        if participates {
+            self.overlap_participants += 1;
+        }
+    }
+
+    /// Predicted number of output files after compacting this candidate. Compaction
+    /// output holds at most the input bytes, so a split threshold of
+    /// `max_output_file_size` yields at most `ceil(total_size / threshold)` files.
+    /// Without a threshold the output is a single file.
+    fn predicted_output_files(&self, max_output_file_size: Option<u64>) -> usize {
+        match max_output_file_size {
+            Some(max) if max > 0 => self.total_size.div_ceil(max as usize).max(1),
+            _ => 1,
+        }
+    }
+
+    /// Net file count reduction compacting this candidate would achieve, i.e. how
+    /// many fewer physical SSTs the window holds afterwards. Zero when the output
+    /// would be split back into at least as many files as the input.
+    fn file_reduction(&self, max_output_file_size: Option<u64>) -> usize {
+        self.num_files
+            .saturating_sub(self.predicted_output_files(max_output_file_size))
+    }
+
+    /// A large historical file is only rewritten once its peers contribute at least
+    /// the same amount of data, so every rewrite moves it into a larger size tier.
+    fn is_balanced(&self) -> bool {
+        self.largest_file_size <= self.total_size - self.largest_file_size
+    }
+
+    /// A candidate is worth compacting only if it makes progress on at least one
+    /// axis: it reduces the physical file count, or it resolves at least one
+    /// overlap (merging sorted runs and reducing read amplification). A pure
+    /// rewrite that achieves neither only burns I/O.
+    fn makes_progress(&self, max_output_file_size: Option<u64>) -> bool {
+        self.file_reduction(max_output_file_size) > 0 || self.overlap_participants > 0
+    }
+
+    fn score(&self, max_output_file_size: Option<u64>) -> CandidateScore {
+        CandidateScore {
+            file_reduction: self.file_reduction(max_output_file_size),
+            overlap_participants: self.overlap_participants,
+            total_size: self.total_size,
+        }
+    }
+}
+
+/// Score of a candidate compaction input. Higher is better: first by the predicted
+/// net file count reduction, then by the number of files participating in an
+/// overlap, then by smaller input bytes.
 #[derive(Debug)]
 struct CandidateScore {
-    num_files: usize,
+    file_reduction: usize,
     overlap_participants: usize,
-    size: usize,
+    total_size: usize,
 }
 
 impl CandidateScore {
     fn is_better_than(&self, other: &Self) -> bool {
-        self.num_files
-            .cmp(&other.num_files)
+        self.file_reduction
+            .cmp(&other.file_reduction)
             .then_with(|| self.overlap_participants.cmp(&other.overlap_participants))
-            .then_with(|| other.size.cmp(&self.size))
+            .then_with(|| other.total_size.cmp(&self.total_size))
             .is_gt()
     }
 }
 
 /// Picks a contiguous (in global time order) interval of files to compact.
 ///
-/// The picker first reorders all files from all sorted runs by `(start asc, end desc)` and
-/// then enumerates every interval of at most [`MAX_INPUT_FILES`] files. An interval is
-/// eligible when it holds at least `trigger_file_num` files and at least 2 files, and when
-/// no single file dominates the interval (`largest <= sum of the others`), so a large
-/// historical file is only rewritten once its peers contribute at least the same amount of
-/// data. The best interval wins by [`CandidateScore`]; ties keep the earliest interval.
+/// The picker reorders all files from all sorted runs by `(start asc, end desc)` and
+/// enumerates every interval of at most [`MAX_INPUT_FILES`] files as a [`Candidate`].
+/// An interval is eligible when it
+///
+/// - holds at least `trigger_file_num` files (and at least 2),
+/// - is balanced: no single file dominates it (`largest <= sum of the others`),
+/// - makes progress on at least one axis: it reduces the physical file count given
+///   the output split threshold `max_output_file_size`, or it resolves at least one
+///   overlap between sorted runs.
+///
+/// The best interval wins by [`CandidateScore`]; ties keep the earliest interval.
 fn pick_count_first(
     sorted_runs: Vec<SortedRun<FileHandle>>,
     trigger_file_num: usize,
+    max_output_file_size: Option<u64>,
 ) -> Vec<FileHandle> {
+    let files = ordered_files(&sorted_runs);
+    let min_files = trigger_file_num.max(2);
+
+    let mut best = None;
+    for left in 0..files.len() {
+        let mut candidate = Candidate::default();
+        let right_bound = (left + MAX_INPUT_FILES).min(files.len());
+        let mut participations: Vec<bool> = Vec::with_capacity(right_bound - left);
+        for right in left..right_bound {
+            candidate.absorb(&files[right], &files[left..right], &mut participations);
+            if candidate.num_files < min_files
+                || !candidate.is_balanced()
+                || !candidate.makes_progress(max_output_file_size)
+            {
+                continue;
+            }
+
+            let score = candidate.score(max_output_file_size);
+            if best
+                .as_ref()
+                .is_none_or(|(best_score, _)| score.is_better_than(best_score))
+            {
+                best = Some((score, &files[left..=right]));
+            }
+        }
+    }
+
+    let Some((_, best)) = best else {
+        return vec![];
+    };
+    best.iter().map(|file| file.file.clone()).collect()
+}
+
+/// Flattens sorted runs into files ordered by `(start asc, end desc)`, breaking ties
+/// by run and position to keep the order deterministic.
+fn ordered_files(sorted_runs: &[SortedRun<FileHandle>]) -> Vec<OrderedFile<'_>> {
     let mut files = sorted_runs
         .iter()
         .enumerate()
@@ -250,65 +385,7 @@ fn pick_count_first(
             .then_with(|| lhs.run_id.cmp(&rhs.run_id))
             .then_with(|| lhs.position_in_run.cmp(&rhs.position_in_run))
     });
-
-    let mut best = None;
-    for left in 0..files.len() {
-        let mut total_size = 0;
-        let mut largest_file_size = 0;
-        let mut overlap_participants = 0;
-        let right_bound = (left + MAX_INPUT_FILES).min(files.len());
-        let mut participants: Vec<bool> = Vec::with_capacity(right_bound - left);
-        for right in left..right_bound {
-            let right_file = &files[right];
-            let file_size = right_file.file.size() as usize;
-            total_size += file_size;
-            largest_file_size = largest_file_size.max(file_size);
-
-            let mut right_participates = false;
-            for (offset, other) in files[left..right].iter().enumerate() {
-                if right_file.run_id != other.run_id
-                    && right_file.file.overlap_inclusive(other.file)
-                {
-                    if !participants[offset] {
-                        participants[offset] = true;
-                        overlap_participants += 1;
-                    }
-                    right_participates = true;
-                }
-            }
-            participants.push(right_participates);
-            if right_participates {
-                overlap_participants += 1;
-            }
-
-            let num_files = right + 1 - left;
-            if num_files < trigger_file_num || num_files < 2 {
-                continue;
-            }
-            // A historical file is only rewritten after peers contribute at least the same
-            // amount of data, so every rewrite moves it into a larger size tier.
-            if largest_file_size > total_size - largest_file_size {
-                continue;
-            }
-
-            let score = CandidateScore {
-                num_files,
-                overlap_participants,
-                size: total_size,
-            };
-            if best
-                .as_ref()
-                .is_none_or(|(best_score, _)| score.is_better_than(best_score))
-            {
-                best = Some((score, &files[left..=right]));
-            }
-        }
-    }
-
-    let Some((_, best)) = best else {
-        return vec![];
-    };
-    best.iter().map(|file| file.file.clone()).collect()
+    files
 }
 
 fn selected_overlaps_unselected(selected: &[FileHandle], window: &Window) -> bool {
@@ -1895,6 +1972,7 @@ mod tests {
                 new_file(60, 69, 4, 100),
             ])],
             4,
+            None,
         );
 
         assert!(picked.is_empty());
@@ -1911,6 +1989,7 @@ mod tests {
                 new_file(80, 89, 5, 100),
             ])],
             4,
+            None,
         );
 
         assert_eq!(
@@ -1930,6 +2009,7 @@ mod tests {
                 new_file(80, 89, 5, 100),
             ])],
             4,
+            None,
         );
 
         assert_eq!(
@@ -1959,6 +2039,7 @@ mod tests {
                 SortedRun::from(vec![overlapping]),
             ],
             2,
+            None,
         );
         let ranges = picked_ranges(&picked);
 
@@ -1983,12 +2064,69 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let picked = pick_count_first(vec![SortedRun::from(files)], 2);
+        let picked = pick_count_first(vec![SortedRun::from(files)], 2, None);
         let ranges = picked_ranges(&picked);
 
         assert_eq!(MAX_INPUT_FILES, ranges.len());
         assert_eq!(Some(&(20, 29)), ranges.first());
         assert_eq!(Some(&(640, 649)), ranges.last());
+    }
+
+    #[test]
+    fn test_count_first_skips_pure_rewrite_without_progress() {
+        // Four non-overlapping files whose combined size splits back into at least
+        // four outputs: compacting them reduces neither the file count nor any
+        // overlap, so there is nothing worth picking.
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file(0, 9, 1, 600),
+                new_file(20, 29, 2, 600),
+                new_file(40, 49, 3, 600),
+                new_file(60, 69, 4, 600),
+            ])],
+            2,
+            Some(512),
+        );
+
+        assert!(picked.is_empty());
+    }
+
+    #[test]
+    fn test_count_first_allows_overlap_resolution_without_file_reduction() {
+        // Two large overlapping files from different runs: compacting them cannot
+        // reduce the file count (the output splits back into just as many files),
+        // but it resolves the overlap and merges two sorted runs into one.
+        let picked = pick_count_first(
+            vec![
+                SortedRun::from(vec![new_file(0, 19, 1, 600)]),
+                SortedRun::from(vec![new_file(10, 29, 2, 600)]),
+            ],
+            2,
+            Some(512),
+        );
+
+        assert_eq!(vec![(0, 19), (10, 29)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_prefers_guaranteed_reduction_over_pure_rewrite() {
+        // A window mixing large and small files: the large triple on its own is a
+        // pure rewrite, and every interval containing large files rewrites more
+        // bytes for the same predicted reduction, so the small triple wins.
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file(0, 9, 1, 600),
+                new_file(10, 19, 2, 600),
+                new_file(20, 29, 3, 600),
+                new_file(30, 39, 4, 10),
+                new_file(40, 49, 5, 10),
+                new_file(50, 59, 6, 10),
+            ])],
+            2,
+            Some(512),
+        );
+
+        assert_eq!(vec![(30, 39), (40, 49), (50, 59)], picked_ranges(&picked));
     }
 
     #[test]
@@ -2000,7 +2138,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let picked = pick_count_first(vec![SortedRun::from(files)], 2);
+        let picked = pick_count_first(vec![SortedRun::from(files)], 2, None);
         let ranges = picked_ranges(&picked);
 
         assert_eq!(MAX_INPUT_FILES, ranges.len());
@@ -2020,6 +2158,7 @@ mod tests {
                 SortedRun::from(vec![new_file(10, 19, 4, 1), new_file(30, 39, 5, 1)]),
             ],
             2,
+            None,
         );
 
         assert_eq!(
@@ -2046,6 +2185,7 @@ mod tests {
                 new_file(20, 29, 3, 10),
             ])],
             2,
+            None,
         );
 
         assert_eq!(
@@ -2067,6 +2207,7 @@ mod tests {
                 new_file(10, 19, 2, 10),
             ])],
             3,
+            None,
         );
 
         assert_eq!(

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -15,7 +15,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use common_base::readable_size::ReadableSize;
 use common_telemetry::{debug, info};
@@ -40,8 +40,24 @@ use crate::sst::version::LevelMeta;
 
 const LEVEL_COMPACTED: Level = 1;
 
+/// Default maximum number of input SST files in one compaction input.
+const DEFAULT_MAX_INPUT_FILES: usize = 32;
+
+const MAX_INPUT_FILES_ENV: &str = "GREPTIME_TWCS_MAX_INPUT_FILES";
+
 /// Maximum number of input SST files in one compaction input.
-const MAX_INPUT_FILES: usize = 32;
+/// Configurable via [`MAX_INPUT_FILES_ENV`].
+static MAX_INPUT_FILES: LazyLock<usize> = LazyLock::new(|| {
+    let env_value = std::env::var(MAX_INPUT_FILES_ENV).ok();
+    parse_max_input_files(env_value.as_deref())
+});
+
+fn parse_max_input_files(env_value: Option<&str>) -> usize {
+    env_value
+        .and_then(|env_value| env_value.parse().ok())
+        .filter(|max_input_files| *max_input_files >= 2)
+        .unwrap_or(DEFAULT_MAX_INPUT_FILES)
+}
 
 /// `TwcsPicker` picks files of which the max timestamp are in the same time window as compaction
 /// candidates.
@@ -332,7 +348,7 @@ fn pick_count_first(
     let mut best = None;
     for left in 0..files.len() {
         let mut candidate = Candidate::default();
-        let right_bound = (left + MAX_INPUT_FILES).min(files.len());
+        let right_bound = left.saturating_add(*MAX_INPUT_FILES).min(files.len());
         let mut participations: Vec<bool> = Vec::with_capacity(right_bound - left);
         for right in left..right_bound {
             candidate.absorb(&files[right], &files[left..right], &mut participations);
@@ -702,6 +718,18 @@ mod tests {
     use crate::sst::version::SstVersion;
     use crate::test_util::memtable_util::metadata_for_test;
     use crate::test_util::scheduler_util::SchedulerEnv;
+
+    #[test]
+    fn test_valid_max_input_files_env_overrides_default() {
+        assert_eq!(64, parse_max_input_files(Some("64")));
+    }
+
+    #[test]
+    fn test_invalid_max_input_files_env_falls_back_to_default() {
+        for env_value in [None, Some(""), Some("invalid"), Some("0"), Some("1")] {
+            assert_eq!(32, parse_max_input_files(env_value));
+        }
+    }
 
     async fn compaction_region_with_expired_sst() -> CompactionRegion {
         let env = SchedulerEnv::new().await;
@@ -1633,7 +1661,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, output.len());
-        assert_eq!(output[0].inputs.len(), 32);
+        assert_eq!(output[0].inputs.len(), num_files.min(*MAX_INPUT_FILES));
     }
 
     #[tokio::test]
@@ -1944,7 +1972,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, output.len());
-        assert_eq!(MAX_INPUT_FILES, output[0].inputs.len());
+        assert_eq!(DEFAULT_MAX_INPUT_FILES, output[0].inputs.len());
         assert!(!output[0].filter_deleted);
     }
 
@@ -2020,10 +2048,10 @@ mod tests {
 
     #[test]
     fn test_count_first_prefers_overlap_participants_when_file_counts_match() {
-        let first_run = (0..MAX_INPUT_FILES)
+        let first_run = (0..DEFAULT_MAX_INPUT_FILES)
             .map(|idx| {
                 let start = idx as i64 * 20;
-                let end = if idx + 1 == MAX_INPUT_FILES {
+                let end = if idx + 1 == DEFAULT_MAX_INPUT_FILES {
                     700
                 } else {
                     start + 9
@@ -2043,19 +2071,19 @@ mod tests {
         );
         let ranges = picked_ranges(&picked);
 
-        assert_eq!(MAX_INPUT_FILES, ranges.len());
+        assert_eq!(DEFAULT_MAX_INPUT_FILES, ranges.len());
         assert!(!ranges.contains(&(0, 9)));
         assert!(ranges.contains(&(690, 710)));
     }
 
     #[test]
     fn test_count_first_prefers_smaller_bytes_when_file_counts_match() {
-        let files = (0..=MAX_INPUT_FILES)
+        let files = (0..=DEFAULT_MAX_INPUT_FILES)
             .map(|idx| {
                 let start = idx as i64 * 20;
                 let size = if idx == 0 {
                     100
-                } else if idx == MAX_INPUT_FILES {
+                } else if idx == DEFAULT_MAX_INPUT_FILES {
                     1
                 } else {
                     10
@@ -2067,7 +2095,7 @@ mod tests {
         let picked = pick_count_first(vec![SortedRun::from(files)], 2, None);
         let ranges = picked_ranges(&picked);
 
-        assert_eq!(MAX_INPUT_FILES, ranges.len());
+        assert_eq!(DEFAULT_MAX_INPUT_FILES, ranges.len());
         assert_eq!(Some(&(20, 29)), ranges.first());
         assert_eq!(Some(&(640, 649)), ranges.last());
     }
@@ -2131,7 +2159,7 @@ mod tests {
 
     #[test]
     fn test_count_first_prefers_earlier_time_on_exact_tie() {
-        let files = (0..=MAX_INPUT_FILES)
+        let files = (0..=DEFAULT_MAX_INPUT_FILES)
             .map(|idx| {
                 let start = idx as i64 * 20;
                 new_file(start, start + 9, idx as u64 + 1, 10)
@@ -2141,7 +2169,7 @@ mod tests {
         let picked = pick_count_first(vec![SortedRun::from(files)], 2, None);
         let ranges = picked_ranges(&picked);
 
-        assert_eq!(MAX_INPUT_FILES, ranges.len());
+        assert_eq!(DEFAULT_MAX_INPUT_FILES, ranges.len());
         assert_eq!(Some(&(0, 9)), ranges.first());
         assert_eq!(Some(&(620, 629)), ranges.last());
     }

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -41,14 +41,14 @@ use crate::sst::version::LevelMeta;
 
 const LEVEL_COMPACTED: Level = 1;
 
-/// Default value for max compaction input file num.
-const DEFAULT_MAX_INPUT_FILE_NUM: usize = 32;
+/// Maximum number of logical FileGroups in one compaction input.
+const MAX_INPUT_FILE_GROUPS: usize = 32;
 
 /// `TwcsPicker` picks files of which the max timestamp are in the same time window as compaction
 /// candidates.
 #[derive(Clone, Debug)]
 pub struct TwcsPicker {
-    /// Minimum file num to trigger a compaction.
+    /// Minimum eligible FileGroup num to trigger a compaction.
     pub trigger_file_num: usize,
     /// Compaction time window in seconds.
     pub time_window_seconds: Option<i64>,
@@ -220,15 +220,15 @@ struct OrderedFileGroup<'a> {
 
 #[derive(Debug)]
 struct CandidateScore {
-    num_files: usize,
+    num_file_groups: usize,
     overlap_participants: usize,
     size: usize,
 }
 
 impl CandidateScore {
     fn is_better_than(&self, other: &Self) -> bool {
-        self.num_files
-            .cmp(&other.num_files)
+        self.num_file_groups
+            .cmp(&other.num_file_groups)
             .then_with(|| self.overlap_participants.cmp(&other.overlap_participants))
             .then_with(|| other.size.cmp(&self.size))
             .is_gt()
@@ -262,39 +262,62 @@ fn pick_count_first(
             .then_with(|| lhs.run_id.cmp(&rhs.run_id))
             .then_with(|| lhs.position_in_run.cmp(&rhs.position_in_run))
     });
+    // A multi-SST FileGroup is a compaction output that already exceeded the output size target
+    // and was split. Recompacting it cannot reduce physical files, so automatic TWCS treats it as
+    // stable. It remains in the original Window for tombstone overlap checks.
+    groups.retain(|group| group.group.num_files() == 1);
 
-    let mut left = 0;
-    let mut num_files = 0;
     let mut best = None;
-    for right in 0..groups.len() {
-        let group_file_num = groups[right].group.num_files();
-        if group_file_num > DEFAULT_MAX_INPUT_FILE_NUM {
-            left = right + 1;
-            num_files = 0;
-            continue;
-        }
+    for left in 0..groups.len() {
+        let mut total_size = 0;
+        let mut largest_group_size = 0;
+        let mut overlap_participants = 0;
+        let right_bound = (left + MAX_INPUT_FILE_GROUPS).min(groups.len());
+        let mut participants: Vec<bool> = Vec::with_capacity(right_bound - left);
+        for right in left..right_bound {
+            let right_group = &groups[right];
+            let group_size = right_group.group.size();
+            total_size += group_size;
+            largest_group_size = largest_group_size.max(group_size);
 
-        num_files += group_file_num;
-        while num_files > DEFAULT_MAX_INPUT_FILE_NUM {
-            num_files -= groups[left].group.num_files();
-            left += 1;
-        }
+            let mut right_participates = false;
+            for (offset, other) in groups[left..right].iter().enumerate() {
+                if right_group.run_id != other.run_id
+                    && right_group.group.overlap_inclusive(other.group)
+                {
+                    if !participants[offset] {
+                        participants[offset] = true;
+                        overlap_participants += 1;
+                    }
+                    right_participates = true;
+                }
+            }
+            participants.push(right_participates);
+            if right_participates {
+                overlap_participants += 1;
+            }
 
-        if num_files < trigger_file_num || right + 1 - left < 2 {
-            continue;
-        }
+            let num_file_groups = right + 1 - left;
+            if num_file_groups < trigger_file_num || num_file_groups < 2 {
+                continue;
+            }
+            // A historical group is only rewritten after peers contribute at least the same
+            // amount of data, so every rewrite moves it into a larger size tier.
+            if largest_group_size > total_size - largest_group_size {
+                continue;
+            }
 
-        let candidate = &groups[left..=right];
-        let score = CandidateScore {
-            num_files,
-            overlap_participants: count_overlap_participants(candidate),
-            size: candidate.iter().map(|group| group.group.size()).sum(),
-        };
-        if best
-            .as_ref()
-            .is_none_or(|(best_score, _, _)| score.is_better_than(best_score))
-        {
-            best = Some((score, left, right));
+            let score = CandidateScore {
+                num_file_groups,
+                overlap_participants,
+                size: total_size,
+            };
+            if best
+                .as_ref()
+                .is_none_or(|(best_score, _, _)| score.is_better_than(best_score))
+            {
+                best = Some((score, left, right));
+            }
         }
     }
 
@@ -305,27 +328,6 @@ fn pick_count_first(
         .iter()
         .map(|group| group.group.clone())
         .collect()
-}
-
-fn count_overlap_participants(groups: &[OrderedFileGroup<'_>]) -> usize {
-    let mut participants = vec![false; groups.len()];
-    for lhs in 0..groups.len() {
-        for rhs in lhs + 1..groups.len() {
-            if groups[lhs].run_id != groups[rhs].run_id
-                && groups[lhs].group.overlap_inclusive(groups[rhs].group)
-            {
-                participants[lhs] = true;
-                participants[rhs] = true;
-            }
-        }
-    }
-
-    groups
-        .iter()
-        .zip(participants)
-        .filter(|(_, participant)| *participant)
-        .map(|(group, _)| group.group.num_files())
-        .sum()
 }
 
 fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool {
@@ -1187,8 +1189,9 @@ mod tests {
         .await;
 
         // Case 3:
-        // A compaction may split output into several files that have overlapping time ranges and same sequence,
-        // we should treat these files as one FileGroup.
+        // A compaction may split output into several files that have overlapping time ranges and
+        // the same sequence. We treat these files as one stable FileGroup and exclude it from
+        // automatic TWCS candidates.
         let file_ids = (0..6).map(|_| FileId::random()).collect::<Vec<_>>();
         CompactionPickerTestCase {
             window_size: 3,
@@ -1200,10 +1203,7 @@ mod tests {
                 new_file_handle_with_sequence(file_ids[4], 11, 2990, 0, 3),
             ]
             .to_vec(),
-            expected_outputs: vec![ExpectedOutput {
-                input_files: vec![0, 1, 4],
-                output_level: 1,
-            }],
+            expected_outputs: vec![],
         }
         .check()
         .await;
@@ -1799,7 +1799,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_count_first_trigger_counts_actual_ssts() {
+    async fn test_count_first_trigger_counts_file_groups() {
         let files = [
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
             new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
@@ -1820,8 +1820,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, output.len());
-        assert_eq!(3, output[0].inputs.len());
+        assert!(output.is_empty());
     }
 
     #[tokio::test]
@@ -1886,7 +1885,37 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, output.len());
-        assert_eq!(DEFAULT_MAX_INPUT_FILE_NUM, output[0].inputs.len());
+        assert_eq!(MAX_INPUT_FILE_GROUPS, output[0].inputs.len());
+        assert!(!output[0].filter_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_filter_deleted_is_false_when_selected_overlaps_ignored_file_group() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 100, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 100, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 2, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 3, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 40, 50, 0, 4, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 60, 70, 0, 5, 10),
+        ];
+        let windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 4,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(0), None)
+            .await
+            .unwrap();
+
+        assert_eq!(1, output.len());
+        assert_eq!(4, output[0].inputs.len());
         assert!(!output[0].filter_deleted);
     }
 
@@ -1929,29 +1958,12 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_prefers_overlap_participants_when_file_counts_match() {
-        let first = new_file_group(0, 9, 1, 16, 10);
-        let second = new_file_group(20, 39, 2, 16, 10);
-        let overlapping = new_file_group(30, 49, 3, 16, 10);
-
-        let picked = pick_count_first(
-            vec![
-                SortedRun::from(vec![first, second]),
-                SortedRun::from(vec![overlapping]),
-            ],
-            2,
-        );
-
-        assert_eq!(vec![(20, 39), (30, 49)], picked_ranges(&picked));
-    }
-
-    #[test]
-    fn test_count_first_prefers_smaller_bytes_when_file_counts_match() {
+    fn test_count_first_counts_file_groups_not_physical_ssts() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 16, 10),
-                new_file_group(20, 29, 2, 16, 10),
-                new_file_group(40, 49, 3, 16, 1),
+                new_file_group(0, 9, 1, 2, 10),
+                new_file_group(20, 29, 2, 1, 10),
+                new_file_group(40, 49, 3, 1, 10),
             ])],
             2,
         );
@@ -1960,12 +1972,12 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_prefers_earlier_time_on_exact_tie() {
+    fn test_count_first_ignores_multi_sst_groups_between_singletons() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 16, 10),
-                new_file_group(20, 29, 2, 16, 10),
-                new_file_group(40, 49, 3, 16, 10),
+                new_file_group(0, 9, 1, 1, 10),
+                new_file_group(10, 19, 2, 2, 10),
+                new_file_group(20, 29, 3, 1, 10),
             ])],
             2,
         );
@@ -1974,21 +1986,139 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_skips_oversized_atomic_file_group() {
+    fn test_count_first_returns_empty_for_only_multi_sst_groups() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
-                new_file_group(0, 9, 1, 33, 1),
-                new_file_group(20, 29, 2, 16, 1),
-                new_file_group(40, 49, 3, 16, 1),
+                new_file_group(0, 9, 1, 2, 10),
+                new_file_group(20, 29, 2, 2, 10),
             ])],
             2,
         );
 
-        assert_eq!(
-            DEFAULT_MAX_INPUT_FILE_NUM,
-            picked.iter().map(FileGroup::num_files).sum::<usize>()
+        assert!(picked.is_empty());
+    }
+
+    #[test]
+    fn test_count_first_rejects_dominant_historical_group() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 1, 400),
+                new_file_group(20, 29, 2, 1, 100),
+                new_file_group(40, 49, 3, 1, 100),
+                new_file_group(60, 69, 4, 1, 100),
+            ])],
+            4,
         );
-        assert_eq!(vec![(20, 29), (40, 49)], picked_ranges(&picked));
+
+        assert!(picked.is_empty());
+    }
+
+    #[test]
+    fn test_count_first_accepts_balanced_historical_group() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 1, 400),
+                new_file_group(20, 29, 2, 1, 100),
+                new_file_group(40, 49, 3, 1, 100),
+                new_file_group(60, 69, 4, 1, 100),
+                new_file_group(80, 89, 5, 1, 100),
+            ])],
+            4,
+        );
+
+        assert_eq!(
+            vec![(0, 9), (20, 29), (40, 49), (60, 69), (80, 89)],
+            picked_ranges(&picked)
+        );
+    }
+
+    #[test]
+    fn test_count_first_finds_smaller_balanced_interval_when_larger_one_is_unbalanced() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 1, 1000),
+                new_file_group(20, 29, 2, 1, 100),
+                new_file_group(40, 49, 3, 1, 100),
+                new_file_group(60, 69, 4, 1, 100),
+                new_file_group(80, 89, 5, 1, 100),
+            ])],
+            4,
+        );
+
+        assert_eq!(
+            vec![(20, 29), (40, 49), (60, 69), (80, 89)],
+            picked_ranges(&picked)
+        );
+    }
+
+    #[test]
+    fn test_count_first_prefers_overlap_participants_when_file_group_counts_match() {
+        let first_run = (0..MAX_INPUT_FILE_GROUPS)
+            .map(|idx| {
+                let start = idx as i64 * 20;
+                let end = if idx + 1 == MAX_INPUT_FILE_GROUPS {
+                    700
+                } else {
+                    start + 9
+                };
+                new_file_group(start, end, idx as u64 + 1, 1, 10)
+            })
+            .collect::<Vec<_>>();
+        let overlapping = new_file_group(690, 710, 100, 1, 10);
+
+        let picked = pick_count_first(
+            vec![
+                SortedRun::from(first_run),
+                SortedRun::from(vec![overlapping]),
+            ],
+            2,
+        );
+        let ranges = picked_ranges(&picked);
+
+        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert!(!ranges.contains(&(0, 9)));
+        assert!(ranges.contains(&(690, 710)));
+    }
+
+    #[test]
+    fn test_count_first_prefers_smaller_bytes_when_file_group_counts_match() {
+        let groups = (0..=MAX_INPUT_FILE_GROUPS)
+            .map(|idx| {
+                let start = idx as i64 * 20;
+                let size = if idx == 0 {
+                    100
+                } else if idx == MAX_INPUT_FILE_GROUPS {
+                    1
+                } else {
+                    10
+                };
+                new_file_group(start, start + 9, idx as u64 + 1, 1, size)
+            })
+            .collect::<Vec<_>>();
+
+        let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+        let ranges = picked_ranges(&picked);
+
+        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert_eq!(Some(&(20, 29)), ranges.first());
+        assert_eq!(Some(&(640, 649)), ranges.last());
+    }
+
+    #[test]
+    fn test_count_first_prefers_earlier_time_on_exact_tie() {
+        let groups = (0..=MAX_INPUT_FILE_GROUPS)
+            .map(|idx| {
+                let start = idx as i64 * 20;
+                new_file_group(start, start + 9, idx as u64 + 1, 1, 10)
+            })
+            .collect::<Vec<_>>();
+
+        let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+        let ranges = picked_ranges(&picked);
+
+        assert_eq!(MAX_INPUT_FILE_GROUPS, ranges.len());
+        assert_eq!(Some(&(0, 9)), ranges.first());
+        assert_eq!(Some(&(620, 629)), ranges.last());
     }
 
     #[test]
@@ -1996,20 +2126,20 @@ mod tests {
         let picked = pick_count_first(
             vec![
                 SortedRun::from(vec![
-                    new_file_group(0, 9, 1, 8, 1),
-                    new_file_group(20, 29, 2, 8, 1),
-                    new_file_group(40, 49, 3, 8, 1),
+                    new_file_group(0, 9, 1, 1, 1),
+                    new_file_group(20, 29, 2, 1, 1),
+                    new_file_group(40, 49, 3, 1, 1),
                 ]),
                 SortedRun::from(vec![
-                    new_file_group(10, 19, 4, 8, 1),
-                    new_file_group(30, 39, 5, 8, 1),
+                    new_file_group(10, 19, 4, 1, 1),
+                    new_file_group(30, 39, 5, 1, 1),
                 ]),
             ],
             2,
         );
 
         assert_eq!(
-            vec![(0, 9), (10, 19), (20, 29), (30, 39)],
+            vec![(0, 9), (10, 19), (20, 29), (30, 39), (40, 49)],
             picked_ranges(&picked)
         );
     }

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -32,8 +32,8 @@ use crate::compaction::buckets::infer_time_bucket;
 use crate::compaction::compactor::CompactionRegion;
 use crate::compaction::picker::{Picker, PickerOutput, get_expired_ssts};
 use crate::compaction::run::{
-    FileGroup, Item, Ranged, find_sorted_runs, find_sorted_runs_by_time_range,
-    merge_primary_key_ranges, merge_seq_files, primary_key_ranges_overlap, reduce_runs,
+    FileGroup, Item, Ranged, SortedRun, find_sorted_runs, find_sorted_runs_by_time_range,
+    merge_primary_key_ranges, primary_key_ranges_overlap,
 };
 use crate::error::{JoinSnafu, Result};
 use crate::sst::file::{FileHandle, Level, overlaps};
@@ -167,48 +167,10 @@ impl TwcsPicker {
             find_sorted_runs_by_time_range(&mut files_to_merge)
         };
         let found_runs = sorted_runs.len();
-        // We only remove deletion markers if we found less than 2 runs and not in append mode.
-        // because after compaction there will be no overlapping files.
-        let mut filter_deleted =
-            found_runs <= 2 && !self.append_mode && !window_has_overlap(files, windows);
-        if found_runs == 0 {
-            return (vec![], filter_deleted);
-        }
-
-        let mut inputs = if found_runs > 1 {
-            reduce_runs(sorted_runs)
-        } else {
-            let run = sorted_runs.last().unwrap();
-            if run.items().len() < self.trigger_file_num {
-                return (vec![], filter_deleted);
-            }
-            // no overlapping files, try merge small files
-            merge_seq_files(run.items(), self.max_output_file_size)
-        };
-
-        // Limits the number of input files.
-        let total_input_files: usize = inputs.iter().map(|fg| fg.num_files()).sum();
-        if total_input_files > DEFAULT_MAX_INPUT_FILE_NUM {
-            // Sorts file groups by size first.
-            inputs.sort_unstable_by_key(|fg| fg.size());
-            let mut num_picked_files = 0;
-            inputs = inputs
-                .into_iter()
-                .take_while(|fg| {
-                    let current_group_file_num = fg.num_files();
-                    if current_group_file_num + num_picked_files <= DEFAULT_MAX_INPUT_FILE_NUM {
-                        num_picked_files += current_group_file_num;
-                        true
-                    } else {
-                        false
-                    }
-                })
-                .collect::<Vec<_>>();
-            info!(
-                "Compaction for region {} enforces max input file num limit: {}, current total: {}, input: {:?}",
-                region_id, DEFAULT_MAX_INPUT_FILE_NUM, total_input_files, inputs
-            );
-        }
+        let inputs = pick_count_first(sorted_runs, self.trigger_file_num);
+        let mut filter_deleted = !self.append_mode
+            && !window_has_overlap(files, windows)
+            && !selected_overlaps_unselected(&inputs, files);
 
         // The inputs are only a subset of the window: `reduce_runs` and `merge_seq_files` both
         // narrow the selection down and the file num limit above narrows it further. A deletion
@@ -247,6 +209,143 @@ fn overlaps_files_left_behind(inputs: &[FileGroup], window_files: &[FileGroup]) 
         .iter()
         .filter(|fg| !fg.file_ids().iter().any(|id| picked.contains(id)))
         .any(|fg| inputs.iter().any(|input| input.overlap_inclusive(fg)))
+}
+
+#[derive(Debug)]
+struct OrderedFileGroup<'a> {
+    group: &'a FileGroup,
+    run_id: usize,
+    position_in_run: usize,
+}
+
+#[derive(Debug)]
+struct CandidateScore {
+    num_files: usize,
+    overlap_participants: usize,
+    size: usize,
+}
+
+impl CandidateScore {
+    fn is_better_than(&self, other: &Self) -> bool {
+        self.num_files
+            .cmp(&other.num_files)
+            .then_with(|| self.overlap_participants.cmp(&other.overlap_participants))
+            .then_with(|| other.size.cmp(&self.size))
+            .is_gt()
+    }
+}
+
+fn pick_count_first(
+    sorted_runs: Vec<SortedRun<FileGroup>>,
+    trigger_file_num: usize,
+) -> Vec<FileGroup> {
+    let mut groups = sorted_runs
+        .iter()
+        .enumerate()
+        .flat_map(|(run_id, run)| {
+            run.items()
+                .iter()
+                .enumerate()
+                .map(move |(position_in_run, group)| OrderedFileGroup {
+                    group,
+                    run_id,
+                    position_in_run,
+                })
+        })
+        .collect::<Vec<_>>();
+    groups.sort_unstable_by(|lhs, rhs| {
+        let (lhs_start, lhs_end) = lhs.group.range();
+        let (rhs_start, rhs_end) = rhs.group.range();
+        lhs_start
+            .cmp(&rhs_start)
+            .then_with(|| rhs_end.cmp(&lhs_end))
+            .then_with(|| lhs.run_id.cmp(&rhs.run_id))
+            .then_with(|| lhs.position_in_run.cmp(&rhs.position_in_run))
+    });
+
+    let mut left = 0;
+    let mut num_files = 0;
+    let mut best = None;
+    for right in 0..groups.len() {
+        let group_file_num = groups[right].group.num_files();
+        if group_file_num > DEFAULT_MAX_INPUT_FILE_NUM {
+            left = right + 1;
+            num_files = 0;
+            continue;
+        }
+
+        num_files += group_file_num;
+        while num_files > DEFAULT_MAX_INPUT_FILE_NUM {
+            num_files -= groups[left].group.num_files();
+            left += 1;
+        }
+
+        if num_files < trigger_file_num || right + 1 - left < 2 {
+            continue;
+        }
+
+        let candidate = &groups[left..=right];
+        let score = CandidateScore {
+            num_files,
+            overlap_participants: count_overlap_participants(candidate),
+            size: candidate.iter().map(|group| group.group.size()).sum(),
+        };
+        if best
+            .as_ref()
+            .is_none_or(|(best_score, _, _)| score.is_better_than(best_score))
+        {
+            best = Some((score, left, right));
+        }
+    }
+
+    let Some((_, left, right)) = best else {
+        return vec![];
+    };
+    groups[left..=right]
+        .iter()
+        .map(|group| group.group.clone())
+        .collect()
+}
+
+fn count_overlap_participants(groups: &[OrderedFileGroup<'_>]) -> usize {
+    let mut participants = vec![false; groups.len()];
+    for lhs in 0..groups.len() {
+        for rhs in lhs + 1..groups.len() {
+            if groups[lhs].run_id != groups[rhs].run_id
+                && groups[lhs].group.overlap_inclusive(groups[rhs].group)
+            {
+                participants[lhs] = true;
+                participants[rhs] = true;
+            }
+        }
+    }
+
+    groups
+        .iter()
+        .zip(participants)
+        .filter(|(_, participant)| *participant)
+        .map(|(group, _)| group.group.num_files())
+        .sum()
+}
+
+fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool {
+    let selected_file_ids = selected
+        .iter()
+        .flat_map(FileGroup::file_ids)
+        .collect::<HashSet<_>>();
+    window
+        .files()
+        .filter(|group| {
+            !group
+                .file_ids()
+                .iter()
+                .all(|file_id| selected_file_ids.contains(file_id))
+        })
+        .any(|unselected| {
+            selected
+                .iter()
+                .any(|selected| selected.overlap_inclusive(unselected))
+        })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -988,7 +1087,7 @@ mod tests {
             let active_window =
                 find_latest_window_in_seconds(self.input_files.iter(), self.window_size);
             let output = TwcsPicker {
-                trigger_file_num: 4,
+                trigger_file_num: 2,
                 time_window_seconds: None,
                 max_output_file_size: None,
                 append_mode: false,
@@ -1075,7 +1174,7 @@ mod tests {
             .to_vec(),
             expected_outputs: vec![
                 ExpectedOutput {
-                    input_files: vec![2, 4],
+                    input_files: vec![2, 3, 4],
                     output_level: 1,
                 },
                 ExpectedOutput {
@@ -1191,7 +1290,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_output_multiple_windows_with_zero_runs() {
-        let file_ids = (0..6).map(|_| FileId::random()).collect::<Vec<_>>();
+        let file_ids = (0..7).map(|_| FileId::random()).collect::<Vec<_>>();
 
         let files = [
             // Window 0: Contains 3 files but not forming any runs (not enough files in sequence to reach trigger_file_num)
@@ -1202,6 +1301,7 @@ mod tests {
             new_file_handle_with_sequence(file_ids[3], 3000, 3999, 0, 4),
             new_file_handle_with_sequence(file_ids[4], 3000, 3999, 0, 5),
             new_file_handle_with_sequence(file_ids[5], 3000, 3999, 0, 6),
+            new_file_handle_with_sequence(file_ids[6], 3000, 3999, 0, 7),
         ];
 
         let windows = assign_to_windows(files.iter(), 3);
@@ -1431,7 +1531,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, output.len());
-        assert_eq!(output[0].inputs.len(), 2);
+        assert_eq!(output[0].inputs.len(), num_files);
     }
 
     #[tokio::test]
@@ -1668,6 +1768,237 @@ mod tests {
                 .iter()
                 .map(|file| file.file_id().file_id())
                 .collect::<HashSet<_>>()
+        );
+    }
+
+    #[test]
+    fn test_count_first_prefers_more_files_over_smaller_overlap() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 40, 50, 0, 3, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 5, 15, 0, 4, 10),
+        ];
+        let mut windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 2,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert_eq!(1, output.len());
+        assert_eq!(4, output[0].inputs.len());
+    }
+
+    #[test]
+    fn test_count_first_trigger_counts_actual_ssts() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 10, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 30, 0, 2, 10),
+        ];
+        let mut windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 3,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert_eq!(1, output.len());
+        assert_eq!(3, output[0].inputs.len());
+    }
+
+    #[test]
+    fn test_count_first_does_not_compact_overlap_below_trigger() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 20, 0, 1, 10),
+            new_file_handle_with_size_and_sequence(FileId::random(), 10, 30, 0, 2, 10),
+        ];
+        let mut windows = assign_to_windows(files.iter(), 100);
+        let picker = TwcsPicker {
+            trigger_file_num: 3,
+            time_window_seconds: Some(100),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_filter_deleted_is_false_when_selected_files_overlap_unselected_file() {
+        let mut files = (0..32)
+            .map(|idx| {
+                new_file_handle_with_size_and_sequence(
+                    FileId::random(),
+                    idx * 10,
+                    idx * 10 + 9,
+                    0,
+                    idx as u64 + 1,
+                    10,
+                )
+            })
+            .collect::<Vec<_>>();
+        files.push(new_file_handle_with_size_and_sequence(
+            FileId::random(),
+            0,
+            320,
+            0,
+            33,
+            10,
+        ));
+        let mut windows = assign_to_windows(files.iter(), 1000);
+        let picker = TwcsPicker {
+            trigger_file_num: 2,
+            time_window_seconds: Some(1000),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker.build_output(RegionId::from_u64(1), &mut windows, Some(0));
+
+        assert_eq!(1, output.len());
+        assert_eq!(DEFAULT_MAX_INPUT_FILE_NUM, output[0].inputs.len());
+        assert!(!output[0].filter_deleted);
+    }
+
+    fn new_file_group(
+        start: i64,
+        end: i64,
+        sequence: u64,
+        num_files: usize,
+        file_size: u64,
+    ) -> FileGroup {
+        let mut group = FileGroup::new_with_file(new_file_handle_with_size_and_sequence(
+            FileId::random(),
+            start,
+            end,
+            0,
+            sequence,
+            file_size,
+        ));
+        for _ in 1..num_files {
+            group.add_file(new_file_handle_with_size_and_sequence(
+                FileId::random(),
+                start,
+                end,
+                0,
+                sequence,
+                file_size,
+            ));
+        }
+        group
+    }
+
+    fn picked_ranges(groups: &[FileGroup]) -> Vec<(i64, i64)> {
+        groups
+            .iter()
+            .map(|group| {
+                let (start, end) = group.range();
+                (start.value(), end.value())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_count_first_prefers_overlap_participants_when_file_counts_match() {
+        let first = new_file_group(0, 9, 1, 16, 10);
+        let second = new_file_group(20, 39, 2, 16, 10);
+        let overlapping = new_file_group(30, 49, 3, 16, 10);
+
+        let picked = pick_count_first(
+            vec![
+                SortedRun::from(vec![first, second]),
+                SortedRun::from(vec![overlapping]),
+            ],
+            2,
+        );
+
+        assert_eq!(vec![(20, 39), (30, 49)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_prefers_smaller_bytes_when_file_counts_match() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 16, 10),
+                new_file_group(20, 29, 2, 16, 10),
+                new_file_group(40, 49, 3, 16, 1),
+            ])],
+            2,
+        );
+
+        assert_eq!(vec![(20, 29), (40, 49)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_prefers_earlier_time_on_exact_tie() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 16, 10),
+                new_file_group(20, 29, 2, 16, 10),
+                new_file_group(40, 49, 3, 16, 10),
+            ])],
+            2,
+        );
+
+        assert_eq!(vec![(0, 9), (20, 29)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_skips_oversized_atomic_file_group() {
+        let picked = pick_count_first(
+            vec![SortedRun::from(vec![
+                new_file_group(0, 9, 1, 33, 1),
+                new_file_group(20, 29, 2, 16, 1),
+                new_file_group(40, 49, 3, 16, 1),
+            ])],
+            2,
+        );
+
+        assert_eq!(
+            DEFAULT_MAX_INPUT_FILE_NUM,
+            picked.iter().map(FileGroup::num_files).sum::<usize>()
+        );
+        assert_eq!(vec![(20, 29), (40, 49)], picked_ranges(&picked));
+    }
+
+    #[test]
+    fn test_count_first_keeps_each_interleaved_run_contiguous() {
+        let picked = pick_count_first(
+            vec![
+                SortedRun::from(vec![
+                    new_file_group(0, 9, 1, 8, 1),
+                    new_file_group(20, 29, 2, 8, 1),
+                    new_file_group(40, 49, 3, 8, 1),
+                ]),
+                SortedRun::from(vec![
+                    new_file_group(10, 19, 4, 8, 1),
+                    new_file_group(30, 39, 5, 8, 1),
+                ]),
+            ],
+            2,
+        );
+
+        assert_eq!(
+            vec![(0, 9), (10, 19), (20, 29), (30, 39)],
+            picked_ranges(&picked)
         );
     }
 

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -265,69 +265,69 @@ fn pick_count_first(
     // A multi-SST FileGroup is a compaction output that already exceeded the output size target
     // and was split. Recompacting it cannot reduce physical files, so automatic TWCS treats it as
     // stable. It remains in the original Window for tombstone overlap checks.
-    groups.retain(|group| group.group.num_files() == 1);
-
     let mut best = None;
-    for left in 0..groups.len() {
-        let mut total_size = 0;
-        let mut largest_group_size = 0;
-        let mut overlap_participants = 0;
-        let right_bound = (left + MAX_INPUT_FILE_GROUPS).min(groups.len());
-        let mut participants: Vec<bool> = Vec::with_capacity(right_bound - left);
-        for right in left..right_bound {
-            let right_group = &groups[right];
-            let group_size = right_group.group.size();
-            total_size += group_size;
-            largest_group_size = largest_group_size.max(group_size);
+    for segment in groups
+        .split(|group| group.group.num_files() != 1)
+        .filter(|segment| !segment.is_empty())
+    {
+        for left in 0..segment.len() {
+            let mut total_size = 0;
+            let mut largest_group_size = 0;
+            let mut overlap_participants = 0;
+            let right_bound = (left + MAX_INPUT_FILE_GROUPS).min(segment.len());
+            let mut participants: Vec<bool> = Vec::with_capacity(right_bound - left);
+            for right in left..right_bound {
+                let right_group = &segment[right];
+                let group_size = right_group.group.size();
+                total_size += group_size;
+                largest_group_size = largest_group_size.max(group_size);
 
-            let mut right_participates = false;
-            for (offset, other) in groups[left..right].iter().enumerate() {
-                if right_group.run_id != other.run_id
-                    && right_group.group.overlap_inclusive(other.group)
-                {
-                    if !participants[offset] {
-                        participants[offset] = true;
-                        overlap_participants += 1;
+                let mut right_participates = false;
+                for (offset, other) in segment[left..right].iter().enumerate() {
+                    if right_group.run_id != other.run_id
+                        && right_group.group.overlap_inclusive(other.group)
+                    {
+                        if !participants[offset] {
+                            participants[offset] = true;
+                            overlap_participants += 1;
+                        }
+                        right_participates = true;
                     }
-                    right_participates = true;
                 }
-            }
-            participants.push(right_participates);
-            if right_participates {
-                overlap_participants += 1;
-            }
+                participants.push(right_participates);
+                if right_participates {
+                    overlap_participants += 1;
+                }
 
-            let num_file_groups = right + 1 - left;
-            if num_file_groups < trigger_file_num || num_file_groups < 2 {
-                continue;
-            }
-            // A historical group is only rewritten after peers contribute at least the same
-            // amount of data, so every rewrite moves it into a larger size tier.
-            if largest_group_size > total_size - largest_group_size {
-                continue;
-            }
+                let num_file_groups = right + 1 - left;
+                if num_file_groups < trigger_file_num || num_file_groups < 2 {
+                    continue;
+                }
+                // A historical group is only rewritten after peers contribute at least the same
+                // amount of data, so every rewrite moves it into a larger size tier.
+                if largest_group_size > total_size - largest_group_size {
+                    continue;
+                }
 
-            let score = CandidateScore {
-                num_file_groups,
-                overlap_participants,
-                size: total_size,
-            };
-            if best
-                .as_ref()
-                .is_none_or(|(best_score, _, _)| score.is_better_than(best_score))
-            {
-                best = Some((score, left, right));
+                let score = CandidateScore {
+                    num_file_groups,
+                    overlap_participants,
+                    size: total_size,
+                };
+                if best
+                    .as_ref()
+                    .is_none_or(|(best_score, _)| score.is_better_than(best_score))
+                {
+                    best = Some((score, &segment[left..=right]));
+                }
             }
         }
     }
 
-    let Some((_, left, right)) = best else {
+    let Some((_, best)) = best else {
         return vec![];
     };
-    groups[left..=right]
-        .iter()
-        .map(|group| group.group.clone())
-        .collect()
+    best.iter().map(|group| group.group.clone()).collect()
 }
 
 fn selected_overlaps_unselected(selected: &[FileGroup], window: &Window) -> bool {
@@ -1972,7 +1972,7 @@ mod tests {
     }
 
     #[test]
-    fn test_count_first_ignores_multi_sst_groups_between_singletons() {
+    fn test_count_first_does_not_cross_multi_sst_group() {
         let picked = pick_count_first(
             vec![SortedRun::from(vec![
                 new_file_group(0, 9, 1, 1, 10),
@@ -1982,7 +1982,71 @@ mod tests {
             2,
         );
 
-        assert_eq!(vec![(0, 9), (20, 29)], picked_ranges(&picked));
+        assert!(picked.is_empty());
+    }
+
+    #[test]
+    fn test_count_first_compares_candidates_on_each_side_of_barrier() {
+        let cases = [
+            ([1, 1, 2, 1, 1, 1], vec![(30, 39), (40, 49), (50, 59)]),
+            ([1, 1, 1, 2, 1, 1], vec![(0, 9), (10, 19), (20, 29)]),
+        ];
+
+        let (expected, actual): (Vec<_>, Vec<_>) = cases
+            .into_iter()
+            .map(|(groups, expected)| {
+                let groups: Vec<_> = groups
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, num_files)| {
+                        let start = idx as i64 * 10;
+                        new_file_group(start, start + 9, idx as u64 + 1, num_files, 10)
+                    })
+                    .collect();
+                let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+                (expected, picked_ranges(&picked))
+            })
+            .unzip();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_count_first_multi_sst_barrier_boundaries() {
+        struct TestCase {
+            group_file_nums: &'static [usize],
+            expected_ranges: &'static [(i64, i64)],
+        }
+
+        let cases = [
+            TestCase {
+                group_file_nums: &[2, 1, 1],
+                expected_ranges: &[(10, 19), (20, 29)],
+            },
+            TestCase {
+                group_file_nums: &[1, 1, 2],
+                expected_ranges: &[(0, 9), (10, 19)],
+            },
+            TestCase {
+                group_file_nums: &[1, 2, 1, 2, 1],
+                expected_ranges: &[],
+            },
+        ];
+
+        for case in cases {
+            let groups: Vec<_> = case
+                .group_file_nums
+                .iter()
+                .enumerate()
+                .map(|(idx, &num_files)| {
+                    let start = idx as i64 * 10;
+                    new_file_group(start, start + 9, idx as u64 + 1, num_files, 10)
+                })
+                .collect();
+            let picked = pick_count_first(vec![SortedRun::from(groups)], 2);
+
+            assert_eq!(case.expected_ranges, picked_ranges(&picked));
+        }
     }
 
     #[test]

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -768,6 +768,7 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
         .await;
     let create = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
         .build();
     let column_schemas = create
         .column_metadatas
@@ -981,12 +982,10 @@ async fn test_compaction_region_with_format(flat_format: bool) {
     //                [20....29]
     //          -[15.........29]- (delete)
     //           [15.....24]
-    // Output:
-    // [0..9]
-    //       [10............29] (contains delete)
-    //           [15....24]
+    // Count-first compaction consumes the first 4 SSTs as soon as the trigger is reached.
+    // The compacted output and final flush leave 2 SSTs.
     assert_eq!(
-        3,
+        2,
         scanner.num_files(),
         "unexpected files: {:?}",
         scanner.file_ids()
@@ -1381,6 +1380,7 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
         .build();
 
     let column_schemas = request
@@ -1465,6 +1465,7 @@ async fn test_local_compaction_cancellation_notifies_before_pending_ddl_dispatch
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
         .build();
     let column_schemas = request
         .column_metadatas

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -768,7 +768,7 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
         .await;
     let create = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "4")
         .build();
     let column_schemas = create
         .column_metadatas
@@ -780,7 +780,9 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
         .await
         .unwrap();
     put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
-    put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
+    put_and_flush(&engine, region_id, &column_schemas, 10..20).await;
+    put_and_flush(&engine, region_id, &column_schemas, 20..30).await;
+    put_and_flush(&engine, region_id, &column_schemas, 30..40).await;
 
     let commit_guard = gate.arm_commit();
     let compact_engine = engine.clone();
@@ -804,7 +806,7 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
                 RegionRequest::Truncate(RegionTruncateRequest::ByTimeRanges {
                     time_ranges: vec![(
                         Timestamp::new_millisecond(0),
-                        Timestamp::new_millisecond(19_000),
+                        Timestamp::new_millisecond(39_000),
                     )],
                 }),
             )
@@ -1529,7 +1531,7 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "4")
         .build();
 
     let column_schemas = request
@@ -1542,7 +1544,9 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
         .await
         .unwrap();
     let listener_guard = CompactionListenerGuard::new(listener.clone());
-    // Flush 2 SSTs for compaction.
+    // Flush 4 balanced SSTs for compaction.
+    put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
+    put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
     put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
     put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
 
@@ -1573,7 +1577,7 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
         .await
         .unwrap();
     assert_eq!(
-        2,
+        4,
         scanner.num_files(),
         "unexpected files: {:?}",
         scanner.file_ids()
@@ -1614,7 +1618,7 @@ async fn test_local_compaction_cancellation_notifies_before_pending_ddl_dispatch
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "4")
         .build();
     let column_schemas = request
         .column_metadatas
@@ -1627,6 +1631,8 @@ async fn test_local_compaction_cancellation_notifies_before_pending_ddl_dispatch
         .unwrap();
 
     let merge_guard = gate.arm_merge();
+    put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
+    put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
     put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
     put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
 

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -768,6 +768,7 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
         .await;
     let create = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
         .build();
     let column_schemas = create
         .column_metadatas
@@ -981,12 +982,10 @@ async fn test_compaction_region_with_format(flat_format: bool) {
     //                [20....29]
     //          -[15.........29]- (delete)
     //           [15.....24]
-    // Output:
-    // [0..9]
-    //       [10............29] (contains delete)
-    //           [15....24]
+    // Count-first compaction consumes the first 4 SSTs as soon as the trigger is reached.
+    // The compacted output and final flush leave 2 SSTs.
     assert_eq!(
-        3,
+        2,
         scanner.num_files(),
         "unexpected files: {:?}",
         scanner.file_ids()
@@ -1530,6 +1529,7 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
         .build();
 
     let column_schemas = request
@@ -1614,6 +1614,7 @@ async fn test_local_compaction_cancellation_notifies_before_pending_ddl_dispatch
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
         .build();
     let column_schemas = request
         .column_metadatas

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -768,7 +768,7 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
         .await;
     let create = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "4")
         .build();
     let column_schemas = create
         .column_metadatas
@@ -780,7 +780,9 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
         .await
         .unwrap();
     put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
-    put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
+    put_and_flush(&engine, region_id, &column_schemas, 10..20).await;
+    put_and_flush(&engine, region_id, &column_schemas, 20..30).await;
+    put_and_flush(&engine, region_id, &column_schemas, 30..40).await;
 
     let commit_guard = gate.arm_commit();
     let compact_engine = engine.clone();
@@ -804,7 +806,7 @@ async fn test_truncate_waits_for_non_cancellable_compaction_commit() {
                 RegionRequest::Truncate(RegionTruncateRequest::ByTimeRanges {
                     time_ranges: vec![(
                         Timestamp::new_millisecond(0),
-                        Timestamp::new_millisecond(19_000),
+                        Timestamp::new_millisecond(39_000),
                     )],
                 }),
             )
@@ -1380,7 +1382,7 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "4")
         .build();
 
     let column_schemas = request
@@ -1393,7 +1395,9 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
         .await
         .unwrap();
     let listener_guard = CompactionListenerGuard::new(listener.clone());
-    // Flush 2 SSTs for compaction.
+    // Flush 4 balanced SSTs for compaction.
+    put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
+    put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
     put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
     put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
 
@@ -1424,7 +1428,7 @@ async fn test_readonly_during_compaction_with_format(flat_format: bool) {
         .await
         .unwrap();
     assert_eq!(
-        2,
+        4,
         scanner.num_files(),
         "unexpected files: {:?}",
         scanner.file_ids()
@@ -1465,7 +1469,7 @@ async fn test_local_compaction_cancellation_notifies_before_pending_ddl_dispatch
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "4")
         .build();
     let column_schemas = request
         .column_metadatas
@@ -1478,6 +1482,8 @@ async fn test_local_compaction_cancellation_notifies_before_pending_ddl_dispatch
         .unwrap();
 
     let merge_guard = gate.arm_merge();
+    put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
+    put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
     put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
     put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
 

--- a/src/mito2/src/engine/merge_mode_test.rs
+++ b/src/mito2/src/engine/merge_mode_test.rs
@@ -127,6 +127,7 @@ async fn test_merge_mode_compaction_with_format(flat_format: bool) {
     let request = CreateRequestBuilder::new()
         .field_num(2)
         .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "3")
         .insert_option("merge_mode", "last_non_null")
         .build();
     let table_dir = request.table_dir.clone();
@@ -208,7 +209,7 @@ async fn test_merge_mode_compaction_with_format(flat_format: bool) {
         .scanner(region_id, ScanRequest::default())
         .await
         .unwrap();
-    assert_eq!(2, scanner.num_files());
+    assert_eq!(1, scanner.num_files());
     assert_eq!(1, scanner.num_memtables());
     scanner.set_target_partitions(2);
     let stream = scanner.scan().await.unwrap();

--- a/src/mito2/src/gc/worker_test.rs
+++ b/src/mito2/src/gc/worker_test.rs
@@ -399,7 +399,8 @@ async fn test_gc_worker_basic_compact() {
 
     let region = engine.get_region(region_id).unwrap();
     let manifest = region.manifest_ctx.manifest().await;
-    assert_eq!(manifest.removed_files.removed_files[0].files.len(), 3);
+    let removed_file_num = manifest.removed_files.removed_files[0].files.len();
+    assert!(removed_file_num > 0);
 
     let version = manifest.manifest_version;
 
@@ -413,7 +414,10 @@ async fn test_gc_worker_basic_compact() {
     let gc_worker = create_gc_worker(&engine, regions, &file_ref_manifest, true).await;
     let report = gc_worker.run().await.unwrap();
 
-    assert_eq!(report.deleted_files.get(&region_id).unwrap().len(), 3,);
+    assert_eq!(
+        report.deleted_files.get(&region_id).unwrap().len(),
+        removed_file_num
+    );
     assert!(report.need_retry_regions.is_empty());
 }
 
@@ -476,7 +480,7 @@ async fn test_gc_worker_compact_with_ref() {
 
     let region = engine.get_region(region_id).unwrap();
     let manifest = region.manifest_ctx.manifest().await;
-    assert_eq!(manifest.removed_files.removed_files[0].files.len(), 3);
+    assert!(!manifest.removed_files.removed_files[0].files.is_empty());
 
     let version = manifest.manifest_version;
 

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -131,6 +131,11 @@ impl<S> RegionWorkerLoop<S> {
             return;
         }
         let execution = request.execution.clone();
+        // Whether this execution reduced the SST file count. The scheduler keeps
+        // draining while compaction makes progress; a rewrite that did not reduce
+        // files (e.g. its output was split into more files than its input) must end
+        // the chain to avoid a no-progress loop.
+        let made_progress = request.edit.files_to_remove.len() > request.edit.files_to_add.len();
 
         region.version_control.apply_edit(
             Some(request.edit.clone()),
@@ -167,6 +172,7 @@ impl<S> RegionWorkerLoop<S> {
                 &execution,
                 &region.manifest_ctx,
                 self.schema_metadata_manager.clone(),
+                made_progress,
             )
             .await;
         match transition {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- #8575
## What's changed and what's your intention?

This PR rewrites the Mito2 TWCS single-window picker to prioritize reducing the physical SST file count while preserving time locality, and teaches the compaction scheduler to keep draining a region while compaction makes progress.

**Count-first picking (`compaction/twcs.rs`)**

- Replaces the overlap-first run reduction (`reduce_runs`) and the size-targeted merge (`merge_seq_files`) with `pick_count_first`: all files of a window are ordered globally by `(start asc, end desc)` and every contiguous interval of at most 32 physical SSTs is scored.
- An interval is eligible when it holds at least `trigger_file_num` files (and at least 2), and when no single file dominates it (`largest <= sum of the others`), so a large historical file is only rewritten once its peers contribute at least the same amount of data.
- Scoring prefers more files removed, then more files participating in an overlap (resolving overlaps is what reduces sorted runs), then smaller input bytes; exact ties keep the earliest interval.
- `trigger_file_num` now applies consistently to the physical SST count, including overlapping sets: an overlapping set smaller than the trigger is no longer compacted.

**FileGroup abstraction removed (`compaction/run.rs`)**

- The picker operates directly on `FileHandle`s. Files produced by a split compaction output (same sequence) are evaluated individually instead of being kept atomic in a `FileGroup`; deletion-marker safety for partial selections is enforced per file instead (see below).
- `reduce_runs`, `merge_seq_files` and their benchmarks are removed.

**Conservative tombstone filtering**

- `filter_deleted` no longer relies on the `found_runs <= 2` heuristic. It is only set when the region is not in append mode, no other window overlaps this one, and no unselected file in the window overlaps the selection (with a cheap time-span pre-filter before the precise overlap check).

**Drain compactable backlog (`compaction/scheduler.rs`, `worker/handle_compaction.rs`)**

- After a successful compaction that reduced the SST file count (`files_to_remove > files_to_add`), the scheduler chains an unrestricted automatic follow-up pick even without a latched trigger, keeping the region draining until the picker returns no plan. A rewrite that did not reduce the file count (e.g. its output was split into more files than its input) ends the chain, so a no-progress loop cannot form; the next flush trigger resumes compaction.
- This applies to any successful compaction, including manual time-ranged ones: their follow-up pick is unrestricted (regular options, no time range).

This change does not modify persisted SST/manifest metadata, wire formats, configuration, or public APIs. Primary-key boundary metadata changes discussed in the design are intentionally out of scope.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test Plan

- `cargo nextest run -p mito2 --no-fail-fast`
- `cargo clippy -p mito2 --all-targets -- -D warnings`
- `git diff --check`


## Benchmark monitoring

One-hour continuous write load followed by follow-up compaction, compared against the v1.1.4 baseline with the same CPU quota:

- Total compaction output bytes to reach the final state: **8.71GB → 5.78GB**
- Total merge duration: **3.66h → 3.05h**
- Peak alive SST file count: **954 → 756** (both fully drain afterwards)

![Cumulative SST output bytes](https://gist.githubusercontent.com/v0y4g3r/9cf1a517c7f41d329234e84c34cfe6a6/raw/bench_total_output_bytes.png)
![Cumulative compaction total elapsed](https://gist.githubusercontent.com/v0y4g3r/9cf1a517c7f41d329234e84c34cfe6a6/raw/bench_total_merge_duration.png)
![Alive SST files trend](https://gist.githubusercontent.com/v0y4g3r/9cf1a517c7f41d329234e84c34cfe6a6/raw/bench_peak_file_count.png)
