### PR TITLE
perf(mito2): optimize dictionary primary key sorting

### DIFF
--- a/src/mito2/benches/memtable_bench.rs
+++ b/src/mito2/benches/memtable_bench.rs
@@ -22,10 +22,17 @@
 
 use std::sync::Arc;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use common_recordbatch::DfRecordBatch;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use datatypes::arrow::array::{
+    ArrayRef, BinaryDictionaryBuilder, Int64Array, TimestampMillisecondArray, UInt8Array,
+    UInt64Array,
+};
+use datatypes::arrow::compute::{SortColumn, SortOptions};
+use datatypes::arrow::datatypes::{DataType, Field, Schema, TimeUnit, UInt32Type};
 use mito_codec::row_converter::DensePrimaryKeyCodec;
 use mito2::memtable::bulk::context::BulkIterContext;
-use mito2::memtable::bulk::part::BulkPartConverter;
+use mito2::memtable::bulk::part::{BulkPartConverter, sort_primary_key_record_batch};
 use mito2::memtable::bulk::part_reader::BulkPartBatchIter;
 use mito2::memtable::bulk::{BulkMemtable, BulkMemtableConfig};
 use mito2::memtable::time_series::TimeSeriesMemtable;
@@ -38,6 +45,111 @@ use mito2::test_util::bench_util::{CpuDataGenerator, cpu_metadata};
 use mito2::test_util::memtable_util;
 
 const DEFAULT_BATCH_SIZE: usize = 8 * 1024;
+
+fn primary_key_sort_batch(
+    series_count: usize,
+    samples_per_series: usize,
+    sorted_within_series: bool,
+) -> DfRecordBatch {
+    let num_rows = series_count * samples_per_series;
+    let primary_keys = (0..series_count)
+        .map(|series| format!("series_{series:08}").into_bytes())
+        .collect::<Vec<_>>();
+    let mut primary_key_builder = BinaryDictionaryBuilder::<UInt32Type>::new();
+    let mut timestamps = Vec::with_capacity(num_rows);
+    let mut sequences = Vec::with_capacity(num_rows);
+
+    for series_order in 0..series_count {
+        // 17 is coprime to the power-of-two cardinalities used below and gives a deterministic
+        // non-lexical series order.
+        let series = series_order * 17 % series_count;
+        for sample_order in 0..samples_per_series {
+            let sample = if sorted_within_series {
+                sample_order
+            } else {
+                sample_order * 37 % samples_per_series
+            };
+            primary_key_builder
+                .append(primary_keys[series].as_slice())
+                .unwrap();
+            timestamps.push(sample as i64);
+            sequences.push((series * samples_per_series + sample_order) as u64);
+        }
+    }
+
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(Int64Array::from_iter_values(0..num_rows as i64)),
+        Arc::new(TimestampMillisecondArray::from(timestamps)),
+        Arc::new(primary_key_builder.finish()),
+        Arc::new(UInt64Array::from(sequences)),
+        Arc::new(UInt8Array::from_value(1, num_rows)),
+    ];
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("value", DataType::Int64, false),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
+        Field::new(
+            "__primary_key",
+            DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Binary)),
+            false,
+        ),
+        Field::new("__sequence", DataType::UInt64, false),
+        Field::new("__op_type", DataType::UInt8, false),
+    ]));
+    DfRecordBatch::try_new(schema, columns).unwrap()
+}
+
+fn lexsort_primary_key_record_batch(batch: &DfRecordBatch) -> DfRecordBatch {
+    let total_columns = batch.num_columns();
+    let sort_columns = vec![
+        SortColumn {
+            values: batch.column(total_columns - 3).clone(),
+            options: Some(SortOptions {
+                descending: false,
+                nulls_first: true,
+            }),
+        },
+        SortColumn {
+            values: batch.column(total_columns - 4).clone(),
+            options: Some(SortOptions {
+                descending: false,
+                nulls_first: true,
+            }),
+        },
+        SortColumn {
+            values: batch.column(total_columns - 2).clone(),
+            options: Some(SortOptions {
+                descending: true,
+                nulls_first: true,
+            }),
+        },
+    ];
+    let indices = datatypes::arrow::compute::lexsort_to_indices(&sort_columns, None).unwrap();
+    datatypes::arrow::compute::take_record_batch(batch, &indices).unwrap()
+}
+
+fn primary_key_sort(c: &mut Criterion) {
+    let mut group = c.benchmark_group("primary_key_sort");
+    group.sample_size(20);
+
+    for (name, series_count, samples_per_series, sorted_within_series) in [
+        ("sorted_runs", 512, 16, true),
+        ("shuffled_runs", 512, 16, false),
+        ("high_cardinality", 8192, 1, true),
+    ] {
+        let batch = primary_key_sort_batch(series_count, samples_per_series, sorted_within_series);
+        group.throughput(Throughput::Elements(batch.num_rows() as u64));
+        group.bench_function(format!("{name}/arrow_lexsort"), |b| {
+            b.iter(|| lexsort_primary_key_record_batch(&batch));
+        });
+        group.bench_function(format!("{name}/rank_scatter"), |b| {
+            b.iter(|| sort_primary_key_record_batch(&batch).unwrap());
+        });
+    }
+}
 
 /// Writes rows.
 fn write_rows(c: &mut Criterion) {
@@ -391,6 +503,7 @@ fn bulk_part_record_batch_iter_filter(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    primary_key_sort,
     write_rows,
     full_scan,
     filter_1_host,

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -30,11 +30,13 @@ use datafusion_common::pruning::PruningStatistics;
 use datafusion_expr::utils::expr_to_columns;
 use datatypes::arrow;
 use datatypes::arrow::array::{
-    Array, ArrayRef, BinaryArray, BooleanArray, StringDictionaryBuilder, UInt8Array, UInt64Array,
+    Array, ArrayRef, BinaryArray, BooleanArray, DictionaryArray, StringDictionaryBuilder,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray, UInt8Array, UInt32Array, UInt64Array,
 };
 use datatypes::arrow::compute::{SortColumn, SortOptions, concat_batches};
 use datatypes::arrow::datatypes::{
-    DataType as ArrowDataType, Field, Schema, SchemaRef, UInt32Type,
+    DataType as ArrowDataType, Field, Schema, SchemaRef, TimeUnit, UInt32Type,
 };
 use datatypes::data_type::DataType;
 use datatypes::extension::json::is_json2_extension_type;
@@ -771,6 +773,147 @@ fn new_primary_key_column_builders(
 
 /// Sorts the record batch with primary key format.
 pub fn sort_primary_key_record_batch(batch: &RecordBatch) -> Result<RecordBatch> {
+    let indices = if let Some(indices) = try_sort_primary_key_indices(batch)? {
+        indices
+    } else {
+        lexsort_primary_key_indices(batch)?
+    };
+
+    datatypes::arrow::compute::take_record_batch(batch, &indices).context(ComputeArrowSnafu)
+}
+
+/// Sorts the known, non-null primary-key layout without comparing encoded keys for every row.
+///
+/// Returns `None` if the batch does not have the exact layout supported by this fast path.
+fn try_sort_primary_key_indices(batch: &RecordBatch) -> Result<Option<UInt32Array>> {
+    let total_columns = batch.num_columns();
+    let timestamp = batch.column(total_columns - 4);
+    let primary_key = batch.column(total_columns - 3);
+    let sequence = batch.column(total_columns - 2);
+
+    let Some(primary_key) = primary_key
+        .as_any()
+        .downcast_ref::<DictionaryArray<UInt32Type>>()
+    else {
+        return Ok(None);
+    };
+    let Some(sequence) = sequence.as_any().downcast_ref::<UInt64Array>() else {
+        return Ok(None);
+    };
+
+    if batch.num_rows() > u32::MAX as usize
+        || primary_key.null_count() != 0
+        || primary_key.values().data_type() != &ArrowDataType::Binary
+        || primary_key.values().null_count() != 0
+        || primary_key.values().len() > batch.num_rows()
+        || timestamp.null_count() != 0
+        || sequence.null_count() != 0
+    {
+        return Ok(None);
+    }
+
+    let indices = match timestamp.data_type() {
+        ArrowDataType::Timestamp(TimeUnit::Second, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampSecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        ArrowDataType::Timestamp(TimeUnit::Millisecond, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        ArrowDataType::Timestamp(TimeUnit::Microsecond, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        ArrowDataType::Timestamp(TimeUnit::Nanosecond, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        _ => None,
+    };
+
+    indices.transpose()
+}
+
+/// Computes sorted row indices by ranking dictionary values, scattering rows into primary-key
+/// buckets, and sorting only buckets that are not already ordered by time and sequence.
+fn sort_primary_key_indices(
+    primary_key: &PrimaryKeyArray,
+    timestamps: &[i64],
+    sequences: &UInt64Array,
+) -> Result<UInt32Array> {
+    debug_assert_eq!(primary_key.len(), timestamps.len());
+    debug_assert_eq!(primary_key.len(), sequences.len());
+    debug_assert_eq!(primary_key.null_count(), 0);
+    debug_assert_eq!(primary_key.values().null_count(), 0);
+    debug_assert_eq!(sequences.null_count(), 0);
+
+    // Ranks compare in the same order as the dictionary values. Equal dictionary values receive
+    // the same rank, which is required because Arrow dictionary concatenation only deduplicates
+    // values on a best-effort basis.
+    let value_ranks = datatypes::arrow::compute::rank(
+        primary_key.values().as_ref(),
+        Some(SortOptions {
+            descending: false,
+            nulls_first: true,
+        }),
+    )
+    .context(ComputeArrowSnafu)?;
+
+    // A rank is at most the number of dictionary values. It is not necessarily dense when the
+    // dictionary contains duplicate values, so keep one extra slot and allow empty buckets.
+    let mut counts = vec![0usize; value_ranks.len() + 1];
+    for &key in primary_key.keys().values() {
+        counts[value_ranks[key as usize] as usize] += 1;
+    }
+
+    let mut bucket_offsets = vec![0usize; counts.len()];
+    let mut offset = 0;
+    for (bucket_offset, &count) in bucket_offsets.iter_mut().zip(&counts) {
+        *bucket_offset = offset;
+        offset += count;
+    }
+
+    // Scatter in input order. This preserves already sorted runs within each primary key.
+    let mut next_offsets = bucket_offsets.clone();
+    let mut indices = vec![0u32; primary_key.len()];
+    for (row, &key) in primary_key.keys().values().iter().enumerate() {
+        let rank = value_ranks[key as usize] as usize;
+        indices[next_offsets[rank]] = row as u32;
+        next_offsets[rank] += 1;
+    }
+
+    let sequences = sequences.values();
+    for (&start, count) in bucket_offsets.iter().zip(counts) {
+        let end = start + count;
+        let bucket = &mut indices[start..end];
+        if !bucket.is_sorted_by(|left, right| {
+            compare_time_sequence(timestamps, sequences, *left, *right).is_le()
+        }) {
+            bucket.sort_unstable_by(|left, right| {
+                compare_time_sequence(timestamps, sequences, *left, *right)
+            });
+        }
+    }
+
+    Ok(UInt32Array::from(indices))
+}
+
+#[inline]
+fn compare_time_sequence(
+    timestamps: &[i64],
+    sequences: &[u64],
+    left: u32,
+    right: u32,
+) -> std::cmp::Ordering {
+    let left = left as usize;
+    let right = right as usize;
+    timestamps[left]
+        .cmp(&timestamps[right])
+        .then_with(|| sequences[right].cmp(&sequences[left]))
+}
+
+fn lexsort_primary_key_indices(batch: &RecordBatch) -> Result<UInt32Array> {
     let total_columns = batch.num_columns();
     let sort_columns = vec![
         // Primary key column (ascending)
@@ -799,10 +942,7 @@ pub fn sort_primary_key_record_batch(batch: &RecordBatch) -> Result<RecordBatch>
         },
     ];
 
-    let indices = datatypes::arrow::compute::lexsort_to_indices(&sort_columns, None)
-        .context(ComputeArrowSnafu)?;
-
-    datatypes::arrow::compute::take_record_batch(batch, &indices).context(ComputeArrowSnafu)
+    datatypes::arrow::compute::lexsort_to_indices(&sort_columns, None).context(ComputeArrowSnafu)
 }
 
 /// Converts a `BulkPart` that is unordered and without encoded primary keys into a `BulkPart`
@@ -1674,6 +1814,8 @@ mod tests {
     use datatypes::prelude::{ConcreteDataType, Value};
     use datatypes::schema::ColumnSchema;
     use mito_codec::row_converter::build_primary_key_codec;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
     use store_api::storage::consts::ReservedColumnId;
@@ -1690,6 +1832,137 @@ mod tests {
         timestamps: &'a [i64],
         v1: &'a [Option<f64>],
         sequence: u64,
+    }
+
+    #[test]
+    fn test_sort_primary_key_record_batch_with_duplicate_dictionary_values() {
+        // Dictionary keys 1 and 2 both represent "series_a". This can happen after Arrow
+        // concatenates dictionaries because dictionary deduplication is best-effort.
+        let primary_key = DictionaryArray::try_new(
+            UInt32Array::from(vec![0, 1, 0, 2, 2]),
+            Arc::new(BinaryArray::from_vec(vec![
+                b"series_b".as_slice(),
+                b"series_a".as_slice(),
+                b"series_a".as_slice(),
+            ])),
+        )
+        .unwrap();
+        let timestamps = TimestampMillisecondArray::from(vec![20, 30, 10, 30, 10]);
+        let sequences = UInt64Array::from(vec![5, 6, 4, 8, 9]);
+        let row_ids = UInt32Array::from_iter_values(0..5);
+        let op_types = UInt8Array::from_value(OpType::Put as u8, 5);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("row_id", ArrowDataType::UInt32, false),
+            Field::new(
+                "ts",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new(
+                PRIMARY_KEY_COLUMN_NAME,
+                ArrowDataType::Dictionary(
+                    Box::new(ArrowDataType::UInt32),
+                    Box::new(ArrowDataType::Binary),
+                ),
+                false,
+            ),
+            Field::new("__sequence", ArrowDataType::UInt64, false),
+            Field::new("__op_type", ArrowDataType::UInt8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(row_ids),
+                Arc::new(timestamps),
+                Arc::new(primary_key),
+                Arc::new(sequences),
+                Arc::new(op_types),
+            ],
+        )
+        .unwrap();
+
+        let expected_indices = lexsort_primary_key_indices(&batch).unwrap();
+        let expected =
+            datatypes::arrow::compute::take_record_batch(&batch, &expected_indices).unwrap();
+        let actual = sort_primary_key_record_batch(&batch).unwrap();
+
+        let expected_row_ids = expected
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let actual_row_ids = actual
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        assert_eq!(expected_row_ids, actual_row_ids);
+        assert_eq!(actual_row_ids.values(), &[4, 3, 1, 2, 0]);
+    }
+
+    #[test]
+    fn test_sort_primary_key_record_batch_against_lexsort() {
+        let mut rng = StdRng::seed_from_u64(0x5eed);
+        for _ in 0..100 {
+            let num_rows = rng.random_range(0..128);
+            let keys = UInt32Array::from_iter_values((0..num_rows).map(|_| rng.random_range(0..8)));
+            let primary_key = DictionaryArray::try_new(
+                keys,
+                Arc::new(BinaryArray::from_vec(vec![
+                    b"d".as_slice(),
+                    b"a".as_slice(),
+                    b"c".as_slice(),
+                    b"b".as_slice(),
+                    b"a".as_slice(),
+                    b"d".as_slice(),
+                    b"b".as_slice(),
+                    b"c".as_slice(),
+                ])),
+            )
+            .unwrap();
+            let timestamps = TimestampMillisecondArray::from_iter_values(
+                (0..num_rows).map(|_| rng.random_range(-1000..1000)),
+            );
+            // Unique sequences ensure that the oracle and fast path have no fully equal sort keys.
+            let sequences = UInt64Array::from_iter_values(0..num_rows as u64);
+            let row_ids = UInt32Array::from_iter_values(0..num_rows as u32);
+            let op_types = UInt8Array::from_value(OpType::Put as u8, num_rows);
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("row_id", ArrowDataType::UInt32, false),
+                Field::new(
+                    "ts",
+                    ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                    false,
+                ),
+                Field::new(
+                    PRIMARY_KEY_COLUMN_NAME,
+                    ArrowDataType::Dictionary(
+                        Box::new(ArrowDataType::UInt32),
+                        Box::new(ArrowDataType::Binary),
+                    ),
+                    false,
+                ),
+                Field::new("__sequence", ArrowDataType::UInt64, false),
+                Field::new("__op_type", ArrowDataType::UInt8, false),
+            ]));
+            let batch = RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(row_ids),
+                    Arc::new(timestamps),
+                    Arc::new(primary_key),
+                    Arc::new(sequences),
+                    Arc::new(op_types),
+                ],
+            )
+            .unwrap();
+
+            let expected_indices = lexsort_primary_key_indices(&batch).unwrap();
+            let expected =
+                datatypes::arrow::compute::take_record_batch(&batch, &expected_indices).unwrap();
+            let actual = sort_primary_key_record_batch(&batch).unwrap();
+            assert_eq!(expected.column(0), actual.column(0));
+        }
     }
 
     #[test]

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -30,11 +30,13 @@ use datafusion_common::pruning::PruningStatistics;
 use datafusion_expr::utils::expr_to_columns;
 use datatypes::arrow;
 use datatypes::arrow::array::{
-    Array, ArrayRef, BinaryArray, BooleanArray, StringDictionaryBuilder, UInt8Array, UInt64Array,
+    Array, ArrayRef, BinaryArray, BooleanArray, DictionaryArray, StringDictionaryBuilder,
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray, UInt8Array, UInt32Array, UInt64Array,
 };
 use datatypes::arrow::compute::{SortColumn, SortOptions, concat_batches};
 use datatypes::arrow::datatypes::{
-    DataType as ArrowDataType, Field, Schema, SchemaRef, UInt32Type,
+    DataType as ArrowDataType, Field, Schema, SchemaRef, TimeUnit, UInt32Type,
 };
 use datatypes::data_type::DataType;
 use datatypes::extension::json::is_structured_json_field;
@@ -765,6 +767,149 @@ fn new_primary_key_column_builders(
 
 /// Sorts the record batch with primary key format.
 pub fn sort_primary_key_record_batch(batch: &RecordBatch) -> Result<RecordBatch> {
+    let indices = if let Some(indices) = try_sort_primary_key_indices(batch)? {
+        indices
+    } else {
+        lexsort_primary_key_indices(batch)?
+    };
+
+    datatypes::arrow::compute::take_record_batch(batch, &indices).context(ComputeArrowSnafu)
+}
+
+/// Sorts the known, non-null primary-key layout without comparing encoded keys for every row.
+///
+/// Returns `None` if the batch does not have the exact layout supported by this fast path.
+fn try_sort_primary_key_indices(batch: &RecordBatch) -> Result<Option<UInt32Array>> {
+    let total_columns = batch.num_columns();
+    let timestamp = batch.column(total_columns - 4);
+    let primary_key = batch.column(total_columns - 3);
+    let sequence = batch.column(total_columns - 2);
+
+    let Some(primary_key) = primary_key
+        .as_any()
+        .downcast_ref::<DictionaryArray<UInt32Type>>()
+    else {
+        return Ok(None);
+    };
+    let Some(sequence) = sequence.as_any().downcast_ref::<UInt64Array>() else {
+        return Ok(None);
+    };
+
+    if batch.num_rows() > u32::MAX as usize
+        || primary_key.null_count() != 0
+        || primary_key.values().data_type() != &ArrowDataType::Binary
+        || primary_key.values().null_count() != 0
+        || primary_key.values().len() > batch.num_rows()
+        || timestamp.null_count() != 0
+        || sequence.null_count() != 0
+    {
+        return Ok(None);
+    }
+
+    let indices = match timestamp.data_type() {
+        ArrowDataType::Timestamp(TimeUnit::Second, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampSecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        ArrowDataType::Timestamp(TimeUnit::Millisecond, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        ArrowDataType::Timestamp(TimeUnit::Microsecond, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        ArrowDataType::Timestamp(TimeUnit::Nanosecond, _) => timestamp
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .map(|timestamp| sort_primary_key_indices(primary_key, timestamp.values(), sequence)),
+        _ => None,
+    };
+
+    indices.transpose()
+}
+
+/// Computes sorted row indices by ranking dictionary values, scattering rows into primary-key
+/// buckets, and sorting only buckets that are not already ordered by time and sequence.
+fn sort_primary_key_indices(
+    primary_key: &PrimaryKeyArray,
+    timestamps: &[i64],
+    sequences: &UInt64Array,
+) -> Result<UInt32Array> {
+    debug_assert_eq!(primary_key.len(), timestamps.len());
+    debug_assert_eq!(primary_key.len(), sequences.len());
+    debug_assert_eq!(primary_key.null_count(), 0);
+    debug_assert_eq!(primary_key.values().null_count(), 0);
+    debug_assert_eq!(sequences.null_count(), 0);
+
+    // Ranks compare in the same order as the dictionary values. Equal dictionary values receive
+    // the same rank, which is required because Arrow dictionary concatenation only deduplicates
+    // values on a best-effort basis.
+    let value_ranks = datatypes::arrow::compute::rank(
+        primary_key.values().as_ref(),
+        Some(SortOptions {
+            descending: false,
+            nulls_first: true,
+        }),
+    )
+    .context(ComputeArrowSnafu)?;
+
+    // A rank is at most the number of dictionary values. It is not necessarily dense when the
+    // dictionary contains duplicate values, so keep one extra slot and allow empty buckets.
+    let mut counts = vec![0usize; value_ranks.len() + 1];
+    for key in primary_key.keys().values() {
+        counts[value_ranks[*key as usize] as usize] += 1;
+    }
+
+    let mut bucket_offsets = vec![0usize; counts.len()];
+    let mut offset = 0;
+    for (bucket_offset, count) in bucket_offsets.iter_mut().zip(&counts) {
+        *bucket_offset = offset;
+        offset += count;
+    }
+
+    // Scatter in input order. This preserves already sorted runs within each primary key.
+    let mut next_offsets = bucket_offsets.clone();
+    let mut indices = vec![0u32; primary_key.len()];
+    for (row, key) in primary_key.keys().values().iter().enumerate() {
+        let rank = value_ranks[*key as usize] as usize;
+        indices[next_offsets[rank]] = row as u32;
+        next_offsets[rank] += 1;
+    }
+
+    for (rank, count) in counts.into_iter().enumerate() {
+        let start = bucket_offsets[rank];
+        let end = start + count;
+        let bucket = &mut indices[start..end];
+        if bucket.windows(2).all(|rows| {
+            compare_time_sequence(timestamps, sequences.values(), rows[0], rows[1]).is_le()
+        }) {
+            continue;
+        }
+
+        bucket.sort_unstable_by(|left, right| {
+            compare_time_sequence(timestamps, sequences.values(), *left, *right)
+        });
+    }
+
+    Ok(UInt32Array::from(indices))
+}
+
+#[inline]
+fn compare_time_sequence(
+    timestamps: &[i64],
+    sequences: &[u64],
+    left: u32,
+    right: u32,
+) -> std::cmp::Ordering {
+    let left = left as usize;
+    let right = right as usize;
+    timestamps[left]
+        .cmp(&timestamps[right])
+        .then_with(|| sequences[right].cmp(&sequences[left]))
+}
+
+fn lexsort_primary_key_indices(batch: &RecordBatch) -> Result<UInt32Array> {
     let total_columns = batch.num_columns();
     let sort_columns = vec![
         // Primary key column (ascending)
@@ -793,10 +938,7 @@ pub fn sort_primary_key_record_batch(batch: &RecordBatch) -> Result<RecordBatch>
         },
     ];
 
-    let indices = datatypes::arrow::compute::lexsort_to_indices(&sort_columns, None)
-        .context(ComputeArrowSnafu)?;
-
-    datatypes::arrow::compute::take_record_batch(batch, &indices).context(ComputeArrowSnafu)
+    datatypes::arrow::compute::lexsort_to_indices(&sort_columns, None).context(ComputeArrowSnafu)
 }
 
 /// Converts a `BulkPart` that is unordered and without encoded primary keys into a `BulkPart`
@@ -1668,6 +1810,8 @@ mod tests {
     use datatypes::prelude::{ConcreteDataType, Value};
     use datatypes::schema::ColumnSchema;
     use mito_codec::row_converter::build_primary_key_codec;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
     use store_api::storage::consts::ReservedColumnId;
@@ -1684,6 +1828,137 @@ mod tests {
         timestamps: &'a [i64],
         v1: &'a [Option<f64>],
         sequence: u64,
+    }
+
+    #[test]
+    fn test_sort_primary_key_record_batch_with_duplicate_dictionary_values() {
+        // Dictionary keys 1 and 2 both represent "series_a". This can happen after Arrow
+        // concatenates dictionaries because dictionary deduplication is best-effort.
+        let primary_key = DictionaryArray::try_new(
+            UInt32Array::from(vec![0, 1, 0, 2, 2]),
+            Arc::new(BinaryArray::from_vec(vec![
+                b"series_b".as_slice(),
+                b"series_a".as_slice(),
+                b"series_a".as_slice(),
+            ])),
+        )
+        .unwrap();
+        let timestamps = TimestampMillisecondArray::from(vec![20, 30, 10, 30, 10]);
+        let sequences = UInt64Array::from(vec![5, 6, 4, 8, 9]);
+        let row_ids = UInt32Array::from_iter_values(0..5);
+        let op_types = UInt8Array::from_value(OpType::Put as u8, 5);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("row_id", ArrowDataType::UInt32, false),
+            Field::new(
+                "ts",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new(
+                PRIMARY_KEY_COLUMN_NAME,
+                ArrowDataType::Dictionary(
+                    Box::new(ArrowDataType::UInt32),
+                    Box::new(ArrowDataType::Binary),
+                ),
+                false,
+            ),
+            Field::new("__sequence", ArrowDataType::UInt64, false),
+            Field::new("__op_type", ArrowDataType::UInt8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(row_ids),
+                Arc::new(timestamps),
+                Arc::new(primary_key),
+                Arc::new(sequences),
+                Arc::new(op_types),
+            ],
+        )
+        .unwrap();
+
+        let expected_indices = lexsort_primary_key_indices(&batch).unwrap();
+        let expected =
+            datatypes::arrow::compute::take_record_batch(&batch, &expected_indices).unwrap();
+        let actual = sort_primary_key_record_batch(&batch).unwrap();
+
+        let expected_row_ids = expected
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let actual_row_ids = actual
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        assert_eq!(expected_row_ids, actual_row_ids);
+        assert_eq!(actual_row_ids.values(), &[4, 3, 1, 2, 0]);
+    }
+
+    #[test]
+    fn test_sort_primary_key_record_batch_against_lexsort() {
+        let mut rng = StdRng::seed_from_u64(0x5eed);
+        for _ in 0..100 {
+            let num_rows = rng.random_range(0..128);
+            let keys = UInt32Array::from_iter_values((0..num_rows).map(|_| rng.random_range(0..8)));
+            let primary_key = DictionaryArray::try_new(
+                keys,
+                Arc::new(BinaryArray::from_vec(vec![
+                    b"d".as_slice(),
+                    b"a".as_slice(),
+                    b"c".as_slice(),
+                    b"b".as_slice(),
+                    b"a".as_slice(),
+                    b"d".as_slice(),
+                    b"b".as_slice(),
+                    b"c".as_slice(),
+                ])),
+            )
+            .unwrap();
+            let timestamps = TimestampMillisecondArray::from_iter_values(
+                (0..num_rows).map(|_| rng.random_range(-1000..1000)),
+            );
+            // Unique sequences ensure that the oracle and fast path have no fully equal sort keys.
+            let sequences = UInt64Array::from_iter_values(0..num_rows as u64);
+            let row_ids = UInt32Array::from_iter_values(0..num_rows as u32);
+            let op_types = UInt8Array::from_value(OpType::Put as u8, num_rows);
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("row_id", ArrowDataType::UInt32, false),
+                Field::new(
+                    "ts",
+                    ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                    false,
+                ),
+                Field::new(
+                    PRIMARY_KEY_COLUMN_NAME,
+                    ArrowDataType::Dictionary(
+                        Box::new(ArrowDataType::UInt32),
+                        Box::new(ArrowDataType::Binary),
+                    ),
+                    false,
+                ),
+                Field::new("__sequence", ArrowDataType::UInt64, false),
+                Field::new("__op_type", ArrowDataType::UInt8, false),
+            ]));
+            let batch = RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(row_ids),
+                    Arc::new(timestamps),
+                    Arc::new(primary_key),
+                    Arc::new(sequences),
+                    Arc::new(op_types),
+                ],
+            )
+            .unwrap();
+
+            let expected_indices = lexsort_primary_key_indices(&batch).unwrap();
+            let expected =
+                datatypes::arrow::compute::take_record_batch(&batch, &expected_indices).unwrap();
+            let actual = sort_primary_key_record_batch(&batch).unwrap();
+            assert_eq!(expected.column(0), actual.column(0));
+        }
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

### Summarize your change

  Optimize Mito2 bulk record-batch sorting when the primary key is encoded as
  `Dictionary<UInt32, Binary>`.

  For eligible batches, replace the generic three-column Arrow lexsort with a
  specialized path that ranks dictionary values once, scatters rows into
  primary-key buckets, and sorts only buckets that are not already ordered by
  timestamp and sequence. Unsupported layouts continue to use the existing Arrow
  lexsort fallback.

  This change also adds correctness tests against Arrow lexsort and targeted
  Criterion benchmarks.

  ### How does this PR work?

  The required row order is:

  1. primary key ascending;
  2. timestamp ascending;
  3. sequence descending.

  The optimized path works as follows:

  1. Rank the dictionary values once. Equal dictionary values receive the same
     rank, even if they use different dictionary keys.
  2. Count rows for each rank and compute bucket offsets.
  3. Scatter row indices into primary-key buckets while preserving their input
     order.
  4. Check whether each bucket is already ordered by `(timestamp ASC, sequence
     DESC)`.
  5. Sort only the unordered buckets using direct typed comparisons.
  6. Apply the resulting indices with `take_record_batch`.

  The fast path avoids repeatedly dereferencing and comparing encoded primary-key
  bytes during an `O(n log n)` multi-column comparison sort.

  For the 8192-row microbenchmarks, the specialized path was:

  - about 17x faster when samples within each series were already ordered;
  - about 11x faster when samples within each series were shuffled;
  - about 1.58x faster for the high-cardinality case with one row per series.

  In the existing 10-million-row remote-write workload, CPU time per row decreased
  by approximately 12.8%, while throughput increased by approximately 13.6%.

  ### Describe clearly one logical change

  This PR contains one logical change: specializing Mito2's existing
  `(primary_key, timestamp, sequence)` bulk sorting operation for its known
  dictionary-encoded primary-key layout. The tests and benchmarks only validate
  that change.

  ### Limitations

  The specialized path currently applies only when:

  - the primary key is `Dictionary<UInt32, Binary>`;
  - the timestamp uses one of Arrow's supported timestamp units with an `i64`
    physical representation;
  - the sequence column is `UInt64`;
  - the three sorting columns contain no nulls;
  - the dictionary does not contain more values than rows.

  Batches outside these conditions fall back to Arrow's existing
  `lexsort_to_indices` implementation.

<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/09620f26-f1e9-4ade-a1f7-9340a88f225a" />


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
