### PR TITLE
fix: cache physical table metadata lookups

### DIFF
--- a/src/catalog/src/kvbackend/manager.rs
+++ b/src/catalog/src/kvbackend/manager.rs
@@ -29,7 +29,7 @@ use common_meta::key::TableMetadataManagerRef;
 use common_meta::key::catalog_name::CatalogNameKey;
 use common_meta::key::flow::FlowMetadataManager;
 use common_meta::key::schema_name::SchemaNameKey;
-use common_meta::key::table_info::{TableInfoManager, TableInfoValue};
+use common_meta::key::table_info::TableInfoValue;
 use common_meta::key::table_name::TableNameKey;
 use common_meta::kv_backend::KvBackendRef;
 use common_procedure::ProcedureManagerRef;
@@ -112,7 +112,7 @@ impl KvBackendCatalogManager {
     // Override logical table's partition key indices with physical table's.
     async fn override_logical_table_partition_key_indices(
         table_route_cache: &TableRouteCacheRef,
-        table_info_manager: &TableInfoManager,
+        table_info_cache: &TableInfoCacheRef,
         table: TableRef,
     ) -> Result<TableRef> {
         // If the table is not a metric table, return the table directly.
@@ -125,7 +125,7 @@ impl KvBackendCatalogManager {
             .await
             .context(TableMetadataManagerSnafu)?
             && let TableRoute::Logical(logical_route) = &*table_route_value
-            && let Some(physical_table_info_value) = table_info_manager
+            && let Some(physical_table_info) = table_info_cache
                 .get(logical_route.physical_table_id())
                 .await
                 .context(TableMetadataManagerSnafu)?
@@ -135,15 +135,13 @@ impl KvBackendCatalogManager {
             let mut phy_part_cols_not_in_logical_table = vec![];
 
             // Remap partition key indices from physical table to logical table
-            new_table_info.meta.partition_key_indices = physical_table_info_value
-                .table_info
+            new_table_info.meta.partition_key_indices = physical_table_info
                 .meta
                 .partition_key_indices
                 .iter()
                 .filter_map(|&physical_index| {
                     // Get the column name from the physical table using the physical index
-                    physical_table_info_value
-                        .table_info
+                    physical_table_info
                         .meta
                         .schema
                         .column_schemas()
@@ -321,9 +319,13 @@ impl CatalogManager for KvBackendCatalogManager {
                 self.cache_registry.get().context(CacheNotFoundSnafu {
                     name: "table_route_cache",
                 })?;
+            let table_info_cache: TableInfoCacheRef =
+                self.cache_registry.get().context(CacheNotFoundSnafu {
+                    name: "table_info_cache",
+                })?;
             return Self::override_logical_table_partition_key_indices(
                 &table_route_cache,
-                self.table_metadata_manager.table_info_manager(),
+                &table_info_cache,
                 table,
             )
             .await
@@ -453,10 +455,21 @@ impl CatalogManager for KvBackendCatalogManager {
             self.cache_registry.get().context(CacheNotFoundSnafu {
                 name: "table_route_cache",
             });
+        let table_info_cache: Result<TableInfoCacheRef> =
+            self.cache_registry.get().context(CacheNotFoundSnafu {
+                name: "table_info_cache",
+            });
 
         common_runtime::spawn_global(async move {
             let table_route_cache = match table_route_cache {
                 Ok(table_route_cache) => table_route_cache,
+                Err(e) => {
+                    let _ = tx.send(Err(e)).await;
+                    return;
+                }
+            };
+            let table_info_cache = match table_info_cache {
+                Ok(table_info_cache) => table_info_cache,
                 Err(e) => {
                     let _ = tx.send(Err(e)).await;
                     return;
@@ -490,6 +503,7 @@ impl CatalogManager for KvBackendCatalogManager {
                 let tx = tx.clone();
                 let semaphore = semaphore.clone();
                 let table_route_cache = table_route_cache.clone();
+                let table_info_cache = table_info_cache.clone();
                 common_runtime::spawn_global(async move {
                     // we don't explicitly close the semaphore so just ignore the potential error.
                     let _ = semaphore.acquire().await;
@@ -509,7 +523,7 @@ impl CatalogManager for KvBackendCatalogManager {
                     for table in table_info_values.into_values().map(build_table) {
                         let table = Self::override_logical_table_partition_key_indices(
                             &table_route_cache,
-                            metadata_manager.table_info_manager(),
+                            &table_info_cache,
                             table,
                         )
                         .await;
@@ -643,5 +657,88 @@ impl SystemCatalog {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use common_meta::cache::{CacheContainer, Initializer};
+    use common_meta::key::table_route::LogicalTableRouteValue;
+    use moka::future::Cache as FutureCache;
+    use table::metadata::TableInfo;
+
+    use super::*;
+
+    fn metric_table_info(
+        table_id: TableId,
+        table_name: &str,
+        partition_key_indices: Vec<usize>,
+    ) -> TableInfo {
+        let mut table_info =
+            common_meta::ddl::test_util::create_table::test_create_table_task(table_name, table_id)
+                .table_info;
+        table_info.meta.engine = METRIC_ENGINE_NAME.to_string();
+        table_info.meta.partition_key_indices = partition_key_indices;
+        table_info
+    }
+
+    #[tokio::test]
+    async fn test_logical_table_uses_cached_physical_table_info() {
+        const LOGICAL_TABLE_ID: TableId = 1;
+        const PHYSICAL_TABLE_ID: TableId = 2;
+
+        let route = Arc::new(TableRoute::Logical(Arc::new(LogicalTableRouteValue::new(
+            PHYSICAL_TABLE_ID,
+        ))));
+        let route_initializer: Initializer<TableId, Arc<TableRoute>> = Arc::new(move |_| {
+            let route = route.clone();
+            Box::pin(async move { Ok(Some(route)) })
+        });
+        let table_route_cache = Arc::new(CacheContainer::new(
+            "test_table_route_cache".to_string(),
+            FutureCache::new(16),
+            Box::new(|_, _| Box::pin(async { Ok(()) })),
+            route_initializer,
+            |_| true,
+        ));
+
+        let load_count = Arc::new(AtomicUsize::new(0));
+        let physical_table_info =
+            Arc::new(metric_table_info(PHYSICAL_TABLE_ID, "physical", vec![1]));
+        let table_info_initializer: Initializer<TableId, Arc<TableInfo>> = {
+            let load_count = load_count.clone();
+            let table_info = physical_table_info.clone();
+            Arc::new(move |_| {
+                load_count.fetch_add(1, Ordering::Relaxed);
+                let table_info = table_info.clone();
+                Box::pin(async move { Ok(Some(table_info)) })
+            })
+        };
+        let table_info_cache = Arc::new(CacheContainer::new(
+            "test_table_info_cache".to_string(),
+            FutureCache::new(16),
+            Box::new(|_, _| Box::pin(async { Ok(()) })),
+            table_info_initializer,
+            |_| true,
+        ));
+
+        let logical_table = DistTable::table(Arc::new(metric_table_info(
+            LOGICAL_TABLE_ID,
+            "logical",
+            vec![],
+        )));
+        for _ in 0..2 {
+            let table = KvBackendCatalogManager::override_logical_table_partition_key_indices(
+                &table_route_cache,
+                &table_info_cache,
+                logical_table.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(table.table_info().meta.partition_key_indices, vec![1]);
+        }
+        assert_eq!(load_count.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request fixes repeated physical-table metadata loads when resolving logical Metric Engine tables by reusing the existing version-checked `table_info_cache`.

### Context

CPU profiling showed significant catalog work during Prometheus remote writes despite a high `table_cache` hit rate. The outer cache was working, but logical Metric Engine table resolution subsequently loaded the physical table metadata directly from the KV backend, bypassing `table_info_cache`.

This occurs after PRW v1 and v2 converge on the shared Metric Engine insertion path, so the issue affects both protocols and other callers resolving logical Metric Engine tables.

### Before

```text
PRW v1/v2
→ RowInsertRequests
→ PromStoreProtocolHandler::write_all()
→ Instance::execute_prom_store_write()
→ Inserter::handle_metric_row_inserts()
→ create_or_alter_tables_on_demand()
→ CatalogManager::table()
→ table_cache.get(logical table)                  [usually hits]
→ override_logical_table_partition_key_indices()
→ table_route_cache.get(logical table ID)
→ TableInfoManager::get(physical table ID)        [bypasses cache]
→ KV backend read
→ TableInfo JSON deserialization                  [repeated every lookup]
→ remap physical partition keys onto logical table
```

The streamed `CatalogManager::tables()` path had the same direct physical metadata lookup.

### After

```text
PRW v1/v2 and other logical-table callers
→ CatalogManager::table() / tables()
→ table_cache.get(logical table)
→ override_logical_table_partition_key_indices()
→ table_route_cache.get(logical table ID)
→ table_info_cache.get(physical table ID)
   ├─ cache hit: reuse Arc<TableInfo>
   └─ miss/invalidation: load once through the existing initializer
→ remap physical partition keys onto logical table
```

The change:

- Passes the existing `TableInfoCacheRef` into the partition-key override helper.
- Uses it from both single-table and streamed table-list paths.
- Reuses existing `CacheIdent::TableId` invalidation and version-checked loading.
- Adds a regression test proving two logical-table resolutions load physical metadata once while preserving the remapped partition keys.
- Adds no new cache, stored state, configuration, or abstraction.

### Profile comparison

Within the `remote_write` subtree:

| Path | Before | After | Change |
|---|---:|---:|---:|
| Physical `TableInfo` JSON decoding | 31 | 0 | −100% |

The targeted metadata hotspot is removed. Final logical-table cloning and partition-key remapping remain unchanged, and cache misses or invalidations still reload metadata as intended.

There are no public API, wire-format, persisted-data, schema, or configuration changes.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
