### PR TITLE
perf: reduce ingestion and flat-merge overhead

### DIFF
--- a/src/mito2/src/read/flat_merge.rs
+++ b/src/mito2/src/read/flat_merge.rs
@@ -512,6 +512,11 @@ impl RowCursor {
         self.offset >= self.columns.num_rows()
     }
 
+    /// Returns whether advancing this cursor will finish the current batch.
+    fn is_last_row(&self) -> bool {
+        self.offset.checked_add(1) == Some(self.columns.num_rows())
+    }
+
     fn advance(&mut self) {
         self.offset += 1;
     }
@@ -819,12 +824,15 @@ impl FlatMergeReader {
             }
         }
 
-        let start = Instant::now();
-        if let Some(next) = hottest.advance_row().await? {
+        // Only read the clock when advancing will attempt to fetch the next batch.
+        // Check first because `None` means either no fetch or EOF after a fetch attempt.
+        let start = hottest.current_cursor().is_last_row().then(Instant::now);
+        let next = hottest.advance_row().await?;
+        if let Some(start) = start {
             self.metrics.fetch_cost += start.elapsed();
+        }
+        if let Some(next) = next {
             self.in_progress.push_batch(hottest.node_index, next);
-        } else {
-            self.metrics.fetch_cost += start.elapsed();
         }
 
         self.algo.reheap(hottest);
@@ -1064,6 +1072,24 @@ mod tests {
 
     fn new_test_iter(batches: Vec<RecordBatch>) -> BoxedRecordBatchIterator {
         Box::new(batches.into_iter().map(Ok))
+    }
+
+    #[test]
+    fn test_row_cursor_last_row() {
+        let batch = create_test_record_batch(
+            &[b"k1", b"k1"],
+            &[1000, 2000],
+            &[21, 22],
+            &[OpType::Put, OpType::Put],
+            &[11, 12],
+        );
+        let mut cursor = RowCursor::new(SortColumns::new(&batch));
+
+        assert!(!cursor.is_last_row());
+        cursor.advance();
+        assert!(cursor.is_last_row());
+        cursor.advance();
+        assert!(!cursor.is_last_row());
     }
 
     /// Helper function to check if two record batches are equivalent.

--- a/src/servers/src/prom_remote_write/v2.rs
+++ b/src/servers/src/prom_remote_write/v2.rs
@@ -90,8 +90,7 @@ pub(crate) fn into_write_requests(request: Request) -> Result<RemoteWriteV2Write
 
     let mut sample_tables = HashMap::<PromCtx, HashMap<String, TableData>>::new();
     let mut histogram_tables = HashMap::<PromCtx, HashMap<String, TableData>>::new();
-    let mut sample_metrics = HashSet::<(PromCtx, String)>::new();
-    let mut histogram_metrics = HashSet::<(PromCtx, String)>::new();
+    let mut label_names = HashSet::new();
     let mut sample_count_total = 0;
     let mut histogram_count_total = 0;
 
@@ -103,31 +102,27 @@ pub(crate) fn into_write_requests(request: Request) -> Result<RemoteWriteV2Write
             continue;
         }
 
-        let (prom_ctx, table_name, tags) = resolve_series_labels(&symbols, &series)?;
+        let (prom_ctx, table_name, tags) =
+            resolve_series_labels(&symbols, &series, &mut label_names)?;
         ensure_no_internal_histogram_labels(&tags)?;
-        let metric_key = (prom_ctx.clone(), table_name.clone());
-        if sample_count > 0 {
-            ensure!(
-                !histogram_metrics.contains(&metric_key),
-                error::InvalidPromRemoteRequestSnafu {
-                    msg: format!(
-                        "remote write v2 metric `{table_name}` contains both samples and native histograms"
-                    ),
-                }
-            );
-            sample_metrics.insert(metric_key.clone());
-        }
-        if histogram_count > 0 {
-            ensure!(
-                !sample_metrics.contains(&metric_key),
-                error::InvalidPromRemoteRequestSnafu {
-                    msg: format!(
-                        "remote write v2 metric `{table_name}` contains both samples and native histograms"
-                    ),
-                }
-            );
-            histogram_metrics.insert(metric_key);
-        }
+        let has_other_value_type = if sample_count > 0 {
+            histogram_count > 0
+                || histogram_tables
+                    .get(&prom_ctx)
+                    .is_some_and(|tables| tables.contains_key(&table_name))
+        } else {
+            sample_tables
+                .get(&prom_ctx)
+                .is_some_and(|tables| tables.contains_key(&table_name))
+        };
+        ensure!(
+            !has_other_value_type,
+            error::InvalidPromRemoteRequestSnafu {
+                msg: format!(
+                    "remote write v2 metric `{table_name}` contains both samples and native histograms"
+                ),
+            }
+        );
 
         if sample_count > 0 && histogram_count == 0 {
             // Fast path for regular sample-only series. Move the resolved labels into
@@ -745,7 +740,11 @@ fn ensure_no_internal_histogram_labels(tags: &PromTags) -> Result<()> {
     Ok(())
 }
 
-fn resolve_series_labels(symbols: &[String], series: &TimeSeries) -> Result<ResolvedSeriesLabels> {
+fn resolve_series_labels<'a>(
+    symbols: &'a [String],
+    series: &TimeSeries,
+    label_names: &mut HashSet<&'a str>,
+) -> Result<ResolvedSeriesLabels> {
     ensure!(
         series.labels_refs.len().is_multiple_of(2),
         error::InvalidPromRemoteRequestSnafu {
@@ -756,7 +755,7 @@ fn resolve_series_labels(symbols: &[String], series: &TimeSeries) -> Result<Reso
     let mut prom_ctx = PromCtx::default();
     let mut table_name = None;
     let mut tags = Vec::with_capacity(series.labels_refs.len() / 2);
-    let mut label_names = HashSet::with_capacity(series.labels_refs.len() / 2);
+    label_names.clear();
 
     for pair in series.labels_refs.chunks_exact(2) {
         let name = symbol_ref(symbols, pair[0], "label name")?;
@@ -1449,6 +1448,26 @@ mod tests {
 
         assert_invalid(
             "same metric samples and histograms",
+            request,
+            "contains both samples and native histograms",
+        );
+
+        let mut request = test_util::request_with_labels_and_samples(
+            vec![(METRIC_NAME_LABEL, "metric")],
+            vec![Sample {
+                value: 1.0,
+                timestamp: 1000,
+                start_timestamp: 0,
+            }],
+        );
+        request.timeseries.push(TimeSeries {
+            labels_refs: request.timeseries[0].labels_refs.clone(),
+            histograms: vec![Histogram::default()],
+            ..Default::default()
+        });
+
+        assert_invalid(
+            "same metric samples and histograms across series",
             request,
             "contains both samples and native histograms",
         );

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use ahash::{HashMap as AHashMap, HashMapExt};
 use api::v1::column_data_type_extension::TypeExt;
 use api::v1::helper::time_index_column_schema;
 use api::v1::value::ValueData;
@@ -37,7 +38,7 @@ use crate::error::{
 pub struct TableData {
     schema: Vec<ColumnSchema>,
     rows: Vec<Row>,
-    column_indexes: HashMap<String, usize>,
+    column_indexes: AHashMap<String, usize>,
 }
 
 impl TableData {
@@ -45,7 +46,7 @@ impl TableData {
         Self {
             schema: Vec::with_capacity(num_columns),
             rows: Vec::with_capacity(num_rows),
-            column_indexes: HashMap::with_capacity(num_columns),
+            column_indexes: AHashMap::with_capacity(num_columns),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request improves ingestion and flat-merge performance by removing redundant hashing and allocations and avoiding per-row clock reads.

- **Column lookup:** Before, `TableData` used the standard `HashMap` hasher for frequent column-name lookups. After, its private index uses the existing AHash implementation.
- **PRW label validation:** Before, every time series allocated a new duplicate-label set. After, one request-scoped set is cleared and reused while keeping validation series-local.
- **PRW value-type validation:** Before, separate sample and histogram sets duplicated keys already stored in the output maps. After, conflicts are derived from those maps while preserving same-series and cross-series rejection.
- **Flat merge timing:** Before, every row advance read the clock and contributed to `fetch_cost`. After, timing occurs only when the last row triggers a next-batch fetch attempt.

The change does not modify public APIs, wire formats, persisted data, or ingestion results. `fetch_cost` now measures batch-fetch work rather than in-memory cursor advances.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
