### PR TITLE
test: rename internal bug numbers in tests to semantic names

### DIFF
--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -3017,12 +3017,12 @@ pub async fn test_prometheus_remote_write_with_pipeline(store_type: StorageType)
     guard.remove_all().await;
 }
 
-fn qx_077_schema_series(schema: &str, value: f64) -> TimeSeries {
+fn schema_series(schema: &str, value: f64) -> TimeSeries {
     TimeSeries {
         labels: vec![
             Label {
                 name: "__name__".to_string(),
-                value: "qx_077_schema_metric".to_string(),
+                value: "schema_metric".to_string(),
             },
             Label {
                 name: "__schema__".to_string(),
@@ -3041,10 +3041,10 @@ fn qx_077_schema_series(schema: &str, value: f64) -> TimeSeries {
     }
 }
 
-fn qx_077_schema_query(schema: Option<&str>) -> Query {
+fn schema_query(schema: Option<&str>) -> Query {
     let mut matchers = vec![LabelMatcher {
         name: "__name__".to_string(),
-        value: "qx_077_schema_metric".to_string(),
+        value: "schema_metric".to_string(),
         r#type: MatcherType::Eq as i32,
     }];
     if let Some(schema) = schema {
@@ -3063,7 +3063,7 @@ fn qx_077_schema_query(schema: Option<&str>) -> Query {
     }
 }
 
-async fn post_qx_077_remote_read(client: &TestClient, queries: Vec<Query>) -> ReadResponse {
+async fn post_remote_read(client: &TestClient, queries: Vec<Query>) -> ReadResponse {
     let read_request = ReadRequest {
         queries,
         ..Default::default()
@@ -3083,10 +3083,7 @@ async fn post_qx_077_remote_read(client: &TestClient, queries: Vec<Query>) -> Re
     ReadResponse::decode(decompressed_response.as_slice()).unwrap()
 }
 
-async fn post_qx_077_remote_read_from_schema_a(
-    client: &TestClient,
-    queries: Vec<Query>,
-) -> ReadResponse {
+async fn post_remote_read_from_schema_a(client: &TestClient, queries: Vec<Query>) -> ReadResponse {
     let read_request = ReadRequest {
         queries,
         ..Default::default()
@@ -3096,7 +3093,7 @@ async fn post_qx_077_remote_read_from_schema_a(
 
     let response = client
         .post("/v1/prometheus/read")
-        .header(GREPTIME_DB_HEADER_NAME.clone(), "qx_077_schema_a")
+        .header(GREPTIME_DB_HEADER_NAME.clone(), "schema_a")
         .body(compressed_request)
         .send()
         .await;
@@ -3107,7 +3104,7 @@ async fn post_qx_077_remote_read_from_schema_a(
     ReadResponse::decode(decompressed_response.as_slice()).unwrap()
 }
 
-fn qx_077_read_sample_values(read_response: ReadResponse) -> Vec<f64> {
+fn read_sample_values(read_response: ReadResponse) -> Vec<f64> {
     read_response
         .results
         .into_iter()
@@ -3127,8 +3124,8 @@ pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
         setup_test_prom_app_with_frontend(store_type, "test_prometheus_remote_schema_labels").await;
     let client = TestClient::new(app).await;
 
-    const SCHEMA_A: &str = "qx_077_schema_a";
-    const SCHEMA_B: &str = "qx_077_schema_b";
+    const SCHEMA_A: &str = "schema_a";
+    const SCHEMA_B: &str = "schema_b";
 
     for schema in [SCHEMA_A, SCHEMA_B] {
         let res = client
@@ -3142,8 +3139,8 @@ pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
     // Both series have the same metric, non-schema labels, and timestamp.
     let write_request = WriteRequest {
         timeseries: vec![
-            qx_077_schema_series(SCHEMA_A, 101.0),
-            qx_077_schema_series(SCHEMA_B, 202.0),
+            schema_series(SCHEMA_A, 101.0),
+            schema_series(SCHEMA_B, 202.0),
         ],
         ..Default::default()
     };
@@ -3160,36 +3157,26 @@ pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
 
     // Independent controls establish that each selector resolves its own schema.
     assert_eq!(
-        qx_077_read_sample_values(
-            post_qx_077_remote_read(&client, vec![qx_077_schema_query(Some(SCHEMA_A))]).await,
-        ),
+        read_sample_values(post_remote_read(&client, vec![schema_query(Some(SCHEMA_A))]).await,),
         vec![101.0]
     );
     assert_eq!(
-        qx_077_read_sample_values(
-            post_qx_077_remote_read(&client, vec![qx_077_schema_query(Some(SCHEMA_B))]).await,
-        ),
+        read_sample_values(post_remote_read(&client, vec![schema_query(Some(SCHEMA_B))]).await,),
         vec![202.0]
     );
 
     // Results must stay aligned with the request query order.
-    let forward_values = qx_077_read_sample_values(
-        post_qx_077_remote_read(
+    let forward_values = read_sample_values(
+        post_remote_read(
             &client,
-            vec![
-                qx_077_schema_query(Some(SCHEMA_A)),
-                qx_077_schema_query(Some(SCHEMA_B)),
-            ],
+            vec![schema_query(Some(SCHEMA_A)), schema_query(Some(SCHEMA_B))],
         )
         .await,
     );
-    let reverse_values = qx_077_read_sample_values(
-        post_qx_077_remote_read(
+    let reverse_values = read_sample_values(
+        post_remote_read(
             &client,
-            vec![
-                qx_077_schema_query(Some(SCHEMA_B)),
-                qx_077_schema_query(Some(SCHEMA_A)),
-            ],
+            vec![schema_query(Some(SCHEMA_B)), schema_query(Some(SCHEMA_A))],
         )
         .await,
     );
@@ -3199,23 +3186,17 @@ pub async fn test_prometheus_remote_schema_labels(store_type: StorageType) {
     );
 
     // With request database A, unqualified queries must resolve to A independently.
-    let explicit_then_default_values = qx_077_read_sample_values(
-        post_qx_077_remote_read_from_schema_a(
+    let explicit_then_default_values = read_sample_values(
+        post_remote_read_from_schema_a(
             &client,
-            vec![
-                qx_077_schema_query(Some(SCHEMA_B)),
-                qx_077_schema_query(None),
-            ],
+            vec![schema_query(Some(SCHEMA_B)), schema_query(None)],
         )
         .await,
     );
-    let default_then_explicit_values = qx_077_read_sample_values(
-        post_qx_077_remote_read_from_schema_a(
+    let default_then_explicit_values = read_sample_values(
+        post_remote_read_from_schema_a(
             &client,
-            vec![
-                qx_077_schema_query(None),
-                qx_077_schema_query(Some(SCHEMA_B)),
-            ],
+            vec![schema_query(None), schema_query(Some(SCHEMA_B))],
         )
         .await,
     );

--- a/tests/cases/standalone/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/copy/copy_from_fs_parquet.result
@@ -243,32 +243,32 @@ drop table demo_with_less_columns;
 
 Affected Rows: 0
 
--- QX-083: COPY FROM Parquet honors LIMIT for a single file.
-CREATE TABLE qx_083_copy_limit_source(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+-- COPY FROM Parquet honors LIMIT for a single file.
+CREATE TABLE copy_limit_source(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
 
-INSERT INTO qx_083_copy_limit_source VALUES
+INSERT INTO copy_limit_source VALUES
     (1, 1704067200000),
     (2, 1704067201000),
     (3, 1704067202000);
 
 Affected Rows: 3
 
-COPY qx_083_copy_limit_source TO '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet');
+COPY copy_limit_source TO '${SQLNESS_HOME}/copy_limit.parquet' WITH (format='parquet');
 
 Affected Rows: 3
 
 -- LIMIT 0 control: affected rows 0; count 0.
-CREATE TABLE qx_083_copy_limit_limit_0(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+CREATE TABLE copy_limit_limit_0(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
 
-COPY qx_083_copy_limit_limit_0 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 0;
+COPY copy_limit_limit_0 FROM '${SQLNESS_HOME}/copy_limit.parquet' WITH (format='parquet') LIMIT 0;
 
 Affected Rows: 0
 
-SELECT count(*) FROM qx_083_copy_limit_limit_0;
+SELECT count(*) FROM copy_limit_limit_0;
 
 +----------+
 | count(*) |
@@ -277,15 +277,15 @@ SELECT count(*) FROM qx_083_copy_limit_limit_0;
 +----------+
 
 -- LIMIT 1 target: affected rows 1; count 1.
-CREATE TABLE qx_083_copy_limit_limit_1(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+CREATE TABLE copy_limit_limit_1(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
 
-COPY qx_083_copy_limit_limit_1 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 1;
+COPY copy_limit_limit_1 FROM '${SQLNESS_HOME}/copy_limit.parquet' WITH (format='parquet') LIMIT 1;
 
 Affected Rows: 1
 
-SELECT count(*) FROM qx_083_copy_limit_limit_1;
+SELECT count(*) FROM copy_limit_limit_1;
 
 +----------+
 | count(*) |
@@ -294,15 +294,15 @@ SELECT count(*) FROM qx_083_copy_limit_limit_1;
 +----------+
 
 -- Cross-file LIMIT 4 target: affected rows 4; count 4.
-CREATE TABLE qx_083_copy_limit_cross_file(host string, cpu double, memory double, ts TIMESTAMP TIME INDEX);
+CREATE TABLE copy_limit_cross_file(host string, cpu double, memory double, ts TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
 
-COPY qx_083_copy_limit_cross_file FROM '${SQLNESS_HOME}/demo/export/parquet_files/' WITH (start_time='2022-06-15 07:02:36') LIMIT 4;
+COPY copy_limit_cross_file FROM '${SQLNESS_HOME}/demo/export/parquet_files/' WITH (start_time='2022-06-15 07:02:36') LIMIT 4;
 
 Affected Rows: 4
 
-SELECT count(*) FROM qx_083_copy_limit_cross_file;
+SELECT count(*) FROM copy_limit_cross_file;
 
 +----------+
 | count(*) |
@@ -310,19 +310,19 @@ SELECT count(*) FROM qx_083_copy_limit_cross_file;
 | 4        |
 +----------+
 
-DROP TABLE qx_083_copy_limit_source;
+DROP TABLE copy_limit_source;
 
 Affected Rows: 0
 
-DROP TABLE qx_083_copy_limit_limit_0;
+DROP TABLE copy_limit_limit_0;
 
 Affected Rows: 0
 
-DROP TABLE qx_083_copy_limit_limit_1;
+DROP TABLE copy_limit_limit_1;
 
 Affected Rows: 0
 
-DROP TABLE qx_083_copy_limit_cross_file;
+DROP TABLE copy_limit_cross_file;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/copy/copy_from_fs_parquet.sql
+++ b/tests/cases/standalone/copy/copy_from_fs_parquet.sql
@@ -100,41 +100,41 @@ drop table demo_with_external_column;
 
 drop table demo_with_less_columns;
 
--- QX-083: COPY FROM Parquet honors LIMIT for a single file.
-CREATE TABLE qx_083_copy_limit_source(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+-- COPY FROM Parquet honors LIMIT for a single file.
+CREATE TABLE copy_limit_source(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
 
-INSERT INTO qx_083_copy_limit_source VALUES
+INSERT INTO copy_limit_source VALUES
     (1, 1704067200000),
     (2, 1704067201000),
     (3, 1704067202000);
 
-COPY qx_083_copy_limit_source TO '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet');
+COPY copy_limit_source TO '${SQLNESS_HOME}/copy_limit.parquet' WITH (format='parquet');
 
 -- LIMIT 0 control: affected rows 0; count 0.
-CREATE TABLE qx_083_copy_limit_limit_0(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+CREATE TABLE copy_limit_limit_0(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
 
-COPY qx_083_copy_limit_limit_0 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 0;
+COPY copy_limit_limit_0 FROM '${SQLNESS_HOME}/copy_limit.parquet' WITH (format='parquet') LIMIT 0;
 
-SELECT count(*) FROM qx_083_copy_limit_limit_0;
+SELECT count(*) FROM copy_limit_limit_0;
 
 -- LIMIT 1 target: affected rows 1; count 1.
-CREATE TABLE qx_083_copy_limit_limit_1(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
+CREATE TABLE copy_limit_limit_1(pk_col INTEGER PRIMARY KEY, ts TIMESTAMP TIME INDEX);
 
-COPY qx_083_copy_limit_limit_1 FROM '${SQLNESS_HOME}/qx_083_copy_limit.parquet' WITH (format='parquet') LIMIT 1;
+COPY copy_limit_limit_1 FROM '${SQLNESS_HOME}/copy_limit.parquet' WITH (format='parquet') LIMIT 1;
 
-SELECT count(*) FROM qx_083_copy_limit_limit_1;
+SELECT count(*) FROM copy_limit_limit_1;
 
 -- Cross-file LIMIT 4 target: affected rows 4; count 4.
-CREATE TABLE qx_083_copy_limit_cross_file(host string, cpu double, memory double, ts TIMESTAMP TIME INDEX);
+CREATE TABLE copy_limit_cross_file(host string, cpu double, memory double, ts TIMESTAMP TIME INDEX);
 
-COPY qx_083_copy_limit_cross_file FROM '${SQLNESS_HOME}/demo/export/parquet_files/' WITH (start_time='2022-06-15 07:02:36') LIMIT 4;
+COPY copy_limit_cross_file FROM '${SQLNESS_HOME}/demo/export/parquet_files/' WITH (start_time='2022-06-15 07:02:36') LIMIT 4;
 
-SELECT count(*) FROM qx_083_copy_limit_cross_file;
+SELECT count(*) FROM copy_limit_cross_file;
 
-DROP TABLE qx_083_copy_limit_source;
+DROP TABLE copy_limit_source;
 
-DROP TABLE qx_083_copy_limit_limit_0;
+DROP TABLE copy_limit_limit_0;
 
-DROP TABLE qx_083_copy_limit_limit_1;
+DROP TABLE copy_limit_limit_1;
 
-DROP TABLE qx_083_copy_limit_cross_file;
+DROP TABLE copy_limit_cross_file;


### PR DESCRIPTION
## What

Renames internal bug identifiers used as test helper names, table names, and string literals to semantic names:

- `tests-integration/tests/http.rs`: helper fns `schema_series`/`schema_query`/`post_remote_read`/`post_remote_read_from_schema_a`/`read_sample_values`, metric `schema_metric`, schema consts `schema_a`/`schema_b`
- `tests/cases/standalone/copy/copy_from_fs_parquet.{sql,result}`: tables `copy_limit_source`/`copy_limit_limit_0`/`copy_limit_limit_1`/`copy_limit_cross_file`, parquet file `copy_limit.parquet`, comment describing COPY FROM LIMIT behavior

## Why

Internal bug identifiers should not appear in public code/tests.

## Checklist

- [x] I have signed off my commits (git commit -s)
- [x] No internal issue numbers referenced in code