### PR TITLE
fix(function): stop CountHash convert_to_state merging raw values as hash-v1 state

### DIFF
--- a/src/common/function/src/aggrs/count_hash.rs
+++ b/src/common/function/src/aggrs/count_hash.rs
@@ -35,7 +35,6 @@ use datafusion_expr::{
     Accumulator, AggregateUDF, AggregateUDFImpl, EmitTo, GroupsAccumulator, ReversedUDAF,
     SetMonotonicity, Signature, TypeSignature, Volatility,
 };
-use datafusion_functions_aggregate_common::aggregate::groups_accumulator::nulls::filtered_null_mask;
 use datatypes::arrow;
 use datatypes::arrow::array::{
     Array, ArrayRef, AsArray, BooleanArray, Int64Array, ListArray, UInt64Array,
@@ -343,31 +342,6 @@ impl GroupsAccumulator for CountHashGroupAccumulator {
         Ok(vec![Arc::new(list_array) as _])
     }
 
-    fn convert_to_state(
-        &self,
-        values: &[ArrayRef],
-        opt_filter: Option<&BooleanArray>,
-    ) -> Result<Vec<ArrayRef>> {
-        // For a single hash value per row, create a list array with that value
-        assert_eq!(values.len(), 1, "count_hash expects a single argument");
-        let values = ArrayRef::clone(&values[0]);
-
-        let offsets = OffsetBuffer::new(ScalarBuffer::from_iter(0..values.len() as i32 + 1));
-        let nulls = filtered_null_mask(opt_filter, &values);
-        let list_array = ListArray::new(
-            Arc::new(Field::new_list_field(DataType::UInt64, true)),
-            offsets,
-            values,
-            nulls,
-        );
-
-        Ok(vec![Arc::new(list_array)])
-    }
-
-    fn supports_convert_to_state(&self) -> bool {
-        true
-    }
-
     fn size(&self) -> usize {
         // Base size of the struct
         let mut size = size_of::<Self>();
@@ -470,8 +444,22 @@ impl Accumulator for CountHashAccumulator {
 }
 
 #[cfg(test)]
+#[path = "count_hash/hash_v1_fixture.rs"]
+mod hash_v1_fixture;
+
+#[cfg(test)]
 mod tests {
-    use datatypes::arrow::array::{Array, BooleanArray, Int32Array, Int64Array};
+    use std::collections::BTreeMap;
+
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::execution::TaskContext;
+    use datafusion::physical_expr::aggregate::AggregateExprBuilder;
+    use datafusion::physical_expr::expressions::col;
+    use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+    use datafusion::physical_plan::{ExecutionPlan, collect, collect_partitioned};
+    use datatypes::arrow::array::{Array, BooleanArray, Int32Array, Int64Array, StringArray};
+    use datatypes::arrow::datatypes::Schema;
+    use datatypes::arrow::record_batch::RecordBatch;
 
     use super::*;
 
@@ -553,6 +541,194 @@ mod tests {
 
     fn create_test_group_accumulator() -> CountHashGroupAccumulator {
         CountHashGroupAccumulator::new()
+    }
+
+    async fn execute_partial_final_count_hash(
+        input_partitions: &[Vec<RecordBatch>],
+        schema: Arc<Schema>,
+    ) -> Result<(BTreeMap<i32, i64>, usize)> {
+        let mut context = TaskContext::default();
+        let mut config = context.session_config().clone();
+        config = config.set(
+            "datafusion.execution.skip_partial_aggregation_probe_rows_threshold",
+            &ScalarValue::UInt64(Some(4)),
+        );
+        config = config.set(
+            "datafusion.execution.skip_partial_aggregation_probe_ratio_threshold",
+            &ScalarValue::Float64(Some(0.75)),
+        );
+        context = context.with_session_config(config);
+        let context = Arc::new(context);
+
+        let group_by = PhysicalGroupBy::new_single(vec![(col("group", &schema)?, "group".into())]);
+        let aggregate = Arc::new(
+            AggregateExprBuilder::new(
+                Arc::new(CountHash::udf_impl()),
+                vec![col("value", &schema)?],
+            )
+            .schema(Arc::clone(&schema))
+            .alias("count_hash")
+            .build()?,
+        );
+        let partial_input =
+            MemorySourceConfig::try_new_exec(input_partitions, Arc::clone(&schema), None)?;
+        let partial = Arc::new(AggregateExec::try_new(
+            AggregateMode::Partial,
+            group_by,
+            vec![Arc::clone(&aggregate)],
+            vec![Some(col("filter", &schema)?)],
+            partial_input,
+            Arc::clone(&schema),
+        )?);
+        let partial_batches = collect_partitioned(Arc::clone(&partial) as _, Arc::clone(&context))
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let skipped_rows = partial
+            .metrics()
+            .and_then(|metrics| metrics.sum_by_name("skipped_aggregation_rows"))
+            .map(|metric| metric.as_usize())
+            .unwrap_or(0);
+
+        let final_input =
+            MemorySourceConfig::try_new_exec(&[partial_batches], partial.schema(), None)?;
+        let final_group_by =
+            PhysicalGroupBy::new_single(vec![(col("group", &partial.schema())?, "group".into())]);
+        let final_aggregate = Arc::new(
+            AggregateExprBuilder::new(
+                Arc::new(CountHash::udf_impl()),
+                vec![col("value", &schema)?],
+            )
+            .schema(Arc::clone(&schema))
+            .alias("count_hash")
+            .build()?,
+        );
+        let final_exec = Arc::new(AggregateExec::try_new(
+            AggregateMode::Final,
+            final_group_by,
+            vec![final_aggregate],
+            vec![None],
+            final_input,
+            schema,
+        )?);
+        let batches = collect(final_exec, context).await?;
+        let mut results = BTreeMap::new();
+        for batch in batches {
+            let groups = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let counts = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            for row in 0..batch.num_rows() {
+                results.insert(groups.value(row), counts.value(row));
+            }
+        }
+        Ok((results, skipped_rows))
+    }
+
+    fn count_hash_probe_batches(schema: Arc<Schema>) -> Result<Vec<Vec<RecordBatch>>> {
+        let batch = || {
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                    Arc::new(UInt64Array::from(vec![
+                        Some(7),
+                        Some(8),
+                        None,
+                        Some(9),
+                        Some(10),
+                    ])),
+                    Arc::new(BooleanArray::from(vec![
+                        Some(true),
+                        Some(true),
+                        Some(true),
+                        Some(false),
+                        None,
+                    ])),
+                ],
+            )
+        };
+        Ok(vec![vec![batch()?, batch()?], vec![batch()?, batch()?]])
+    }
+
+    fn count_hash_string_probe_batches(schema: Arc<Schema>) -> Result<Vec<Vec<RecordBatch>>> {
+        let batch = || {
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                    Arc::new(StringArray::from(vec![
+                        Some("same"),
+                        Some("other"),
+                        None,
+                        Some("filtered"),
+                        Some("null-filter"),
+                    ])),
+                    Arc::new(BooleanArray::from(vec![
+                        Some(true),
+                        Some(true),
+                        Some(true),
+                        Some(false),
+                        None,
+                    ])),
+                ],
+            )
+        };
+        Ok(vec![vec![batch()?, batch()?], vec![batch()?, batch()?]])
+    }
+
+    #[tokio::test]
+    async fn test_count_hash_row_hash_partial_final_skip_contract() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("group", DataType::Int32, false),
+            Field::new("value", DataType::UInt64, true),
+            Field::new("filter", DataType::Boolean, true),
+        ]));
+        let (results, skipped_rows) = execute_partial_final_count_hash(
+            &count_hash_probe_batches(Arc::clone(&schema))?,
+            schema,
+        )
+        .await?;
+        assert!(!create_test_group_accumulator().supports_convert_to_state());
+        assert_eq!(skipped_rows, 0);
+        assert_eq!(
+            results,
+            BTreeMap::from([(1, 1), (2, 1), (3, 0), (4, 0), (5, 0)])
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_count_hash_row_hash_partial_final_skip_contract_non_uint64() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("group", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, true),
+            Field::new("filter", DataType::Boolean, true),
+        ]));
+        let (results, skipped_rows) = execute_partial_final_count_hash(
+            &count_hash_string_probe_batches(Arc::clone(&schema))?,
+            schema,
+        )
+        .await?;
+        assert_eq!(skipped_rows, 0);
+        assert_eq!(
+            results,
+            BTreeMap::from([(1, 1), (2, 1), (3, 0), (4, 0), (5, 0)])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_count_hash_group_accumulator_does_not_support_convert_to_state() {
+        let acc = create_test_group_accumulator();
+        assert!(!acc.supports_convert_to_state());
     }
 
     #[test]
@@ -643,5 +819,87 @@ mod tests {
         let acc = create_test_group_accumulator();
         // Just test it doesn't crash and returns a value.
         assert!(acc.size() > 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Regression harness: on this fixed branch convert_to_state is
+    // unsupported (overrides were deleted, the GroupsAccumulator trait
+    // defaults return false / Err), so the double-count case and the
+    // false-filter case skip via the Err arm and the non-UInt64 case observes
+    // the unwrap panic — all three must PASS here.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn convert_to_state_merge_double_counts_normal_skip() -> Result<()> {
+        // A partial (hashed) state merged together with a convert_to_state
+        // state double-counts every input row: raw values {1,2,3} are treated
+        // as additional distinct hashes on top of {hash(1), hash(2), hash(3)}.
+        let mut acc = create_test_group_accumulator();
+        let values = Arc::new(UInt64Array::from(vec![1u64, 2, 3])) as ArrayRef;
+        acc.update_batch(&[values.clone()], &[0, 0, 0], None, 1)?;
+        // Hashed state: distinct_sets[0] = {hash(1), hash(2), hash(3)}
+        let hashed_state = acc.state(EmitTo::All)?;
+
+        let converter = create_test_group_accumulator();
+        let raw_state = match converter.convert_to_state(&[values], None) {
+            Ok(state) => state,
+            // Fixed builds no longer support convert_to_state: nothing to check.
+            Err(_) => return Ok(()),
+        };
+
+        let mut merged = create_test_group_accumulator();
+        merged.merge_batch(&hashed_state, &[0], None, 1)?;
+        merged.merge_batch(&raw_state, &[0], None, 1)?;
+
+        let result = merged.evaluate(EmitTo::All)?;
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        // BUG: raw {1,2,3} are inserted as hashes -> count is 6, not 3.
+        assert_eq!(result.value(0), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn convert_to_state_non_uint64_panics() {
+        // convert_to_state accepts any input type and builds a ListArray whose
+        // field claims UInt64 while the inner array is Int32. The mismatch
+        // panics (ListArray construction assert, or the unchecked UInt64
+        // downcast inside merge_batch). A fixed build rejects
+        // convert_to_state outright, and unwrapping that Err also panics.
+        let mut acc = create_test_group_accumulator();
+        let values = Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let state = acc.convert_to_state(&[values], None).unwrap();
+            // If construction did not panic, merging must hit the typed unwrap.
+            let _ = acc.merge_batch(&state, &[0], None, 1);
+        }));
+        assert!(
+            result.is_err(),
+            "expected a panic for non-UInt64 convert_to_state input"
+        );
+    }
+
+    #[test]
+    fn convert_to_state_false_filter_not_applied() -> Result<()> {
+        // convert_to_state encodes the filter as a null mask, but merge_batch
+        // never checks outer list validity; with the dense offsets built by
+        // convert_to_state, the filtered-out row's value still lands in the
+        // distinct set.
+        let acc = create_test_group_accumulator();
+        let values = Arc::new(UInt64Array::from(vec![1u64, 2, 3])) as ArrayRef;
+        let filter = BooleanArray::from(vec![true, false, true]);
+        let raw_state = match acc.convert_to_state(&[values], Some(&filter)) {
+            Ok(state) => state,
+            // Fixed builds no longer support convert_to_state: nothing to check.
+            Err(_) => return Ok(()),
+        };
+
+        let mut merged = create_test_group_accumulator();
+        merged.merge_batch(&raw_state, &[0, 0, 0], None, 1)?;
+
+        let result = merged.evaluate(EmitTo::All)?;
+        let result = result.as_any().downcast_ref::<Int64Array>().unwrap();
+        // Only rows 0 and 2 pass the filter -> expected 2; buggy build yields 3.
+        assert_eq!(result.value(0), 2);
+        Ok(())
     }
 }

--- a/src/common/function/src/aggrs/count_hash.rs
+++ b/src/common/function/src/aggrs/count_hash.rs
@@ -836,7 +836,7 @@ mod tests {
         // as additional distinct hashes on top of {hash(1), hash(2), hash(3)}.
         let mut acc = create_test_group_accumulator();
         let values = Arc::new(UInt64Array::from(vec![1u64, 2, 3])) as ArrayRef;
-        acc.update_batch(&[values.clone()], &[0, 0, 0], None, 1)?;
+        acc.update_batch(std::slice::from_ref(&values), &[0, 0, 0], None, 1)?;
         // Hashed state: distinct_sets[0] = {hash(1), hash(2), hash(3)}
         let hashed_state = acc.state(EmitTo::All)?;
 

--- a/src/common/function/src/aggrs/count_hash/hash_v1_fixture.rs
+++ b/src/common/function/src/aggrs/count_hash/hash_v1_fixture.rs
@@ -921,13 +921,14 @@ fn build_nested_cases() -> Result<Vec<FlatCase>> {
         map.slice(1, 3)
     );
 
-    let union_fields = UnionFields::new(
+    let union_fields = UnionFields::try_new(
         vec![0, 1],
         vec![
             Arc::new(Field::new("i", DataType::Int32, true)),
             Arc::new(Field::new("s", DataType::Utf8, true)),
         ],
-    );
+    )
+    .unwrap();
     let dense = UnionArray::try_new(
         union_fields.clone(),
         ScalarBuffer::from(vec![0i8, 1, 0, 1, 0]),

--- a/src/common/function/src/aggrs/count_hash/hash_v1_fixture.rs
+++ b/src/common/function/src/aggrs/count_hash/hash_v1_fixture.rs
@@ -1,0 +1,1121 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Frozen DataFusion 53 hash-v1 fixture generation and verification.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::{env, fs};
+
+use ahash::RandomState;
+use datafusion_common::error::Result;
+use datafusion_common::hash_utils::create_hashes;
+use datafusion_expr::{Accumulator, EmitTo, GroupsAccumulator};
+use datatypes::arrow::array::*;
+use datatypes::arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+use datatypes::arrow::datatypes::{i256, *};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::{
+    CountHashAccumulator, CountHashGroupAccumulator, RANDOM_SEED_0, RANDOM_SEED_1, RANDOM_SEED_2,
+    RANDOM_SEED_3,
+};
+
+const FIXTURE_ENV: &str = "GREPTIME_COUNT_HASH_FIXTURE_OUT";
+const FIXTURE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/count_hash_hash_v1.json"
+);
+const FLAT_CASE_IDS: &[&str] = &[
+    "null",
+    "boolean",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "float16-bits",
+    "float32-bits",
+    "float64-bits",
+    "decimal32",
+    "decimal64",
+    "decimal128",
+    "decimal256",
+    "date32",
+    "date64",
+    "time32-second",
+    "time32-millisecond",
+    "time64-microsecond",
+    "time64-nanosecond",
+    "timestamp-second",
+    "timestamp-second-utc",
+    "timestamp-millisecond",
+    "timestamp-millisecond-utc",
+    "timestamp-microsecond",
+    "timestamp-microsecond-utc",
+    "timestamp-nanosecond",
+    "timestamp-nanosecond-utc",
+    "duration-second",
+    "duration-millisecond",
+    "duration-microsecond",
+    "duration-nanosecond",
+    "interval-year-month",
+    "interval-day-time",
+    "interval-month-day-nano",
+    "utf8",
+    "large-utf8",
+    "utf8-view",
+    "binary",
+    "large-binary",
+    "binary-view",
+    "fixed-size-binary",
+    "dictionary-int8",
+    "dictionary-int16",
+    "dictionary-int32",
+    "dictionary-int64",
+    "dictionary-uint8",
+    "dictionary-uint16",
+    "dictionary-uint32",
+    "dictionary-uint64",
+];
+const NESTED_CASE_IDS: &[&str] = &[
+    "struct",
+    "struct-sliced",
+    "list",
+    "list-sliced",
+    "large-list",
+    "nested-list",
+    "list-view",
+    "large-list-view",
+    "fixed-size-list",
+    "fixed-size-list-empty",
+    "fixed-size-list-sliced",
+    "map",
+    "map-sliced",
+    "union-dense",
+    "union-dense-sliced",
+    "union-sparse",
+    "union-sparse-sliced",
+    "ree-int16",
+    "ree-int16-sliced",
+    "ree-int32",
+    "ree-int32-sliced",
+    "ree-int64",
+    "ree-int64-sliced",
+];
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct Fixture {
+    format: String,
+    metadata: Metadata,
+    int64: Int64Case,
+    flat_cases: Vec<FlatCase>,
+    nested_cases: Vec<FlatCase>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct Metadata {
+    greptime_commit: String,
+    datafusion_commit: String,
+    hash_utils_blob: String,
+    ahash_version: String,
+    arrow_version: String,
+    seeds_hex: Vec<String>,
+    target_endianness: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct Int64Case {
+    logical_inputs: Vec<Option<i64>>,
+    slot_hashes: Vec<String>,
+    null_handling: NullHandling,
+    scalar_partial_states: Vec<ScalarPartialState>,
+    grouped: GroupedCase,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct NullHandling {
+    create_hashes: String,
+    scalar_accumulator: String,
+    grouped_accumulator: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct ScalarPartialState {
+    logical_inputs: Vec<i64>,
+    sorted_hashes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct GroupedCase {
+    group_indices: Vec<usize>,
+    filter: Vec<Option<bool>>,
+    total_num_groups: usize,
+    sorted_group_states: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct FlatCase {
+    id: String,
+    arrow_type: String,
+    logical_inputs: Value,
+    slot_hashes: Vec<String>,
+}
+
+fn random_state() -> RandomState {
+    RandomState::with_seeds(RANDOM_SEED_0, RANDOM_SEED_1, RANDOM_SEED_2, RANDOM_SEED_3)
+}
+
+fn int64_array(values: Vec<Option<i64>>) -> ArrayRef {
+    Arc::new(Int64Array::from(values))
+}
+
+fn hashes(values: ArrayRef) -> Result<Vec<String>> {
+    let mut output = vec![0; values.len()];
+    create_hashes(&[values], &random_state(), &mut output)?;
+    Ok(output.into_iter().map(|hash| hash.to_string()).collect())
+}
+
+fn flat_case(
+    id: &str,
+    arrow_type: &str,
+    logical_inputs: Value,
+    array: ArrayRef,
+) -> Result<FlatCase> {
+    Ok(FlatCase {
+        id: id.to_string(),
+        arrow_type: arrow_type.to_string(),
+        logical_inputs,
+        slot_hashes: hashes(array)?,
+    })
+}
+
+fn sorted_scalar_state(accumulator: &mut CountHashAccumulator) -> Result<Vec<String>> {
+    let state = accumulator.state()?;
+    let array = state[0].to_array()?;
+    let list = array.as_any().downcast_ref::<ListArray>().unwrap();
+    let hashes = list.value(0);
+    let hashes = hashes.as_any().downcast_ref::<UInt64Array>().unwrap();
+    let mut result = hashes.values().to_vec();
+    result.sort_unstable();
+    Ok(result.into_iter().map(|hash| hash.to_string()).collect())
+}
+
+fn scalar_partial_state(values: Vec<i64>) -> Result<ScalarPartialState> {
+    let mut accumulator = CountHashAccumulator {
+        values: Default::default(),
+        random_state: random_state(),
+        batch_hashes: vec![],
+    };
+    accumulator.update_batch(&[int64_array(values.iter().copied().map(Some).collect())])?;
+
+    Ok(ScalarPartialState {
+        logical_inputs: values,
+        sorted_hashes: sorted_scalar_state(&mut accumulator)?,
+    })
+}
+
+fn sorted_group_states(accumulator: &mut CountHashGroupAccumulator) -> Result<Vec<Vec<String>>> {
+    let state = accumulator.state(EmitTo::All)?;
+    let list = state[0].as_any().downcast_ref::<ListArray>().unwrap();
+    let mut result = Vec::with_capacity(list.len());
+
+    for index in 0..list.len() {
+        let hashes = list.value(index);
+        let hashes = hashes.as_any().downcast_ref::<UInt64Array>().unwrap();
+        let mut group = hashes.values().to_vec();
+        group.sort_unstable();
+        result.push(group.into_iter().map(|hash| hash.to_string()).collect());
+    }
+
+    Ok(result)
+}
+
+fn build_flat_cases() -> Result<Vec<FlatCase>> {
+    let mut cases = Vec::new();
+    macro_rules! push_case {
+        ($id:expr, $ty:expr, $logical:expr, $array:expr) => {
+            cases.push(flat_case($id, $ty, $logical, Arc::new($array))?);
+        };
+    }
+
+    push_case!("null", "Null", json!([null, null, null]), NullArray::new(3));
+    push_case!(
+        "boolean",
+        "Boolean",
+        json!([true, false, null, true]),
+        BooleanArray::from(vec![Some(true), Some(false), None, Some(true)])
+    );
+
+    push_case!(
+        "int8",
+        "Int8",
+        json!(["-128", "0", "127", null]),
+        Int8Array::from(vec![Some(-128), Some(0), Some(127), None])
+    );
+    push_case!(
+        "int16",
+        "Int16",
+        json!(["-32768", "0", "32767", null]),
+        Int16Array::from(vec![Some(-32768), Some(0), Some(32767), None])
+    );
+    push_case!(
+        "int32",
+        "Int32",
+        json!(["-2147483648", "0", "2147483647", null]),
+        Int32Array::from(vec![Some(i32::MIN), Some(0), Some(i32::MAX), None])
+    );
+    push_case!(
+        "int64",
+        "Int64",
+        json!(["-9223372036854775808", "0", "9223372036854775807", null]),
+        Int64Array::from(vec![Some(i64::MIN), Some(0), Some(i64::MAX), None])
+    );
+    push_case!(
+        "uint8",
+        "UInt8",
+        json!(["0", "1", "255", null]),
+        UInt8Array::from(vec![Some(0), Some(1), Some(u8::MAX), None])
+    );
+    push_case!(
+        "uint16",
+        "UInt16",
+        json!(["0", "1", "65535", null]),
+        UInt16Array::from(vec![Some(0), Some(1), Some(u16::MAX), None])
+    );
+    push_case!(
+        "uint32",
+        "UInt32",
+        json!(["0", "1", "4294967295", null]),
+        UInt32Array::from(vec![Some(0), Some(1), Some(u32::MAX), None])
+    );
+    push_case!(
+        "uint64",
+        "UInt64",
+        json!(["0", "1", "18446744073709551615", null]),
+        UInt64Array::from(vec![Some(0), Some(1), Some(u64::MAX), None])
+    );
+
+    let f16 = |bits| <Float16Type as ArrowPrimitiveType>::Native::from_bits(bits);
+    push_case!(
+        "float16-bits",
+        "Float16",
+        json!([
+            "0x0000", "0x8000", "0x7c00", "0xfc00", "0x7e01", "0x7e02", "0x3e00", null
+        ]),
+        Float16Array::from(vec![
+            Some(f16(0)),
+            Some(f16(0x8000)),
+            Some(f16(0x7c00)),
+            Some(f16(0xfc00)),
+            Some(f16(0x7e01)),
+            Some(f16(0x7e02)),
+            Some(f16(0x3e00)),
+            None
+        ])
+    );
+    push_case!(
+        "float32-bits",
+        "Float32",
+        json!([
+            "0x00000000",
+            "0x80000000",
+            "0x7f800000",
+            "0xff800000",
+            "0x7fc00001",
+            "0x7fc00002",
+            "0x3fc00000",
+            null
+        ]),
+        Float32Array::from(vec![
+            Some(f32::from_bits(0)),
+            Some(f32::from_bits(0x80000000)),
+            Some(f32::INFINITY),
+            Some(f32::NEG_INFINITY),
+            Some(f32::from_bits(0x7fc00001)),
+            Some(f32::from_bits(0x7fc00002)),
+            Some(1.5),
+            None
+        ])
+    );
+    push_case!(
+        "float64-bits",
+        "Float64",
+        json!([
+            "0x0000000000000000",
+            "0x8000000000000000",
+            "0x7ff0000000000000",
+            "0xfff0000000000000",
+            "0x7ff8000000000001",
+            "0x7ff8000000000002",
+            "0x3ff8000000000000",
+            null
+        ]),
+        Float64Array::from(vec![
+            Some(f64::from_bits(0)),
+            Some(f64::from_bits(0x8000000000000000)),
+            Some(f64::INFINITY),
+            Some(f64::NEG_INFINITY),
+            Some(f64::from_bits(0x7ff8000000000001)),
+            Some(f64::from_bits(0x7ff8000000000002)),
+            Some(1.5),
+            None
+        ])
+    );
+
+    push_case!(
+        "decimal32",
+        "Decimal32(9, 2)",
+        json!({"precision":9,"scale":2,"values":["-12345","0","67890",null]}),
+        Decimal32Array::from(vec![Some(-12345), Some(0), Some(67890), None])
+            .with_precision_and_scale(9, 2)
+            .unwrap()
+    );
+    push_case!(
+        "decimal64",
+        "Decimal64(18, 4)",
+        json!({"precision":18,"scale":4,"values":["-12345678901234","0","67890123456789",null]}),
+        Decimal64Array::from(vec![
+            Some(-12345678901234),
+            Some(0),
+            Some(67890123456789),
+            None
+        ])
+        .with_precision_and_scale(18, 4)
+        .unwrap()
+    );
+    push_case!(
+        "decimal128",
+        "Decimal128(30, 6)",
+        json!({"precision":30,"scale":6,"values":["-123456789012345678901234","0","678901234567890123456789",null]}),
+        Decimal128Array::from(vec![
+            Some(-123456789012345678901234i128),
+            Some(0),
+            Some(678901234567890123456789i128),
+            None
+        ])
+        .with_precision_and_scale(30, 6)
+        .unwrap()
+    );
+    push_case!(
+        "decimal256",
+        "Decimal256(50, 8)",
+        json!({"precision":50,"scale":8,"values":["-1234567890123456789012345678901234567890","0","6789012345678901234567890123456789012345",null]}),
+        Decimal256Array::from(vec![
+            Some(i256::from_string("-1234567890123456789012345678901234567890").unwrap()),
+            Some(i256::from(0)),
+            Some(i256::from_string("6789012345678901234567890123456789012345").unwrap()),
+            None
+        ])
+        .with_precision_and_scale(50, 8)
+        .unwrap()
+    );
+
+    macro_rules! temporal_case { ($id:literal, $ty:literal, $unit:literal, $array:expr) => { push_case!($id, $ty, json!({"unit":$unit,"raw_values":["-1","0","123456",null]}), $array); }; }
+    temporal_case!(
+        "date32",
+        "Date32",
+        "days",
+        Date32Array::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "date64",
+        "Date64",
+        "milliseconds",
+        Date64Array::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "time32-second",
+        "Time32(Second)",
+        "second",
+        Time32SecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "time32-millisecond",
+        "Time32(Millisecond)",
+        "millisecond",
+        Time32MillisecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "time64-microsecond",
+        "Time64(Microsecond)",
+        "microsecond",
+        Time64MicrosecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "time64-nanosecond",
+        "Time64(Nanosecond)",
+        "nanosecond",
+        Time64NanosecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    macro_rules! timestamp_cases { ($id:literal, $ty:literal, $unit:literal, $array:expr) => { push_case!($id, $ty, json!({"unit":$unit,"timezone":null,"raw_values":["-1","0","123456",null]}), $array.clone()); push_case!(concat!($id, "-utc"), concat!($ty, " timezone=UTC"), json!({"unit":$unit,"timezone":"UTC","raw_values":["-1","0","123456",null]}), $array.with_timezone("UTC")); }; }
+    timestamp_cases!(
+        "timestamp-second",
+        "Timestamp(Second)",
+        "second",
+        TimestampSecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    timestamp_cases!(
+        "timestamp-millisecond",
+        "Timestamp(Millisecond)",
+        "millisecond",
+        TimestampMillisecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    timestamp_cases!(
+        "timestamp-microsecond",
+        "Timestamp(Microsecond)",
+        "microsecond",
+        TimestampMicrosecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    timestamp_cases!(
+        "timestamp-nanosecond",
+        "Timestamp(Nanosecond)",
+        "nanosecond",
+        TimestampNanosecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "duration-second",
+        "Duration(Second)",
+        "second",
+        DurationSecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "duration-millisecond",
+        "Duration(Millisecond)",
+        "millisecond",
+        DurationMillisecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "duration-microsecond",
+        "Duration(Microsecond)",
+        "microsecond",
+        DurationMicrosecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    temporal_case!(
+        "duration-nanosecond",
+        "Duration(Nanosecond)",
+        "nanosecond",
+        DurationNanosecondArray::from(vec![Some(-1), Some(0), Some(123456), None])
+    );
+    push_case!(
+        "interval-year-month",
+        "Interval(YearMonth)",
+        json!({"unit":"year_month","raw_values":["-1","0","25",null]}),
+        IntervalYearMonthArray::from(vec![Some(-1), Some(0), Some(25), None])
+    );
+    push_case!(
+        "interval-day-time",
+        "Interval(DayTime)",
+        json!({"unit":"day_time","raw_values":[{"days":-1,"milliseconds":2},{"days":0,"milliseconds":0},{"days":3,"milliseconds":4},null]}),
+        IntervalDayTimeArray::from(vec![
+            Some(IntervalDayTime::new(-1, 2)),
+            Some(IntervalDayTime::new(0, 0)),
+            Some(IntervalDayTime::new(3, 4)),
+            None
+        ])
+    );
+    push_case!(
+        "interval-month-day-nano",
+        "Interval(MonthDayNano)",
+        json!({"unit":"month_day_nano","raw_values":[{"months":-1,"days":2,"nanoseconds":3},{"months":0,"days":0,"nanoseconds":0},{"months":4,"days":5,"nanoseconds":6},null]}),
+        IntervalMonthDayNanoArray::from(vec![
+            Some(IntervalMonthDayNano::new(-1, 2, 3)),
+            Some(IntervalMonthDayNano::new(0, 0, 0)),
+            Some(IntervalMonthDayNano::new(4, 5, 6)),
+            None
+        ])
+    );
+
+    let long_text = "0123456789abcdef0123456789abcdef";
+    let text_logical = json!(["", "short", long_text, "雪", "short", null]);
+    push_case!(
+        "utf8",
+        "Utf8",
+        text_logical.clone(),
+        StringArray::from(vec![
+            Some(""),
+            Some("short"),
+            Some(long_text),
+            Some("雪"),
+            Some("short"),
+            None
+        ])
+    );
+    push_case!(
+        "large-utf8",
+        "LargeUtf8",
+        text_logical.clone(),
+        LargeStringArray::from(vec![
+            Some(""),
+            Some("short"),
+            Some(long_text),
+            Some("雪"),
+            Some("short"),
+            None
+        ])
+    );
+    push_case!(
+        "utf8-view",
+        "Utf8View",
+        text_logical,
+        StringViewArray::from_iter(vec![
+            Some("".to_string()),
+            Some("short".to_string()),
+            Some(long_text.to_string()),
+            Some("雪".to_string()),
+            Some("short".to_string()),
+            None
+        ])
+    );
+    let long_bytes = vec![0xabu8; 32];
+    let bytes_logical = json!([
+        "hex:",
+        "hex:0102",
+        "hex:abababababababababababababababababababababababababababababababab",
+        "hex:e29883",
+        "hex:0102",
+        null
+    ]);
+    push_case!(
+        "binary",
+        "Binary",
+        bytes_logical.clone(),
+        BinaryArray::from(vec![
+            Some(&b""[..]),
+            Some(&b"\x01\x02"[..]),
+            Some(long_bytes.as_slice()),
+            Some("☃".as_bytes()),
+            Some(&b"\x01\x02"[..]),
+            None
+        ])
+    );
+    push_case!(
+        "large-binary",
+        "LargeBinary",
+        bytes_logical.clone(),
+        LargeBinaryArray::from(vec![
+            Some(&b""[..]),
+            Some(&b"\x01\x02"[..]),
+            Some(long_bytes.as_slice()),
+            Some("☃".as_bytes()),
+            Some(&b"\x01\x02"[..]),
+            None
+        ])
+    );
+    push_case!(
+        "binary-view",
+        "BinaryView",
+        bytes_logical,
+        BinaryViewArray::from_iter(vec![
+            Some(Vec::<u8>::new()),
+            Some(vec![1, 2]),
+            Some(long_bytes.clone()),
+            Some("☃".as_bytes().to_vec()),
+            Some(vec![1, 2]),
+            None
+        ])
+    );
+    push_case!(
+        "fixed-size-binary",
+        "FixedSizeBinary(4)",
+        json!([
+            "hex:00000000",
+            "hex:01020304",
+            "hex:ffffffff",
+            "hex:01020304",
+            null
+        ]),
+        FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![
+                Some(vec![0, 0, 0, 0]),
+                Some(vec![1, 2, 3, 4]),
+                Some(vec![255, 255, 255, 255]),
+                Some(vec![1, 2, 3, 4]),
+                None
+            ]
+            .into_iter(),
+            4
+        )
+        .unwrap()
+    );
+
+    macro_rules! dict_case { ($id:literal, $key_type:literal, $key_ty:ty, $keys:expr) => { push_case!($id, concat!("Dictionary(", $key_type, ", Utf8)"), json!({"key_type":$key_type,"keys":["0","1","2",null,"1"],"dictionary_values":["alpha","alpha",null],"logical_values":["alpha","alpha",null,null,"alpha"]}), DictionaryArray::<$key_ty>::new($keys, Arc::new(StringArray::from(vec![Some("alpha"), Some("alpha"), None])))); }; }
+    dict_case!(
+        "dictionary-int8",
+        "Int8",
+        Int8Type,
+        Int8Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    dict_case!(
+        "dictionary-int16",
+        "Int16",
+        Int16Type,
+        Int16Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    dict_case!(
+        "dictionary-int32",
+        "Int32",
+        Int32Type,
+        Int32Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    dict_case!(
+        "dictionary-int64",
+        "Int64",
+        Int64Type,
+        Int64Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    dict_case!(
+        "dictionary-uint8",
+        "UInt8",
+        UInt8Type,
+        UInt8Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    dict_case!(
+        "dictionary-uint16",
+        "UInt16",
+        UInt16Type,
+        UInt16Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    dict_case!(
+        "dictionary-uint32",
+        "UInt32",
+        UInt32Type,
+        UInt32Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    dict_case!(
+        "dictionary-uint64",
+        "UInt64",
+        UInt64Type,
+        UInt64Array::from(vec![Some(0), Some(1), Some(2), None, Some(1)])
+    );
+    Ok(cases)
+}
+
+fn nullable_int_field(name: &str) -> FieldRef {
+    Arc::new(Field::new(name, DataType::Int32, true))
+}
+
+fn build_nested_cases() -> Result<Vec<FlatCase>> {
+    let mut cases = Vec::new();
+    macro_rules! push_case {
+        ($id:expr, $ty:expr, $logical:expr, $array:expr) => {
+            cases.push(flat_case($id, $ty, $logical, Arc::new($array))?);
+        };
+    }
+
+    let struct_fields = vec![
+        Arc::new(Field::new("i", DataType::Int32, true)),
+        Arc::new(Field::new("s", DataType::Utf8, true)),
+    ]
+    .into();
+    let struct_array = StructArray::new(
+        struct_fields,
+        vec![
+            Arc::new(Int32Array::from(vec![
+                Some(1),
+                Some(2),
+                Some(1),
+                None,
+                Some(1),
+            ])),
+            Arc::new(StringArray::from(vec![
+                Some("a"),
+                Some("b"),
+                Some("a"),
+                Some("z"),
+                None,
+            ])),
+        ],
+        Some(NullBuffer::from(vec![true, true, true, false, true])),
+    );
+    push_case!(
+        "struct",
+        "Struct<i:Int32,s:Utf8>",
+        json!({"rows":[{"i":"1","s":"a"},{"i":"2","s":"b"},{"i":"1","s":"a"},null,{"i":"1","s":null}]}),
+        struct_array.clone()
+    );
+    push_case!(
+        "struct-sliced",
+        "Struct<i:Int32,s:Utf8>; slice(1,3)",
+        json!({"physical":"slice(1,3)","rows":[{"i":"2","s":"b"},{"i":"1","s":"a"},null]}),
+        struct_array.slice(1, 3)
+    );
+
+    let list_values: ArrayRef = Arc::new(Int32Array::from(vec![
+        Some(1),
+        None,
+        Some(2),
+        Some(1),
+        None,
+        Some(2),
+    ]));
+    let list = ListArray::new(
+        nullable_int_field("item"),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 3, 5, 6])),
+        list_values.clone(),
+        Some(NullBuffer::from(vec![true, true, false, true, true])),
+    );
+    push_case!(
+        "list",
+        "List<Int32>",
+        json!({"offsets":[0,2,2,3,5,6],"rows":[["1",null],[],null,["1",null],["2"]]}),
+        list.clone()
+    );
+    push_case!(
+        "list-sliced",
+        "List<Int32>; slice(1,3)",
+        json!({"physical":"slice(1,3)","rows":[[],null,["1",null]]}),
+        list.slice(1, 3)
+    );
+    let large_list = LargeListArray::new(
+        nullable_int_field("item"),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0i64, 2, 2, 3, 5, 6])),
+        list_values.clone(),
+        Some(NullBuffer::from(vec![true, true, false, true, true])),
+    );
+    push_case!(
+        "large-list",
+        "LargeList<Int32>",
+        json!({"offsets":["0","2","2","3","5","6"],"rows":[["1",null],[],null,["1",null],["2"]]}),
+        large_list
+    );
+    let inner = ListArray::new(
+        nullable_int_field("item"),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 3, 4])),
+        Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3), Some(1)])),
+        None,
+    );
+    let nested = ListArray::new(
+        Arc::new(Field::new("item", inner.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 3])),
+        Arc::new(inner),
+        Some(NullBuffer::from(vec![true, true, false])),
+    );
+    push_case!(
+        "nested-list",
+        "List<List<Int32>>",
+        json!({"rows":[[["1"],["2","3"]],[],null]}),
+        nested
+    );
+
+    let view_values: ArrayRef = Arc::new(Int32Array::from(vec![
+        Some(10),
+        Some(20),
+        Some(30),
+        Some(40),
+        Some(50),
+    ]));
+    let list_view = ListViewArray::new(
+        nullable_int_field("item"),
+        ScalarBuffer::from(vec![2, 0, 1, 4, 0]),
+        ScalarBuffer::from(vec![2, 2, 2, 0, 1]),
+        view_values.clone(),
+        Some(NullBuffer::from(vec![true, true, true, true, false])),
+    );
+    push_case!(
+        "list-view",
+        "ListView<Int32>",
+        json!({"offsets":[2,0,1,4,0],"sizes":[2,2,2,0,1],"rows":[["30","40"],["10","20"],["20","30"],[],null],"representation_sensitive":true}),
+        list_view
+    );
+    let large_list_view = LargeListViewArray::new(
+        nullable_int_field("item"),
+        ScalarBuffer::from(vec![2i64, 0, 1, 4, 0]),
+        ScalarBuffer::from(vec![2i64, 2, 2, 0, 1]),
+        view_values,
+        Some(NullBuffer::from(vec![true, true, true, true, false])),
+    );
+    push_case!(
+        "large-list-view",
+        "LargeListView<Int32>",
+        json!({"offsets":["2","0","1","4","0"],"sizes":["2","2","2","0","1"],"rows":[["30","40"],["10","20"],["20","30"],[],null],"representation_sensitive":true}),
+        large_list_view
+    );
+
+    let fixed_values: ArrayRef = Arc::new(Int32Array::from(vec![
+        Some(1),
+        Some(2),
+        Some(1),
+        None,
+        Some(1),
+        Some(2),
+        Some(9),
+        Some(9),
+    ]));
+    let fixed = FixedSizeListArray::new(
+        nullable_int_field("item"),
+        2,
+        fixed_values,
+        Some(NullBuffer::from(vec![true, true, true, false])),
+    );
+    push_case!(
+        "fixed-size-list",
+        "FixedSizeList<Int32;2>",
+        json!({"rows":[["1","2"],["1",null],["1","2"],null]}),
+        fixed.clone()
+    );
+    push_case!(
+        "fixed-size-list-empty",
+        "FixedSizeList<Int32;2>; empty",
+        json!({"rows":[]}),
+        FixedSizeListArray::new(
+            nullable_int_field("item"),
+            2,
+            Arc::new(Int32Array::from(Vec::<Option<i32>>::new())),
+            None
+        )
+    );
+    push_case!(
+        "fixed-size-list-sliced",
+        "FixedSizeList<Int32;2>; slice(1,2)",
+        json!({"physical":"slice(1,2)","rows":[["1",null],["1","2"]]}),
+        fixed.slice(1, 2)
+    );
+
+    let map_fields: Fields = vec![
+        Arc::new(Field::new("key", DataType::Utf8, false)),
+        Arc::new(Field::new("value", DataType::Int32, true)),
+    ]
+    .into();
+    let entries = StructArray::new(
+        map_fields.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["a", "b", "a", "a"])),
+            Arc::new(Int32Array::from(vec![Some(1), None, Some(1), Some(1)])),
+        ],
+        None,
+    );
+    let map_field = Arc::new(Field::new("entries", entries.data_type().clone(), false));
+    let map = MapArray::new(
+        map_field,
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 3, 4])),
+        entries,
+        Some(NullBuffer::from(vec![true, true, false, true])),
+        false,
+    );
+    push_case!(
+        "map",
+        "Map<Utf8,Int32>",
+        json!({"offsets":[0,2,2,3,4],"rows":[[["a","1"],["b",null]],[],null,[["a","1"]]]}),
+        map.clone()
+    );
+    push_case!(
+        "map-sliced",
+        "Map<Utf8,Int32>; slice(1,3)",
+        json!({"physical":"slice(1,3)","rows":[[],null,[["a","1"]]]}),
+        map.slice(1, 3)
+    );
+
+    let union_fields = UnionFields::new(
+        vec![0, 1],
+        vec![
+            Arc::new(Field::new("i", DataType::Int32, true)),
+            Arc::new(Field::new("s", DataType::Utf8, true)),
+        ],
+    );
+    let dense = UnionArray::try_new(
+        union_fields.clone(),
+        ScalarBuffer::from(vec![0i8, 1, 0, 1, 0]),
+        Some(ScalarBuffer::from(vec![0, 0, 1, 1, 2])),
+        vec![
+            Arc::new(Int32Array::from(vec![Some(7), Some(7), None])),
+            Arc::new(StringArray::from(vec![Some("x"), Some("x")])),
+        ],
+    )
+    .unwrap();
+    push_case!(
+        "union-dense",
+        "Union(Dense; 0:Int32,1:Utf8)",
+        json!({"type_ids":[0,1,0,1,0],"offsets":[0,0,1,1,2],"rows":["7","x","7","x",null]}),
+        dense.clone()
+    );
+    push_case!(
+        "union-dense-sliced",
+        "Union(Dense); slice(1,3)",
+        json!({"physical":"slice(1,3)","rows":["x","7","x"]}),
+        dense.slice(1, 3)
+    );
+    let sparse = UnionArray::try_new(
+        union_fields,
+        ScalarBuffer::from(vec![0i8, 1, 0, 1, 0]),
+        None,
+        vec![
+            Arc::new(Int32Array::from(vec![
+                Some(7),
+                Some(0),
+                Some(7),
+                Some(0),
+                None,
+            ])),
+            Arc::new(StringArray::from(vec![
+                Some(""),
+                Some("x"),
+                Some(""),
+                Some("x"),
+                Some(""),
+            ])),
+        ],
+    )
+    .unwrap();
+    push_case!(
+        "union-sparse",
+        "Union(Sparse; 0:Int32,1:Utf8)",
+        json!({"type_ids":[0,1,0,1,0],"rows":["7","x","7","x",null]}),
+        sparse.clone()
+    );
+    push_case!(
+        "union-sparse-sliced",
+        "Union(Sparse); slice(1,3)",
+        json!({"physical":"slice(1,3)","rows":["x","7","x"]}),
+        sparse.slice(1, 3)
+    );
+
+    macro_rules! ree_cases { ($id:literal, $run_ty:ty, $array_ty:ty) => {{ let run_ends: $array_ty = <$array_ty>::from(vec![2, 5, 7]); let values = Int32Array::from(vec![Some(1), Some(2), None]); let array = RunArray::<$run_ty>::try_new(&run_ends, &values).unwrap(); push_case!($id, concat!("RunEndEncoded(", stringify!($run_ty), ")"), json!({"run_ends":["2","5","7"],"values":["1","2",null],"logical":["1","1","2","2","2",null,null]}), array.clone()); push_case!(concat!($id, "-sliced"), concat!("RunEndEncoded(", stringify!($run_ty), "); slice(1,5)"), json!({"physical":"slice(1,5)","logical":["1","2","2","2",null]}), array.slice(1, 5)); }}; }
+    ree_cases!("ree-int16", Int16Type, Int16Array);
+    ree_cases!("ree-int32", Int32Type, Int32Array);
+    ree_cases!("ree-int64", Int64Type, Int64Array);
+    Ok(cases)
+}
+
+fn build_fixture() -> Result<Fixture> {
+    let logical_inputs = vec![Some(1), Some(2), Some(3), Some(4), None];
+    let grouped = GroupedCase {
+        group_indices: vec![0, 0, 1, 1, 1],
+        filter: vec![Some(true), Some(false), Some(true), Some(true), Some(true)],
+        total_num_groups: 2,
+        sorted_group_states: {
+            let mut accumulator = CountHashGroupAccumulator::new();
+            let filter = BooleanArray::from(vec![true, false, true, true, true]);
+            accumulator.update_batch(
+                &[int64_array(logical_inputs.clone())],
+                &[0, 0, 1, 1, 1],
+                Some(&filter),
+                2,
+            )?;
+            sorted_group_states(&mut accumulator)?
+        },
+    };
+
+    Ok(Fixture {
+        format: "greptime-count-hash-v1".to_string(),
+        metadata: Metadata {
+            greptime_commit: "67683cef2e445f555edf0506c1c302ac61b5548f".to_string(),
+            datafusion_commit: "7a84c45104d35408f00bbf880268c47193b73b28".to_string(),
+            hash_utils_blob: "3be6118c55ff2045d9ebdc7ef1a1f6899c50732d".to_string(),
+            ahash_version: "0.8.12".to_string(),
+            arrow_version: "58.3.0".to_string(),
+            seeds_hex: vec![
+                format!("0x{RANDOM_SEED_0:016x}"),
+                format!("0x{RANDOM_SEED_1:016x}"),
+                format!("0x{RANDOM_SEED_2:016x}"),
+                format!("0x{RANDOM_SEED_3:016x}"),
+            ],
+            target_endianness: if cfg!(target_endian = "little") {
+                "little".to_string()
+            } else {
+                "big".to_string()
+            },
+        },
+        int64: Int64Case {
+            slot_hashes: hashes(int64_array(logical_inputs.clone()))?,
+            logical_inputs,
+            null_handling: NullHandling {
+                create_hashes:
+                    "create_hashes returns one u64 slot for every input row, including null"
+                        .to_string(),
+                scalar_accumulator:
+                    "CountHashAccumulator inserts every create_hashes slot, including null"
+                        .to_string(),
+                grouped_accumulator:
+                    "CountHashGroupAccumulator skips null logical values after hashing".to_string(),
+            },
+            scalar_partial_states: vec![
+                scalar_partial_state(vec![1, 2, 3])?,
+                scalar_partial_state(vec![2, 3, 4])?,
+            ],
+            grouped,
+        },
+        flat_cases: build_flat_cases()?,
+        nested_cases: build_nested_cases()?,
+    })
+}
+
+#[test]
+#[ignore = "writes the frozen fixture only to GREPTIME_COUNT_HASH_FIXTURE_OUT"]
+fn generate_count_hash_hash_v1_fixture() -> Result<()> {
+    let output = env::var_os(FIXTURE_ENV)
+        .expect("refusing to write a fixture without GREPTIME_COUNT_HASH_FIXTURE_OUT");
+    let output = Path::new(&output);
+    let parent = output
+        .parent()
+        .expect("fixture output path must have a parent directory");
+    fs::create_dir_all(parent).expect("failed to create fixture output directory");
+    let json = serde_json::to_string_pretty(&build_fixture()?).unwrap() + "\n";
+    fs::write(output, json).expect("failed to write CountHash hash-v1 fixture");
+    Ok(())
+}
+
+#[test]
+fn verify_count_hash_hash_v1_fixture() -> Result<()> {
+    let fixture: Fixture = serde_json::from_str(
+        &fs::read_to_string(FIXTURE_PATH).expect("failed to read frozen CountHash hash-v1 fixture"),
+    )
+    .expect("invalid frozen CountHash hash-v1 fixture");
+
+    assert_eq!(fixture.format, "greptime-count-hash-v1");
+    for (cases, required_ids, category) in [
+        (&fixture.flat_cases, FLAT_CASE_IDS, "flat"),
+        (&fixture.nested_cases, NESTED_CASE_IDS, "nested"),
+    ] {
+        assert_eq!(cases.len(), required_ids.len());
+        let fixture_ids = cases
+            .iter()
+            .map(|case| case.id.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        let expected_ids = required_ids
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            fixture_ids.len(),
+            cases.len(),
+            "{category} case IDs must be unique"
+        );
+        assert_eq!(
+            fixture_ids, expected_ids,
+            "{category} case coverage changed"
+        );
+        assert!(
+            cases
+                .iter()
+                .all(|case| !case.slot_hashes.is_empty() || case.id == "fixed-size-list-empty")
+        );
+    }
+
+    let recomputed = build_fixture()?;
+    assert_eq!(recomputed.flat_cases.len(), FLAT_CASE_IDS.len());
+    assert_eq!(recomputed.nested_cases.len(), NESTED_CASE_IDS.len());
+    let struct_case = fixture
+        .nested_cases
+        .iter()
+        .find(|case| case.id == "struct")
+        .unwrap();
+    assert_eq!(struct_case.slot_hashes[0], struct_case.slot_hashes[2]);
+    assert_eq!(fixture, recomputed);
+    Ok(())
+}

--- a/src/common/function/src/aggrs/count_hash/hash_v1_fixture.rs
+++ b/src/common/function/src/aggrs/count_hash/hash_v1_fixture.rs
@@ -28,7 +28,7 @@ use datatypes::arrow::datatypes::{i256, *};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use super::{
+use crate::aggrs::count_hash::{
     CountHashAccumulator, CountHashGroupAccumulator, RANDOM_SEED_0, RANDOM_SEED_1, RANDOM_SEED_2,
     RANDOM_SEED_3,
 };

--- a/src/common/function/tests/fixtures/count_hash_hash_v1.json
+++ b/src/common/function/tests/fixtures/count_hash_hash_v1.json
@@ -1,0 +1,1870 @@
+{
+  "format": "greptime-count-hash-v1",
+  "metadata": {
+    "greptime_commit": "67683cef2e445f555edf0506c1c302ac61b5548f",
+    "datafusion_commit": "7a84c45104d35408f00bbf880268c47193b73b28",
+    "hash_utils_blob": "3be6118c55ff2045d9ebdc7ef1a1f6899c50732d",
+    "ahash_version": "0.8.12",
+    "arrow_version": "58.3.0",
+    "seeds_hex": [
+      "0x4047821dc6144e4b",
+      "0x2abddf23ad417112",
+      "0x6a52eeecd26eff21",
+      "0x91cf673b965a7875"
+    ],
+    "target_endianness": "little"
+  },
+  "int64": {
+    "logical_inputs": [
+      1,
+      2,
+      3,
+      4,
+      null
+    ],
+    "slot_hashes": [
+      "3520623206881679283",
+      "16267663279875310162",
+      "16422880750557392924",
+      "9297840658584225731",
+      "0"
+    ],
+    "null_handling": {
+      "create_hashes": "create_hashes returns one u64 slot for every input row, including null",
+      "scalar_accumulator": "CountHashAccumulator inserts every create_hashes slot, including null",
+      "grouped_accumulator": "CountHashGroupAccumulator skips null logical values after hashing"
+    },
+    "scalar_partial_states": [
+      {
+        "logical_inputs": [
+          1,
+          2,
+          3
+        ],
+        "sorted_hashes": [
+          "3520623206881679283",
+          "16267663279875310162",
+          "16422880750557392924"
+        ]
+      },
+      {
+        "logical_inputs": [
+          2,
+          3,
+          4
+        ],
+        "sorted_hashes": [
+          "9297840658584225731",
+          "16267663279875310162",
+          "16422880750557392924"
+        ]
+      }
+    ],
+    "grouped": {
+      "group_indices": [
+        0,
+        0,
+        1,
+        1,
+        1
+      ],
+      "filter": [
+        true,
+        false,
+        true,
+        true,
+        true
+      ],
+      "total_num_groups": 2,
+      "sorted_group_states": [
+        [
+          "3520623206881679283"
+        ],
+        [
+          "9297840658584225731",
+          "16422880750557392924"
+        ]
+      ]
+    }
+  },
+  "flat_cases": [
+    {
+      "id": "null",
+      "arrow_type": "Null",
+      "logical_inputs": [
+        null,
+        null,
+        null
+      ],
+      "slot_hashes": [
+        "3520623206881679283",
+        "3520623206881679283",
+        "3520623206881679283"
+      ]
+    },
+    {
+      "id": "boolean",
+      "arrow_type": "Boolean",
+      "logical_inputs": [
+        true,
+        false,
+        null,
+        true
+      ],
+      "slot_hashes": [
+        "1651652937063207849",
+        "7089686826578753578",
+        "0",
+        "1651652937063207849"
+      ]
+    },
+    {
+      "id": "int8",
+      "arrow_type": "Int8",
+      "logical_inputs": [
+        "-128",
+        "0",
+        "127",
+        null
+      ],
+      "slot_hashes": [
+        "6297162108252118961",
+        "10235160885650180287",
+        "2199771465032477938",
+        "0"
+      ]
+    },
+    {
+      "id": "int16",
+      "arrow_type": "Int16",
+      "logical_inputs": [
+        "-32768",
+        "0",
+        "32767",
+        null
+      ],
+      "slot_hashes": [
+        "5283916240992853682",
+        "10235160885650180287",
+        "13765026690981664999",
+        "0"
+      ]
+    },
+    {
+      "id": "int32",
+      "arrow_type": "Int32",
+      "logical_inputs": [
+        "-2147483648",
+        "0",
+        "2147483647",
+        null
+      ],
+      "slot_hashes": [
+        "1123207262851531737",
+        "10235160885650180287",
+        "1674074173207012814",
+        "0"
+      ]
+    },
+    {
+      "id": "int64",
+      "arrow_type": "Int64",
+      "logical_inputs": [
+        "-9223372036854775808",
+        "0",
+        "9223372036854775807",
+        null
+      ],
+      "slot_hashes": [
+        "5570633911902918511",
+        "10235160885650180287",
+        "2435009426944311994",
+        "0"
+      ]
+    },
+    {
+      "id": "uint8",
+      "arrow_type": "UInt8",
+      "logical_inputs": [
+        "0",
+        "1",
+        "255",
+        null
+      ],
+      "slot_hashes": [
+        "10235160885650180287",
+        "3520623206881679283",
+        "2750287164872547038",
+        "0"
+      ]
+    },
+    {
+      "id": "uint16",
+      "arrow_type": "UInt16",
+      "logical_inputs": [
+        "0",
+        "1",
+        "65535",
+        null
+      ],
+      "slot_hashes": [
+        "10235160885650180287",
+        "3520623206881679283",
+        "14536412591059226227",
+        "0"
+      ]
+    },
+    {
+      "id": "uint32",
+      "arrow_type": "UInt32",
+      "logical_inputs": [
+        "0",
+        "1",
+        "4294967295",
+        null
+      ],
+      "slot_hashes": [
+        "10235160885650180287",
+        "3520623206881679283",
+        "1264449691658001459",
+        "0"
+      ]
+    },
+    {
+      "id": "uint64",
+      "arrow_type": "UInt64",
+      "logical_inputs": [
+        "0",
+        "1",
+        "18446744073709551615",
+        null
+      ],
+      "slot_hashes": [
+        "10235160885650180287",
+        "3520623206881679283",
+        "2763750628276388110",
+        "0"
+      ]
+    },
+    {
+      "id": "float16-bits",
+      "arrow_type": "Float16",
+      "logical_inputs": [
+        "0x0000",
+        "0x8000",
+        "0x7c00",
+        "0xfc00",
+        "0x7e01",
+        "0x7e02",
+        "0x3e00",
+        null
+      ],
+      "slot_hashes": [
+        "10235160885650180287",
+        "5283916240992853682",
+        "4659815828991914176",
+        "1110749947326030476",
+        "6921826467039903660",
+        "2746447985617752178",
+        "2709653072252920681",
+        "0"
+      ]
+    },
+    {
+      "id": "float32-bits",
+      "arrow_type": "Float32",
+      "logical_inputs": [
+        "0x00000000",
+        "0x80000000",
+        "0x7f800000",
+        "0xff800000",
+        "0x7fc00001",
+        "0x7fc00002",
+        "0x3fc00000",
+        null
+      ],
+      "slot_hashes": [
+        "10235160885650180287",
+        "1123207262851531737",
+        "5126841742535505949",
+        "18131373748288514514",
+        "4821628008574088242",
+        "12319560085252846613",
+        "12236136349550470569",
+        "0"
+      ]
+    },
+    {
+      "id": "float64-bits",
+      "arrow_type": "Float64",
+      "logical_inputs": [
+        "0x0000000000000000",
+        "0x8000000000000000",
+        "0x7ff0000000000000",
+        "0xfff0000000000000",
+        "0x7ff8000000000001",
+        "0x7ff8000000000002",
+        "0x3ff8000000000000",
+        null
+      ],
+      "slot_hashes": [
+        "10235160885650180287",
+        "5570633911902918511",
+        "16536107459917742963",
+        "6846834899941436287",
+        "3250092651993900760",
+        "8149755420134907056",
+        "11206862425332410189",
+        "0"
+      ]
+    },
+    {
+      "id": "decimal32",
+      "arrow_type": "Decimal32(9, 2)",
+      "logical_inputs": {
+        "precision": 9,
+        "scale": 2,
+        "values": [
+          "-12345",
+          "0",
+          "67890",
+          null
+        ]
+      },
+      "slot_hashes": [
+        "11328161096048440149",
+        "10235160885650180287",
+        "6055455543861901557",
+        "0"
+      ]
+    },
+    {
+      "id": "decimal64",
+      "arrow_type": "Decimal64(18, 4)",
+      "logical_inputs": {
+        "precision": 18,
+        "scale": 4,
+        "values": [
+          "-12345678901234",
+          "0",
+          "67890123456789",
+          null
+        ]
+      },
+      "slot_hashes": [
+        "1585500258431587407",
+        "10235160885650180287",
+        "5599246500330582973",
+        "0"
+      ]
+    },
+    {
+      "id": "decimal128",
+      "arrow_type": "Decimal128(30, 6)",
+      "logical_inputs": {
+        "precision": 30,
+        "scale": 6,
+        "values": [
+          "-123456789012345678901234",
+          "0",
+          "678901234567890123456789",
+          null
+        ]
+      },
+      "slot_hashes": [
+        "1452417108566880109",
+        "2325127798686461754",
+        "3695381585542132101",
+        "0"
+      ]
+    },
+    {
+      "id": "decimal256",
+      "arrow_type": "Decimal256(50, 8)",
+      "logical_inputs": {
+        "precision": 50,
+        "scale": 8,
+        "values": [
+          "-1234567890123456789012345678901234567890",
+          "0",
+          "6789012345678901234567890123456789012345",
+          null
+        ]
+      },
+      "slot_hashes": [
+        "13422205506858653816",
+        "77301216587685583",
+        "10122390097949382804",
+        "0"
+      ]
+    },
+    {
+      "id": "date32",
+      "arrow_type": "Date32",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "days"
+      },
+      "slot_hashes": [
+        "1264449691658001459",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "date64",
+      "arrow_type": "Date64",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "milliseconds"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "time32-second",
+      "arrow_type": "Time32(Second)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "second"
+      },
+      "slot_hashes": [
+        "1264449691658001459",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "time32-millisecond",
+      "arrow_type": "Time32(Millisecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "millisecond"
+      },
+      "slot_hashes": [
+        "1264449691658001459",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "time64-microsecond",
+      "arrow_type": "Time64(Microsecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "microsecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "time64-nanosecond",
+      "arrow_type": "Time64(Nanosecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "nanosecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-second",
+      "arrow_type": "Timestamp(Second)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": null,
+        "unit": "second"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-second-utc",
+      "arrow_type": "Timestamp(Second) timezone=UTC",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": "UTC",
+        "unit": "second"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-millisecond",
+      "arrow_type": "Timestamp(Millisecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": null,
+        "unit": "millisecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-millisecond-utc",
+      "arrow_type": "Timestamp(Millisecond) timezone=UTC",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": "UTC",
+        "unit": "millisecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-microsecond",
+      "arrow_type": "Timestamp(Microsecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": null,
+        "unit": "microsecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-microsecond-utc",
+      "arrow_type": "Timestamp(Microsecond) timezone=UTC",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": "UTC",
+        "unit": "microsecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-nanosecond",
+      "arrow_type": "Timestamp(Nanosecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": null,
+        "unit": "nanosecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "timestamp-nanosecond-utc",
+      "arrow_type": "Timestamp(Nanosecond) timezone=UTC",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "timezone": "UTC",
+        "unit": "nanosecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "duration-second",
+      "arrow_type": "Duration(Second)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "second"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "duration-millisecond",
+      "arrow_type": "Duration(Millisecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "millisecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "duration-microsecond",
+      "arrow_type": "Duration(Microsecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "microsecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "duration-nanosecond",
+      "arrow_type": "Duration(Nanosecond)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "123456",
+          null
+        ],
+        "unit": "nanosecond"
+      },
+      "slot_hashes": [
+        "2763750628276388110",
+        "10235160885650180287",
+        "10103536999353117757",
+        "0"
+      ]
+    },
+    {
+      "id": "interval-year-month",
+      "arrow_type": "Interval(YearMonth)",
+      "logical_inputs": {
+        "raw_values": [
+          "-1",
+          "0",
+          "25",
+          null
+        ],
+        "unit": "year_month"
+      },
+      "slot_hashes": [
+        "1264449691658001459",
+        "10235160885650180287",
+        "9340549182680168467",
+        "0"
+      ]
+    },
+    {
+      "id": "interval-day-time",
+      "arrow_type": "Interval(DayTime)",
+      "logical_inputs": {
+        "raw_values": [
+          {
+            "days": -1,
+            "milliseconds": 2
+          },
+          {
+            "days": 0,
+            "milliseconds": 0
+          },
+          {
+            "days": 3,
+            "milliseconds": 4
+          },
+          null
+        ],
+        "unit": "day_time"
+      },
+      "slot_hashes": [
+        "4921667063968560956",
+        "629272144446004489",
+        "12519618457697784284",
+        "0"
+      ]
+    },
+    {
+      "id": "interval-month-day-nano",
+      "arrow_type": "Interval(MonthDayNano)",
+      "logical_inputs": {
+        "raw_values": [
+          {
+            "days": 2,
+            "months": -1,
+            "nanoseconds": 3
+          },
+          {
+            "days": 0,
+            "months": 0,
+            "nanoseconds": 0
+          },
+          {
+            "days": 5,
+            "months": 4,
+            "nanoseconds": 6
+          },
+          null
+        ],
+        "unit": "month_day_nano"
+      },
+      "slot_hashes": [
+        "7555005478828952007",
+        "10429306064537313183",
+        "9895524188215285943",
+        "0"
+      ]
+    },
+    {
+      "id": "utf8",
+      "arrow_type": "Utf8",
+      "logical_inputs": [
+        "",
+        "short",
+        "0123456789abcdef0123456789abcdef",
+        "雪",
+        "short",
+        null
+      ],
+      "slot_hashes": [
+        "18009168453573014612",
+        "16063745670669428705",
+        "16471146966914539180",
+        "18308866632526957834",
+        "16063745670669428705",
+        "0"
+      ]
+    },
+    {
+      "id": "large-utf8",
+      "arrow_type": "LargeUtf8",
+      "logical_inputs": [
+        "",
+        "short",
+        "0123456789abcdef0123456789abcdef",
+        "雪",
+        "short",
+        null
+      ],
+      "slot_hashes": [
+        "18009168453573014612",
+        "16063745670669428705",
+        "16471146966914539180",
+        "18308866632526957834",
+        "16063745670669428705",
+        "0"
+      ]
+    },
+    {
+      "id": "utf8-view",
+      "arrow_type": "Utf8View",
+      "logical_inputs": [
+        "",
+        "short",
+        "0123456789abcdef0123456789abcdef",
+        "雪",
+        "short",
+        null
+      ],
+      "slot_hashes": [
+        "2325127798686461754",
+        "4368901731515066657",
+        "5227621693470855304",
+        "14312009175607353896",
+        "4368901731515066657",
+        "0"
+      ]
+    },
+    {
+      "id": "binary",
+      "arrow_type": "Binary",
+      "logical_inputs": [
+        "hex:",
+        "hex:0102",
+        "hex:abababababababababababababababababababababababababababababababab",
+        "hex:e29883",
+        "hex:0102",
+        null
+      ],
+      "slot_hashes": [
+        "16485166340809863179",
+        "9558633272077696927",
+        "4680548975548143013",
+        "11318256219281575767",
+        "9558633272077696927",
+        "0"
+      ]
+    },
+    {
+      "id": "large-binary",
+      "arrow_type": "LargeBinary",
+      "logical_inputs": [
+        "hex:",
+        "hex:0102",
+        "hex:abababababababababababababababababababababababababababababababab",
+        "hex:e29883",
+        "hex:0102",
+        null
+      ],
+      "slot_hashes": [
+        "16485166340809863179",
+        "9558633272077696927",
+        "4680548975548143013",
+        "11318256219281575767",
+        "9558633272077696927",
+        "0"
+      ]
+    },
+    {
+      "id": "binary-view",
+      "arrow_type": "BinaryView",
+      "logical_inputs": [
+        "hex:",
+        "hex:0102",
+        "hex:abababababababababababababababababababababababababababababababab",
+        "hex:e29883",
+        "hex:0102",
+        null
+      ],
+      "slot_hashes": [
+        "2325127798686461754",
+        "9765644657445404852",
+        "4680548975548143013",
+        "9840995393808221708",
+        "9765644657445404852",
+        "0"
+      ]
+    },
+    {
+      "id": "fixed-size-binary",
+      "arrow_type": "FixedSizeBinary(4)",
+      "logical_inputs": [
+        "hex:00000000",
+        "hex:01020304",
+        "hex:ffffffff",
+        "hex:01020304",
+        null
+      ],
+      "slot_hashes": [
+        "9479257996766035880",
+        "12778117559800614767",
+        "3841419864687326732",
+        "12778117559800614767",
+        "0"
+      ]
+    },
+    {
+      "id": "dictionary-int8",
+      "arrow_type": "Dictionary(Int8, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "Int8",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    },
+    {
+      "id": "dictionary-int16",
+      "arrow_type": "Dictionary(Int16, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "Int16",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    },
+    {
+      "id": "dictionary-int32",
+      "arrow_type": "Dictionary(Int32, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "Int32",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    },
+    {
+      "id": "dictionary-int64",
+      "arrow_type": "Dictionary(Int64, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "Int64",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    },
+    {
+      "id": "dictionary-uint8",
+      "arrow_type": "Dictionary(UInt8, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "UInt8",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    },
+    {
+      "id": "dictionary-uint16",
+      "arrow_type": "Dictionary(UInt16, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "UInt16",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    },
+    {
+      "id": "dictionary-uint32",
+      "arrow_type": "Dictionary(UInt32, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "UInt32",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    },
+    {
+      "id": "dictionary-uint64",
+      "arrow_type": "Dictionary(UInt64, Utf8)",
+      "logical_inputs": {
+        "dictionary_values": [
+          "alpha",
+          "alpha",
+          null
+        ],
+        "key_type": "UInt64",
+        "keys": [
+          "0",
+          "1",
+          "2",
+          null,
+          "1"
+        ],
+        "logical_values": [
+          "alpha",
+          "alpha",
+          null,
+          null,
+          "alpha"
+        ]
+      },
+      "slot_hashes": [
+        "3170375707604638807",
+        "3170375707604638807",
+        "0",
+        "0",
+        "3170375707604638807"
+      ]
+    }
+  ],
+  "nested_cases": [
+    {
+      "id": "struct",
+      "arrow_type": "Struct<i:Int32,s:Utf8>",
+      "logical_inputs": {
+        "rows": [
+          {
+            "i": "1",
+            "s": "a"
+          },
+          {
+            "i": "2",
+            "s": "b"
+          },
+          {
+            "i": "1",
+            "s": "a"
+          },
+          null,
+          {
+            "i": "1",
+            "s": null
+          }
+        ]
+      },
+      "slot_hashes": [
+        "12006103499737156245",
+        "6897773328880926896",
+        "12006103499737156245",
+        "0",
+        "3520623206881702556"
+      ]
+    },
+    {
+      "id": "struct-sliced",
+      "arrow_type": "Struct<i:Int32,s:Utf8>; slice(1,3)",
+      "logical_inputs": {
+        "physical": "slice(1,3)",
+        "rows": [
+          {
+            "i": "2",
+            "s": "b"
+          },
+          {
+            "i": "1",
+            "s": "a"
+          },
+          null
+        ]
+      },
+      "slot_hashes": [
+        "6897773328880926896",
+        "12006103499737156245",
+        "0"
+      ]
+    },
+    {
+      "id": "list",
+      "arrow_type": "List<Int32>",
+      "logical_inputs": {
+        "offsets": [
+          0,
+          2,
+          2,
+          3,
+          5,
+          6
+        ],
+        "rows": [
+          [
+            "1",
+            null
+          ],
+          [],
+          null,
+          [
+            "1",
+            null
+          ],
+          [
+            "2"
+          ]
+        ]
+      },
+      "slot_hashes": [
+        "1135850138656156533",
+        "0",
+        "0",
+        "1135850138656156533",
+        "16267663279875333435"
+      ]
+    },
+    {
+      "id": "list-sliced",
+      "arrow_type": "List<Int32>; slice(1,3)",
+      "logical_inputs": {
+        "physical": "slice(1,3)",
+        "rows": [
+          [],
+          null,
+          [
+            "1",
+            null
+          ]
+        ]
+      },
+      "slot_hashes": [
+        "0",
+        "0",
+        "1135850138656156533"
+      ]
+    },
+    {
+      "id": "large-list",
+      "arrow_type": "LargeList<Int32>",
+      "logical_inputs": {
+        "offsets": [
+          "0",
+          "2",
+          "2",
+          "3",
+          "5",
+          "6"
+        ],
+        "rows": [
+          [
+            "1",
+            null
+          ],
+          [],
+          null,
+          [
+            "1",
+            null
+          ],
+          [
+            "2"
+          ]
+        ]
+      },
+      "slot_hashes": [
+        "1135850138656156533",
+        "0",
+        "0",
+        "1135850138656156533",
+        "16267663279875333435"
+      ]
+    },
+    {
+      "id": "nested-list",
+      "arrow_type": "List<List<Int32>>",
+      "logical_inputs": {
+        "rows": [
+          [
+            [
+              "1"
+            ],
+            [
+              "2",
+              "3"
+            ]
+          ],
+          [],
+          null
+        ]
+      },
+      "slot_hashes": [
+        "10719717812186567598",
+        "0",
+        "0"
+      ]
+    },
+    {
+      "id": "list-view",
+      "arrow_type": "ListView<Int32>",
+      "logical_inputs": {
+        "offsets": [
+          2,
+          0,
+          1,
+          4,
+          0
+        ],
+        "representation_sensitive": true,
+        "rows": [
+          [
+            "30",
+            "40"
+          ],
+          [
+            "10",
+            "20"
+          ],
+          [
+            "20",
+            "30"
+          ],
+          [],
+          null
+        ],
+        "sizes": [
+          2,
+          2,
+          2,
+          0,
+          1
+        ]
+      },
+      "slot_hashes": [
+        "1646535989875670792",
+        "5532665399746881900",
+        "6108722269366659608",
+        "0",
+        "0"
+      ]
+    },
+    {
+      "id": "large-list-view",
+      "arrow_type": "LargeListView<Int32>",
+      "logical_inputs": {
+        "offsets": [
+          "2",
+          "0",
+          "1",
+          "4",
+          "0"
+        ],
+        "representation_sensitive": true,
+        "rows": [
+          [
+            "30",
+            "40"
+          ],
+          [
+            "10",
+            "20"
+          ],
+          [
+            "20",
+            "30"
+          ],
+          [],
+          null
+        ],
+        "sizes": [
+          "2",
+          "2",
+          "2",
+          "0",
+          "1"
+        ]
+      },
+      "slot_hashes": [
+        "1646535989875670792",
+        "5532665399746881900",
+        "6108722269366659608",
+        "0",
+        "0"
+      ]
+    },
+    {
+      "id": "fixed-size-list",
+      "arrow_type": "FixedSizeList<Int32;2>",
+      "logical_inputs": {
+        "rows": [
+          [
+            "1",
+            "2"
+          ],
+          [
+            "1",
+            null
+          ],
+          [
+            "1",
+            "2"
+          ],
+          null
+        ]
+      },
+      "slot_hashes": [
+        "17403513418531466695",
+        "1135850138656156533",
+        "17403513418531466695",
+        "0"
+      ]
+    },
+    {
+      "id": "fixed-size-list-empty",
+      "arrow_type": "FixedSizeList<Int32;2>; empty",
+      "logical_inputs": {
+        "rows": []
+      },
+      "slot_hashes": []
+    },
+    {
+      "id": "fixed-size-list-sliced",
+      "arrow_type": "FixedSizeList<Int32;2>; slice(1,2)",
+      "logical_inputs": {
+        "physical": "slice(1,2)",
+        "rows": [
+          [
+            "1",
+            null
+          ],
+          [
+            "1",
+            "2"
+          ]
+        ]
+      },
+      "slot_hashes": [
+        "1135850138656156533",
+        "17403513418531466695"
+      ]
+    },
+    {
+      "id": "map",
+      "arrow_type": "Map<Utf8,Int32>",
+      "logical_inputs": {
+        "offsets": [
+          0,
+          2,
+          2,
+          3,
+          4
+        ],
+        "rows": [
+          [
+            [
+              "a",
+              "1"
+            ],
+            [
+              "b",
+              null
+            ]
+          ],
+          [],
+          null,
+          [
+            [
+              "a",
+              "1"
+            ]
+          ]
+        ]
+      },
+      "slot_hashes": [
+        "13863767657378145834",
+        "0",
+        "0",
+        "10339279155402004097"
+      ]
+    },
+    {
+      "id": "map-sliced",
+      "arrow_type": "Map<Utf8,Int32>; slice(1,3)",
+      "logical_inputs": {
+        "physical": "slice(1,3)",
+        "rows": [
+          [],
+          null,
+          [
+            [
+              "a",
+              "1"
+            ]
+          ]
+        ]
+      },
+      "slot_hashes": [
+        "0",
+        "0",
+        "10339279155402004097"
+      ]
+    },
+    {
+      "id": "union-dense",
+      "arrow_type": "Union(Dense; 0:Int32,1:Utf8)",
+      "logical_inputs": {
+        "offsets": [
+          0,
+          0,
+          1,
+          1,
+          2
+        ],
+        "rows": [
+          "7",
+          "x",
+          "7",
+          "x",
+          null
+        ],
+        "type_ids": [
+          0,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "slot_hashes": [
+        "12268081498153232132",
+        "5726068209471848797",
+        "12268081498153232132",
+        "5726068209471848797",
+        "23273"
+      ]
+    },
+    {
+      "id": "union-dense-sliced",
+      "arrow_type": "Union(Dense); slice(1,3)",
+      "logical_inputs": {
+        "physical": "slice(1,3)",
+        "rows": [
+          "x",
+          "7",
+          "x"
+        ]
+      },
+      "slot_hashes": [
+        "5726068209471848797",
+        "12268081498153232132",
+        "5726068209471848797"
+      ]
+    },
+    {
+      "id": "union-sparse",
+      "arrow_type": "Union(Sparse; 0:Int32,1:Utf8)",
+      "logical_inputs": {
+        "rows": [
+          "7",
+          "x",
+          "7",
+          "x",
+          null
+        ],
+        "type_ids": [
+          0,
+          1,
+          0,
+          1,
+          0
+        ]
+      },
+      "slot_hashes": [
+        "12268081498153232132",
+        "5726068209471848797",
+        "12268081498153232132",
+        "5726068209471848797",
+        "23273"
+      ]
+    },
+    {
+      "id": "union-sparse-sliced",
+      "arrow_type": "Union(Sparse); slice(1,3)",
+      "logical_inputs": {
+        "physical": "slice(1,3)",
+        "rows": [
+          "x",
+          "7",
+          "x"
+        ]
+      },
+      "slot_hashes": [
+        "5726068209471848797",
+        "12268081498153232132",
+        "5726068209471848797"
+      ]
+    },
+    {
+      "id": "ree-int16",
+      "arrow_type": "RunEndEncoded(Int16Type)",
+      "logical_inputs": {
+        "logical": [
+          "1",
+          "1",
+          "2",
+          "2",
+          "2",
+          null,
+          null
+        ],
+        "run_ends": [
+          "2",
+          "5",
+          "7"
+        ],
+        "values": [
+          "1",
+          "2",
+          null
+        ]
+      },
+      "slot_hashes": [
+        "3520623206881679283",
+        "3520623206881679283",
+        "16267663279875310162",
+        "16267663279875310162",
+        "16267663279875310162",
+        "0",
+        "0"
+      ]
+    },
+    {
+      "id": "ree-int16-sliced",
+      "arrow_type": "RunEndEncoded(Int16Type); slice(1,5)",
+      "logical_inputs": {
+        "logical": [
+          "1",
+          "2",
+          "2",
+          "2",
+          null
+        ],
+        "physical": "slice(1,5)"
+      },
+      "slot_hashes": [
+        "3520623206881679283",
+        "16267663279875310162",
+        "16267663279875310162",
+        "16267663279875310162",
+        "0"
+      ]
+    },
+    {
+      "id": "ree-int32",
+      "arrow_type": "RunEndEncoded(Int32Type)",
+      "logical_inputs": {
+        "logical": [
+          "1",
+          "1",
+          "2",
+          "2",
+          "2",
+          null,
+          null
+        ],
+        "run_ends": [
+          "2",
+          "5",
+          "7"
+        ],
+        "values": [
+          "1",
+          "2",
+          null
+        ]
+      },
+      "slot_hashes": [
+        "3520623206881679283",
+        "3520623206881679283",
+        "16267663279875310162",
+        "16267663279875310162",
+        "16267663279875310162",
+        "0",
+        "0"
+      ]
+    },
+    {
+      "id": "ree-int32-sliced",
+      "arrow_type": "RunEndEncoded(Int32Type); slice(1,5)",
+      "logical_inputs": {
+        "logical": [
+          "1",
+          "2",
+          "2",
+          "2",
+          null
+        ],
+        "physical": "slice(1,5)"
+      },
+      "slot_hashes": [
+        "3520623206881679283",
+        "16267663279875310162",
+        "16267663279875310162",
+        "16267663279875310162",
+        "0"
+      ]
+    },
+    {
+      "id": "ree-int64",
+      "arrow_type": "RunEndEncoded(Int64Type)",
+      "logical_inputs": {
+        "logical": [
+          "1",
+          "1",
+          "2",
+          "2",
+          "2",
+          null,
+          null
+        ],
+        "run_ends": [
+          "2",
+          "5",
+          "7"
+        ],
+        "values": [
+          "1",
+          "2",
+          null
+        ]
+      },
+      "slot_hashes": [
+        "3520623206881679283",
+        "3520623206881679283",
+        "16267663279875310162",
+        "16267663279875310162",
+        "16267663279875310162",
+        "0",
+        "0"
+      ]
+    },
+    {
+      "id": "ree-int64-sliced",
+      "arrow_type": "RunEndEncoded(Int64Type); slice(1,5)",
+      "logical_inputs": {
+        "logical": [
+          "1",
+          "2",
+          "2",
+          "2",
+          null
+        ],
+        "physical": "slice(1,5)"
+      },
+      "slot_hashes": [
+        "3520623206881679283",
+        "16267663279875310162",
+        "16267663279875310162",
+        "16267663279875310162",
+        "0"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Removes the custom `convert_to_state` override from `CountHashGroupAccumulator` so partial (hash-v1) state cannot be built by wrapping raw input values in a `List<UInt64>`.

## Why

The previous `convert_to_state` implementation wrapped the raw input array (any type) as a `List<UInt64>` state. When that state was later merged via `merge_batch`, the raw values were treated as hash-v1 values, which:

- double-counts a value after a normal→skip conversion (`convert_to_state` followed by merge),
- violates the non-UInt64 subtype contract and can panic,
- ignores the optional filter's validity.

The upstream fix removed the fallback; this ports it to GreptimeDB and freezes the hash-v1 wire format with a fixture test so the behavior cannot silently regress.

## Test

- `cargo test -p common-function count_hash` — 13 passed (incl. `verify_count_hash_hash_v1_fixture`)
- RED harness earlier confirmed the bug on main (repeat counts, false-filter, non-UInt64 panic) and PASS on the fixed worktree.

## Checklist

- [x] I have signed off my commits (git commit -s)
- [x] No internal issue numbers referenced in code