### PR TITLE
fix(operator): sum affected_rows across flownodes in FLUSH_FLOW

### DIFF
--- a/src/operator/src/flow.rs
+++ b/src/operator/src/flow.rs
@@ -120,7 +120,7 @@ impl FlowServiceOperator {
             };
 
             if let Some(prev) = &mut final_result {
-                prev.affected_rows = res.affected_rows;
+                prev.affected_rows += res.affected_rows;
                 prev.affected_flows.extend(res.affected_flows);
                 prev.extensions.extend(res.extensions);
             } else {
@@ -129,5 +129,115 @@ impl FlowServiceOperator {
         }
 
         final_result.context(common_query::error::FlownodeNotFoundSnafu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api::v1::FlowId;
+    use api::v1::flow::{FlowRequest, FlowResponse};
+    use api::v1::meta::Peer;
+    use async_trait::async_trait;
+    use common_meta::error::Result as MetaResult;
+    use common_meta::key::flow::FlowMetadataManager;
+    use common_meta::key::flow::flow_info::{FlowInfoValue, FlowStatus};
+    use common_meta::key::flow::flow_route::FlowRouteValue;
+    use common_meta::kv_backend::memory::MemoryKvBackend;
+    use common_meta::node_manager::NodeManagerRef;
+    use common_meta::test_util::{MockFlownodeHandler, MockFlownodeManager};
+    use session::context::QueryContext;
+    use table::table_name::TableName;
+
+    use super::*;
+
+    /// A mock flownode handler that returns a configurable `affected_rows` per flownode peer.
+    #[derive(Clone)]
+    struct MockFlushHandler {
+        affected_rows: std::collections::HashMap<u64, u64>,
+    }
+
+    #[async_trait]
+    impl MockFlownodeHandler for MockFlushHandler {
+        async fn handle(&self, peer: &Peer, request: FlowRequest) -> MetaResult<FlowResponse> {
+            // Sanity check: the flush request must target the expected flow id.
+            let flow_id = match request.body {
+                Some(api::v1::flow::flow_request::Body::Flush(flush)) => flush.flow_id.unwrap().id,
+                _ => panic!("expected a flush flow request"),
+            };
+            let affected_rows = self
+                .affected_rows
+                .get(&peer.id)
+                .copied()
+                .unwrap_or_default();
+            Ok(FlowResponse {
+                header: None,
+                affected_rows,
+                affected_flows: vec![FlowId { id: flow_id }],
+                extensions: [(format!("flownode-{}", peer.id), vec![peer.id as u8])]
+                    .into_iter()
+                    .collect(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn flush_flow_merges_affected_rows_across_flownodes() {
+        let flow_id: u32 = 42;
+        let catalog = "greptime";
+        let flow_name = "test_flow";
+
+        let flow_metadata_manager =
+            Arc::new(FlowMetadataManager::new(Arc::new(MemoryKvBackend::new())));
+        let flow_info = FlowInfoValue {
+            catalog_name: catalog.to_string(),
+            query_context: None,
+            flow_name: flow_name.to_string(),
+            source_table_ids: vec![1024],
+            all_source_table_names: vec![],
+            unresolved_source_table_names: vec![],
+            sink_table_name: TableName {
+                catalog_name: catalog.to_string(),
+                schema_name: "my_schema".to_string(),
+                table_name: "sink_table".to_string(),
+            },
+            flownode_ids: [(0u32, 1u64), (1u32, 2u64)].into_iter().collect(),
+            raw_sql: "SELECT * FROM source_table".to_string(),
+            expire_after: None,
+            eval_interval_secs: None,
+            comment: String::new(),
+            options: Default::default(),
+            status: FlowStatus::Active,
+            created_time: chrono::Utc::now(),
+            updated_time: chrono::Utc::now(),
+            eval_schedule: None,
+        };
+        // Two partitions routed to two different flownodes.
+        let flow_routes = vec![
+            (0u32, FlowRouteValue::from(Peer::new(1, "flownode-1"))),
+            (1u32, FlowRouteValue::from(Peer::new(2, "flownode-2"))),
+        ];
+        flow_metadata_manager
+            .create_flow_metadata(flow_id, flow_info, flow_routes)
+            .await
+            .unwrap();
+
+        let handler = MockFlushHandler {
+            affected_rows: [(1, 100), (2, 200)].into_iter().collect(),
+        };
+        let node_manager: NodeManagerRef = Arc::new(MockFlownodeManager::new(handler));
+        let operator = FlowServiceOperator::new(flow_metadata_manager, node_manager);
+
+        let res = operator
+            .flush_inner(catalog, flow_name, QueryContext::arc())
+            .await
+            .unwrap();
+
+        // `affected_rows` must be the SUM across all flownodes, not the last response's value.
+        assert_eq!(300, res.affected_rows);
+        // `affected_flows` from every flownode are accumulated.
+        assert_eq!(2, res.affected_flows.len());
+        assert_eq!(2, res.extensions.len());
     }
 }


### PR DESCRIPTION
## What

`FlowServiceOperator::flush_inner` merged per-flownode `FlushFlow` responses by *overwriting* `affected_rows` while correctly accumulating `affected_flows`/`extensions`. The reported count was therefore whichever flownode finished last in the `FuturesUnordered` collection order, not the sum across flownodes.

One-line fix: `prev.affected_rows = res.affected_rows` → `prev.affected_rows += res.affected_rows`.

## Test

- Test-first: new `flush_flow_merges_affected_rows_across_flownodes` (mock two flownodes returning 100 and 200) failed before the fix with `left: 300, right: 200`, passes after.
- `cargo test -p operator flow` — 15 passed.
- sqlness `flow_flush`/`flow_basic` mask the flush count via `SQLNESS REPLACE`, so no golden-file changes needed.

## Checklist

- [x] Signed off commits
- [x] No internal issue numbers in code