### PR TITLE
perf(promql): specialize count over time ranges (rolling kernel Phase 1)

### DIFF
--- a/src/promql/benches/bench_range_fn.rs
+++ b/src/promql/benches/bench_range_fn.rs
@@ -37,7 +37,7 @@ use datatypes::arrow::datatypes::{DataType, Field};
 use futures::StreamExt;
 use promql::extension_plan::RangeManipulate;
 use promql::functions::{
-    Changes, Delta, IDelta, Increase, PredictLinear, QuantileOverTime, Rate, Resets,
+    Changes, CountOverTime, Delta, IDelta, Increase, PredictLinear, QuantileOverTime, Rate, Resets,
 };
 use promql::range_array::RangeArray;
 
@@ -280,6 +280,34 @@ fn assert_edge_count_output(
     let output = output.as_any().downcast_ref::<Float64Array>().unwrap();
     let actual = output.iter().collect::<Vec<_>>();
     assert_eq!(actual, expected);
+}
+
+fn count_over_time_oracle(ranges: &[(u32, u32)]) -> Vec<Option<f64>> {
+    ranges
+        .iter()
+        .map(|(_, length)| (*length != 0).then_some(*length as f64))
+        .collect()
+}
+
+fn assert_count_over_time_output(
+    udf: &datafusion::logical_expr::ScalarUDF,
+    prepared: &PreparedUdfCall,
+    ranges: &[(u32, u32)],
+) {
+    let expected = count_over_time_oracle(ranges);
+    let output = invoke_prepared_output(udf, prepared);
+    let ColumnarValue::Array(output) = output else {
+        panic!("count-over-time range UDF must return an array");
+    };
+    let output = output.as_any().downcast_ref::<Float64Array>().unwrap();
+
+    assert_eq!(output.len(), expected.len());
+    for (index, expected) in expected.iter().enumerate() {
+        assert_eq!(output.is_valid(index), expected.is_some());
+        if let Some(expected) = expected {
+            assert_eq!(output.value(index).to_bits(), expected.to_bits());
+        }
+    }
 }
 
 fn bench_range_functions(c: &mut Criterion) {
@@ -555,6 +583,74 @@ fn bench_edge_count_functions(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_count_over_time_current_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("count_over_time_current_baseline");
+    let num_points = 4_096;
+    let values = build_default_values(num_points);
+    let udf = CountOverTime::scalar_udf();
+
+    for window_size in [4u32, 20, 240] {
+        let ranges = (0..=num_points - window_size as usize)
+            .map(|offset| (offset as u32, window_size))
+            .collect::<Vec<_>>();
+        let prepared = PreparedUdfCall::new(make_edge_count_input_with_ranges(
+            values.clone(),
+            ranges.clone(),
+        ));
+
+        // Validate the current macro-generated UDF before Criterion starts timing it.
+        assert_count_over_time_output(&udf, &prepared, &ranges);
+        group.bench_with_input(
+            BenchmarkId::new(
+                "count_over_time_prebuilt_range_array",
+                format!("N{num_points}_k{window_size}"),
+            ),
+            &(),
+            |b, _| b.iter(|| invoke_prepared(&udf, &prepared)),
+        );
+    }
+
+    // Keep N=4096 but cover only eight four-slot windows to expose global-backing scans.
+    let low_coverage_ranges = vec![
+        (0, 4),
+        (512, 4),
+        (1_024, 4),
+        (1_536, 4),
+        (2_048, 4),
+        (2_560, 4),
+        (3_584, 4),
+        (4_092, 4),
+    ];
+    let low_coverage_prepared = PreparedUdfCall::new(make_edge_count_input_with_ranges(
+        values.clone(),
+        low_coverage_ranges.clone(),
+    ));
+    assert_count_over_time_output(&udf, &low_coverage_prepared, &low_coverage_ranges);
+    group.bench_with_input(
+        BenchmarkId::new(
+            "count_over_time_low_coverage_full_backing",
+            "N4096_windows8_k4",
+        ),
+        &(),
+        |b, _| b.iter(|| invoke_prepared(&udf, &low_coverage_prepared)),
+    );
+
+    // This control includes gapped, repeated, reordered, and empty windows.
+    let arbitrary_ranges = vec![(0, 4), (512, 4), (512, 4), (1_024, 0), (3_584, 4), (20, 20)];
+    let arbitrary_prepared = PreparedUdfCall::new(make_edge_count_input_with_ranges(
+        values,
+        arbitrary_ranges.clone(),
+    ));
+    assert_count_over_time_output(&udf, &arbitrary_prepared, &arbitrary_ranges);
+    group.bench_with_input(
+        BenchmarkId::new("count_over_time_arbitrary_layout", "N4096_windows6"),
+        &(),
+        |b, _| b.iter(|| invoke_prepared(&udf, &arbitrary_prepared)),
+    );
+
+    group.finish();
+}
+
 const RANGE_MANIPULATE_CADENCE_MS: i64 = 15_000;
 
 fn make_range_manipulate_batch(timestamps: Vec<i64>, field_count: usize) -> RecordBatch {
@@ -782,5 +878,6 @@ criterion_group!(
     benches,
     bench_range_functions,
     bench_edge_count_functions,
+    bench_count_over_time_current_baseline,
     bench_range_manipulate_wall_time
 );

--- a/src/promql/src/functions.rs
+++ b/src/promql/src/functions.rs
@@ -24,6 +24,7 @@ mod predict_linear;
 mod quantile;
 mod quantile_aggr;
 mod resets;
+mod rolling;
 mod round;
 #[cfg(test)]
 mod test_util;

--- a/src/promql/src/functions/aggr_over_time.rs
+++ b/src/promql/src/functions/aggr_over_time.rs
@@ -19,6 +19,7 @@ use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::{ScalarUDF, Volatility};
 use datafusion::physical_plan::ColumnarValue;
+use datafusion_expr::create_udf;
 use datatypes::arrow::array::Array;
 use datatypes::arrow::compute;
 use datatypes::arrow::datatypes::DataType;
@@ -81,16 +82,49 @@ pub fn sum_over_time(_: &TimestampMillisecondArray, values: &Float64Array) -> Op
 }
 
 /// The count of all values in the specified interval.
-#[range_fn(
-    name = CountOverTime,
-    ret = Float64Array,
-    display_name = prom_count_over_time
-)]
+#[allow(dead_code)]
 pub fn count_over_time(_: &TimestampMillisecondArray, values: &Float64Array) -> Option<f64> {
     if values.is_empty() {
         None
     } else {
         Some(values.len() as f64)
+    }
+}
+
+#[derive(Debug)]
+pub struct CountOverTime {}
+
+impl CountOverTime {
+    pub const fn name() -> &'static str {
+        "prom_count_over_time"
+    }
+
+    pub fn scalar_udf() -> ScalarUDF {
+        create_udf(
+            Self::name(),
+            Self::input_type(),
+            Self::return_type(),
+            Volatility::Volatile,
+            Arc::new(Self::calc) as _,
+        )
+    }
+
+    fn input_type() -> Vec<DataType> {
+        vec![
+            RangeArray::convert_data_type(
+                TimestampMillisecondArray::new_null(0).data_type().clone(),
+            ),
+            RangeArray::convert_data_type(Float64Array::new_null(0).data_type().clone()),
+        ]
+    }
+
+    fn return_type() -> DataType {
+        Float64Array::new_null(0).data_type().clone()
+    }
+
+    fn calc(input: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
+        assert_eq!(input.len(), 2);
+        crate::functions::rolling::count::calc(input, Self::name())
     }
 }
 

--- a/src/promql/src/functions/aggr_over_time.rs
+++ b/src/promql/src/functions/aggr_over_time.rs
@@ -194,6 +194,11 @@ pub fn stddev_over_time(_: &TimestampMillisecondArray, values: &Float64Array) ->
 
 #[cfg(test)]
 mod test {
+    use datafusion::arrow::buffer::NullBuffer;
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_expr::ScalarFunctionArgs;
+    use datatypes::arrow::datatypes::Field;
+
     use super::*;
     use crate::functions::test_util::simple_range_udf_runner;
 
@@ -216,6 +221,254 @@ mod test {
 
         assert_over_time_value(min_over_time(&timestamps, &values), expected_min);
         assert_over_time_value(max_over_time(&timestamps, &values), expected_max);
+    }
+
+    fn count_over_time_oracle(ranges: &[(u32, u32)]) -> Vec<Option<f64>> {
+        ranges
+            .iter()
+            .map(|&(_, length)| (length != 0).then_some(f64::from(length)))
+            .collect()
+    }
+
+    fn invoke_count_over_time(
+        udf: &ScalarUDF,
+        timestamps: RangeArray,
+        values: RangeArray,
+    ) -> Result<Float64Array, DataFusionError> {
+        let number_rows = timestamps.len();
+        let args = vec![
+            ColumnarValue::Array(Arc::new(timestamps.into_dict())),
+            ColumnarValue::Array(Arc::new(values.into_dict())),
+        ];
+        let arg_fields = vec![
+            Arc::new(Field::new("timestamps", args[0].data_type(), false)),
+            Arc::new(Field::new("values", args[1].data_type(), false)),
+        ];
+        let result = udf.invoke_with_args(ScalarFunctionArgs {
+            args,
+            arg_fields,
+            number_rows,
+            return_field: Arc::new(Field::new("result", DataType::Float64, false)),
+            config_options: Arc::new(ConfigOptions::default()),
+        })?;
+        let result = extract_array(&result)?;
+
+        Ok(result
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("count_over_time must return a Float64Array")
+            .clone())
+    }
+
+    fn assert_count_over_time_result(actual: &Float64Array, expected: &[Option<f64>]) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, expected) in expected.iter().enumerate() {
+            match expected {
+                Some(expected) => {
+                    assert!(actual.is_valid(index), "row {index} should be valid");
+                    assert_eq!(
+                        actual.value(index).to_bits(),
+                        expected.to_bits(),
+                        "row {index}"
+                    );
+                }
+                None => assert!(!actual.is_valid(index), "row {index} should be null"),
+            }
+        }
+    }
+
+    fn timestamp_backing(len: usize) -> Arc<TimestampMillisecondArray> {
+        Arc::new(TimestampMillisecondArray::from_iter(
+            (0..len).map(|index| Some(index as i64)),
+        ))
+    }
+
+    fn run_count_over_time_case(
+        udf: &ScalarUDF,
+        timestamps: Arc<TimestampMillisecondArray>,
+        values: Arc<Float64Array>,
+        timestamp_ranges: &[(u32, u32)],
+        value_ranges: &[(u32, u32)],
+    ) {
+        let expected = count_over_time_oracle(value_ranges);
+        let timestamps =
+            RangeArray::from_ranges(timestamps, timestamp_ranges.iter().copied()).unwrap();
+        let values = RangeArray::from_ranges(values, value_ranges.iter().copied()).unwrap();
+        let actual = invoke_count_over_time(udf, timestamps, values).unwrap();
+
+        assert_count_over_time_result(&actual, &expected);
+    }
+
+    fn assert_execution_error(error: DataFusionError, expected: &str) {
+        match error {
+            DataFusionError::Execution(message) => assert_eq!(message, expected),
+            other => panic!("expected execution error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn count_over_time_freezes_physical_slot_semantics() {
+        const RANGES: &[(u32, u32)] = &[
+            (0, 0), // empty
+            (0, 1), // finite
+            (1, 1), // NaN
+            (2, 1), // positive infinity
+            (3, 1), // negative infinity
+            (3, 3), // mixed valid and null slots
+            (4, 2), // all null slots
+            (4, 1), // raw nonzero value under a null slot
+        ];
+
+        let values = Arc::new(Float64Array::new(
+            vec![
+                1.25,
+                f64::from_bits(0x7ff8_0000_0000_0000),
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                42.0,
+                -7.0,
+            ]
+            .into(),
+            Some(NullBuffer::from(vec![true, true, true, true, false, false])),
+        ));
+        assert!(!values.is_valid(4));
+        assert_eq!(values.value(4).to_bits(), 42.0f64.to_bits());
+
+        let udf = CountOverTime::scalar_udf();
+        run_count_over_time_case(
+            &udf,
+            timestamp_backing(values.len()),
+            values,
+            RANGES,
+            RANGES,
+        );
+    }
+
+    #[test]
+    fn count_over_time_freezes_dense_and_arbitrary_layouts() {
+        const DENSE_SLIDING_RANGES: &[(u32, u32)] =
+            &[(1, 2), (2, 2), (3, 2), (4, 2), (5, 2), (6, 2), (8, 0)];
+        const ARBITRARY_RANGES: &[(u32, u32)] = &[
+            (5, 2),
+            (0, 3),
+            (3, 0),
+            (1, 4),
+            (1, 4),
+            (7, 1),
+            (3, 2),
+            (8, 0),
+        ];
+
+        let values = Arc::new(Float64Array::from_iter((0..8).map(|value| value as f64)));
+        let udf = CountOverTime::scalar_udf();
+
+        run_count_over_time_case(
+            &udf,
+            timestamp_backing(values.len()),
+            values.clone(),
+            DENSE_SLIDING_RANGES,
+            DENSE_SLIDING_RANGES,
+        );
+        run_count_over_time_case(
+            &udf,
+            timestamp_backing(values.len()),
+            values,
+            ARBITRARY_RANGES,
+            ARBITRARY_RANGES,
+        );
+    }
+
+    #[test]
+    fn count_over_time_ignores_timestamp_offsets_and_validity_after_shape_validation() {
+        const TIMESTAMP_RANGES: &[(u32, u32)] = &[(2, 2), (4, 1), (7, 0), (5, 3)];
+        const VALUE_RANGES: &[(u32, u32)] = &[(1, 2), (5, 1), (4, 0), (2, 3)];
+
+        let timestamps = Arc::new(TimestampMillisecondArray::new(
+            vec![100, 200, 300, 400, 500, 600, 700, 800].into(),
+            Some(NullBuffer::from(vec![
+                true, true, false, true, true, true, true, true,
+            ])),
+        ));
+        assert!(!timestamps.is_valid(2));
+        assert_eq!(timestamps.value(2), 300);
+
+        let values = Arc::new(Float64Array::from_iter((0..8).map(|value| value as f64)));
+        let udf = CountOverTime::scalar_udf();
+        run_count_over_time_case(&udf, timestamps, values, TIMESTAMP_RANGES, VALUE_RANGES);
+    }
+
+    #[test]
+    fn count_over_time_freezes_zero_window_outer_invocation() {
+        const NO_RANGES: &[(u32, u32)] = &[];
+
+        let values = Arc::new(Float64Array::from_iter([1.0, 2.0, 3.0]));
+        let udf = CountOverTime::scalar_udf();
+        run_count_over_time_case(
+            &udf,
+            timestamp_backing(values.len()),
+            values,
+            NO_RANGES,
+            NO_RANGES,
+        );
+    }
+
+    #[test]
+    fn count_over_time_same_udf_resets_between_invocations() {
+        const FIRST_RANGES: &[(u32, u32)] = &[(0, 3), (3, 0), (4, 2)];
+        const SECOND_RANGES: &[(u32, u32)] = &[(1, 1), (4, 3), (0, 0), (2, 2)];
+
+        let udf = CountOverTime::scalar_udf();
+        let first_values = Arc::new(Float64Array::from_iter([
+            10.0, 20.0, 30.0, 40.0, 50.0, 60.0,
+        ]));
+        run_count_over_time_case(
+            &udf,
+            timestamp_backing(first_values.len()),
+            first_values,
+            FIRST_RANGES,
+            FIRST_RANGES,
+        );
+
+        let second_values = Arc::new(Float64Array::from_iter([
+            f64::NAN,
+            f64::NEG_INFINITY,
+            3.0,
+            4.0,
+            f64::INFINITY,
+            6.0,
+            7.0,
+        ]));
+        run_count_over_time_case(
+            &udf,
+            timestamp_backing(second_values.len()),
+            second_values,
+            SECOND_RANGES,
+            SECOND_RANGES,
+        );
+    }
+
+    #[test]
+    fn count_over_time_preserves_range_shape_errors() {
+        let udf = CountOverTime::scalar_udf();
+        let timestamps = RangeArray::from_ranges(timestamp_backing(2), [(0, 1), (1, 1)]).unwrap();
+        let values =
+            RangeArray::from_ranges(Arc::new(Float64Array::from_iter([1.0, 2.0])), [(0, 1)])
+                .unwrap();
+        let error = invoke_count_over_time(&udf, timestamps, values).unwrap_err();
+        assert_execution_error(
+            error,
+            "RangeArray have different lengths in PromQL function prom_count_over_time: array1=2, array2=1",
+        );
+
+        let timestamps = RangeArray::from_ranges(timestamp_backing(2), [(0, 2)]).unwrap();
+        let values =
+            RangeArray::from_ranges(Arc::new(Float64Array::from_iter([1.0, 2.0])), [(0, 1)])
+                .unwrap();
+        let error = invoke_count_over_time(&udf, timestamps, values).unwrap_err();
+        assert_execution_error(
+            error,
+            "RangeArray's element 0 have different lengths in PromQL function prom_count_over_time: array1=2, array2=1",
+        );
     }
 
     #[test]

--- a/src/promql/src/functions/rolling/count.rs
+++ b/src/promql/src/functions/rolling/count.rs
@@ -19,8 +19,8 @@ use datafusion::common::DataFusionError;
 use datafusion::physical_plan::ColumnarValue;
 use datatypes::arrow::array::Array;
 
-use super::{Layout, Window, classify, transition, window_from_raw};
 use crate::functions::extract_range_array;
+use crate::functions::rolling::{Layout, Window, classify, transition, window_from_raw};
 use crate::range_array::RangeArray;
 
 pub(crate) fn calc(input: &[ColumnarValue], name: &str) -> Result<ColumnarValue, DataFusionError> {

--- a/src/promql/src/functions/rolling/count.rs
+++ b/src/promql/src/functions/rolling/count.rs
@@ -1,0 +1,283 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
+use datafusion::common::DataFusionError;
+use datafusion::physical_plan::ColumnarValue;
+use datatypes::arrow::array::Array;
+
+use super::{Layout, Window, classify, transition, window_from_raw};
+use crate::functions::extract_range_array;
+use crate::range_array::RangeArray;
+
+pub(crate) fn calc(input: &[ColumnarValue], name: &str) -> Result<ColumnarValue, DataFusionError> {
+    let timestamps = extract_range_array(&input[0])?;
+    let values = extract_range_array(&input[1])?;
+    if timestamps.len() != values.len() {
+        return Err(DataFusionError::Execution(format!(
+            "RangeArray have different lengths in PromQL function {name}: array1={}, array2={}",
+            timestamps.len(),
+            values.len()
+        )));
+    }
+
+    let timestamp_backing = timestamps
+        .values()
+        .as_any()
+        .downcast_ref::<TimestampMillisecondArray>()
+        .unwrap();
+    let value_backing = values
+        .values()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    let prepared = prepare_windows(
+        &timestamps,
+        &values,
+        timestamp_backing.len(),
+        value_backing.len(),
+        name,
+    )?;
+
+    let result = match prepared.layout {
+        Layout::Sliding => evaluate_sliding(&prepared.value_windows),
+        Layout::Arbitrary => evaluate_direct(&prepared.value_windows),
+    };
+    Ok(ColumnarValue::Array(Arc::new(Float64Array::from_iter(
+        result,
+    ))))
+}
+
+#[derive(Debug)]
+struct PreparedWindows {
+    layout: Layout,
+    value_windows: Vec<Window>,
+}
+
+fn prepare_windows(
+    timestamps: &RangeArray,
+    values: &RangeArray,
+    timestamp_backing_len: usize,
+    value_backing_len: usize,
+    name: &str,
+) -> Result<PreparedWindows, DataFusionError> {
+    let mut value_windows = Vec::with_capacity(values.len());
+    let mut timestamp_ranges = timestamps.ranges();
+    let mut value_ranges = values.ranges();
+    for index in 0..values.len() {
+        let (timestamp_offset, timestamp_len) =
+            timestamp_ranges.next().flatten().ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "RangeArray's element {index} is unavailable in PromQL function {name}"
+                ))
+            })?;
+        let timestamp_window = window_from_raw(
+            timestamp_offset,
+            timestamp_len,
+            timestamp_backing_len,
+            index,
+            name,
+        )?;
+        let (value_offset, value_len) = value_ranges.next().flatten().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "RangeArray's element {index} is unavailable in PromQL function {name}"
+            ))
+        })?;
+        let value_window =
+            window_from_raw(value_offset, value_len, value_backing_len, index, name)?;
+        if timestamp_window.len() != value_window.len() {
+            return Err(DataFusionError::Execution(format!(
+                "RangeArray's element {index} have different lengths in PromQL function {name}: array1={}, array2={}",
+                timestamp_window.len(),
+                value_window.len()
+            )));
+        }
+        value_windows.push(value_window);
+    }
+
+    Ok(PreparedWindows {
+        layout: classify(&value_windows),
+        value_windows,
+    })
+}
+
+fn evaluate_sliding(windows: &[Window]) -> Vec<Option<f64>> {
+    let Some((&first, rest)) = windows.split_first() else {
+        return Vec::new();
+    };
+
+    let mut count = first.len();
+    let mut result = Vec::with_capacity(windows.len());
+    result.push(count_result(count));
+    let mut previous = first;
+    for &current in rest {
+        let delta = transition(previous, current);
+        count -= delta.removed.len();
+        count += delta.added.len();
+        result.push(count_result(count));
+        previous = current;
+    }
+    result
+}
+
+fn evaluate_direct(windows: &[Window]) -> Vec<Option<f64>> {
+    windows
+        .iter()
+        .map(|window| count_result(window.len()))
+        .collect()
+}
+
+fn count_result(len: usize) -> Option<f64> {
+    (len != 0).then_some(len as f64)
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
+    use datafusion::physical_plan::ColumnarValue;
+
+    use super::*;
+
+    fn range_arrays(
+        timestamp_ranges: &[(u32, u32)],
+        value_ranges: &[(u32, u32)],
+    ) -> (RangeArray, RangeArray) {
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter(
+            (0..64).map(|value| Some(value as i64)),
+        ));
+        let values = Arc::new(Float64Array::from_iter((0..64).map(|value| value as f64)));
+        (
+            RangeArray::from_ranges(timestamps, timestamp_ranges.iter().copied()).unwrap(),
+            RangeArray::from_ranges(values, value_ranges.iter().copied()).unwrap(),
+        )
+    }
+
+    fn run(timestamp_ranges: &[(u32, u32)], value_ranges: &[(u32, u32)]) -> Float64Array {
+        let (timestamps, values) = range_arrays(timestamp_ranges, value_ranges);
+        let input = [
+            ColumnarValue::Array(Arc::new(timestamps.into_dict())),
+            ColumnarValue::Array(Arc::new(values.into_dict())),
+        ];
+        let result = calc(&input, "prom_count_over_time").unwrap();
+        let ColumnarValue::Array(result) = result else {
+            panic!("count_over_time must return an array");
+        };
+        result
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .clone()
+    }
+
+    fn oracle(value_ranges: &[(u32, u32)]) -> Vec<Option<f64>> {
+        value_ranges
+            .iter()
+            .map(|&(_, len)| (len != 0).then_some(f64::from(len)))
+            .collect()
+    }
+
+    fn assert_exact(actual: &Float64Array, expected: &[Option<f64>]) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, expected) in expected.iter().enumerate() {
+            match expected {
+                Some(expected) => {
+                    assert!(actual.is_valid(index));
+                    assert_eq!(actual.value(index).to_bits(), expected.to_bits());
+                }
+                None => assert!(!actual.is_valid(index)),
+            }
+        }
+    }
+
+    #[test]
+    fn applies_sliding_transitions_for_repeated_disjoint_and_empty_windows() {
+        let ranges = &[(1, 3), (1, 3), (4, 2), (6, 0), (6, 2), (9, 2)];
+        assert_exact(&run(ranges, ranges), &oracle(ranges));
+    }
+
+    #[test]
+    fn falls_back_for_an_incompatible_suffix_after_a_compatible_prefix() {
+        let ranges = &[(1, 3), (2, 3), (0, 2), (4, 1)];
+        let (timestamps, values) = range_arrays(ranges, ranges);
+        let prepared = prepare_windows(
+            &timestamps,
+            &values,
+            timestamps.values().len(),
+            values.values().len(),
+            "prom_count_over_time",
+        )
+        .unwrap();
+        assert_eq!(prepared.layout, Layout::Arbitrary);
+        assert_exact(&run(ranges, ranges), &oracle(ranges));
+    }
+
+    #[test]
+    fn prevalidates_all_rows_and_reports_the_first_mismatch() {
+        let timestamp_ranges = &[(0, 2), (1, 2), (4, 3), (8, 2)];
+        let value_ranges = &[(0, 2), (1, 2), (4, 2), (8, 1)];
+        let (timestamps, values) = range_arrays(timestamp_ranges, value_ranges);
+        let error = prepare_windows(
+            &timestamps,
+            &values,
+            timestamps.values().len(),
+            values.values().len(),
+            "prom_count_over_time",
+        )
+        .unwrap_err();
+        match error {
+            DataFusionError::Execution(message) => assert_eq!(
+                message,
+                "RangeArray's element 2 have different lengths in PromQL function prom_count_over_time: array1=3, array2=2"
+            ),
+            other => panic!("expected execution error, got {other:?}"),
+        }
+    }
+
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u32 {
+            self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (self.0 >> 32) as u32
+        }
+    }
+
+    #[test]
+    fn seeded_layout_differential_matches_the_raw_tuple_oracle() {
+        let mut lcg = Lcg(0x5eed_c0de);
+        let mut monotone = Vec::new();
+        let mut left = 0u32;
+        let mut right = 0u32;
+        for _ in 0..48 {
+            left = left.saturating_add(lcg.next() % 2);
+            right = right.max(left).saturating_add(lcg.next() % 3);
+            right = right.min(63);
+            left = left.min(right);
+            monotone.push((left, right - left));
+        }
+        assert_exact(&run(&monotone, &monotone), &oracle(&monotone));
+
+        let arbitrary = (0..48)
+            .map(|_| {
+                let left = lcg.next() % 63;
+                (left, lcg.next() % (64 - left))
+            })
+            .collect::<Vec<_>>();
+        assert_exact(&run(&arbitrary, &arbitrary), &oracle(&arbitrary));
+    }
+}

--- a/src/promql/src/functions/rolling/mod.rs
+++ b/src/promql/src/functions/rolling/mod.rs
@@ -1,0 +1,183 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(super) mod count;
+
+use std::ops::Range;
+
+use datafusion::common::DataFusionError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct Window {
+    pub(super) left: usize,
+    pub(super) right: usize,
+}
+
+impl Window {
+    pub(super) fn len(self) -> usize {
+        self.right - self.left
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Layout {
+    Sliding,
+    Arbitrary,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct Transition {
+    pub(super) removed: Range<usize>,
+    pub(super) added: Range<usize>,
+}
+
+pub(super) fn window_from_raw(
+    offset: u32,
+    len: u32,
+    backing_len: usize,
+    index: usize,
+    name: &str,
+) -> Result<Window, DataFusionError> {
+    let left = usize::try_from(offset).map_err(|_| invalid_range_error(index, name))?;
+    let len = usize::try_from(len).map_err(|_| invalid_range_error(index, name))?;
+    let right = left
+        .checked_add(len)
+        .filter(|right| *right <= backing_len)
+        .ok_or_else(|| invalid_range_error(index, name))?;
+
+    Ok(Window { left, right })
+}
+
+pub(super) fn classify(windows: &[Window]) -> Layout {
+    if windows
+        .windows(2)
+        .all(|pair| pair[1].left >= pair[0].left && pair[1].right >= pair[0].right)
+    {
+        Layout::Sliding
+    } else {
+        Layout::Arbitrary
+    }
+}
+
+pub(super) fn transition(old: Window, new: Window) -> Transition {
+    Transition {
+        removed: old.left..new.left.min(old.right),
+        added: old.right.max(new.left)..new.right,
+    }
+}
+
+fn invalid_range_error(index: usize, name: &str) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "RangeArray's element {index} has an invalid range in PromQL function {name}"
+    ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn window(left: usize, right: usize) -> Window {
+        Window { left, right }
+    }
+
+    #[test]
+    fn classifies_dense_repeated_disjoint_and_arbitrary_layouts() {
+        assert_eq!(classify(&[]), Layout::Sliding);
+        assert_eq!(
+            classify(&[window(1, 3), window(2, 4), window(2, 4), window(5, 7)]),
+            Layout::Sliding
+        );
+        assert_eq!(
+            classify(&[window(1, 5), window(2, 4)]),
+            Layout::Arbitrary,
+            "a decreasing right edge falls back for the whole invocation"
+        );
+        assert_eq!(
+            classify(&[window(2, 4), window(1, 5)]),
+            Layout::Arbitrary,
+            "a compatible prefix does not create a partial sliding run"
+        );
+        assert_eq!(classify(&[window(1, 5), window(2, 5)]), Layout::Sliding);
+    }
+
+    #[test]
+    fn computes_exact_monotone_transition_differences() {
+        assert_eq!(
+            transition(window(1, 5), window(2, 6)),
+            Transition {
+                removed: 1..2,
+                added: 5..6,
+            }
+        );
+        assert_eq!(
+            transition(window(1, 3), window(1, 5)),
+            Transition {
+                removed: 1..1,
+                added: 3..5,
+            }
+        );
+        assert_eq!(
+            transition(window(1, 5), window(3, 5)),
+            Transition {
+                removed: 1..3,
+                added: 5..5,
+            }
+        );
+        assert_eq!(
+            transition(window(1, 5), window(1, 5)),
+            Transition {
+                removed: 1..1,
+                added: 5..5,
+            }
+        );
+        assert_eq!(
+            transition(window(1, 3), window(5, 7)),
+            Transition {
+                removed: 1..3,
+                added: 5..7,
+            }
+        );
+        assert_eq!(
+            transition(window(2, 5), window(5, 5)),
+            Transition {
+                removed: 2..5,
+                added: 5..5,
+            }
+        );
+        assert_eq!(
+            transition(window(5, 5), window(5, 7)),
+            Transition {
+                removed: 5..5,
+                added: 5..7,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_checked_end_failures_with_the_frozen_error() {
+        assert_eq!(
+            window_from_raw(1, 3, 4, 0, "prom_count_over_time").unwrap(),
+            window(1, 4)
+        );
+
+        let error = window_from_raw(1, 1, 1, 0, "prom_count_over_time").unwrap_err();
+        match error {
+            DataFusionError::Execution(message) => assert_eq!(
+                message,
+                "RangeArray's element 0 has an invalid range in PromQL function prom_count_over_time"
+            ),
+            other => panic!("expected execution error, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the PromQL rolling-kernel work: specialize `count_over_time` with a hand-written UDF wrapper backed by a private rolling kernel in `src/promql/src/functions/rolling/`.

## Changes

- `src/promql/src/functions/rolling/mod.rs`: window validation/classification/transition engine (`Window`/`Layout`/`Transition`), frozen transition cases.
- `src/promql/src/functions/rolling/count.rs`: count evaluator + exact prefix fallback, frozen count tests.
- `src/promql/src/functions/aggr_over_time.rs`: manual `CountOverTime` wrapper delegating to the rolling count kernel.
- `src/promql/src/functions/bench_range_fn.rs`: count benchmarks (k=4/20/240, low coverage, arbitrary layout).

## Semantics

Count freezing semantics unchanged: every physical value slot counts (null/NaN/infinity included); zero-slot window returns null.

## Evidence

- Focused count tests: 7/7; rolling white-box/differential tests: 7/7.
- Full promql gate: 199/199 tests, clippy -D warnings, fmt pass.
- Micro ABBA (CPU18, 3x A/B/B/A): 90.5-90.6% median reduction on sliding layouts (10.6-10.7x), 74.7% low-coverage, 68.3% arbitrary fallback.
- Distributed ABBA (4 rounds, order-balanced): count reductions 10.4% (1m), 11.3% (5m), 9.1% (1h), all samples plan/output-row parity.
- Fail-closed audit: clean HEAD/version identity, 31 direct hashes, 260 Criterion files, 117 distributed files.
- Oracle review: READY TO CLOSE PHASE 1.

## Status

Draft, based on current main (which already includes the #8646 sliding-range work). Phase 2 (min/max) is planned separately.