### PR TITLE
ci: stop running enterprise tests in OSS CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -139,9 +139,7 @@ jobs:
         run: ../../.github/scripts/pull-test-deps-images.sh && docker compose up -d --wait
 
       - name: Run nextest cases
-        run: |
-          cargo nextest run --workspace -F dashboard -F pg_kvbackend -F mysql_kvbackend -F vector_index
-          cargo nextest run -p tests-integration --test main --features enterprise -E 'test(=table_ddl_event::test_table_ddl_procedure_events)'
+        run: cargo nextest run --workspace -F dashboard -F pg_kvbackend -F mysql_kvbackend -F vector_index
         env:
           CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
           RUST_BACKTRACE: 1


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8747.

## What's changed and what's your intention?

This PR stops running the targeted enterprise-only `table_ddl_event` nextest case in the open-source repository's Rust CI workflow.

Enterprise CI already validates changes from the OSS repository and owns enterprise runtime test coverage. Removing the duplicate invocation reduces OSS CI time while preserving:

- the normal OSS workspace nextest run;
- `cargo check --workspace --all-targets --all-features` coverage for enterprise feature compilation;
- enterprise feature propagation and license checks.

This is a CI-only change with no API, schema, data, or runtime behavior impact.

Verification:

- `git diff --check`
- parsed `.github/workflows/rust.yml` with PyYAML
- confirmed no enterprise nextest invocation remains in OSS workflows
- confirmed all-features compilation and enterprise license checks remain enabled

## PR Checklist

- [x] I have written the necessary rustdoc comments. (Not applicable: CI-only change.)
- [x] I have added the necessary unit tests and integration tests. (Not applicable: workflow-only change; static workflow checks were run.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible. (No API changes.)
- [x] Schema or data changes are backward compatible. (No schema or data changes.)
