### PR TITLE
feat(promql): support native histogram vector operators

### DIFF
--- a/.agents/architecture-invariants.md
+++ b/.agents/architecture-invariants.md
@@ -43,8 +43,8 @@ The workspace is layered; dependencies point downward only.
   `file-engine`) implement it; `datanode` drives engines **through the trait**,
   not through engine internals.
 - `frontend` reaches storage through `operator` / `query` / `catalog`, not by
-  depending on `datanode` internals. Standalone mode is the one bridge, via a
-  `RegionServer` wrapper (`src/frontend/src/instance/standalone.rs`).
+  depending on `datanode` internals. Standalone mode is the one bridge, via the
+  `RegionServer` adapter in `src/standalone/src/datanode_manager.rs`.
 - Do not introduce circular dependencies. New deps go through
   `[workspace.dependencies]` in the root `Cargo.toml`, not per-crate version
   literals.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5586,7 +5586,6 @@ dependencies = [
  "dashmap",
  "datafusion",
  "datafusion-expr",
- "datanode",
  "datatypes",
  "futures",
  "hostname 0.4.1",
@@ -5596,7 +5595,6 @@ dependencies = [
  "lazy_static",
  "log-query",
  "meta-client",
- "meta-srv",
  "num_cpus",
  "opentelemetry-proto 0.31.0",
  "opentelemetry-semantic-conventions 0.31.0",
@@ -14108,6 +14106,7 @@ dependencies = [
 name = "standalone"
 version = "1.3.0"
 dependencies = [
+ "api",
  "async-trait",
  "catalog",
  "client",
@@ -14121,6 +14120,7 @@ dependencies = [
  "common-options",
  "common-procedure",
  "common-query",
+ "common-recordbatch",
  "common-stat",
  "common-telemetry",
  "common-time",

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -60,7 +60,6 @@ use flow::{
     FrontendInvoker, GrpcQueryHandlerWithBoxedError,
 };
 use frontend::frontend::Frontend;
-use frontend::instance::StandaloneDatanodeManager;
 use frontend::instance::builder::FrontendBuilder;
 use frontend::server::Services;
 use meta_srv::metasrv::{FLOW_ID_SEQ, TABLE_ID_SEQ};
@@ -72,7 +71,10 @@ use plugins::standalone::context::DdlManagerConfigureContext;
 use servers::tls::{TlsMode, TlsOption, merge_tls_option};
 use snafu::{OptionExt, ResultExt};
 use standalone::options::StandaloneOptions;
-use standalone::{StandaloneInformationExtension, StandaloneRepartitionProcedureFactory};
+use standalone::{
+    StandaloneDatanodeManager, StandaloneInformationExtension,
+    StandaloneRepartitionProcedureFactory,
+};
 use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::error::{OtherSnafu, Result, StartFlownodeSnafu};

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -16,8 +16,9 @@ reads go to the query engine (`query` crate), writes go to the inserter/deleter
 Boundary with `servers`: the `servers` crate implements the wire protocols and
 network I/O; `frontend` provides the business logic by implementing handler
 traits (`SqlQueryHandler`, `GrpcQueryHandler`, `InfluxdbLineProtocolHandler`,
-...). In standalone mode the frontend embeds a datanode `RegionServer`; in
-distributed mode it talks to remote datanodes via `operator`/`client`.
+...). In standalone mode the `standalone` crate bridges the frontend to an
+embedded datanode `RegionServer`; in distributed mode the frontend talks to
+remote datanodes via `operator`/`client`.
 
 ## Module map
 
@@ -26,7 +27,6 @@ distributed mode it talks to remote datanodes via `operator`/`client`.
 | `instance` | `src/frontend/src/instance.rs` | `Instance`: the core handler; implements `SqlQueryHandler`, `PrometheusHandler`, etc. |
 | `instance/builder` | `src/frontend/src/instance/builder.rs` | `FrontendBuilder` assembles `Instance` from its dependencies |
 | `instance/grpc` | `src/frontend/src/instance/grpc.rs` | `GrpcQueryHandler`: insert/delete/query/promql over gRPC |
-| `instance/standalone` | `src/frontend/src/instance/standalone.rs` | Calls the local `RegionServer` instead of RPC |
 | `instance/region_query` | `src/frontend/src/instance/region_query.rs` | Routes distributed region reads to datanodes |
 | `instance/*` | `src/frontend/src/instance/` | Per-protocol handlers (`influxdb.rs`, `promql.rs`, `otlp/`, `jaeger.rs`, `logs.rs`, `prom_store.rs`, ...) |
 | `frontend` | `src/frontend/src/frontend.rs` | `Frontend` lifecycle wrapper (`FrontendOptions`, start/shutdown) |
@@ -73,9 +73,9 @@ cargo nextest run -p frontend
 
 - Keep the frontend/servers split straight: wire format and network live in
   `servers`; permissions, planning, and routing live here.
-- Standalone vs distributed diverge in datanode access (local `RegionServer` vs
-  `NodeClients` RPC), MetaClient usage, and whether heartbeat matters. In
-  standalone, the cache invalidator is a no-op.
+- Standalone vs distributed diverge in datanode access (the `standalone` crate's
+  local `RegionServer` adapter vs `NodeClients` RPC), MetaClient usage, and
+  whether heartbeat matters. In standalone, the cache invalidator is a no-op.
 
 ## Maintenance contract
 

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -52,7 +52,6 @@ common-version.workspace = true
 dashmap.workspace = true
 datafusion.workspace = true
 datafusion-expr.workspace = true
-datanode.workspace = true
 datatypes.workspace = true
 futures.workspace = true
 hostname.workspace = true
@@ -91,11 +90,9 @@ tracing.workspace = true
 [dev-dependencies]
 catalog = { workspace = true, features = ["testing"] }
 common-test-util.workspace = true
-datanode.workspace = true
 datatypes.workspace = true
 futures.workspace = true
 hyper-util = { workspace = true, features = ["tokio"] }
-meta-srv.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 strfmt = "0.2"

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -193,13 +193,6 @@ pub enum Error {
         source: query::error::Error,
     },
 
-    #[snafu(display("Operation to region server failed"))]
-    InvokeRegionServer {
-        #[snafu(implicit)]
-        location: Location,
-        source: servers::error::Error,
-    },
-
     #[snafu(display("Not supported: {}", feat))]
     NotSupported { feat: String },
 
@@ -285,9 +278,6 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
-
-    #[snafu(display("Invalid region request, reason: {}", reason))]
-    InvalidRegionRequest { reason: String },
 
     #[snafu(display("Table operation error"))]
     TableOperation {
@@ -415,8 +405,6 @@ impl ErrorExt for Error {
 
             Error::CacheRequired { .. } => StatusCode::Internal,
 
-            Error::InvalidRegionRequest { .. } => StatusCode::IllegalState,
-
             Error::TableNotFound { .. } => StatusCode::TableNotFound,
 
             Error::Catalog { source, .. } => source.status_code(),
@@ -427,7 +415,6 @@ impl ErrorExt for Error {
             | Error::ReadTable { source, .. }
             | Error::ExecLogicalPlan { source, .. } => source.status_code(),
 
-            Error::InvokeRegionServer { source, .. } => source.status_code(),
             Error::External { source, .. } | Error::InitPlugin { source, .. } => {
                 source.status_code()
             }
@@ -461,7 +448,6 @@ impl ErrorExt for Error {
 
             Error::StartServer { source, .. }
             | Error::ShutdownServer { source, .. }
-            | Error::InvokeRegionServer { source, .. }
             | Error::ExecutePromql { source, .. }
             | Error::PromStoreRemoteQueryPlan { source, .. }
             | Error::PrometheusMetricNamesQueryPlan { source, .. } => source.retry_hint(),

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -165,6 +165,7 @@ impl Frontend {
 mod tests {
     use std::any::Any;
     use std::net::SocketAddr;
+    use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::time::Duration;
 
@@ -186,9 +187,9 @@ mod tests {
     use common_meta::heartbeat::handler::suspend::SuspendHandler;
     use common_meta::instruction::Instruction;
     use common_stat::ResourceStatImpl;
+    use futures::Stream;
     use meta_client::MetaClientRef;
     use meta_client::client::MetaClientBuilder;
-    use meta_srv::service::GrpcStream;
     use servers::grpc::{FlightCompression, GRPC_SERVER};
     use servers::http::HTTP_SERVER;
     use servers::http::result::greptime_result_v1::GreptimedbV1Response;
@@ -205,6 +206,9 @@ mod tests {
     };
     use crate::instance::builder::FrontendBuilder;
     use crate::server::Services;
+
+    type GrpcStream<T> =
+        Pin<Box<dyn Stream<Item = std::result::Result<T, Status>> + Send + Sync + 'static>>;
 
     #[test]
     fn test_toml() {

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -25,7 +25,6 @@ mod otlp;
 pub mod prom_store;
 mod promql;
 mod region_query;
-pub mod standalone;
 
 use std::collections::HashSet;
 use std::pin::Pin;
@@ -100,7 +99,6 @@ use sql::statements::statement::Statement;
 use sql::statements::tql::Tql;
 use sql::util::{extract_tables_from_prom_expr_checked, extract_tables_from_statement_checked};
 use sqlparser::ast::{AnalyzeFormat, ObjectName};
-pub use standalone::StandaloneDatanodeManager;
 use table::requests::{OTLP_METRIC_COMPAT_KEY, OTLP_METRIC_COMPAT_PROM};
 use tracing::Span;
 

--- a/src/standalone/Cargo.toml
+++ b/src/standalone/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+api.workspace = true
 async-trait.workspace = true
 catalog.workspace = true
 client.workspace = true
@@ -21,6 +22,7 @@ common-meta.workspace = true
 common-options.workspace = true
 common-procedure.workspace = true
 common-query.workspace = true
+common-recordbatch.workspace = true
 common-stat.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true

--- a/src/standalone/src/datanode_manager.rs
+++ b/src/standalone/src/datanode_manager.rs
@@ -54,12 +54,12 @@ impl FlownodeManager for StandaloneDatanodeManager {
 }
 
 /// Relative to [client::region::RegionRequester]
-pub struct RegionInvoker {
+struct RegionInvoker {
     region_server: RegionServer,
 }
 
 impl RegionInvoker {
-    pub fn arc(region_server: RegionServer) -> Arc<Self> {
+    fn arc(region_server: RegionServer) -> Arc<Self> {
         Arc::new(Self { region_server })
     }
 

--- a/src/standalone/src/error.rs
+++ b/src/standalone/src/error.rs
@@ -14,7 +14,7 @@
 
 use std::any::Any;
 
-use common_error::ext::{BoxedError, ErrorExt};
+use common_error::ext::{BoxedError, ErrorExt, RetryHint};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -28,6 +28,13 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
         source: BoxedError,
+    },
+
+    #[snafu(display("Operation to region server failed"))]
+    InvokeRegionServer {
+        #[snafu(implicit)]
+        location: Location,
+        source: servers::error::Error,
     },
 
     #[snafu(display("External error"))]
@@ -49,6 +56,9 @@ pub enum Error {
     #[snafu(display("Invalid url scheme: {}", scheme))]
     InvalidUrlScheme { scheme: String },
 
+    #[snafu(display("Invalid region request, reason: {}", reason))]
+    InvalidRegionRequest { reason: String },
+
     #[snafu(display("Repartition procedure is not supported in standalone mode"))]
     NoSupportRepartitionProcedure {
         #[snafu(implicit)]
@@ -62,14 +72,23 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
             Error::OpenMetadataKvBackend { source, .. } => source.status_code(),
+            Error::InvokeRegionServer { source, .. } => source.status_code(),
             Error::External { source, .. } => source.status_code(),
             Error::ParseUrl { .. } => StatusCode::InvalidArguments,
             Error::InvalidUrlScheme { .. } => StatusCode::InvalidArguments,
+            Error::InvalidRegionRequest { .. } => StatusCode::IllegalState,
             Error::NoSupportRepartitionProcedure { .. } => StatusCode::Unsupported,
         }
     }
 
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn retry_hint(&self) -> RetryHint {
+        match self {
+            Error::InvokeRegionServer { source, .. } => source.retry_hint(),
+            _ => RetryHint::NonRetryable,
+        }
     }
 }

--- a/src/standalone/src/lib.rs
+++ b/src/standalone/src/lib.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod datanode_manager;
 pub mod error;
 pub mod information_extension;
 pub mod metadata;
 pub mod options;
 pub mod procedure;
 
+pub use datanode_manager::StandaloneDatanodeManager;
 pub use information_extension::StandaloneInformationExtension;
 pub use metadata::{build_metadata_kv_from_url, build_metadata_kvbackend};
 pub use procedure::{StandaloneRepartitionProcedureFactory, build_procedure_manager};

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -49,14 +49,14 @@ use common_wal::config::{DatanodeWalConfig, MetasrvWalConfig};
 use datanode::datanode::DatanodeBuilder;
 use flow::{FlownodeBuilder, FrontendClient, GrpcQueryHandlerWithBoxedError};
 use frontend::frontend::Frontend;
+use frontend::instance::Instance;
 use frontend::instance::builder::FrontendBuilder;
-use frontend::instance::{Instance, StandaloneDatanodeManager};
 use frontend::server::Services;
 use meta_srv::metasrv::{FLOW_ID_SEQ, TABLE_ID_SEQ};
 use servers::grpc::GrpcOptions;
 use snafu::ResultExt;
-use standalone::StandaloneRepartitionProcedureFactory;
 use standalone::options::StandaloneOptions;
+use standalone::{StandaloneDatanodeManager, StandaloneRepartitionProcedureFactory};
 
 use crate::test_util::{self, StorageType, TestGuard, create_tmp_dir_and_datanode_opts};
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This is the 4th PR of the 6 PRs of native histogram.

This pull request adds native histogram support to PromQL unary negation, arithmetic and comparison operators, and set operations. It preserves mixed float/native-histogram vectors through `or`, scalar broadcasting, filtering, and downstream operators while keeping annotation-producing UDFs on the frontend in distributed plans.

Unsupported histogram pairings are dropped with accurate info annotations only when matched samples are present, avoiding silent drops and false-positive annotations. The change does not alter public configuration, persisted data, or wire formats.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
