### PR TITLE
perf: micro-optimizations across query paths (prepared stmts, MySQL writer, distributed scan, memtable gauge)

### DIFF
--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -80,6 +80,14 @@ impl Datanode for RegionRequester {
             .map_err(BoxedError::new)
             .context(meta_error::ExternalSnafu)?
             .to_vec();
+        self.handle_query_encoded(request, plan).await
+    }
+
+    async fn handle_query_encoded(
+        &self,
+        request: QueryRequest,
+        plan: Vec<u8>,
+    ) -> MetaResult<SendableRecordBatchStream> {
         let request = api::v1::region::QueryRequest {
             header: request.header,
             region_id: request.region_id.as_u64(),

--- a/src/common/meta/src/node_manager.rs
+++ b/src/common/meta/src/node_manager.rs
@@ -32,6 +32,18 @@ pub trait Datanode: Send + Sync {
 
     /// Handles query requests
     async fn handle_query(&self, request: QueryRequest) -> Result<SendableRecordBatchStream>;
+
+    /// Handles query requests with a substrait plan that was encoded once for
+    /// the whole query instead of once per region. The encoded bytes are
+    /// region-invariant; the default implementation falls back to re-encoding
+    /// via [`Datanode::handle_query`].
+    async fn handle_query_encoded(
+        &self,
+        request: QueryRequest,
+        _encoded_plan: Vec<u8>,
+    ) -> Result<SendableRecordBatchStream> {
+        self.handle_query(request).await
+    }
 }
 
 pub type DatanodeRef = Arc<dyn Datanode>;

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -49,9 +49,9 @@ use table::table::adapter::DfTableProviderAdapter;
 use table::table_name::TableName;
 
 use crate::error::{
-    CatalogSnafu, DataFusionSnafu, Error, ExternalSnafu, IncompleteGrpcRequestSnafu,
-    NotSupportedSnafu, PermissionSnafu, PlanStatementSnafu, Result,
-    SubstraitDecodeLogicalPlanSnafu, TableNotFoundSnafu, TableOperationSnafu,
+    CatalogSnafu, Error, ExternalSnafu, IncompleteGrpcRequestSnafu, NotSupportedSnafu,
+    PermissionSnafu, PlanStatementSnafu, Result, SubstraitDecodeLogicalPlanSnafu,
+    TableNotFoundSnafu, TableOperationSnafu,
 };
 use crate::instance::{Instance, attach_timer};
 use crate::metrics::{
@@ -497,19 +497,11 @@ impl Instance {
         let insert_into = add_insert_to_logical_plan(table_name, table_source, logical_plan)
             .context(SubstraitDecodeLogicalPlanSnafu)?;
 
-        let engine_ctx = self.query_engine().engine_context(ctx.clone());
-        let state = engine_ctx.state();
-        // Analyze the plan
-        let analyzed_plan = state
-            .analyzer()
-            .execute_and_check(insert_into, state.config_options(), |_, _| {})
-            .context(DataFusionSnafu)?;
-
-        // Optimize the plan
-        let optimized_plan = state.optimize(&analyzed_plan).context(DataFusionSnafu)?;
-
+        // `do_exec_plan_inner` → `create_physical_plan` already runs the analyzer and
+        // optimizer internally (with MergeScan/Explain guards), so pass the decoded,
+        // unoptimized plan directly.
         let output = self
-            .do_exec_plan_inner(optimized_plan, None, ctx.clone())
+            .do_exec_plan_inner(insert_into, None, ctx.clone())
             .await?;
 
         Ok(attach_timer(output, timer))

--- a/src/frontend/src/instance/region_query.rs
+++ b/src/frontend/src/instance/region_query.rs
@@ -71,6 +71,18 @@ impl RegionQueryHandler for FrontendRegionQueryHandler {
             .context(RegionQuerySnafu)
     }
 
+    async fn do_get_encoded(
+        &self,
+        target: &RegionQueryTarget,
+        request: QueryRequest,
+        encoded_plan: Vec<u8>,
+    ) -> QueryResult<common_recordbatch::SendableRecordBatchStream> {
+        self.do_get_encoded_inner(target, request, encoded_plan)
+            .await
+            .map_err(BoxedError::new)
+            .context(RegionQuerySnafu)
+    }
+
     async fn handle_remote_dyn_filter_update(
         &self,
         target: &RegionQueryTarget,
@@ -123,6 +135,20 @@ impl FrontendRegionQueryHandler {
             .datanode(target.peer())
             .await
             .handle_query(request)
+            .await
+            .context(RequestQuerySnafu)
+    }
+
+    async fn do_get_encoded_inner(
+        &self,
+        target: &RegionQueryTarget,
+        request: QueryRequest,
+        encoded_plan: Vec<u8>,
+    ) -> Result<common_recordbatch::SendableRecordBatchStream> {
+        self.node_manager
+            .datanode(target.peer())
+            .await
+            .handle_query_encoded(request, encoded_plan)
             .await
             .context(RequestQuerySnafu)
     }

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -1056,7 +1056,9 @@ impl ValueBuilder {
             .enumerate()
             .map(|(i, v)| {
                 if let Some(v) = v {
-                    MEMTABLE_ACTIVE_FIELD_BUILDER_COUNT.dec();
+                    // `finish_cloned` only clones the builder, which stays alive and remains
+                    // counted in `MEMTABLE_ACTIVE_FIELD_BUILDER_COUNT`. The count is released
+                    // by `Values::from(ValueBuilder)` (write/flush path) and `SeriesMap::drop`.
                     v.finish_cloned()
                 } else {
                     let mut single_null = self.field_types[i].create_mutable_vector(num_rows);
@@ -1388,6 +1390,26 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(expect, &read);
+    }
+
+    #[test]
+    fn test_field_builder_gauge_balance_after_read_and_flush() {
+        let region_metadata = schema_for_test();
+        let mut series = Series::new(&region_metadata);
+        let gauge_before = MEMTABLE_ACTIVE_FIELD_BUILDER_COUNT.get();
+
+        series.push(ts_value_ref(1), 0, OpType::Put, field_value_ref(1, 10.1));
+        // Pushing the two field values creates one field builder per column.
+        assert_eq!(MEMTABLE_ACTIVE_FIELD_BUILDER_COUNT.get(), gauge_before + 2);
+
+        // `read_to_values` clones the active builders without consuming them, so the
+        // active field builder count must stay unchanged.
+        let _values = series.read_to_values();
+        assert_eq!(MEMTABLE_ACTIVE_FIELD_BUILDER_COUNT.get(), gauge_before + 2);
+
+        // Freezing consumes the builders via `Values::from`, releasing the gauge.
+        series.freeze(&region_metadata);
+        assert_eq!(MEMTABLE_ACTIVE_FIELD_BUILDER_COUNT.get(), gauge_before);
     }
 
     #[test]

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -25,6 +25,7 @@ use arrow_schema::{
 };
 use async_stream::stream;
 use common_catalog::parse_catalog_and_schema_from_db_string;
+use common_meta::peer::Peer;
 use common_plugins::GREPTIME_EXEC_READ_COST;
 use common_query::request::QueryRequest;
 use common_recordbatch::adapter::{RecordBatchMetrics, region_scan_output_bytes};
@@ -59,7 +60,8 @@ use session::context::{
     SUPPORT_FLIGHT_METRICS_BEFORE_BATCH_EXTENSION_KEY,
 };
 use store_api::metrics::{REGION_QUERY_CPU_TIME, REGION_QUERY_SCANNED_BYTES};
-use store_api::storage::RegionId;
+use store_api::storage::{RegionId, RegionNumber};
+use substrait::{DFLogicalSubstraitConvertor, SubstraitPlan};
 use table::table_name::TableName;
 use tokio::time;
 use tokio::time::Instant;
@@ -77,8 +79,8 @@ use crate::dist_plan::{
 };
 use crate::metrics::{MERGE_SCAN_ERRORS_TOTAL, MERGE_SCAN_POLL_ELAPSED, MERGE_SCAN_REGIONS};
 use crate::options::{FlowQueryExtensions, remote_dyn_filter_pushdown_enabled_from_extensions};
-use crate::query_engine::QueryEngineState;
-use crate::region_query::RegionQueryHandlerRef;
+use crate::query_engine::{DefaultSerializer, QueryEngineState};
+use crate::region_query::{RegionQueryHandlerRef, RegionQueryTarget};
 
 fn query_engine_state_from_task_context(context: &TaskContext) -> Option<Arc<QueryEngineState>> {
     context.session_config().get_extension()
@@ -98,6 +100,29 @@ fn record_merge_scan_schema_error() {
 
     #[cfg(test)]
     TEST_MERGE_SCAN_SCHEMA_ERRORS.with(|count| count.set(count.get() + 1));
+}
+
+/// Returns true when any timestamp field of `actual` differs from `expected` in
+/// timezone only, i.e. when [`patch_batch_timezone`] would cast a column.
+///
+/// Mirrors the cast condition inside `patch_batch_timezone` (same time unit,
+/// different timezone). RecordBatch construction guarantees that each column's
+/// data type equals its schema field's data type, so comparing the schemas is
+/// equivalent to the per-column comparison the patch performs.
+fn needs_timezone_patch(expected: &ArrowSchema, actual: &ArrowSchema) -> bool {
+    expected
+        .fields()
+        .iter()
+        .zip(actual.fields().iter())
+        .any(|(expected_field, actual_field)| {
+            matches!(
+                (expected_field.data_type(), actual_field.data_type()),
+                (
+                    ArrowDataType::Timestamp(expected_unit, expected_tz),
+                    ArrowDataType::Timestamp(actual_unit, actual_tz),
+                ) if expected_unit == actual_unit && expected_tz != actual_tz
+            )
+        })
 }
 
 #[cfg(test)]
@@ -380,6 +405,11 @@ pub struct MergeScanExec {
     target_partition: usize,
     partition_cols: AliasMapping,
     enable_per_region_metrics: bool,
+    /// Region → leader peer map resolved once per query from the table route
+    /// snapshot fetched during planning. `to_stream` consults it instead of
+    /// re-resolving the leader per region, falling back to `select_target` on
+    /// miss (the leader may be absent from the snapshot).
+    region_leader_map: Arc<HashMap<RegionNumber, Peer>>,
 }
 
 impl std::fmt::Debug for MergeScanExec {
@@ -480,7 +510,18 @@ impl MergeScanExec {
             target_partition,
             partition_cols,
             enable_per_region_metrics,
+            region_leader_map: Arc::default(),
         })
+    }
+
+    /// Attaches the region → leader map resolved during planning so that
+    /// `to_stream` can skip per-region leader resolution.
+    pub fn with_region_leader_map(
+        mut self,
+        region_leader_map: HashMap<RegionNumber, Peer>,
+    ) -> Self {
+        self.region_leader_map = Arc::new(region_leader_map);
+        self
     }
 
     pub fn to_stream(
@@ -497,6 +538,7 @@ impl MergeScanExec {
         let sub_stage_metrics_moved = self.sub_stage_metrics.clone();
         let partition_metrics_moved = self.partition_metrics.clone();
         let plan = self.plan.clone();
+        let region_leader_map = self.region_leader_map.clone();
         let target_partition = self.target_partition;
         let remote_dyn_filter_enabled = remote_dyn_filter_enabled(&self.query_ctx)?;
         let captured_remote_dyn_filters = if remote_dyn_filter_enabled {
@@ -522,6 +564,15 @@ impl MergeScanExec {
             if partition == 0 {
                 MERGE_SCAN_REGIONS.observe(regions.len() as f64);
             }
+
+            // Encode the pushed-down plan once per stream: the encoded bytes are
+            // region-invariant (region_id is a sibling request field, not part of
+            // the plan), so reusing them across regions avoids re-encoding the
+            // same plan once per region.
+            let encoded_plan = DFLogicalSubstraitConvertor
+                .encode(&plan, DefaultSerializer)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+                .to_vec();
 
             let _finish_timer = metric.finish_time().timer();
             let mut ready_timer = metric.ready_time().timer();
@@ -550,14 +601,17 @@ impl MergeScanExec {
                     &captured_remote_dyn_filters,
                 );
                 let select_target_start = Instant::now();
-                let target = region_query_handler
-                    .select_target(read_preference, region_id)
-                    .instrument(region_span.clone())
-                    .await
-                    .map_err(|e| {
-                        MERGE_SCAN_ERRORS_TOTAL.inc();
-                        DataFusionError::External(Box::new(e))
-                    })?;
+                let target = match region_leader_map.get(&region_id.region_number()) {
+                    Some(peer) => RegionQueryTarget::new(peer.clone()),
+                    None => region_query_handler
+                        .select_target(read_preference, region_id)
+                        .instrument(region_span.clone())
+                        .await
+                        .map_err(|e| {
+                            MERGE_SCAN_ERRORS_TOTAL.inc();
+                            DataFusionError::External(Box::new(e))
+                        })?,
+                };
                 let select_target_cost = select_target_start.elapsed();
                 let mut subscriber_rollback =
                     remote_dyn_filter_registry_lease.as_ref().map(|lease| {
@@ -604,7 +658,7 @@ impl MergeScanExec {
 
                 let do_get_start = Instant::now();
                 let do_get_result = region_query_handler
-                    .do_get(&target, request)
+                    .do_get_encoded(&target, request, encoded_plan.clone())
                     .instrument(region_span.clone())
                     .await;
                 if do_get_result.is_err() {
@@ -625,6 +679,12 @@ impl MergeScanExec {
                     "advertised remote stream",
                 )
                 .inspect_err(|_| record_merge_scan_schema_error())?;
+                // The timezone patch is only needed when a timestamp column's
+                // timezone differs between the expected schema and the remote
+                // schema. Precompute it once per region stream so batches pass
+                // through unchanged when no cast is required.
+                let mut needs_tz_patch =
+                    needs_timezone_patch(arrow_schema.as_ref(), advertised_schema.as_ref());
                 let do_get_cost = select_target_cost + do_get_start.elapsed();
 
                 if let Some(remote_dyn_filter_registry_lease) =
@@ -678,9 +738,23 @@ impl MergeScanExec {
                         )
                         .inspect_err(|_| record_merge_scan_schema_error())?;
                         advertised_schema = df_batch.schema_ref().clone();
+                        needs_tz_patch =
+                            needs_timezone_patch(arrow_schema.as_ref(), advertised_schema.as_ref());
                     }
-                    let batch =
-                        patch_batch_timezone(arrow_schema.clone(), df_batch.columns().to_vec())?;
+                    let batch = if needs_tz_patch
+                        || df_batch.schema_ref().as_ref() != arrow_schema.as_ref()
+                    {
+                        // Either a timestamp column needs a timezone cast, or the
+                        // batch still carries a schema that differs from the
+                        // expected one (e.g. top-level metadata): rebuild it
+                        // exactly like before.
+                        patch_batch_timezone(arrow_schema.clone(), df_batch.columns().to_vec())?
+                    } else {
+                        // No cast is needed and the batch schema already matches
+                        // the expected one, so the rebuild would be a no-op: pass
+                        // the incoming batch through directly.
+                        df_batch
+                    };
                     metric.record_output_batch_rows(batch.num_rows());
                     if let Some(mut first_consume_timer) = first_consume_timer.take() {
                         first_consume_timer.stop();
@@ -846,6 +920,7 @@ impl MergeScanExec {
             target_partition: self.target_partition,
             partition_cols: self.partition_cols.clone(),
             enable_per_region_metrics: self.enable_per_region_metrics,
+            region_leader_map: self.region_leader_map.clone(),
         })
     }
 

--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -21,6 +21,7 @@ use arrow_schema::SortOptions;
 use async_trait::async_trait;
 use catalog::CatalogManagerRef;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use common_meta::peer::Peer;
 use common_telemetry::debug;
 use datafusion::common::Result;
 use datafusion::datasource::DefaultTableSource;
@@ -36,7 +37,7 @@ use partition::expr::PartitionExpr;
 use partition::manager::{PartitionRuleManagerRef, create_partitions_from_region_routes};
 use session::context::QueryContext;
 use snafu::{OptionExt, ResultExt};
-use store_api::storage::RegionId;
+use store_api::storage::{RegionId, RegionNumber};
 use table::metadata::TableInfo;
 pub use table::metadata::TableType;
 use table::table::adapter::DfTableProviderAdapter;
@@ -189,7 +190,8 @@ impl ExtensionPlanner for DistExtensionPlanner {
             return fallback(optimized_plan).await;
         };
 
-        let Ok(regions) = self.get_regions(&table_name, input_plan).await else {
+        let Ok((regions, region_leader_map)) = self.get_regions(&table_name, input_plan).await
+        else {
             // no peers found, going to execute them locally
             return fallback(optimized_plan).await;
         };
@@ -212,7 +214,8 @@ impl ExtensionPlanner for DistExtensionPlanner {
             merge_scan.partition_cols().clone(),
             merge_scan.remote_dyn_filter_producer_id(),
             self.enable_per_region_metrics,
-        )?;
+        )?
+        .with_region_leader_map(region_leader_map);
         Ok(Some(Arc::new(merge_scan_plan) as _))
     }
 }
@@ -229,7 +232,7 @@ impl DistExtensionPlanner {
         &self,
         table_name: &TableName,
         logical_plan: &LogicalPlan,
-    ) -> Result<Vec<RegionId>> {
+    ) -> Result<(Vec<RegionId>, HashMap<RegionNumber, Peer>)> {
         let table = self
             .catalog_manager
             .table(
@@ -255,6 +258,19 @@ impl DistExtensionPlanner {
             .iter()
             .map(|r| RegionId::new(table_info.table_id(), r.region.id.region_number()))
             .collect::<Vec<_>>();
+        // Resolve the region → leader map once per query from the same route
+        // snapshot so `MergeScanExec::to_stream` does not re-resolve the leader
+        // per region. Leaders may be absent from the snapshot; `to_stream`
+        // falls back to `select_target` on such misses.
+        let region_leader_map = physical_table_route
+            .region_routes
+            .iter()
+            .filter_map(|r| {
+                r.leader_peer
+                    .as_ref()
+                    .map(|peer| (r.region.id.region_number(), peer.clone()))
+            })
+            .collect::<HashMap<_, _>>();
         let logical_partition_columns = partition_column_types(&table_info);
         let partition_columns = logical_partition_columns
             .iter()
@@ -269,7 +285,7 @@ impl DistExtensionPlanner {
             all_regions,
         );
         if partition_columns.is_empty() {
-            return Ok(all_regions);
+            return Ok((all_regions, region_leader_map));
         }
         // Extract predicates from logical plan
         let partition_expressions = match PredicateExtractor::extract_partition_expressions(
@@ -284,12 +300,12 @@ impl DistExtensionPlanner {
                     table.table_info().table_id(),
                     err
                 );
-                return Ok(all_regions);
+                return Ok((all_regions, region_leader_map));
             }
         };
 
         if partition_expressions.is_empty() {
-            return Ok(all_regions);
+            return Ok((all_regions, region_leader_map));
         }
 
         let Some(partition_column_types) = self
@@ -302,7 +318,7 @@ impl DistExtensionPlanner {
             )
             .await
         else {
-            return Ok(all_regions);
+            return Ok((all_regions, region_leader_map));
         };
 
         // Get partition information for the table if partition rule manager is available
@@ -317,11 +333,11 @@ impl DistExtensionPlanner {
                     table_name,
                     err
                 );
-                return Ok(all_regions);
+                return Ok((all_regions, region_leader_map));
             }
         };
         if partitions.is_empty() {
-            return Ok(all_regions);
+            return Ok((all_regions, region_leader_map));
         }
         // Apply region pruning based on partition rules
         let pruned_regions = match ConstraintPruner::prune_regions(
@@ -336,7 +352,7 @@ impl DistExtensionPlanner {
                     table_name,
                     err
                 );
-                return Ok(all_regions);
+                return Ok((all_regions, region_leader_map));
             }
         };
 
@@ -348,7 +364,7 @@ impl DistExtensionPlanner {
             pruned_regions.len()
         );
 
-        Ok(pruned_regions)
+        Ok((pruned_regions, region_leader_map))
     }
 
     /// Resolves the partition-column types that are safe to use for region pruning.
@@ -752,7 +768,7 @@ mod tests {
 
         assert_eq!(
             vec![RegionId::new(LOGICAL_TABLE_ID, 1)],
-            planner.get_regions(&table_name, &plan).await.unwrap()
+            planner.get_regions(&table_name, &plan).await.unwrap().0
         );
     }
 
@@ -761,7 +777,7 @@ mod tests {
         let (planner, plan, table_name) =
             planner_and_plan(vec![0], physical_partition_expressions()).await;
 
-        assert_all_logical_regions(planner.get_regions(&table_name, &plan).await.unwrap());
+        assert_all_logical_regions(planner.get_regions(&table_name, &plan).await.unwrap().0);
     }
 
     #[tokio::test]
@@ -770,7 +786,7 @@ mod tests {
         expressions[1] = None;
         let (planner, plan, table_name) = planner_and_plan(vec![0, 1], expressions).await;
 
-        assert_all_logical_regions(planner.get_regions(&table_name, &plan).await.unwrap());
+        assert_all_logical_regions(planner.get_regions(&table_name, &plan).await.unwrap().0);
     }
 
     fn assert_all_logical_regions(mut regions: Vec<RegionId>) {

--- a/src/query/src/region_query.rs
+++ b/src/query/src/region_query.rs
@@ -68,6 +68,19 @@ pub trait RegionQueryHandler: Send + Sync {
         request: QueryRequest,
     ) -> Result<SendableRecordBatchStream>;
 
+    /// Fetches a record batch stream with a substrait plan that was encoded once
+    /// for the whole query instead of once per region. The encoded bytes are
+    /// region-invariant; the default implementation falls back to [`do_get`],
+    /// letting the datanode client encode the plan.
+    async fn do_get_encoded(
+        &self,
+        target: &RegionQueryTarget,
+        request: QueryRequest,
+        _encoded_plan: Vec<u8>,
+    ) -> Result<SendableRecordBatchStream> {
+        self.do_get(target, request).await
+    }
+
     async fn handle_remote_dyn_filter_update(
         &self,
         target: &RegionQueryTarget,

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -15,6 +15,9 @@
 #![feature(try_blocks)]
 #![feature(exclusive_wrapper)]
 
+use std::collections::HashMap;
+
+use arrow_schema::DataType;
 use datafusion_expr::LogicalPlan;
 use sql::statements::statement::Statement;
 // Re-export for use in add_service! macro
@@ -60,8 +63,10 @@ pub enum SqlPlan {
     Empty,
     /// Hardcoded SQL shortcuts
     Shortcut(String),
-    /// Datafusion parsed execution plan with the original statement
-    Plan(LogicalPlan, Statement),
+    /// Datafusion parsed execution plan with the original statement and the
+    /// inferred placeholder parameter types (a pure function of the plan,
+    /// computed once at prepare time).
+    Plan(LogicalPlan, Statement, HashMap<String, Option<DataType>>),
     /// Parsed statement when execution is not managed by datafusion
     /// eg. CREATE TABLE
     /// The String is the original query string to avoid AST round-trip issues

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -203,19 +203,21 @@ impl MysqlInstanceShim {
             .await?;
         let plan = describe_result.map(|DescribeResult { logical_plan }| logical_plan);
 
-        let (params, can_cache_as_plan) = if let Some(plan) = &plan {
-            let param_types = DfLogicalPlanner::get_inferred_parameter_types(plan)
-                .context(InferParameterTypesSnafu)?
-                .into_iter()
-                .map(|(k, v)| (k, v.map(|v| ConcreteDataType::from_arrow_type(&v))))
-                .collect();
+        let (params, can_cache_as_plan, inferred_param_types) = if let Some(plan) = &plan {
+            let inferred_param_types = DfLogicalPlanner::get_inferred_parameter_types(plan)
+                .context(InferParameterTypesSnafu)?;
+            let param_types = inferred_param_types
+                .iter()
+                .map(|(k, v)| (k.clone(), v.as_ref().map(ConcreteDataType::from_arrow_type)))
+                .collect::<HashMap<_, _>>();
 
             (
                 prepared_params(&param_types, param_num)?,
                 all_params_have_types(&param_types, param_num),
+                Some(inferred_param_types),
             )
         } else {
-            (dummy_params(param_num)?, false)
+            (dummy_params(param_num)?, false, None)
         };
 
         let columns =
@@ -242,10 +244,15 @@ impl MysqlInstanceShim {
 
         match plan {
             Some(plan) if can_cache_as_plan => {
-                self.save_plan(SqlPlan::Plan(plan, statement), stmt_key)
-                    .inspect_err(|e| {
-                        error!(e; "Failed to save prepared statement");
-                    })?;
+                // `inferred_param_types` is always `Some` here because
+                // `can_cache_as_plan` implies a logical plan was produced.
+                self.save_plan(
+                    SqlPlan::Plan(plan, statement, inferred_param_types.unwrap_or_default()),
+                    stmt_key,
+                )
+                .inspect_err(|e| {
+                    error!(e; "Failed to save prepared statement");
+                })?;
             }
             _ => {
                 self.save_plan(
@@ -275,9 +282,8 @@ impl MysqlInstanceShim {
         };
 
         let outputs = match sql_plan {
-            SqlPlan::Plan(plan, stmt) => {
-                let param_types = DfLogicalPlanner::get_inferred_parameter_types(&plan)
-                    .context(InferParameterTypesSnafu)?
+            SqlPlan::Plan(plan, stmt, inferred_param_types) => {
+                let param_types = inferred_param_types
                     .into_iter()
                     .map(|(k, v)| (k, v.map(|v| ConcreteDataType::from_arrow_type(&v))))
                     .collect::<HashMap<_, _>>();
@@ -527,12 +533,17 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
             .start_timer();
 
         // Clear warnings for non SHOW WARNINGS queries
-        let query_upcase = query.to_uppercase();
-        if !query_upcase.starts_with("SHOW WARNINGS") {
+        if !query
+            .get(..13)
+            .is_some_and(|s| s.eq_ignore_ascii_case("SHOW WARNINGS"))
+        {
             self.session.clear_warnings();
         }
 
-        if query_upcase.starts_with("PREPARE ") {
+        if query
+            .get(..8)
+            .is_some_and(|s| s.eq_ignore_ascii_case("PREPARE "))
+        {
             match ParserContext::parse_mysql_prepare_stmt(query, query_ctx.sql_dialect()) {
                 Ok((stmt_name, stmt)) => {
                     let prepare_results =
@@ -559,7 +570,10 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
                     return Ok(());
                 }
             }
-        } else if query_upcase.starts_with("EXECUTE ") {
+        } else if query
+            .get(..8)
+            .is_some_and(|s| s.eq_ignore_ascii_case("EXECUTE "))
+        {
             match ParserContext::parse_mysql_execute_stmt(query, query_ctx.sql_dialect()) {
                 Ok((stmt_name, params)) => {
                     let outputs = match self
@@ -588,7 +602,10 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
                     return Ok(());
                 }
             }
-        } else if query_upcase.starts_with("DEALLOCATE ") {
+        } else if query
+            .get(..11)
+            .is_some_and(|s| s.eq_ignore_ascii_case("DEALLOCATE "))
+        {
             match ParserContext::parse_mysql_deallocate_stmt(query, query_ctx.sql_dialect()) {
                 Ok(stmt_name) => {
                     self.do_close(stmt_name);

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -230,6 +230,9 @@ impl MysqlResultWriter {
     ) -> Result<()> {
         let schema = record_batch.schema.clone();
         let record_batch = record_batch.into_df_record_batch();
+        // The session timezone is fixed for the whole query, hoist it out of the
+        // per-cell loop to avoid an RwLock read + `Timezone` clone for every timestamp.
+        let timezone = query_context.timezone();
         let mut timestamp_slots = vec![None; record_batch.num_columns()];
         let mut staged_timestamps = record_batch
             .columns()
@@ -250,7 +253,7 @@ impl MysqlResultWriter {
                 if !column.is_null(i) {
                     let timestamp = datatypes::arrow_array::timestamp_array_value(column, i);
                     let datetime = timestamp
-                        .to_chrono_datetime_with_timezone(Some(&query_context.timezone()))
+                        .to_chrono_datetime_with_timezone(Some(&timezone))
                         .with_context(|| TimestampOverflowSnafu {
                             error: format!(
                                 "timestamp {} overflow with unit {}",

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -364,8 +364,12 @@ impl QueryParser for DefaultQueryParser {
                 .map_err(convert_err)?
                 .map(|DescribeResult { logical_plan }| logical_plan)
             {
+                let inferred_param_types =
+                    DfLogicalPlanner::get_inferred_parameter_types(&logical_plan)
+                        .context(InferParameterTypesSnafu)
+                        .map_err(convert_err)?;
                 Ok(PgSqlPlan {
-                    plan: SqlPlan::Plan(logical_plan, stmt),
+                    plan: SqlPlan::Plan(logical_plan, stmt, inferred_param_types),
                     copy_to_stdout_format,
                 })
             } else {
@@ -442,7 +446,7 @@ impl ExtendedQueryHandler for PostgresServerHandlerInner {
                     return Ok(Response::EmptyQuery);
                 }
             }
-            SqlPlan::Plan(plan, stmt) => {
+            SqlPlan::Plan(plan, stmt, _) => {
                 let values = parameters_to_scalar_values(plan, portal)?;
                 let plan = plan
                     .clone()
@@ -488,7 +492,7 @@ impl ExtendedQueryHandler for PostgresServerHandlerInner {
         let sql_plan = &stmt.statement.plan;
         // client provided parameter types, can be empty if client doesn't try to parse statement
         let provided_param_types = &stmt.parameter_types;
-        let server_inferenced_types = if let SqlPlan::Plan(plan, _) = &sql_plan {
+        let server_inferenced_types = if let SqlPlan::Plan(plan, _, _) = &sql_plan {
             let param_types = DfLogicalPlanner::get_inferred_parameter_types(plan)
                 .context(InferParameterTypesSnafu)
                 .map_err(convert_err)?
@@ -555,7 +559,7 @@ fn describe_fields(
 ) -> PgWireResult<Vec<FieldInfo>> {
     match sql_plan {
         // query
-        SqlPlan::Plan(plan, _) if !matches!(plan, LogicalPlan::Dml(_) | LogicalPlan::Ddl(_)) => {
+        SqlPlan::Plan(plan, _, _) if !matches!(plan, LogicalPlan::Dml(_) | LogicalPlan::Ddl(_)) => {
             let schema: Schema = plan.schema().clone().try_into().map_err(convert_err)?;
             schema_to_pg(&schema, format, None).map_err(convert_err)
         }


### PR DESCRIPTION
## Summary

A batch of small, independently-verified micro-optimizations across the query path, derived from a code-level survey of SQL/PromQL/distributed/storage read paths. Each change is behavior-preserving; no perf-regression cases are attached yet (a separate perf-case PR is in flight).

### A. Server / protocol layer
- **Prepared statements (MySQL + Postgres)**: cache the inferred placeholder parameter types in `SqlPlan::Plan` at prepare time instead of recomputing the plan walk on every execute (`mysql/handler.rs`, `postgres/handler.rs`, `servers/lib.rs`).
- **MySQL writer**: hoist `query_context.timezone()` (RwLock read + clone) out of the per-timestamp-cell loop to once per batch (`mysql/writer.rs`).
- **MySQL handler**: replace the per-query `query.to_uppercase()` full-string allocation with bounded case-insensitive prefix checks for `SHOW WARNINGS` / `PREPARE` / `EXECUTE` / `DEALLOCATE`, preserving the existing no-trim behavior (`mysql/handler.rs`).

### B. gRPC insert path
- Drop the redundant explicit analyzer + optimizer passes on `InsertIntoPlan`; `create_physical_plan` already runs both internally (with the MergeScan/Explain guards preserved) (`frontend/instance/grpc.rs`).

### C. Distributed scan (frontend)
- **Encode the pushed-down plan once per query** instead of once per region; the encoded bytes are region-invariant (region id is a sibling request field). New `Datanode::handle_query_encoded` / `RegionQueryHandler::do_get_encoded` have default impls that fall back to the old path, so all existing impls keep working (`client/region.rs`, `common-meta/node_manager.rs`, `query/region_query.rs`, `frontend/instance/region_query.rs`, `dist_plan/merge_scan.rs`).
- **Resolve the region → leader map once per query** from the table route snapshot instead of O(R²) per-region lookups; fall back to `select_target` on leader miss (`dist_plan/planner.rs`, `dist_plan/merge_scan.rs`).
- **Precompute `needs_timezone_patch` once per region stream**; pass batches through unchanged when no timestamp timezone cast is required, preserving the existing schema-validation semantics (`dist_plan/merge_scan.rs`).

### D. mito2
- Remove a gauge decrement on the read path in `finish_cloned`; the builder is only cloned (stays alive and counted), so the counter drifted negative across reads. Added a gauge-balance unit test (`memtable/time_series.rs`).

## Testing
- `cargo check` on all touched crates (servers, query, frontend, mito2, client, common-meta): clean.
- `cargo fmt` / `cargo clippy` on touched crates: clean.
- Unit tests: mito2 memtable (112 + new B1 test), mysql (51), postgres (61×2), frontend instance (78), query (364), client+common-meta (568) — all green.

## Checklist
- [ ] CLA signed
- [ ] Perf-regression cases for the distributed-scan changes (in progress, separate PR)