### PR TITLE
chore(ci): warn when a member has too many open pull requests

### DIFF
--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -1,0 +1,111 @@
+// Warns when a repository member has too many open pull requests.
+//
+// Review capacity is the bottleneck, so authors are expected to land or close
+// existing work before opening more. Drafts count: they still occupy attention.
+// This is advisory only — it never closes a pull request or fails the job.
+
+import { appendFileSync } from "node:fs";
+
+const MARKER = "<!-- pr-open-limit -->";
+// Associations that identify an organization member. Outside collaborators and
+// community contributors are out of scope.
+const MEMBER_ASSOCIATIONS = ["OWNER", "MEMBER"];
+// Keep the comment readable for authors who are far over the limit.
+const MAX_LISTED_PRS = 10;
+
+function summary(text) {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${text}\n`);
+  }
+  console.log(text);
+}
+
+function buildComment(author, total, limit, openPrs) {
+  const listed = openPrs
+    .slice(0, MAX_LISTED_PRS)
+    .map((pr) => `- #${pr.number} ${pr.title}${pr.draft ? " _(draft)_" : ""}`);
+  const hidden = openPrs.length - listed.length;
+  const list = hidden > 0 ? `${listed.join("\n")}\n- ...and ${hidden} more` : listed.join("\n");
+
+  return `${MARKER}
+> [!WARNING]
+> @${author} has **${total}** open pull requests in this repository, over the limit of **${limit}**.
+
+Review is the scarcest resource here. Please land or close some of these before
+pushing this one forward:
+
+${list}
+
+This check is advisory for now and blocks nothing.`;
+}
+
+async function upsertComment(octokit, params, body) {
+  const comments = await octokit.paginate(octokit.issues.listComments, {
+    ...params,
+    per_page: 100,
+  });
+  const existing = comments.find((comment) => comment.body?.includes(MARKER));
+
+  if (existing) {
+    await octokit.issues.updateComment({
+      owner: params.owner,
+      repo: params.repo,
+      comment_id: existing.id,
+      body,
+    });
+  } else {
+    await octokit.issues.createComment({ ...params, body });
+  }
+}
+
+(async () => {
+  const { Octokit } = await import("@octokit/rest");
+
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  const prNumber = Number(process.env.PR_NUMBER);
+  const author = process.env.PR_AUTHOR;
+  const association = process.env.PR_AUTHOR_ASSOCIATION;
+  const limit = Number(process.env.MAX_OPEN_PRS || 5);
+
+  if (author.endsWith("[bot]")) {
+    summary(`Skipping bot author \`${author}\`.`);
+    return;
+  }
+
+  if (!MEMBER_ASSOCIATIONS.includes(association)) {
+    summary(`Skipping \`${author}\`: association is \`${association}\`, not an org member.`);
+    return;
+  }
+
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+  const allOpen = await octokit.paginate(octokit.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    sort: "created",
+    direction: "asc",
+    per_page: 100,
+  });
+  // The pull request that triggered this run is already open, so exclude it and
+  // report the total separately.
+  const others = allOpen.filter(
+    (pr) => pr.user?.login === author && pr.number !== prNumber
+  );
+  const total = others.length + 1;
+
+  if (others.length < limit) {
+    summary(`\`${author}\` has ${total} open pull requests (limit ${limit}). OK.`);
+    return;
+  }
+
+  summary(`\`${author}\` has ${total} open pull requests, over the limit of ${limit}.`);
+  await upsertComment(
+    octokit,
+    { owner, repo, issue_number: prNumber },
+    buildComment(author, total, limit, others)
+  );
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -7,6 +7,8 @@
 import { appendFileSync } from "node:fs";
 
 const MARKER = "<!-- pr-open-limit -->";
+// GITHUB_TOKEN can only edit comments authored by the Actions bot itself.
+const COMMENT_AUTHOR = "github-actions[bot]";
 // Associations that identify an organization member. Outside collaborators and
 // community contributors are out of scope.
 const MEMBER_ASSOCIATIONS = ["OWNER", "MEMBER"];
@@ -44,7 +46,10 @@ async function upsertComment(octokit, params, body) {
     ...params,
     per_page: 100,
   });
-  const existing = comments.find((comment) => comment.body?.includes(MARKER));
+  const existing = comments.find(
+    (comment) =>
+      comment.user?.login === COMMENT_AUTHOR && comment.body?.includes(MARKER)
+  );
 
   if (existing) {
     await octokit.issues.updateComment({
@@ -65,7 +70,8 @@ async function upsertComment(octokit, params, body) {
   const prNumber = Number(process.env.PR_NUMBER);
   const author = process.env.PR_AUTHOR;
   const association = process.env.PR_AUTHOR_ASSOCIATION;
-  const limit = Number(process.env.MAX_OPEN_PRS || 5);
+  const rawLimit = Number(process.env.MAX_OPEN_PRS);
+  const limit = Number.isInteger(rawLimit) && rawLimit >= 0 ? rawLimit : 5;
 
   if (author.endsWith("[bot]")) {
     summary(`Skipping bot author \`${author}\`.`);

--- a/.github/workflows/pr-open-limit.yml
+++ b/.github/workflows/pr-open-limit.yml
@@ -10,9 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# The warning comment goes through the issues API, hence `issues: write`.
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
   issues: write
 
 jobs:
@@ -20,6 +21,8 @@ jobs:
     name: Check Open Pull Request Limit
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Advisory: a script failure must not put a red cross on the pull request.
+    continue-on-error: true
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-open-limit.yml
+++ b/.github/workflows/pr-open-limit.yml
@@ -1,0 +1,45 @@
+name: PR Open Limit
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-open-limit:
+    name: Check Open Pull Request Limit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: npm ci
+
+      - name: Check open pull request limit
+        working-directory: .github/scripts
+        run: node pr-open-limit.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          MAX_OPEN_PRS: ${{ vars.MAX_OPEN_PRS_PER_AUTHOR || 5 }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

We have 58 open PRs right now and 25 of them come from one author. Nobody can review a queue that deep, so this adds a workflow to push authors to clean up before opening more.

When a PR is opened or reopened, if the author is an org member with more than 5 open PRs already (drafts count), the workflow leaves a comment listing their oldest open PRs and asks them to land or close some first.

It only comments. It doesn't close anything and doesn't fail any check. GitHub gives us no way to block PR creation itself, and I'd rather start soft and see whether the number moves before making it enforce anything. The threshold can be changed via the `MAX_OPEN_PRS_PER_AUTHOR` repo variable. Community contributors and bots are not affected. Reopening updates the existing comment instead of posting a new one.

I dry-ran the script against this repo's live data (author over / under / at the limit, outside contributor, bot) and tested comment posting on a fork. The workflow itself only takes effect after merge, since `pull_request_target` runs the copy on main.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.