### PR TITLE
perf(servers)!: speed up Prometheus JSON response building with ryu and per-series entry reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13470,6 +13470,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
+ "ryu",
  "serde",
  "serde_json",
  "servers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13470,7 +13470,6 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "ryu",
  "serde",
  "serde_json",
  "servers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,7 @@ rstest_reuse = "0.7"
 rust_decimal = "1.33"
 rustc-hash = "2.0"
 rustls = { version = "0.23.25", default-features = false }
+ryu = "1"
 sea-query = "0.32"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,7 @@ rstest_reuse = "0.7"
 rust_decimal = "1.33"
 rustc-hash = "2.0"
 rustls = { version = "0.23.25", default-features = false }
+ryu = "1.0"
 sea-query = "0.32"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,6 @@ rstest_reuse = "0.7"
 rust_decimal = "1.33"
 rustc-hash = "2.0"
 rustls = { version = "0.23.25", default-features = false }
-ryu = "1"
 sea-query = "0.32"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/src/cmd/src/bin/query_regression_runner/direct.rs
+++ b/src/cmd/src/bin/query_regression_runner/direct.rs
@@ -166,7 +166,28 @@ fn create_table_sql(table: &Table) -> Result<String> {
     let columns = table
         .columns
         .iter()
-        .map(|column| format!("{} {}", sql_ident(&column.name), column.data_type))
+        .map(|column| {
+            // The direct-SST fixture generator (`query_perf_fixture::direct_sst::
+            // build_region_metadata`) bakes index metadata into the region
+            // manifest's column schemas: tag columns get an inverted index and
+            // a skipping index with granularity 1, field columns get a skipping
+            // index with granularity 1. The CREATE TABLE must declare the same
+            // column options, otherwise the table schema (frontend) and the
+            // region schema (datanode, from the manifest) disagree and the
+            // MergeScan remote schema validation fails with "advertised remote
+            // stream schema field mismatch".
+            let mut sql = format!("{} {}", sql_ident(&column.name), column.data_type);
+            match column.semantic.as_deref() {
+                Some("tag") => {
+                    sql.push_str(" SKIPPING INDEX WITH (granularity='1') INVERTED INDEX");
+                }
+                Some("field") => {
+                    sql.push_str(" SKIPPING INDEX WITH (granularity='1')");
+                }
+                _ => {}
+            }
+            sql
+        })
         .collect::<Vec<_>>()
         .join(",\n  ");
     let primary_key = table
@@ -455,10 +476,12 @@ mod tests {
                 Column {
                     name: "host".to_string(),
                     data_type: "STRING".to_string(),
+                    semantic: Some("tag".to_string()),
                 },
                 Column {
                     name: "ts".to_string(),
                     data_type: "TIMESTAMP(9)".to_string(),
+                    semantic: Some("timestamp".to_string()),
                 },
             ],
             primary_key: vec!["host".to_string()],
@@ -469,7 +492,86 @@ mod tests {
         };
         assert_eq!(
             create_table_sql(&table).unwrap(),
-            "CREATE TABLE \"metric\"\"name\" (\n  \"host\" STRING,\n  \"ts\" TIMESTAMP(9),\n  TIME INDEX (\"ts\"),\n  PRIMARY KEY (\"host\")\n) ENGINE=mito\nWITH ('append_mode'='true', 'sst_format'='flat');"
+            "CREATE TABLE \"metric\"\"name\" (\n  \"host\" STRING SKIPPING INDEX WITH (granularity='1') INVERTED INDEX,\n  \"ts\" TIMESTAMP(9),\n  TIME INDEX (\"ts\"),\n  PRIMARY KEY (\"host\")\n) ENGINE=mito\nWITH ('append_mode'='true', 'sst_format'='flat');"
+        );
+    }
+
+    #[test]
+    fn create_table_sql_declares_indexes_matching_fixture_metadata() {
+        // Mirrors the index metadata baked by
+        // query_perf_fixture::direct_sst::build_region_metadata: tag columns
+        // get SKIPPING INDEX WITH (granularity='1') + INVERTED INDEX, field
+        // columns get SKIPPING INDEX WITH (granularity='1'), timestamp columns
+        // get no column options. Without these options the frontend table
+        // schema and the datanode region schema (from the fixture manifest)
+        // disagree and the MergeScan remote schema validation fails.
+        let table = Table {
+            database: "public".to_string(),
+            name: "metric".to_string(),
+            engine: "mito".to_string(),
+            columns: vec![
+                Column {
+                    name: "host".to_string(),
+                    data_type: "STRING".to_string(),
+                    semantic: Some("tag".to_string()),
+                },
+                Column {
+                    name: "instance".to_string(),
+                    data_type: "STRING".to_string(),
+                    semantic: Some("tag".to_string()),
+                },
+                Column {
+                    name: "value".to_string(),
+                    data_type: "DOUBLE".to_string(),
+                    semantic: Some("field".to_string()),
+                },
+                Column {
+                    name: "ts".to_string(),
+                    data_type: "TIMESTAMP(9)".to_string(),
+                    semantic: Some("timestamp".to_string()),
+                },
+            ],
+            primary_key: vec!["host".to_string(), "instance".to_string()],
+            time_index: Some("ts".to_string()),
+            append_mode: Some(true),
+            sst_format: Some("flat".to_string()),
+            validate_show_create_engine: true,
+        };
+        assert_eq!(
+            create_table_sql(&table).unwrap(),
+            "CREATE TABLE \"metric\" (\n  \"host\" STRING SKIPPING INDEX WITH (granularity='1') INVERTED INDEX,\n  \"instance\" STRING SKIPPING INDEX WITH (granularity='1') INVERTED INDEX,\n  \"value\" DOUBLE SKIPPING INDEX WITH (granularity='1'),\n  \"ts\" TIMESTAMP(9),\n  TIME INDEX (\"ts\"),\n  PRIMARY KEY (\"host\", \"instance\")\n) ENGINE=mito\nWITH ('append_mode'='true', 'sst_format'='flat');"
+        );
+    }
+
+    #[test]
+    fn create_table_sql_without_semantic_keeps_bare_columns() {
+        // Columns without a semantic type must keep the historical bare form so
+        // tables that predate the index-metadata fix are unaffected.
+        let table = Table {
+            database: "public".to_string(),
+            name: "metric".to_string(),
+            engine: "mito".to_string(),
+            columns: vec![
+                Column {
+                    name: "host".to_string(),
+                    data_type: "STRING".to_string(),
+                    semantic: None,
+                },
+                Column {
+                    name: "ts".to_string(),
+                    data_type: "TIMESTAMP(9)".to_string(),
+                    semantic: None,
+                },
+            ],
+            primary_key: vec!["host".to_string()],
+            time_index: Some("ts".to_string()),
+            append_mode: None,
+            sst_format: None,
+            validate_show_create_engine: true,
+        };
+        assert_eq!(
+            create_table_sql(&table).unwrap(),
+            "CREATE TABLE \"metric\" (\n  \"host\" STRING,\n  \"ts\" TIMESTAMP(9),\n  TIME INDEX (\"ts\"),\n  PRIMARY KEY (\"host\")\n) ENGINE=mito;"
         );
     }
 

--- a/src/cmd/src/bin/query_regression_runner/measure.rs
+++ b/src/cmd/src/bin/query_regression_runner/measure.rs
@@ -199,7 +199,9 @@ async fn run_target(
             let mut sample = post_query(client, port, query, db).await;
             let execution_time = sample
                 .get("response")
-                .and_then(extract_execution_time)
+                .and_then(|response| {
+                    extract_execution_time_for_kind(query.kind.as_deref(), response)
+                })
                 .cloned()
                 .unwrap_or(Value::Null);
             sample
@@ -263,6 +265,14 @@ fn response_text(body: &Value) -> String {
     body.as_str()
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| serde_json::to_string(body).unwrap_or_default())
+}
+
+fn extract_execution_time_for_kind<'a>(kind: Option<&str>, body: &'a Value) -> Option<&'a Value> {
+    if kind == Some("prom_http") {
+        None
+    } else {
+        extract_execution_time(body)
+    }
 }
 
 fn extract_execution_time(body: &Value) -> Option<&Value> {
@@ -399,6 +409,24 @@ mod tests {
         assert_eq!(
             extract_execution_time(&json!({"output": [{"elapsed": 3}]})),
             Some(&json!(3))
+        );
+    }
+
+    #[test]
+    fn prom_http_does_not_extract_execution_time_from_response() {
+        let response = json!({
+            "data": {
+                "result": [{"metric": {"job": "api", "elapsed": "label"}}],
+                "elapsed": 42
+            }
+        });
+        assert_eq!(
+            extract_execution_time_for_kind(Some("prom_http"), &response),
+            None
+        );
+        assert_eq!(
+            extract_execution_time_for_kind(Some("sql"), &response),
+            Some(&json!(42))
         );
     }
 

--- a/src/cmd/src/bin/query_regression_runner/measure.rs
+++ b/src/cmd/src/bin/query_regression_runner/measure.rs
@@ -21,7 +21,7 @@ use serde_json::{Map, Value, json};
 
 use crate::query_regression_runner::model::{Measurement, Query, QueryResult, Scenario, Table};
 use crate::query_regression_runner::plan::{load_plan, normalize_scenario};
-use crate::query_regression_runner::sql::{http_post_sql, sql_ident};
+use crate::query_regression_runner::sql::{http_post_prom_range_query, http_post_sql, sql_ident};
 use crate::query_regression_runner::{MeasureArgs, Result};
 
 pub(super) async fn run_measure(args: MeasureArgs) -> Result<()> {
@@ -106,6 +106,26 @@ fn target_report(name: &str, http_port: u16, result: QueryResult) -> Value {
     })
 }
 
+/// Routes a configured query to the right endpoint: `prom_http` queries hit
+/// the Prometheus HTTP range API (which exercises the Prometheus JSON response
+/// builder), everything else goes through `/v1/sql` (including `TQL ANALYZE`).
+async fn post_query(client: &Client, port: u16, query: &Query, db: &str) -> Value {
+    if query.kind.as_deref() == Some("prom_http") {
+        http_post_prom_range_query(
+            client,
+            port,
+            &query.query,
+            query.start.as_deref(),
+            query.end.as_deref(),
+            query.step.as_deref(),
+            db,
+        )
+        .await
+    } else {
+        http_post_sql(client, port, &query.query, db).await
+    }
+}
+
 async fn run_target(
     port: u16,
     tables: &[Table],
@@ -118,6 +138,9 @@ async fn run_target(
             name: Some("count_all".to_string()),
             kind: Some("sql".to_string()),
             query: format!("SELECT count(*) FROM {}", sql_ident(&tables[0].name)),
+            start: None,
+            end: None,
+            step: None,
             warmup: 0,
             iterations: 1,
             thresholds: Map::new(),
@@ -147,7 +170,7 @@ async fn run_target(
         }
         validation.push(sample);
     }
-    let first = http_post_sql(client, port, &queries[0].query, db).await;
+    let first = post_query(client, port, &queries[0], db).await;
     if !first["ok"].as_bool().unwrap_or(false) {
         validation_errors.push(json!({
             "sql": queries[0].query,
@@ -160,7 +183,7 @@ async fn run_target(
     let mut measurements = Vec::with_capacity(queries.len());
     for query in &queries {
         for _ in 0..query.warmup {
-            let warmup = http_post_sql(client, port, &query.query, db).await;
+            let warmup = post_query(client, port, query, db).await;
             if !warmup["ok"].as_bool().unwrap_or(false) {
                 validation_errors.push(json!({
                     "sql": query.query,
@@ -173,7 +196,7 @@ async fn run_target(
         let mut samples = Vec::with_capacity(query.iterations);
         let mut good_latencies = Vec::with_capacity(query.iterations);
         for _ in 0..query.iterations {
-            let mut sample = http_post_sql(client, port, &query.query, db).await;
+            let mut sample = post_query(client, port, query, db).await;
             let execution_time = sample
                 .get("response")
                 .and_then(extract_execution_time)
@@ -385,6 +408,9 @@ mod tests {
             name: Some("q".to_string()),
             kind: None,
             query: "SELECT 1".to_string(),
+            start: None,
+            end: None,
+            step: None,
             warmup: 0,
             iterations: 1,
             thresholds: Map::from_iter([

--- a/src/cmd/src/bin/query_regression_runner/model.rs
+++ b/src/cmd/src/bin/query_regression_runner/model.rs
@@ -90,6 +90,12 @@ pub(super) struct Column {
     pub(super) name: String,
     #[serde(rename = "type")]
     pub(super) data_type: String,
+    /// Semantic type ("tag", "field", "timestamp") from the case TOML. The
+    /// direct-SST fixture generator bakes index metadata into the region
+    /// manifest based on this semantic, so the CREATE TABLE must declare the
+    /// matching column options (see `create_table_sql` in `direct.rs`).
+    #[serde(default)]
+    pub(super) semantic: Option<String>,
 }
 
 const fn default_show_create_engine() -> bool {
@@ -203,6 +209,13 @@ pub(super) struct Query {
     #[serde(default)]
     pub(super) kind: Option<String>,
     pub(super) query: String,
+    /// Prometheus HTTP range query parameters (`kind = "prom_http"` only).
+    #[serde(default)]
+    pub(super) start: Option<String>,
+    #[serde(default)]
+    pub(super) end: Option<String>,
+    #[serde(default)]
+    pub(super) step: Option<String>,
     #[serde(default)]
     pub(super) warmup: usize,
     #[serde(default = "one")]

--- a/src/cmd/src/bin/query_regression_runner/sql.rs
+++ b/src/cmd/src/bin/query_regression_runner/sql.rs
@@ -145,13 +145,12 @@ pub(super) async fn http_post_prom_range_query(
 ) -> Value {
     let mut sample = post_form(
         client,
-        format!("http://127.0.0.1:{port}/v1/prometheus/api/v1/query_range"),
+        prom_range_query_url(port, db),
         &[
             ("query", query),
             ("start", start.unwrap_or_default()),
             ("end", end.unwrap_or_default()),
             ("step", step.unwrap_or_default()),
-            ("db", db),
         ],
     )
     .await;
@@ -160,6 +159,15 @@ pub(super) async fn http_post_prom_range_query(
         .expect("HTTP samples are objects")
         .insert("query".to_string(), Value::String(query.to_string()));
     sample
+}
+
+fn prom_range_query_url(port: u16, db: &str) -> String {
+    let mut url = reqwest::Url::parse(&format!(
+        "http://127.0.0.1:{port}/v1/prometheus/api/v1/query_range"
+    ))
+    .expect("fixed Prometheus range query URL must be valid");
+    url.query_pairs_mut().append_pair("db", db);
+    url.into()
 }
 
 async fn post_form(client: &Client, url: String, form: &[(&str, &str)]) -> Value {
@@ -248,6 +256,17 @@ pub(super) fn sql_ident(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prom_range_query_url_places_database_in_query_parameters() {
+        let url = reqwest::Url::parse(&prom_range_query_url(4000, "catalog-schema name"))
+            .expect("generated URL must be valid");
+        assert_eq!(url.path(), "/v1/prometheus/api/v1/query_range");
+        assert_eq!(
+            url.query_pairs().collect::<Vec<_>>(),
+            vec![("db".into(), "catalog-schema name".into())]
+        );
+    }
 
     #[test]
     fn top_level_errors_do_not_inspect_rows() {

--- a/src/cmd/src/bin/query_regression_runner/sql.rs
+++ b/src/cmd/src/bin/query_regression_runner/sql.rs
@@ -117,10 +117,54 @@ pub(super) fn value_f64(value: Option<&Value>) -> Option<f64> {
 }
 
 pub(super) async fn http_post_sql(client: &Client, port: u16, sql: &str, db: &str) -> Value {
+    let mut sample = post_form(
+        client,
+        format!("http://127.0.0.1:{port}/v1/sql"),
+        &[("sql", sql), ("db", db), ("format", "json")],
+    )
+    .await;
+    sample
+        .as_object_mut()
+        .expect("HTTP samples are objects")
+        .insert("sql".to_string(), Value::String(sql.to_string()));
+    sample
+}
+
+/// Posts a Prometheus HTTP API range query (`/v1/prometheus/api/v1/query_range`)
+/// and measures the full request-to-body latency. This exercises the Prometheus
+/// JSON response building path (`PrometheusJsonResponse::record_batches_to_data`)
+/// that `/v1/sql` (including `TQL ANALYZE`) does not go through.
+pub(super) async fn http_post_prom_range_query(
+    client: &Client,
+    port: u16,
+    query: &str,
+    start: Option<&str>,
+    end: Option<&str>,
+    step: Option<&str>,
+    db: &str,
+) -> Value {
+    let mut sample = post_form(
+        client,
+        format!("http://127.0.0.1:{port}/v1/prometheus/api/v1/query_range"),
+        &[
+            ("query", query),
+            ("start", start.unwrap_or_default()),
+            ("end", end.unwrap_or_default()),
+            ("step", step.unwrap_or_default()),
+            ("db", db),
+        ],
+    )
+    .await;
+    sample
+        .as_object_mut()
+        .expect("HTTP samples are objects")
+        .insert("query".to_string(), Value::String(query.to_string()));
+    sample
+}
+
+async fn post_form(client: &Client, url: String, form: &[(&str, &str)]) -> Value {
     let started = Instant::now();
-    let request = client
-        .post(format!("http://127.0.0.1:{port}/v1/sql"))
-        .form(&[("sql", sql), ("db", db), ("format", "json")]);
+    let request = client.post(url).form(form);
     match request.send().await {
         Ok(response) => {
             let status = response.status().as_u16();
@@ -133,7 +177,6 @@ pub(super) async fn http_post_sql(client: &Client, port: u16, sql: &str, db: &st
                         "status": status,
                         "latency_ms": started.elapsed().as_secs_f64() * 1000.0,
                         "response": body,
-                        "sql": sql,
                     });
                     if status >= 400 {
                         sample
@@ -148,7 +191,6 @@ pub(super) async fn http_post_sql(client: &Client, port: u16, sql: &str, db: &st
                     "status": status,
                     "latency_ms": started.elapsed().as_secs_f64() * 1000.0,
                     "error": error.to_string(),
-                    "sql": sql,
                 }),
             }
         }
@@ -157,7 +199,6 @@ pub(super) async fn http_post_sql(client: &Client, port: u16, sql: &str, db: &st
             "status": Value::Null,
             "latency_ms": started.elapsed().as_secs_f64() * 1000.0,
             "error": error.to_string(),
-            "sql": sql,
         }),
     }
 }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -115,7 +115,6 @@ rust_decimal = { workspace = true, features = ["db-postgres"] }
 rustls = { workspace = true, default-features = false, features = ["aws_lc_rs", "logging", "std", "tls12"] }
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.0"
-ryu.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 session.workspace = true

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -115,6 +115,7 @@ rust_decimal = { workspace = true, features = ["db-postgres"] }
 rustls = { workspace = true, default-features = false, features = ["aws_lc_rs", "logging", "std", "tls12"] }
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.0"
+ryu.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 session.workspace = true

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -72,27 +72,9 @@ fn prometheus_native_histogram(histogram: &NativeHistogram) -> Result<PromNative
 
 /// Formats a sample value for the Prometheus HTTP API.
 ///
-/// Finite values are formatted with `ryu` (shortest round-trip), which is
-/// significantly faster than `f64::to_string()` and is the hot path when
-/// building large responses. ryu prints integral values with a trailing ".0"
-/// ("1.0"), but the Prometheus wire format (like std `f64::to_string()`)
-/// expects "1", so the ".0" suffix is stripped. ryu only emits ".0" for
-/// integral values (its scientific notation never ends in ".0"), so
-/// non-integral values, negative zero (`-0.0` -> `"-0"`) and extreme values
-/// (`1e30`, `f64::MAX`) are unaffected. Non-finite values (`NaN`, `+Inf`,
-/// `-Inf`) are not supported by `ryu::Buffer::format_finite`, so they keep the
-/// previous `f64::to_string()` output (`"NaN"`, `"inf"`, `"-inf"`).
+/// Keep Rust's `f64::to_string()` output for wire compatibility.
 fn format_prometheus_sample_value(value: f64) -> String {
-    if value.is_finite() {
-        let mut buffer = ryu::Buffer::new();
-        let formatted = buffer.format_finite(value);
-        match formatted.strip_suffix(".0") {
-            Some(integral) => integral.to_string(),
-            None => formatted.to_string(),
-        }
-    } else {
-        value.to_string()
-    }
+    value.to_string()
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -618,29 +600,33 @@ mod tests {
     }
 
     #[test]
-    fn format_prometheus_sample_value_matches_prometheus_wire_format() {
-        // Integral values must not carry a fractional part ("1", not "1.0"),
-        // matching std `f64::to_string()` and the Prometheus wire format.
-        assert_eq!(format_prometheus_sample_value(1.0), "1");
-        assert_eq!(format_prometheus_sample_value(0.0), "0");
-        assert_eq!(format_prometheus_sample_value(-0.0), "-0");
-        assert_eq!(format_prometheus_sample_value(100.0), "100");
-        // Non-integral values keep the ryu shortest round-trip output.
-        assert_eq!(format_prometheus_sample_value(1.5), "1.5");
-        assert_eq!(format_prometheus_sample_value(0.1), "0.1");
-        // Extreme values keep the ryu scientific notation; integral values in
-        // scientific notation ("1e30") must not be misdetected as non-integral.
-        assert_eq!(format_prometheus_sample_value(1e21), "1e21");
-        assert_eq!(format_prometheus_sample_value(1e30), "1e30");
-        assert_eq!(format_prometheus_sample_value(1e-7), "1e-7");
-        assert_eq!(
-            format_prometheus_sample_value(f64::MAX),
-            "1.7976931348623157e308"
-        );
-        // Non-finite values keep the std `f64::to_string()` output.
-        assert_eq!(format_prometheus_sample_value(f64::NAN), "NaN");
-        assert_eq!(format_prometheus_sample_value(f64::INFINITY), "inf");
-        assert_eq!(format_prometheus_sample_value(f64::NEG_INFINITY), "-inf");
+    fn format_prometheus_sample_value_matches_f64_to_string() {
+        let values = [
+            1.5,
+            0.1,
+            1.0,
+            0.0,
+            -0.0,
+            100.0,
+            1e-6,
+            1e-7,
+            1e21,
+            1e30,
+            f64::MAX,
+            f64::MIN_POSITIVE,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            // These ordinary decimal values differ between ryu and Rust's
+            // `f64::to_string()` shortest representations.
+            f64::from_bits(0x42374876e8000400),
+            f64::from_bits(0x3ff0000800000000),
+            f64::from_bits(0x430a8e5672bc7312),
+        ];
+
+        for value in values {
+            assert_eq!(format_prometheus_sample_value(value), value.to_string());
+        }
     }
 
     #[test]
@@ -688,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn record_batches_to_data_formats_finite_values_with_ryu() {
+    fn record_batches_to_data_formats_values_with_f64_to_string() {
         let schema = Arc::new(Schema::new(vec![
             ColumnSchema::new(
                 "timestamp",
@@ -728,23 +714,18 @@ mod tests {
         };
 
         assert_eq!(series.len(), 1);
-        assert_eq!(
-            series[0].values,
-            vec![
-                (1.0, "0".to_string()),
-                (2.0, "-0".to_string()),
-                (3.0, "1.25".to_string()),
-                (4.0, "1e30".to_string()),
-                (5.0, "1e-7".to_string()),
-                (6.0, "1.7976931348623157e308".to_string()),
-            ]
-        );
+        let input_values = [0.0, -0.0, 1.25, 1e30, 1e-7, f64::MAX];
+        let expected = input_values
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| ((index + 1) as f64, value.to_string()))
+            .collect::<Vec<_>>();
+        assert_eq!(series[0].values, expected);
     }
 
     #[test]
     fn record_batches_to_data_preserves_infinity_output() {
-        // `ryu::Buffer::format_finite` only supports finite values; NaN and the
-        // infinities must keep the previous `f64::to_string()` output.
+        // NaN and infinities use Rust's `f64::to_string()` output.
         let schema = Arc::new(Schema::new(vec![
             ColumnSchema::new(
                 "timestamp",

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -38,6 +38,7 @@ use datatypes::prelude::ConcreteDataType;
 use indexmap::IndexMap;
 use promql_parser::label::METRIC_NAME;
 use promql_parser::parser::value::ValueType;
+use ryu::Buffer;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::{OptionExt, ResultExt};
@@ -72,9 +73,15 @@ fn prometheus_native_histogram(histogram: &NativeHistogram) -> Result<PromNative
 
 /// Formats a sample value for the Prometheus HTTP API.
 ///
-/// Keep Rust's `f64::to_string()` output for wire compatibility.
+/// Finite sample strings use ryu's shortest-roundtrip representation and may
+/// differ textually from previous Rust/Prometheus wire formatting; values parse
+/// identically. Non-finite values retain Rust's `f64::to_string()` output.
 fn format_prometheus_sample_value(value: f64) -> String {
-    value.to_string()
+    if value.is_finite() {
+        Buffer::new().format_finite(value).to_string()
+    } else {
+        value.to_string()
+    }
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -316,12 +323,11 @@ impl PrometheusJsonResponse {
 
         // Query output is clustered by series (the range plan sorts by series
         // key + timestamp), so consecutive rows usually belong to the same
-        // series. Remember the previous row's tags and the index of its entry
-        // in `buffer`, and reuse the entry directly when the tags are
-        // unchanged. This avoids building and hashing the label vector on
-        // every row; the worst case adds one `Vec` comparison per series
-        // transition before falling back to the map lookup.
-        let mut last_tags: Option<Vec<(&str, &str)>> = None;
+        // series. Remember the index of the previous row's entry in `buffer`,
+        // and reuse it directly when its tags are unchanged. This avoids
+        // building and hashing the label vector on every row; the worst case
+        // adds one `Vec` comparison per series transition before falling back
+        // to the map lookup.
         let mut last_entry_index = None;
 
         let schema = batches.schema();
@@ -397,22 +403,21 @@ impl PrometheusJsonResponse {
                     }
                 }
 
-                let samples = if last_tags.as_ref().is_some_and(|prev| prev == &tags) {
-                    // Same series as the previous row: reuse its entry without
-                    // re-hashing the label vector. Entries are never removed
-                    // from `buffer`, so the captured index stays valid.
-                    let index = last_entry_index
-                        .expect("last entry index is always set together with last tags");
-                    &mut buffer
+                let reuse = last_entry_index.filter(|index| {
+                    buffer
+                        .get_index(*index)
+                        .is_some_and(|(key, _)| key == &tags)
+                });
+                let samples = if let Some(index) = reuse {
+                    buffer
                         .get_index_mut(index)
-                        .expect("reused series entry must exist")
-                        .1
+                        .map(|(_, samples)| samples)
+                        .with_context(|| UnexpectedResultSnafu {
+                            reason: "reused series entry must exist",
+                        })?
                 } else {
-                    // Tags changed: fall back to the map lookup.
-                    let entry = buffer.entry(tags.clone());
-                    let index = entry.index();
-                    last_entry_index = Some(index);
-                    last_tags = Some(tags);
+                    let entry = buffer.entry(tags);
+                    last_entry_index = Some(entry.index());
                     entry.or_default()
                 };
                 if let Some((timestamp_millis, histogram)) = histogram {
@@ -600,7 +605,7 @@ mod tests {
     }
 
     #[test]
-    fn format_prometheus_sample_value_matches_f64_to_string() {
+    fn format_prometheus_sample_value_uses_ryu_for_finite_values() {
         let values = [
             1.5,
             0.1,
@@ -614,19 +619,50 @@ mod tests {
             1e30,
             f64::MAX,
             f64::MIN_POSITIVE,
-            f64::NAN,
-            f64::INFINITY,
-            f64::NEG_INFINITY,
-            // These ordinary decimal values differ between ryu and Rust's
-            // `f64::to_string()` shortest representations.
-            f64::from_bits(0x42374876e8000400),
-            f64::from_bits(0x3ff0000800000000),
-            f64::from_bits(0x430a8e5672bc7312),
         ];
 
         for value in values {
-            assert_eq!(format_prometheus_sample_value(value), value.to_string());
+            let output = format_prometheus_sample_value(value);
+            assert_eq!(output.parse::<f64>().unwrap().to_bits(), value.to_bits());
         }
+
+        // Representative integral values use ryu's explicit .0 form.
+        assert_eq!(format_prometheus_sample_value(1.0), "1.0");
+        assert_eq!(format_prometheus_sample_value(-0.0), "-0.0");
+        assert_eq!(format_prometheus_sample_value(100.0), "100.0");
+        assert_eq!(format_prometheus_sample_value(1e-6), "1e-6");
+        assert_eq!(format_prometheus_sample_value(1e-7), "1e-7");
+        assert_eq!(format_prometheus_sample_value(1e21), "1e21");
+
+        // These known shortest-roundtrip tie cases have different text but
+        // remain numerically equivalent to Rust's representation.
+        for value in [
+            f64::from_bits(0x42374876e8000400),
+            f64::from_bits(0x3ff0000800000000),
+            f64::from_bits(0x430a8e5672bc7312),
+        ] {
+            let ryu_output = format_prometheus_sample_value(value);
+            let std_output = value.to_string();
+            assert_ne!(ryu_output, std_output);
+            assert_eq!(ryu_output.parse::<f64>().unwrap(), value);
+            assert_eq!(std_output.parse::<f64>().unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn format_prometheus_sample_value_preserves_nonfinite_values() {
+        assert_eq!(format_prometheus_sample_value(f64::NAN), "NaN");
+        assert_eq!(format_prometheus_sample_value(f64::INFINITY), "inf");
+        assert_eq!(format_prometheus_sample_value(f64::NEG_INFINITY), "-inf");
+
+        // Parsing a NaN does not preserve its payload bits, so NaN is checked
+        // by its required semantic spelling rather than by to_bits().
+        assert!(
+            format_prometheus_sample_value(f64::NAN)
+                .parse::<f64>()
+                .unwrap()
+                .is_nan()
+        );
     }
 
     #[test]
@@ -669,12 +705,12 @@ mod tests {
         assert_eq!(series.len(), 1);
         assert_eq!(
             series[0].values,
-            vec![(1.0, "1".to_string()), (2.0, "NaN".to_string())]
+            vec![(1.0, "1.0".to_string()), (2.0, "NaN".to_string())]
         );
     }
 
     #[test]
-    fn record_batches_to_data_formats_values_with_f64_to_string() {
+    fn record_batches_to_data_formats_values_with_ryu() {
         let schema = Arc::new(Schema::new(vec![
             ColumnSchema::new(
                 "timestamp",
@@ -715,10 +751,20 @@ mod tests {
 
         assert_eq!(series.len(), 1);
         let input_values = [0.0, -0.0, 1.25, 1e30, 1e-7, f64::MAX];
+        // Keep this expected-value generation independent from the production
+        // formatter while still asserting the Arrow/batch-to-Prometheus path.
         let expected = input_values
             .into_iter()
             .enumerate()
-            .map(|(index, value)| ((index + 1) as f64, value.to_string()))
+            .map(|(index, value)| {
+                let expected_value = if value.is_finite() {
+                    let mut buffer = Buffer::new();
+                    buffer.format_finite(value).to_string()
+                } else {
+                    value.to_string()
+                };
+                ((index + 1) as f64, expected_value)
+            })
             .collect::<Vec<_>>();
         assert_eq!(series[0].values, expected);
     }
@@ -838,9 +884,9 @@ mod tests {
             vec!["a", "b", "c"]
         );
         // Vector results keep the last sample of each series.
-        assert_eq!(series[0].value, Some((4.0, "4".to_string())));
-        assert_eq!(series[1].value, Some((5.0, "5".to_string())));
-        assert_eq!(series[2].value, Some((6.0, "6".to_string())));
+        assert_eq!(series[0].value, Some((4.0, "4.0".to_string())));
+        assert_eq!(series[1].value, Some((5.0, "5.0".to_string())));
+        assert_eq!(series[2].value, Some((6.0, "6.0".to_string())));
     }
 
     #[test]
@@ -948,7 +994,7 @@ mod tests {
         assert_eq!(series[0].metric["__name__"], "label_replace_repro");
         assert_eq!(series[0].metric["host"], "server-01");
         assert_eq!(series[0].metric["host_copy"], "server-01");
-        assert_eq!(series[0].value, Some((1.0, "1".to_string())));
+        assert_eq!(series[0].value, Some((1.0, "1.0".to_string())));
     }
 
     #[test]

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -74,12 +74,22 @@ fn prometheus_native_histogram(histogram: &NativeHistogram) -> Result<PromNative
 ///
 /// Finite values are formatted with `ryu` (shortest round-trip), which is
 /// significantly faster than `f64::to_string()` and is the hot path when
-/// building large responses. Non-finite values (`NaN`, `+Inf`, `-Inf`) are not
-/// supported by `ryu::Buffer::format_finite`, so they keep the previous
-/// `f64::to_string()` output (`"NaN"`, `"inf"`, `"-inf"`).
+/// building large responses. ryu prints integral values with a trailing ".0"
+/// ("1.0"), but the Prometheus wire format (like std `f64::to_string()`)
+/// expects "1", so the ".0" suffix is stripped. ryu only emits ".0" for
+/// integral values (its scientific notation never ends in ".0"), so
+/// non-integral values, negative zero (`-0.0` -> `"-0"`) and extreme values
+/// (`1e30`, `f64::MAX`) are unaffected. Non-finite values (`NaN`, `+Inf`,
+/// `-Inf`) are not supported by `ryu::Buffer::format_finite`, so they keep the
+/// previous `f64::to_string()` output (`"NaN"`, `"inf"`, `"-inf"`).
 fn format_prometheus_sample_value(value: f64) -> String {
     if value.is_finite() {
-        ryu::Buffer::new().format_finite(value).to_string()
+        let mut buffer = ryu::Buffer::new();
+        let formatted = buffer.format_finite(value);
+        match formatted.strip_suffix(".0") {
+            Some(integral) => integral.to_string(),
+            None => formatted.to_string(),
+        }
     } else {
         value.to_string()
     }
@@ -608,6 +618,32 @@ mod tests {
     }
 
     #[test]
+    fn format_prometheus_sample_value_matches_prometheus_wire_format() {
+        // Integral values must not carry a fractional part ("1", not "1.0"),
+        // matching std `f64::to_string()` and the Prometheus wire format.
+        assert_eq!(format_prometheus_sample_value(1.0), "1");
+        assert_eq!(format_prometheus_sample_value(0.0), "0");
+        assert_eq!(format_prometheus_sample_value(-0.0), "-0");
+        assert_eq!(format_prometheus_sample_value(100.0), "100");
+        // Non-integral values keep the ryu shortest round-trip output.
+        assert_eq!(format_prometheus_sample_value(1.5), "1.5");
+        assert_eq!(format_prometheus_sample_value(0.1), "0.1");
+        // Extreme values keep the ryu scientific notation; integral values in
+        // scientific notation ("1e30") must not be misdetected as non-integral.
+        assert_eq!(format_prometheus_sample_value(1e21), "1e21");
+        assert_eq!(format_prometheus_sample_value(1e30), "1e30");
+        assert_eq!(format_prometheus_sample_value(1e-7), "1e-7");
+        assert_eq!(
+            format_prometheus_sample_value(f64::MAX),
+            "1.7976931348623157e308"
+        );
+        // Non-finite values keep the std `f64::to_string()` output.
+        assert_eq!(format_prometheus_sample_value(f64::NAN), "NaN");
+        assert_eq!(format_prometheus_sample_value(f64::INFINITY), "inf");
+        assert_eq!(format_prometheus_sample_value(f64::NEG_INFINITY), "-inf");
+    }
+
+    #[test]
     fn matrix_response_preserves_ordinary_nan_and_filters_stale_markers() {
         let schema = Arc::new(Schema::new(vec![
             ColumnSchema::new(
@@ -647,7 +683,7 @@ mod tests {
         assert_eq!(series.len(), 1);
         assert_eq!(
             series[0].values,
-            vec![(1.0, "1.0".to_string()), (2.0, "NaN".to_string())]
+            vec![(1.0, "1".to_string()), (2.0, "NaN".to_string())]
         );
     }
 
@@ -695,8 +731,8 @@ mod tests {
         assert_eq!(
             series[0].values,
             vec![
-                (1.0, "0.0".to_string()),
-                (2.0, "-0.0".to_string()),
+                (1.0, "0".to_string()),
+                (2.0, "-0".to_string()),
                 (3.0, "1.25".to_string()),
                 (4.0, "1e30".to_string()),
                 (5.0, "1e-7".to_string()),
@@ -821,9 +857,9 @@ mod tests {
             vec!["a", "b", "c"]
         );
         // Vector results keep the last sample of each series.
-        assert_eq!(series[0].value, Some((4.0, "4.0".to_string())));
-        assert_eq!(series[1].value, Some((5.0, "5.0".to_string())));
-        assert_eq!(series[2].value, Some((6.0, "6.0".to_string())));
+        assert_eq!(series[0].value, Some((4.0, "4".to_string())));
+        assert_eq!(series[1].value, Some((5.0, "5".to_string())));
+        assert_eq!(series[2].value, Some((6.0, "6".to_string())));
     }
 
     #[test]

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -70,6 +70,21 @@ fn prometheus_native_histogram(histogram: &NativeHistogram) -> Result<PromNative
     })
 }
 
+/// Formats a sample value for the Prometheus HTTP API.
+///
+/// Finite values are formatted with `ryu` (shortest round-trip), which is
+/// significantly faster than `f64::to_string()` and is the hot path when
+/// building large responses. Non-finite values (`NaN`, `+Inf`, `-Inf`) are not
+/// supported by `ryu::Buffer::format_finite`, so they keep the previous
+/// `f64::to_string()` output (`"NaN"`, `"inf"`, `"-inf"`).
+fn format_prometheus_sample_value(value: f64) -> String {
+    if value.is_finite() {
+        ryu::Buffer::new().format_finite(value).to_string()
+    } else {
+        value.to_string()
+    }
+}
+
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct PrometheusJsonResponse {
     pub status: String,
@@ -307,6 +322,16 @@ impl PrometheusJsonResponse {
         // Tag order matters, e.g., after sorc and sort_desc, the output order must be kept.
         let mut buffer = IndexMap::<Vec<(&str, &str)>, PromSeriesSamples>::new();
 
+        // Query output is clustered by series (the range plan sorts by series
+        // key + timestamp), so consecutive rows usually belong to the same
+        // series. Remember the previous row's tags and the index of its entry
+        // in `buffer`, and reuse the entry directly when the tags are
+        // unchanged. This avoids building and hashing the label vector on
+        // every row; the worst case adds one `Vec` comparison per series
+        // transition before falling back to the map lookup.
+        let mut last_tags: Option<Vec<(&str, &str)>> = None;
+        let mut last_entry_index = None;
+
         let schema = batches.schema();
         for batch in batches.iter() {
             // prepare things...
@@ -380,15 +405,33 @@ impl PrometheusJsonResponse {
                     }
                 }
 
-                let entry = buffer.entry(tags).or_default();
+                let samples = if last_tags.as_ref().is_some_and(|prev| prev == &tags) {
+                    // Same series as the previous row: reuse its entry without
+                    // re-hashing the label vector. Entries are never removed
+                    // from `buffer`, so the captured index stays valid.
+                    let index = last_entry_index
+                        .expect("last entry index is always set together with last tags");
+                    &mut buffer
+                        .get_index_mut(index)
+                        .expect("reused series entry must exist")
+                        .1
+                } else {
+                    // Tags changed: fall back to the map lookup.
+                    let entry = buffer.entry(tags.clone());
+                    let index = entry.index();
+                    last_entry_index = Some(index);
+                    last_tags = Some(tags);
+                    entry.or_default()
+                };
                 if let Some((timestamp_millis, histogram)) = histogram {
-                    entry
+                    samples
                         .histograms
                         .push((timestamp_millis as f64 / 1000.0, histogram));
                 } else if let Some((timestamp_millis, value)) = value {
-                    entry
-                        .values
-                        .push((timestamp_millis as f64 / 1000.0, value.to_string()));
+                    samples.values.push((
+                        timestamp_millis as f64 / 1000.0,
+                        format_prometheus_sample_value(value),
+                    ));
                 }
             }
         }
@@ -604,8 +647,183 @@ mod tests {
         assert_eq!(series.len(), 1);
         assert_eq!(
             series[0].values,
-            vec![(1.0, "1".to_string()), (2.0, "NaN".to_string())]
+            vec![(1.0, "1.0".to_string()), (2.0, "NaN".to_string())]
         );
+    }
+
+    #[test]
+    fn record_batches_to_data_formats_finite_values_with_ryu() {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new(
+                "timestamp",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+            ColumnSchema::new("value", ConcreteDataType::float64_datatype(), true),
+        ]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondVector::from_vec(vec![
+                    1_000, 2_000, 3_000, 4_000, 5_000, 6_000,
+                ])) as _,
+                Arc::new(Float64Vector::from(vec![
+                    Some(0.0),
+                    Some(-0.0),
+                    Some(1.25),
+                    Some(1e30),
+                    Some(1e-7),
+                    Some(f64::MAX),
+                ])) as _,
+            ],
+        )
+        .unwrap();
+        let batches = RecordBatches::try_new(schema, vec![batch]).unwrap();
+
+        let response =
+            PrometheusJsonResponse::record_batches_to_data(batches, None, ValueType::Matrix)
+                .unwrap();
+        let PrometheusResponse::PromData(PromData {
+            result: PromQueryResult::Matrix(series),
+            ..
+        }) = response
+        else {
+            panic!("expected matrix response");
+        };
+
+        assert_eq!(series.len(), 1);
+        assert_eq!(
+            series[0].values,
+            vec![
+                (1.0, "0.0".to_string()),
+                (2.0, "-0.0".to_string()),
+                (3.0, "1.25".to_string()),
+                (4.0, "1e30".to_string()),
+                (5.0, "1e-7".to_string()),
+                (6.0, "1.7976931348623157e308".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn record_batches_to_data_preserves_infinity_output() {
+        // `ryu::Buffer::format_finite` only supports finite values; NaN and the
+        // infinities must keep the previous `f64::to_string()` output.
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new(
+                "timestamp",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+            ColumnSchema::new("value", ConcreteDataType::float64_datatype(), true),
+        ]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondVector::from_vec(vec![
+                    1_000, 2_000, 3_000,
+                ])) as _,
+                Arc::new(Float64Vector::from(vec![
+                    Some(f64::INFINITY),
+                    Some(f64::NEG_INFINITY),
+                    Some(f64::NAN),
+                ])) as _,
+            ],
+        )
+        .unwrap();
+        let batches = RecordBatches::try_new(schema, vec![batch]).unwrap();
+
+        let response =
+            PrometheusJsonResponse::record_batches_to_data(batches, None, ValueType::Matrix)
+                .unwrap();
+        let PrometheusResponse::PromData(PromData {
+            result: PromQueryResult::Matrix(series),
+            ..
+        }) = response
+        else {
+            panic!("expected matrix response");
+        };
+
+        assert_eq!(series.len(), 1);
+        assert_eq!(
+            series[0].values,
+            vec![
+                (1.0, "inf".to_string()),
+                (2.0, "-inf".to_string()),
+                (3.0, "NaN".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn record_batches_to_data_reuses_entries_for_clustered_series() {
+        // Rows are clustered by series (a, b, a, a, b, c): consecutive rows of
+        // the same series exercise the entry-reuse fast path, while series
+        // transitions fall back to the map lookup. The result must keep the
+        // first-occurrence order and accumulate values per series as before.
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new(
+                "timestamp",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+            ColumnSchema::new("host", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("value", ConcreteDataType::float64_datatype(), true),
+        ]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondVector::from_vec(vec![
+                    1_000, 2_000, 3_000, 4_000, 5_000, 6_000,
+                ])) as _,
+                Arc::new(StringVector::from(vec![
+                    Some("a"),
+                    Some("b"),
+                    Some("a"),
+                    Some("a"),
+                    Some("b"),
+                    Some("c"),
+                ])) as _,
+                Arc::new(Float64Vector::from(vec![
+                    Some(1.0),
+                    Some(2.0),
+                    Some(3.0),
+                    Some(4.0),
+                    Some(5.0),
+                    Some(6.0),
+                ])) as _,
+            ],
+        )
+        .unwrap();
+        let batches = RecordBatches::try_new(schema, vec![batch]).unwrap();
+
+        let response = PrometheusJsonResponse::record_batches_to_data(
+            batches,
+            Some("metric".to_string()),
+            ValueType::Vector,
+        )
+        .unwrap();
+        let PrometheusResponse::PromData(PromData {
+            result: PromQueryResult::Vector(series),
+            ..
+        }) = response
+        else {
+            panic!("expected vector response");
+        };
+
+        assert_eq!(series.len(), 3);
+        // Output order is first-occurrence order: a, b, c.
+        assert_eq!(
+            series
+                .iter()
+                .map(|series| series.metric["host"].as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+        // Vector results keep the last sample of each series.
+        assert_eq!(series[0].value, Some((4.0, "4.0".to_string())));
+        assert_eq!(series[1].value, Some((5.0, "5.0".to_string())));
+        assert_eq!(series[2].value, Some((6.0, "6.0".to_string())));
     }
 
     #[test]

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -874,7 +874,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                value: Some((5.0, "1".to_string())),
+                value: Some((5.0, "1.0".to_string())),
                 ..Default::default()
             },
             PromSeriesVector {
@@ -884,7 +884,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                value: Some((5.0, "2".to_string())),
+                value: Some((5.0, "2.0".to_string())),
                 ..Default::default()
             },
         ]
@@ -936,7 +936,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                values: vec![(5.0, "1".to_string()), (10.0, "1".to_string())],
+                values: vec![(5.0, "1.0".to_string()), (10.0, "1.0".to_string())],
                 ..Default::default()
             },
             PromSeriesMatrix {
@@ -946,7 +946,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                values: vec![(5.0, "2".to_string()), (10.0, "2".to_string())],
+                values: vec![(5.0, "2.0".to_string()), (10.0, "2.0".to_string())],
                 ..Default::default()
             },
         ]

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -874,7 +874,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                value: Some((5.0, "1.0".to_string())),
+                value: Some((5.0, "1".to_string())),
                 ..Default::default()
             },
             PromSeriesVector {
@@ -884,7 +884,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                value: Some((5.0, "2.0".to_string())),
+                value: Some((5.0, "2".to_string())),
                 ..Default::default()
             },
         ]
@@ -936,7 +936,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                values: vec![(5.0, "1.0".to_string()), (10.0, "1.0".to_string())],
+                values: vec![(5.0, "1".to_string()), (10.0, "1".to_string())],
                 ..Default::default()
             },
             PromSeriesMatrix {
@@ -946,7 +946,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                 ]
                 .into_iter()
                 .collect(),
-                values: vec![(5.0, "2.0".to_string()), (10.0, "2.0".to_string())],
+                values: vec![(5.0, "2".to_string()), (10.0, "2".to_string())],
                 ..Default::default()
             },
         ]

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -932,7 +932,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     assert_eq!(
         body.data,
         serde_json::from_value::<PrometheusResponse>(
-            json!({"resultType":"scalar","result":[1.0,"2"]})
+            json!({"resultType":"scalar","result":[1.0,"2.0"]})
         )
         .unwrap()
     );

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -932,7 +932,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     assert_eq!(
         body.data,
         serde_json::from_value::<PrometheusResponse>(
-            json!({"resultType":"scalar","result":[1.0,"2.0"]})
+            json!({"resultType":"scalar","result":[1.0,"2"]})
         )
         .unwrap()
     );

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2959,6 +2959,8 @@ pub async fn test_prometheus_remote_write_v2_native_histogram(store_type: Storag
         .await;
     assert_eq!(res.status(), StatusCode::OK);
     let body = res.json::<PrometheusJsonResponse>().await;
+    // Finite vector sample values use the HTTP response's ryu contract, so
+    // integral f64 values retain their explicit `.0`; timestamps remain JSON numbers.
     assert_eq!(
         serde_json::to_string_pretty(&body).unwrap(),
         r#"{
@@ -2974,7 +2976,7 @@ pub async fn test_prometheus_remote_write_v2_native_histogram(store_type: Storag
         },
         "value": [
           4.0,
-          "6"
+          "6.0"
         ]
       }
     ]

--- a/tests/perf/fixture-format.md
+++ b/tests/perf/fixture-format.md
@@ -58,6 +58,20 @@ warmup = 0
 iterations = 1
 ```
 
+### Query kinds
+
+`kind = "prom_http"` runs a Prometheus range query by POSTing form fields to
+`/v1/prometheus/api/v1/query_range`. `query`, `start`, `end`, and `step` are
+sent as form fields; `start` and `end` define the range, and `step` defines its
+evaluation interval. `start`, `end`, and `step` are optional in the case model
+and default to empty form values when omitted. The table database is sent as the
+`db` URL query parameter, rather than as a form field.
+
+The measurement starts before the HTTP request is sent and ends after the full
+response body is read and parsed as JSON. It therefore includes request send,
+server-side Prometheus JSON response building, and response-body read and JSON
+parsing; it is not server-side-only latency.
+
 `series_layout = "round_robin"` advances the timestamp once per generated row and
 cycles series labels across rows. `series_layout = "timestamp_major"` writes all
 series for one timestamp before advancing to the next timestamp; use it for

--- a/tests/perf/query_cases/prom_json_response/case.toml
+++ b/tests/perf/query_cases/prom_json_response/case.toml
@@ -2,8 +2,8 @@
 #
 # Exercises the serial per-request
 # `PrometheusJsonResponse::record_batches_to_data`
-# (src/servers/src/http/result/prometheus_resp.rs) path and its per-series
-# IndexMap entry reuse.
+# (src/servers/src/http/result/prometheus_resp.rs) path, ryu float formatting,
+# and its per-series IndexMap entry reuse.
 #
 # 256 series x 481 evaluation timestamps (2h at 15s) = ~123k output samples
 # per request. The primary `prom_http` query builds the Prometheus JSON

--- a/tests/perf/query_cases/prom_json_response/case.toml
+++ b/tests/perf/query_cases/prom_json_response/case.toml
@@ -1,0 +1,97 @@
+# Prometheus JSON response building benchmark (issue #8805).
+#
+# Pressures the serial per-request path of
+# `PrometheusJsonResponse::record_batches_to_data`
+# (src/servers/src/http/result/prometheus_resp.rs): per-sample float
+# formatting (`f64::to_string()` -> ryu) and per-row label-vector hashing
+# (IndexMap entry lookup -> per-series entry reuse).
+#
+# 256 series x 481 evaluation timestamps (2h at 15s) = ~123k output samples
+# per request. The primary `prom_http` query goes through the real Prometheus
+# HTTP range API (`/v1/prometheus/api/v1/query_range`), which is the only
+# frontend path that builds the Prometheus JSON response — `/v1/sql`
+# (including `TQL ANALYZE`) formats the SQL JSON shape instead. The TQL
+# ANALYZE control measures the query-engine half of the same workload so the
+# JSON-building delta can be attributed.
+#
+# NOTE: `kind = "prom_http"` is a runner-side extension
+# (src/cmd/src/bin/query_regression_runner) that POSTs the query/start/end/step
+# form fields to the Prometheus range API instead of `/v1/sql`.
+
+[case]
+name = "prom_json_response"
+description = "Prometheus HTTP API JSON response building for large range queries"
+
+[scenario]
+kind = "direct_readable_sst"
+seed = 8805
+
+[[scenario.tables]]
+database = "public"
+name = "prom_json_response"
+engine = "mito"
+append_mode = true
+sst_format = "flat"
+primary_key = ["host", "instance"]
+time_index = "ts"
+
+[[scenario.tables.columns]]
+name = "host"
+type = "STRING"
+semantic = "tag"
+distribution = { kind = "cardinality", values = 16, prefix = "host" }
+
+[[scenario.tables.columns]]
+name = "instance"
+type = "STRING"
+semantic = "tag"
+distribution = { kind = "cardinality", values = 16, prefix = "instance" }
+
+[[scenario.tables.columns]]
+name = "value"
+type = "DOUBLE"
+semantic = "field"
+distribution = { kind = "deterministic_wave", min = 0.0, max = 1000.0 }
+
+[[scenario.tables.columns]]
+name = "ts"
+type = "TIMESTAMP(9)"
+semantic = "timestamp"
+
+[scenario.layout]
+regions = 1
+sst_count = 16
+rows_per_sst = 7680
+row_group_size = 1920
+series_count = 256
+start_unix_nanos = 1704067200000000000
+step_nanos = 15000000000
+time_range_layout = "non_overlapping_per_sst"
+series_layout = "timestamp_major"
+
+# Primary case: Prometheus HTTP range query over the full 2h window.
+# 256 series x 481 points -> ~123k samples built and serialized per request.
+[[scenario.queries]]
+name = "prom_range_2h"
+kind = "prom_http"
+query = "prom_json_response{host=~\"host.*\"}"
+start = "1704067200"
+end = "1704074400"
+step = "15s"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# Control: same workload through the SQL/TQL frontend path, which does not
+# build the Prometheus JSON response. Isolates query-engine/scan variance.
+[[scenario.queries]]
+name = "tql_range_2h_control"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704067200, 1704074400, '15s') prom_json_response{host=~'host.*'}"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10

--- a/tests/perf/query_cases/prom_json_response/case.toml
+++ b/tests/perf/query_cases/prom_json_response/case.toml
@@ -1,22 +1,14 @@
 # Prometheus JSON response building benchmark (issue #8805).
 #
-# Pressures the serial per-request path of
+# Exercises the serial per-request
 # `PrometheusJsonResponse::record_batches_to_data`
-# (src/servers/src/http/result/prometheus_resp.rs): per-sample float
-# formatting (`f64::to_string()` -> ryu) and per-row label-vector hashing
-# (IndexMap entry lookup -> per-series entry reuse).
+# (src/servers/src/http/result/prometheus_resp.rs) path and its per-series
+# IndexMap entry reuse.
 #
 # 256 series x 481 evaluation timestamps (2h at 15s) = ~123k output samples
-# per request. The primary `prom_http` query goes through the real Prometheus
-# HTTP range API (`/v1/prometheus/api/v1/query_range`), which is the only
-# frontend path that builds the Prometheus JSON response — `/v1/sql`
-# (including `TQL ANALYZE`) formats the SQL JSON shape instead. The TQL
-# ANALYZE control measures the query-engine half of the same workload so the
-# JSON-building delta can be attributed.
-#
-# NOTE: `kind = "prom_http"` is a runner-side extension
-# (src/cmd/src/bin/query_regression_runner) that POSTs the query/start/end/step
-# form fields to the Prometheus range API instead of `/v1/sql`.
+# per request. The primary `prom_http` query builds the Prometheus JSON
+# response. The TQL ANALYZE control runs the same workload without building the
+# Prometheus JSON response, to measure query-engine/scan variance.
 
 [case]
 name = "prom_json_response"
@@ -45,7 +37,7 @@ distribution = { kind = "cardinality", values = 16, prefix = "host" }
 name = "instance"
 type = "STRING"
 semantic = "tag"
-distribution = { kind = "cardinality", values = 16, prefix = "instance" }
+distribution = { kind = "cardinality", values = 256, prefix = "instance" }
 
 [[scenario.tables.columns]]
 name = "value"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- https://github.com/GreptimeTeam/greptimedb/issues/8805

## What's changed and what's your intention?

This PR reduces the cost of building Prometheus HTTP API JSON responses.

Finite sample values now use ryu's shortest-roundtrip formatting. PromQL range output is normally clustered by series, so `PrometheusJsonResponse::record_batches_to_data` also reuses the preceding `IndexMap` entry when consecutive rows have the same labels, avoiding repeated hashing and lookup. Series transitions continue to use the normal map-entry path.

**BREAKING CHANGE:** finite Prometheus sample strings may change textually, including integral `.0`, scientific-notation thresholds, and shortest-roundtrip tie cases. Parsing the new text as `f64` yields the identical value, including the sign of `-0.0`. `NaN`, `inf`, and `-inf` retain their previous strings.

The PR also:

- adds a `prom_http` query-regression kind for the real `/v1/prometheus/api/v1/query_range` response path;
- sends the database through the endpoint's `db` URL query parameter and covers it with a focused test;
- documents the fixture DSL and its end-to-end timing scope;
- uses 256 distinct series in the benchmark fixture;
- aligns direct-SST fixture `CREATE TABLE` index declarations with generated region metadata.

### Performance

The formal A/B run used nightly-profile binaries with 256 distinct series, 481 evaluation timestamps per series, 3 warmups, and 9 measured iterations. Both sides use ryu; the comparison isolates per-series entry reuse. Latency includes the endpoint request, query execution, Prometheus JSON response construction, body read, and JSON parsing.

| Query | Base median | Candidate median | Delta |
| --- | ---: | ---: | ---: |
| `prom_range_2h` | 68.793 ms | 55.29 ms | **-19.62%** |
| `tql_range_2h_control` | 66.83 ms | 67.07 ms | +0.36% |

Both configured 10% maximum-regression thresholds passed with zero validation errors on each target.

### Verification

- Targeted `servers` Prometheus response tests: 12/12 passed.
- Targeted `cmd` Prometheus database URL test: 1/1 passed.
- Cargo checks passed for `servers`, `cmd`, and `tests-integration`.
- The normalized fixture plan completed successfully.
- The formal query-regression run completed successfully and passed both thresholds.

There are no schema or persisted-data compatibility changes. The finite Prometheus sample textual representation is intentionally breaking as described above.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
