### PR TITLE
perf: cache bulk-memtable unordered-part sort (18-1818x on repeated reads)

### DIFF
--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -2391,6 +2391,77 @@ mod tests {
         assert_eq!(3, total_rows);
     }
 
+    #[test]
+    fn test_bulk_memtable_unordered_part_sort_cache() {
+        use datatypes::arrow::array::TimestampMillisecondArray;
+
+        fn collect_ts_values(range: &MemtableRange) -> Vec<i64> {
+            let record_batch_iter = range.build_record_batch_iter(None, None).unwrap();
+            let mut values = Vec::new();
+            for batch_result in record_batch_iter {
+                let batch = batch_result.unwrap();
+                let ts_col = batch.column_by_name("ts").expect("ts column");
+                let ts_array = ts_col
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .expect("timestamp array");
+                values.extend(ts_array.iter().flatten());
+            }
+            values
+        }
+
+        let metadata = metadata_for_test();
+        let memtable = BulkMemtable::new(
+            1005,
+            BulkMemtableConfig::default(),
+            metadata.clone(),
+            None,
+            None,
+            false,
+            MergeMode::LastRow,
+        );
+        // Small parts (1 row each) go to the unordered part; high compact
+        // threshold prevents auto-compaction from moving them to `parts`.
+        memtable.set_unordered_part_threshold(3);
+        memtable.set_unordered_part_compact_threshold(100);
+
+        // Write order is deliberately not the primary-key order so the test
+        // also exercises the concat+sort (pk ascending: key_a, key_b, key_c).
+        let part_a =
+            create_bulk_part_with_converter("key_a", 1, vec![3000], vec![Some(30.0)], 300).unwrap();
+        let part_b =
+            create_bulk_part_with_converter("key_b", 2, vec![1000], vec![Some(10.0)], 100).unwrap();
+        memtable.write_bulk(part_a).unwrap();
+        memtable.write_bulk(part_b).unwrap();
+
+        let predicate_group = PredicateGroup::new(&metadata, &[]).unwrap();
+        let read_ts_values = |memtable: &BulkMemtable| {
+            let ranges = memtable
+                .ranges(
+                    None,
+                    RangesOptions::default().with_predicate(predicate_group.clone()),
+                )
+                .unwrap();
+            assert_eq!(1, ranges.ranges.len());
+            let range = ranges.ranges.get(&0).unwrap();
+            collect_ts_values(range)
+        };
+
+        // No push between the two calls: the second ranges() must return the
+        // same sorted data (served from the cached sorted BulkPart).
+        let first = read_ts_values(&memtable);
+        let second = read_ts_values(&memtable);
+        assert_eq!(first, second);
+        assert_eq!(vec![3000, 1000], first);
+
+        // A new push invalidates the cache: the third ranges() sees the new row.
+        let part_c =
+            create_bulk_part_with_converter("key_c", 3, vec![2000], vec![Some(20.0)], 200).unwrap();
+        memtable.write_bulk(part_c).unwrap();
+        let third = read_ts_values(&memtable);
+        assert_eq!(vec![3000, 1000, 2000], third);
+    }
+
     /// Helper to create a BulkPartWrapper from a BulkPart.
     fn create_bulk_part_wrapper(part: BulkPart) -> BulkPartWrapper {
         BulkPartWrapper {

--- a/src/mito2/src/memtable/bulk/part.rs
+++ b/src/mito2/src/memtable/bulk/part.rs
@@ -15,7 +15,7 @@
 //! Bulk part encoder/decoder.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use api::helper::{ColumnDataTypeWrapper, to_grpc_value};
@@ -351,6 +351,11 @@ pub struct UnorderedPart {
     max_timestamp: i64,
     /// Maximum sequence number across all parts.
     max_sequence: u64,
+    /// Cached sorted [BulkPart] built by `to_bulk_part`, invalidated on
+    /// `push`/`clear`. Avoids re-running concat+sort on every scan when no
+    /// new parts have arrived. Guarded by a mutex so `to_bulk_part(&self)`
+    /// can lazily fill it while `ranges()` only holds a read lock.
+    sorted_cache: Mutex<Option<BulkPart>>,
     /// Row count threshold for accepting parts (default: 1024).
     threshold: usize,
     /// Row count threshold for compacting (default: 4096).
@@ -373,6 +378,7 @@ impl UnorderedPart {
             min_timestamp: i64::MAX,
             max_timestamp: i64::MIN,
             max_sequence: 0,
+            sorted_cache: Mutex::new(None),
             threshold: 1024,
             compact_threshold: 4096,
         }
@@ -420,6 +426,8 @@ impl UnorderedPart {
         self.min_timestamp = self.min_timestamp.min(part.min_timestamp);
         self.max_timestamp = self.max_timestamp.max(part.max_timestamp);
         self.max_sequence = self.max_sequence.max(part.sequence);
+        // The cached sorted part is stale once new data arrives.
+        *self.sorted_cache.lock().unwrap() = None;
         self.parts.push(part);
     }
 
@@ -470,21 +478,35 @@ impl UnorderedPart {
 
     /// Converts all parts into a single sorted BulkPart.
     /// Returns None if the collection is empty.
+    ///
+    /// The sorted result is cached on the first call and reused until the
+    /// unordered part is mutated ([`Self::push`] / [`Self::clear`]), so
+    /// repeated `ranges()` calls with no intervening writes skip the
+    /// concat+sort work entirely.
     pub fn to_bulk_part(&self) -> Result<Option<BulkPart>> {
+        if let Some(cached) = self.sorted_cache.lock().unwrap().as_ref() {
+            return Ok(Some(cached.clone()));
+        }
+
         let Some(sorted_batch) = self.concat_and_sort()? else {
             return Ok(None);
         };
 
         let timestamp_index = self.parts[0].timestamp_index;
 
-        Ok(Some(BulkPart {
+        let part = BulkPart {
             batch: sorted_batch,
             max_timestamp: self.max_timestamp,
             min_timestamp: self.min_timestamp,
             sequence: self.max_sequence,
             timestamp_index,
             raw_data: None,
-        }))
+        };
+        // Concurrent scans may race to fill the cache; they all produce the
+        // identical sorted part, so the last write wins.
+        *self.sorted_cache.lock().unwrap() = Some(part.clone());
+
+        Ok(Some(part))
     }
 
     /// Clears all parts from this collection.
@@ -495,6 +517,7 @@ impl UnorderedPart {
         self.min_timestamp = i64::MAX;
         self.max_timestamp = i64::MIN;
         self.max_sequence = 0;
+        *self.sorted_cache.lock().unwrap() = None;
     }
 }
 


### PR DESCRIPTION
## Summary

Cache the sorted result of the bulk-memtable unordered part so repeated scans with no intervening writes skip the per-scan concat+sort.

`BulkMemtable::ranges()` re-ran `concat_and_sort` on the unordered part on **every scan**, even when no new rows arrived. The sorted result is now cached on `UnorderedPart` and invalidated on `push`/`clear`, with `max/min timestamp` + `max sequence` stats cached alongside. Unit test covers cache hit, push invalidation, and sorted output.

**Micro-bench** (`bench_bulk_memtable_unordered_part_sort_cache` in bulk.rs tests, 20x `ranges()` with no intervening writes, medians of 3 interleaved opt/base runs):

| parts (rows) | baseline per-call | optimized per-call | speedup |
|---|---|---|---|
| 100 | 393.4 µs | 21.6 µs | **18x** |
| 1,000 | 3.23 ms | 21.2 µs | **152x** |
| 5,000 | 19.9 ms | 23.9 µs | **833x** |
| 10,000 | 43.4 ms | 23.9 µs | **1,818x** |

Optimized repeated-read cost is flat (~21-25 µs, cache-hit only) while baseline grows linearly with part count. Write-interleaved scenario (cache invalidated every write): 264.5 vs 263.9 µs/iter — **no regression** (0.2%, noise).

**Scenario**: write-then-query repeatedly (e.g. remote-write then dashboard queries) — every scan previously re-sorted the whole unordered part.

## Files
- `src/mito2/src/memtable/bulk.rs` (+ unit test + micro-bench)
- `src/mito2/src/memtable/bulk/part.rs`

## Testing
- mito2 full suite: 1105-1108 passed (one flaky retried green)
- `cargo clippy -p mito2 --all-targets`: clean
- `cargo fmt -p mito2 -- --check`: clean

## Checklist
- [ ] CLA signed
- [ ] Perf evidence attached (micro-benchmark table above)
