### PR TITLE
fix(ci): identify team members by repository permission

### DIFF
--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -9,9 +9,8 @@ import { appendFileSync } from "node:fs";
 const MARKER = "<!-- pr-open-limit -->";
 // GITHUB_TOKEN can only edit comments authored by the Actions bot itself.
 const COMMENT_AUTHOR = "github-actions[bot]";
-// Associations that identify an organization member. Outside collaborators and
-// community contributors are out of scope.
-const MEMBER_ASSOCIATIONS = ["OWNER", "MEMBER"];
+// Repository permissions that mark someone as part of the team.
+const TEAM_PERMISSIONS = ["admin", "write"];
 // Keep the comment readable for authors who are far over the limit.
 const MAX_LISTED_PRS = 10;
 
@@ -20,6 +19,29 @@ function summary(text) {
     appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${text}\n`);
   }
   console.log(text);
+}
+
+// `author_association` cannot be used here: it is computed from what the caller
+// is allowed to see, so GITHUB_TOKEN reports a private organization member as
+// CONTRIBUTOR. Repository permission is viewer-independent.
+//
+// On error this returns true rather than false. A token that cannot read
+// permissions would otherwise make the whole check silently pass everyone.
+async function isTeamMember(octokit, owner, repo, username) {
+  try {
+    const { data } = await octokit.repos.getCollaboratorPermissionLevel({
+      owner,
+      repo,
+      username,
+    });
+    console.log(`Repository permission for \`${username}\`: ${data.permission}.`);
+    return TEAM_PERMISSIONS.includes(data.permission);
+  } catch (error) {
+    console.log(
+      `Cannot read repository permission for \`${username}\` (HTTP ${error.status}); applying the limit anyway.`
+    );
+    return true;
+  }
 }
 
 function buildComment(author, total, limit, openPrs) {
@@ -69,7 +91,6 @@ async function upsertComment(octokit, params, body) {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
   const prNumber = Number(process.env.PR_NUMBER);
   const author = process.env.PR_AUTHOR;
-  const association = process.env.PR_AUTHOR_ASSOCIATION;
   const rawLimit = Number(process.env.MAX_OPEN_PRS);
   const limit = Number.isInteger(rawLimit) && rawLimit >= 0 ? rawLimit : 5;
 
@@ -78,12 +99,12 @@ async function upsertComment(octokit, params, body) {
     return;
   }
 
-  if (!MEMBER_ASSOCIATIONS.includes(association)) {
-    summary(`Skipping \`${author}\`: association is \`${association}\`, not an org member.`);
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+  if (!(await isTeamMember(octokit, owner, repo, author))) {
+    summary(`Skipping \`${author}\`: no write access, not a team member.`);
     return;
   }
-
-  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
   const allOpen = await octokit.paginate(octokit.pulls.list, {
     owner,

--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -34,7 +34,7 @@ async function isTeamMember(octokit, owner, repo, username) {
       repo,
       username,
     });
-    console.log(`Repository permission for \`${username}\`: ${data.permission}.`);
+    // Never log the level itself: job logs are public.
     return TEAM_PERMISSIONS.includes(data.permission);
   } catch (error) {
     console.log(
@@ -102,7 +102,7 @@ async function upsertComment(octokit, params, body) {
   const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
   if (!(await isTeamMember(octokit, owner, repo, author))) {
-    summary(`Skipping \`${author}\`: no write access, not a team member.`);
+    summary(`Skipping \`${author}\`: not a team member.`);
     return;
   }
 

--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -10,7 +10,7 @@ const MARKER = "<!-- pr-open-limit -->";
 // GITHUB_TOKEN can only edit comments authored by the Actions bot itself.
 const COMMENT_AUTHOR = "github-actions[bot]";
 // Repository permissions that mark someone as part of the team.
-const TEAM_PERMISSIONS = ["admin", "write"];
+const TEAM_PERMISSIONS = ["admin", "maintain", "write"];
 // Keep the comment readable for authors who are far over the limit.
 const MAX_LISTED_PRS = 10;
 

--- a/.github/workflows/pr-open-limit.yml
+++ b/.github/workflows/pr-open-limit.yml
@@ -44,5 +44,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           MAX_OPEN_PRS: ${{ vars.MAX_OPEN_PRS_PER_AUTHOR || 5 }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8813.

## What's changed and what's your intention?

#8813 has skipped every pull request since it merged.

It gated on `author_association`, treating `OWNER` / `MEMBER` as being on the team. That value depends on what the caller can see: a member whose organization membership is not public reads as `CONTRIBUTOR` to any caller that cannot see the membership, and `GITHUB_TOKEN` is such a caller. Most of our members are in that position, so the check was inert for nearly everyone it targets.

Gate on the author's repository permission instead, which does not depend on who is asking. Two consequences:

- On error the check applies the limit rather than skipping. Failing closed is what caused this bug, and it failed silently.
- Outside collaborators with write access are now in scope.

The resolved permission is not logged; job logs are public.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.