### PR TITLE
fix(meta): validate leaders before enabling skip_wal

### DIFF
--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -198,6 +198,12 @@ impl AlterTableProcedure {
                 // DDL manager can submit another procedure with locks for the current route.
                 return Ok(Status::done_with_output(RegionRouteChanged));
             }
+            ensure!(
+                !find_leaders(&physical_table_route.region_routes).is_empty(),
+                NoLeaderSnafu {
+                    table_id: physical_table_id
+                }
+            );
             self.data.region_distribution =
                 Some(region_distribution(&physical_table_route.region_routes));
         }
@@ -264,9 +270,8 @@ impl AlterTableProcedure {
                 MultipleResults::PartialRetryable(error) => Err(error),
                 MultipleResults::PartialNonRetryable(error)
                 | MultipleResults::AllNonRetryable(error) => {
-                    // The metadata already enables skip-WAL. Keep retrying until every
-                    // replica applies the runtime option instead of leaving the table in
-                    // a permanently inconsistent state.
+                    // The metadata already enables skip-WAL. Retry the idempotent request
+                    // so later attempts can update the remaining replicas.
                     Err(BoxedError::new(error)).context(RetryLaterSnafu {
                         clean_poisons: true,
                     })

--- a/src/common/meta/src/ddl/tests/alter_table.rs
+++ b/src/common/meta/src/ddl/tests/alter_table.rs
@@ -851,6 +851,66 @@ async fn test_skip_wal_detects_region_route_change() {
 }
 
 #[tokio::test]
+async fn test_skip_wal_rejects_no_leader_before_updating_metadata() {
+    let ddl_context = new_ddl_context(Arc::new(MockDatanodeManager::new(())));
+    let table_name = "foo";
+    let table_id = 1024;
+    let task = test_create_table_task(table_name, table_id);
+    let mut region_routes = prepare_table_route(table_id)
+        .region_routes()
+        .unwrap()
+        .clone();
+    for route in &mut region_routes {
+        route.leader_peer = None;
+    }
+    let region_locks = region_routes.iter().map(|route| route.region.id).collect();
+    ddl_context
+        .table_metadata_manager
+        .create_table_metadata(
+            task.table_info,
+            TableRouteValue::physical(region_routes),
+            HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+    let alter_task = AlterTableTask {
+        alter_table: AlterTableExpr {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: table_name.to_string(),
+            kind: Some(Kind::SetTableOptions(SetTableOptions {
+                table_options: vec![api::v1::Option {
+                    key: SKIP_WAL_KEY.to_string(),
+                    value: "true".to_string(),
+                }],
+            })),
+        },
+    };
+    let mut procedure = AlterTableProcedure::new_with_region_locks(
+        table_id,
+        alter_task,
+        EventContext::default(),
+        region_locks,
+        ddl_context.clone(),
+    )
+    .unwrap();
+
+    let error = procedure.on_prepare().await.unwrap_err();
+    assert_matches!(error, Error::NoLeader { .. });
+    let table_info = ddl_context
+        .table_metadata_manager
+        .table_info_manager()
+        .get(table_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .into_inner()
+        .table_info;
+    assert!(!table_info.meta.options.skip_wal);
+}
+
+#[tokio::test]
 async fn test_skip_wal_updates_metadata_before_all_replicas() {
     let (tx, mut rx) = mpsc::channel(8);
     let node_manager = Arc::new(MockDatanodeManager::new(DatanodeWatcher::new(tx)));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8730. The leaderless case was found while reviewing the v1.2 backport in #8817.

## What's changed and what's your intention?

Enabling `skip_wal` uses a metadata-first flow because changing a replica to skip WAL is irreversible. Previously, a table with no region leaders could commit `skip_wal = true` in table metadata and then fail the following region step at its existing `NoLeader` check.

This PR validates that the locked physical route has at least one leader during the prepare step, before the procedure advances to update metadata. It also adds a regression test asserting that the leaderless error leaves `skip_wal` disabled in table metadata.

The replica request remains idempotent and uses the existing bounded procedure retry behavior. This PR does not change the common procedure retry policy.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

Validation:

- `cargo nextest run -p common-meta skip_wal`
- `cargo nextest run -p mito2 test_alter_skip_wal_stops_wal_and_flushes_on_close`
- `cargo fmt --all -- --check`
