### PR TITLE
feat: complete the derived-edge vocabulary of the entity graph

### DIFF
--- a/src/frontend/src/instance/entity_graph.rs
+++ b/src/frontend/src/instance/entity_graph.rs
@@ -34,10 +34,8 @@ use auth::{
 use catalog::CatalogManager;
 use catalog::system_schema::semantic_graph::EntityGraphProvider;
 use common_catalog::consts::{
-    DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DURATION_NANO_COLUMN,
-    INFORMATION_SCHEMA_NAME, PARENT_SPAN_ID_COLUMN, PG_CATALOG_NAME,
-    SEMANTIC_RELATIONSHIPS_DECLARED_TABLE_NAME, SERVICE_NAME_COLUMN, SPAN_ID_COLUMN,
-    SPAN_KIND_COLUMN, SPAN_STATUS_CODE_COLUMN, TRACE_ID_COLUMN, TRACE_TIMESTAMP_COLUMN,
+    DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME, PG_CATALOG_NAME,
+    SEMANTIC_RELATIONSHIPS_DECLARED_TABLE_NAME, SERVICE_NAME_COLUMN,
 };
 use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
@@ -83,39 +81,6 @@ struct TraceSource {
     service: Option<EntityDeclaration>,
     agent: Option<EntityDeclaration>,
     table: TableRef,
-}
-
-/// Whether a trace-model table still carries the fixed `greptime_trace_v1`
-/// columns (with their ingest types) the calls/agent derivations reference.
-/// `table_data_model` is only an option: a stale or hand-made table missing
-/// them would otherwise fail plan building and poison every relationships
-/// scan.
-fn trace_v1_schema_matches(table_info: &TableInfo) -> bool {
-    use datatypes::prelude::ConcreteDataType;
-    let schema = &table_info.meta.schema;
-    let column_type = |name: &str| {
-        schema
-            .column_schema_by_name(name)
-            .map(|column| column.data_type.clone())
-    };
-    // The derivations filter and bucket by this column; if it is not the time
-    // index, the window predicate cannot prune the scan and the buckets
-    // diverge from the table's time semantics.
-    schema
-        .timestamp_column()
-        .is_some_and(|column| column.name == TRACE_TIMESTAMP_COLUMN)
-        && column_type(TRACE_TIMESTAMP_COLUMN)
-            == Some(ConcreteDataType::timestamp_nanosecond_datatype())
-        && [
-            TRACE_ID_COLUMN,
-            SPAN_ID_COLUMN,
-            PARENT_SPAN_ID_COLUMN,
-            SPAN_KIND_COLUMN,
-            SPAN_STATUS_CODE_COLUMN,
-        ]
-        .iter()
-        .all(|column| column_type(column) == Some(ConcreteDataType::string_datatype()))
-        && column_type(DURATION_NANO_COLUMN) == Some(ConcreteDataType::uint64_datatype())
 }
 
 impl EntityGraphProviderImpl {
@@ -309,20 +274,7 @@ impl EntityGraphProviderImpl {
             while let Some(table) = tables.try_next().await.map_err(BoxedError::new)? {
                 let table_info = table.table_info();
                 let table_declarations = Self::declarations_for(&table_info);
-                let is_trace = match is_trace_v1_table(&table_info) {
-                    true if trace_v1_schema_matches(&table_info) => true,
-                    true => {
-                        // Schema drift never poisons a scan: derive around the
-                        // malformed table instead of failing plan building.
-                        warn!(
-                            "Trace table `{}` does not match the fixed trace-v1 schema; \
-                             skipping calls derivation",
-                            table_info.name
-                        );
-                        false
-                    }
-                    false => false,
-                };
+                let is_trace = is_trace_v1_table(&table_info);
                 // Authorize only tables that would contribute rows.
                 if per_table_auth
                     && (is_trace || !table_declarations.is_empty())
@@ -694,79 +646,6 @@ mod tests {
             ],
         );
         assert!(EntityGraphProviderImpl::declarations_for(&info).is_empty());
-    }
-
-    /// The canonical fixed trace-v1 columns, with an injection point for the
-    /// aspects `trace_v1_schema_matches` must reject.
-    fn trace_v1_info(mutate: impl FnOnce(&mut Vec<ColumnSchema>)) -> TableInfo {
-        let string =
-            |name: &str| ColumnSchema::new(name, ConcreteDataType::string_datatype(), true);
-        let mut columns = vec![
-            ColumnSchema::new(
-                TRACE_TIMESTAMP_COLUMN,
-                ConcreteDataType::timestamp_nanosecond_datatype(),
-                false,
-            )
-            .with_time_index(true),
-            string(TRACE_ID_COLUMN),
-            string(SPAN_ID_COLUMN),
-            string(PARENT_SPAN_ID_COLUMN),
-            string(SPAN_KIND_COLUMN),
-            string(SPAN_STATUS_CODE_COLUMN),
-            ColumnSchema::new(
-                DURATION_NANO_COLUMN,
-                ConcreteDataType::uint64_datatype(),
-                true,
-            ),
-        ];
-        mutate(&mut columns);
-        assemble_table_info(columns, &[(TABLE_DATA_MODEL, TABLE_DATA_MODEL_TRACE_V1)])
-    }
-
-    #[test]
-    fn malformed_trace_v1_schema_is_rejected() {
-        assert!(trace_v1_schema_matches(&trace_v1_info(|_| {})));
-
-        let missing_duration = trace_v1_info(|columns| {
-            columns.retain(|c| c.name != DURATION_NANO_COLUMN);
-        });
-        assert!(!trace_v1_schema_matches(&missing_duration));
-
-        let wrong_kind_type = trace_v1_info(|columns| {
-            columns
-                .iter_mut()
-                .find(|c| c.name == SPAN_KIND_COLUMN)
-                .unwrap()
-                .data_type = ConcreteDataType::int64_datatype();
-        });
-        assert!(!trace_v1_schema_matches(&wrong_kind_type));
-
-        // A millisecond time index is not the trace-v1 ingest schema.
-        let ms_timestamp = trace_v1_info(|columns| {
-            columns[0] = ColumnSchema::new(
-                TRACE_TIMESTAMP_COLUMN,
-                ConcreteDataType::timestamp_millisecond_datatype(),
-                false,
-            )
-            .with_time_index(true);
-        });
-        assert!(!trace_v1_schema_matches(&ms_timestamp));
-
-        // "timestamp" present with the right type, but the time index is a
-        // different column: the derivations would bucket by a non-indexed
-        // column and the window predicate could not prune the scan.
-        let time_index_elsewhere = trace_v1_info(|columns| {
-            columns[0] = columns[0].clone().with_time_index(false);
-            columns.push(
-                ColumnSchema::new(
-                    "ts",
-                    ConcreteDataType::timestamp_nanosecond_datatype(),
-                    false,
-                )
-                .with_time_index(true),
-            );
-        });
-        assert!(!trace_v1_schema_matches(&time_index_elsewhere));
     }
 
     #[test]

--- a/src/frontend/src/instance/entity_graph.rs
+++ b/src/frontend/src/instance/entity_graph.rs
@@ -34,8 +34,10 @@ use auth::{
 use catalog::CatalogManager;
 use catalog::system_schema::semantic_graph::EntityGraphProvider;
 use common_catalog::consts::{
-    DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME, PG_CATALOG_NAME,
-    SEMANTIC_RELATIONSHIPS_DECLARED_TABLE_NAME, SERVICE_NAME_COLUMN,
+    DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, DURATION_NANO_COLUMN,
+    INFORMATION_SCHEMA_NAME, PARENT_SPAN_ID_COLUMN, PG_CATALOG_NAME,
+    SEMANTIC_RELATIONSHIPS_DECLARED_TABLE_NAME, SERVICE_NAME_COLUMN, SPAN_ID_COLUMN,
+    SPAN_KIND_COLUMN, SPAN_STATUS_CODE_COLUMN, TRACE_ID_COLUMN, TRACE_TIMESTAMP_COLUMN,
 };
 use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
@@ -47,9 +49,9 @@ use datafusion::dataframe::DataFrame;
 use datafusion_expr::LogicalPlan;
 use futures::TryStreamExt;
 use operator::statement::semantic_graph::{
-    CallsSource, DeclaredSource, EntityDeclaration, GraphQueryWindow, OBSERVED_AT_COLUMN,
-    RegistrySource, build_registry_plan, build_relationships_plan,
-    declared_relationships_schema_matches,
+    CallsSource, CoDeclaredSource, DeclaredSource, EntityDeclaration, GraphQueryWindow,
+    OBSERVED_AT_COLUMN, RegistrySource, RelationshipSources, build_registry_plan,
+    build_relationships_plan, declared_relationships_schema_matches,
 };
 use query::QueryEngineRef;
 use session::context::{QueryContext, QueryContextBuilder, QueryContextRef};
@@ -73,7 +75,40 @@ pub struct EntityGraphProviderImpl {
 
 struct EntitySource {
     declarations: Vec<EntityDeclaration>,
+    is_trace: bool,
     table: TableRef,
+}
+
+struct TraceSource {
+    service: EntityDeclaration,
+    agent: Option<EntityDeclaration>,
+    table: TableRef,
+}
+
+/// Whether a trace-model table still carries the fixed `greptime_trace_v1`
+/// columns (with their ingest types) the calls/agent derivations reference.
+/// `table_data_model` is only an option: a stale or hand-made table missing
+/// them would otherwise fail plan building and poison every relationships
+/// scan.
+fn trace_v1_schema_matches(table_info: &TableInfo) -> bool {
+    use datatypes::prelude::ConcreteDataType;
+    let schema = &table_info.meta.schema;
+    let column_type = |name: &str| {
+        schema
+            .column_schema_by_name(name)
+            .map(|column| column.data_type.clone())
+    };
+    column_type(TRACE_TIMESTAMP_COLUMN) == Some(ConcreteDataType::timestamp_nanosecond_datatype())
+        && [
+            TRACE_ID_COLUMN,
+            SPAN_ID_COLUMN,
+            PARENT_SPAN_ID_COLUMN,
+            SPAN_KIND_COLUMN,
+            SPAN_STATUS_CODE_COLUMN,
+        ]
+        .iter()
+        .all(|column| column_type(column) == Some(ConcreteDataType::string_datatype()))
+        && column_type(DURATION_NANO_COLUMN) == Some(ConcreteDataType::uint64_datatype())
 }
 
 impl EntityGraphProviderImpl {
@@ -222,7 +257,7 @@ impl EntityGraphProviderImpl {
         &self,
         catalog: &str,
         query_ctx: Option<&QueryContext>,
-    ) -> Result<(Vec<EntitySource>, Vec<(EntityDeclaration, TableRef)>), BoxedError> {
+    ) -> Result<(Vec<EntitySource>, Vec<TraceSource>), BoxedError> {
         let Some(catalog_manager) = self.catalog_manager.upgrade() else {
             return Ok((vec![], vec![]));
         };
@@ -267,7 +302,20 @@ impl EntityGraphProviderImpl {
             while let Some(table) = tables.try_next().await.map_err(BoxedError::new)? {
                 let table_info = table.table_info();
                 let table_declarations = Self::declarations_for(&table_info);
-                let is_trace = is_trace_v1_table(&table_info);
+                let is_trace = match is_trace_v1_table(&table_info) {
+                    true if trace_v1_schema_matches(&table_info) => true,
+                    true => {
+                        // Schema drift never poisons a scan: derive around the
+                        // malformed table instead of failing plan building.
+                        warn!(
+                            "Trace table `{}` does not match the fixed trace-v1 schema; \
+                             skipping calls derivation",
+                            table_info.name
+                        );
+                        false
+                    }
+                    false => false,
+                };
                 // Authorize only tables that would contribute rows.
                 if per_table_auth
                     && (is_trace || !table_declarations.is_empty())
@@ -288,15 +336,18 @@ impl EntityGraphProviderImpl {
                     continue;
                 }
                 if is_trace {
-                    // TODO(entity-graph): validate the complete fixed trace-v1
-                    // schema before adding the table to calls derivation, and
-                    // skip malformed/stale tables instead of letting one poison
-                    // the whole relationship scan.
                     match table_declarations
                         .iter()
                         .find(|d| d.entity_type == "service")
                     {
-                        Some(service) => traces.push((service.clone(), table.clone())),
+                        Some(service) => traces.push(TraceSource {
+                            service: service.clone(),
+                            agent: table_declarations
+                                .iter()
+                                .find(|d| d.entity_type == "agent")
+                                .cloned(),
+                            table: table.clone(),
+                        }),
                         // No usable service identity: the table cannot
                         // contribute calls edges (see declarations_for).
                         None => warn!(
@@ -308,6 +359,7 @@ impl EntityGraphProviderImpl {
                 if !table_declarations.is_empty() {
                     declarations.push(EntitySource {
                         declarations: table_declarations,
+                        is_trace,
                         table,
                     });
                 }
@@ -480,21 +532,37 @@ impl EntityGraphProvider for EntityGraphProviderImpl {
         request: ScanRequest,
         query_ctx: Option<QueryContextRef>,
     ) -> Result<Option<SendableRecordBatchStream>, BoxedError> {
-        let (_, traces) = self.enumerate(catalog, query_ctx.as_deref()).await?;
-        let mut scans = Vec::with_capacity(traces.len());
-        for (service, trace) in traces {
-            scans.push(CallsSource {
-                service,
-                scan: self.read_table(trace)?,
+        let (sources, traces) = self.enumerate(catalog, query_ctx.as_deref()).await?;
+        let mut calls = Vec::with_capacity(traces.len());
+        for trace in traces {
+            calls.push(CallsSource {
+                service: trace.service,
+                agent: trace.agent,
+                scan: self.read_table(trace.table)?,
+            });
+        }
+        let mut co_declared = Vec::with_capacity(sources.len());
+        for source in sources {
+            co_declared.push(CoDeclaredSource {
+                declarations: source.declarations,
+                is_trace: source.is_trace,
+                scan: self.read_table(source.table)?,
             });
         }
         let declared = self.declared_source(catalog, query_ctx.as_deref()).await?;
         let Some(window) = Self::query_window(&request)? else {
             return Ok(None);
         };
-        let Some(plan) = build_relationships_plan(scans, declared, &window)
-            .context(error::DataFusionSnafu)
-            .map_err(BoxedError::new)?
+        let Some(plan) = build_relationships_plan(
+            RelationshipSources {
+                traces: calls,
+                co_declared,
+                declared,
+            },
+            &window,
+        )
+        .context(error::DataFusionSnafu)
+        .map_err(BoxedError::new)?
         else {
             return Ok(None);
         };
@@ -529,6 +597,10 @@ mod tests {
                 .iter()
                 .map(|c| ColumnSchema::new(*c, ConcreteDataType::string_datatype(), true)),
         );
+        assemble_table_info(column_schemas, extra)
+    }
+
+    fn assemble_table_info(column_schemas: Vec<ColumnSchema>, extra: &[(&str, &str)]) -> TableInfo {
         let schema = Arc::new(
             SchemaBuilder::try_from_columns(column_schemas)
                 .unwrap()
@@ -611,6 +683,63 @@ mod tests {
             ],
         );
         assert!(EntityGraphProviderImpl::declarations_for(&info).is_empty());
+    }
+
+    /// The canonical fixed trace-v1 columns, with an injection point for the
+    /// aspects `trace_v1_schema_matches` must reject.
+    fn trace_v1_info(mutate: impl FnOnce(&mut Vec<ColumnSchema>)) -> TableInfo {
+        let string =
+            |name: &str| ColumnSchema::new(name, ConcreteDataType::string_datatype(), true);
+        let mut columns = vec![
+            ColumnSchema::new(
+                TRACE_TIMESTAMP_COLUMN,
+                ConcreteDataType::timestamp_nanosecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+            string(TRACE_ID_COLUMN),
+            string(SPAN_ID_COLUMN),
+            string(PARENT_SPAN_ID_COLUMN),
+            string(SPAN_KIND_COLUMN),
+            string(SPAN_STATUS_CODE_COLUMN),
+            ColumnSchema::new(
+                DURATION_NANO_COLUMN,
+                ConcreteDataType::uint64_datatype(),
+                true,
+            ),
+        ];
+        mutate(&mut columns);
+        assemble_table_info(columns, &[(TABLE_DATA_MODEL, TABLE_DATA_MODEL_TRACE_V1)])
+    }
+
+    #[test]
+    fn malformed_trace_v1_schema_is_rejected() {
+        assert!(trace_v1_schema_matches(&trace_v1_info(|_| {})));
+
+        let missing_duration = trace_v1_info(|columns| {
+            columns.retain(|c| c.name != DURATION_NANO_COLUMN);
+        });
+        assert!(!trace_v1_schema_matches(&missing_duration));
+
+        let wrong_kind_type = trace_v1_info(|columns| {
+            columns
+                .iter_mut()
+                .find(|c| c.name == SPAN_KIND_COLUMN)
+                .unwrap()
+                .data_type = ConcreteDataType::int64_datatype();
+        });
+        assert!(!trace_v1_schema_matches(&wrong_kind_type));
+
+        // A millisecond time index is not the trace-v1 ingest schema.
+        let ms_timestamp = trace_v1_info(|columns| {
+            columns[0] = ColumnSchema::new(
+                TRACE_TIMESTAMP_COLUMN,
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true);
+        });
+        assert!(!trace_v1_schema_matches(&ms_timestamp));
     }
 
     #[test]

--- a/src/frontend/src/instance/entity_graph.rs
+++ b/src/frontend/src/instance/entity_graph.rs
@@ -80,7 +80,7 @@ struct EntitySource {
 }
 
 struct TraceSource {
-    service: EntityDeclaration,
+    service: Option<EntityDeclaration>,
     agent: Option<EntityDeclaration>,
     table: TableRef,
 }
@@ -98,7 +98,14 @@ fn trace_v1_schema_matches(table_info: &TableInfo) -> bool {
             .column_schema_by_name(name)
             .map(|column| column.data_type.clone())
     };
-    column_type(TRACE_TIMESTAMP_COLUMN) == Some(ConcreteDataType::timestamp_nanosecond_datatype())
+    // The derivations filter and bucket by this column; if it is not the time
+    // index, the window predicate cannot prune the scan and the buckets
+    // diverge from the table's time semantics.
+    schema
+        .timestamp_column()
+        .is_some_and(|column| column.name == TRACE_TIMESTAMP_COLUMN)
+        && column_type(TRACE_TIMESTAMP_COLUMN)
+            == Some(ConcreteDataType::timestamp_nanosecond_datatype())
         && [
             TRACE_ID_COLUMN,
             SPAN_ID_COLUMN,
@@ -336,24 +343,28 @@ impl EntityGraphProviderImpl {
                     continue;
                 }
                 if is_trace {
-                    match table_declarations
-                        .iter()
-                        .find(|d| d.entity_type == "service")
-                    {
-                        Some(service) => traces.push(TraceSource {
-                            service: service.clone(),
-                            agent: table_declarations
-                                .iter()
-                                .find(|d| d.entity_type == "agent")
-                                .cloned(),
-                            table: table.clone(),
-                        }),
+                    let find = |entity_type: &str| {
+                        table_declarations
+                            .iter()
+                            .find(|d| d.entity_type == entity_type)
+                            .cloned()
+                    };
+                    let service = find("service");
+                    let agent = find("agent");
+                    if service.is_none() {
                         // No usable service identity: the table cannot
-                        // contribute calls edges (see declarations_for).
-                        None => warn!(
+                        // contribute service-calls edges (see declarations_for).
+                        warn!(
                             "Trace table `{}` has no usable service declaration; skipping calls derivation",
                             table_info.name
-                        ),
+                        );
+                    }
+                    if service.is_some() || agent.is_some() {
+                        traces.push(TraceSource {
+                            service,
+                            agent,
+                            table: table.clone(),
+                        });
                     }
                 }
                 if !table_declarations.is_empty() {
@@ -740,6 +751,22 @@ mod tests {
             .with_time_index(true);
         });
         assert!(!trace_v1_schema_matches(&ms_timestamp));
+
+        // "timestamp" present with the right type, but the time index is a
+        // different column: the derivations would bucket by a non-indexed
+        // column and the window predicate could not prune the scan.
+        let time_index_elsewhere = trace_v1_info(|columns| {
+            columns[0] = columns[0].clone().with_time_index(false);
+            columns.push(
+                ColumnSchema::new(
+                    "ts",
+                    ConcreteDataType::timestamp_nanosecond_datatype(),
+                    false,
+                )
+                .with_time_index(true),
+            );
+        });
+        assert!(!trace_v1_schema_matches(&time_index_elsewhere));
     }
 
     #[test]

--- a/src/operator/src/statement/semantic_graph.rs
+++ b/src/operator/src/statement/semantic_graph.rs
@@ -45,7 +45,9 @@ use datafusion::functions::{core as core_fns, datetime as datetime_fns, string a
 use datafusion::functions_nested::expr_fn::make_array;
 use datafusion_common::{Column, Result as DfResult, ScalarValue};
 use datafusion_expr::{Expr, LogicalPlan, ScalarUDF, cast, ident, lit};
-pub use relationships::{CallsSource, DeclaredSource, build_relationships_plan};
+pub use relationships::{
+    CallsSource, CoDeclaredSource, DeclaredSource, RelationshipSources, build_relationships_plan,
+};
 use store_api::mito_engine_options::{APPEND_MODE_KEY, MERGE_MODE_KEY, TTL_KEY};
 
 /// Whether an existing declared-edge table still matches the canonical
@@ -513,11 +515,44 @@ const REGISTRY_COLUMNS: [&str; 10] = [
 
 const REGISTRY_VALID_COLUMN: &str = "__entity_valid";
 
-/// Projects all entity declarations of one source table with one source scan.
-///
-/// Each output field is first built as an array whose entries correspond to the
-/// table's declarations. Unnesting the arrays expands one source row into one
-/// row per declared entity without cloning the table scan under `UNION ALL`.
+/// Expands one source row into one output row per entry of `rows` with a
+/// single source scan: each output field is first built as an array whose
+/// entries correspond to the rows, then unnested. Every row is `[valid,
+/// values...]` aligned with `columns`; rows whose `valid` expression is false
+/// are dropped, and the distinct output columns are `columns`.
+fn unnest_rows(
+    df: DataFrame,
+    window_predicate: Expr,
+    valid_column: &'static str,
+    columns: &[&'static str],
+    rows: Vec<Vec<Expr>>,
+) -> DfResult<DataFrame> {
+    let mut arrays = vec![Vec::with_capacity(rows.len()); columns.len() + 1];
+    for row in rows {
+        debug_assert_eq!(row.len(), arrays.len());
+        for (array, value) in arrays.iter_mut().zip(row) {
+            array.push(value);
+        }
+    }
+    let array_names = std::iter::once(valid_column)
+        .chain(columns.iter().copied())
+        .collect::<Vec<_>>();
+    let array_projection = array_names
+        .iter()
+        .zip(arrays)
+        .map(|(name, values)| make_array(values).alias(*name))
+        .collect::<Vec<_>>();
+
+    df.filter(window_predicate)?
+        .select(array_projection)?
+        .unnest_columns(&array_names)?
+        .filter(ident(valid_column))?
+        .select(columns.iter().map(|c| ident(*c)).collect::<Vec<_>>())?
+        .distinct()
+}
+
+/// Projects all entity declarations of one source table with one source scan
+/// via [`unnest_rows`].
 fn registry_source(
     first: &EntityDeclaration,
     rest: &[EntityDeclaration],
@@ -531,7 +566,7 @@ fn registry_source(
         .gt_eq(window.source_start())
         .and(ts.lt(window.source_end()));
 
-    let mut arrays = vec![Vec::new(); REGISTRY_COLUMNS.len() + 1];
+    let mut rows = Vec::with_capacity(1 + rest.len());
     for decl in std::iter::once(first).chain(rest) {
         // CAST even a single-column id: id columns must be tags but not
         // necessarily strings, and the computed table declares entity_id
@@ -575,7 +610,7 @@ fn registry_source(
             predicate.and(ident(id).is_not_null())
         });
 
-        let row = [
+        rows.push(vec![
             valid,
             bin.clone(),
             bin.clone(),
@@ -587,27 +622,16 @@ fn registry_source(
             scope,
             descriptive,
             source_tables,
-        ];
-        for (array, value) in arrays.iter_mut().zip(row) {
-            array.push(value);
-        }
+        ]);
     }
 
-    let array_names = std::iter::once(REGISTRY_VALID_COLUMN)
-        .chain(REGISTRY_COLUMNS)
-        .collect::<Vec<_>>();
-    let array_projection = array_names
-        .iter()
-        .zip(arrays)
-        .map(|(name, values)| make_array(values).alias(*name))
-        .collect::<Vec<_>>();
-
-    df.filter(window_predicate)?
-        .select(array_projection)?
-        .unnest_columns(&array_names)?
-        .filter(ident(REGISTRY_VALID_COLUMN))?
-        .select(REGISTRY_COLUMNS.into_iter().map(ident).collect::<Vec<_>>())?
-        .distinct()
+    unnest_rows(
+        df,
+        window_predicate,
+        REGISTRY_VALID_COLUMN,
+        &REGISTRY_COLUMNS,
+        rows,
+    )
 }
 
 /// A declaring table's scan paired with the entity declarations it carries —

--- a/src/operator/src/statement/semantic_graph/relationships.rs
+++ b/src/operator/src/statement/semantic_graph/relationships.rs
@@ -34,6 +34,7 @@ use datafusion_expr::{Expr, ExprFunctionExt, JoinType, LogicalPlan, cast, ident,
 use crate::statement::semantic_graph::{
     DECLARED_EDGE_IDENTITY_COLUMNS, EntityDeclaration, GraphQueryWindow, OBSERVED_AT_COLUMN,
     bin_interval, bin_ms, entity_id_expr, interval, null_json, parse_json_expr, qcol, union_all,
+    unnest_rows,
 };
 
 /// The projected columns of `semantic_relationships`, in order. Every derived
@@ -217,7 +218,7 @@ fn co_declared_branch(
             })
             .collect();
 
-        let branch = super::unnest_rows(
+        let branch = unnest_rows(
             source.scan,
             window_predicate,
             CO_DECLARED_VALID_COLUMN,

--- a/src/operator/src/statement/semantic_graph/relationships.rs
+++ b/src/operator/src/statement/semantic_graph/relationships.rs
@@ -68,9 +68,11 @@ const CHILD_SPAN_EARLY_NANOS: i64 = 5 * 60 * 1_000_000_000;
 const CHILD_SPAN_LATE_NANOS: i64 = 60 * 60 * 1_000_000_000;
 
 /// A trace table's scan paired with the `service` declaration it derives
-/// `calls` edges for — a unit of `build_relationships_plan`.
+/// `calls` edges for — a unit of `build_relationships_plan`. A table that
+/// also declares an `agent` entity feeds the agent-calls derivation.
 pub struct CallsSource {
     pub service: EntityDeclaration,
+    pub agent: Option<EntityDeclaration>,
     pub scan: DataFrame,
 }
 
@@ -104,7 +106,10 @@ pub fn build_relationships_plan(
     sources: RelationshipSources,
     window: &GraphQueryWindow,
 ) -> DfResult<Option<LogicalPlan>> {
-    let mut union_df = calls_branch(sources.traces, window)?;
+    let mut union_df = calls_branch(&sources.traces, window)?;
+    if let Some(agent_calls) = agent_calls_branch(&sources.traces, window)? {
+        union_df = union_all(union_df, agent_calls)?;
+    }
     if let Some(co_declared) = co_declared_branch(sources.co_declared, window)? {
         union_df = union_all(union_df, co_declared)?;
     }
@@ -329,15 +334,15 @@ const VIRTUAL_NODE_CONFIDENCE: f64 = 0.5;
 /// pair, the edge reports only the pair population (the RFC pins RED metrics
 /// to observed span pairs) and the unmatched clients are suppressed, so one
 /// `(window, edge)` never yields two rows.
-fn calls_branch(
-    traces: Vec<CallsSource>,
-    window: &GraphQueryWindow,
-) -> DfResult<Option<DataFrame>> {
+fn calls_branch(traces: &[CallsSource], window: &GraphQueryWindow) -> DfResult<Option<DataFrame>> {
     let mut clients: Option<DataFrame> = None;
     let mut servers: Option<DataFrame> = None;
     for trace in traces {
-        clients = union_all(clients, client_spans(&trace, window)?)?;
-        servers = union_all(servers, server_spans(&trace.service, trace.scan, window)?)?;
+        clients = union_all(clients, client_spans(trace, window)?)?;
+        servers = union_all(
+            servers,
+            server_spans(&trace.service, trace.scan.clone(), window)?,
+        )?;
     }
     let (Some(clients), Some(servers)) = (clients, servers) else {
         return Ok(None);
@@ -573,6 +578,108 @@ fn server_spans(
         ])
 }
 
+/// The `parent_agent calls agent` derivation over trace tables declaring an
+/// `agent` entity: pair each span with its child span (no span-kind filter —
+/// agent spans are typically INTERNAL) across all agent-declaring tables, keep
+/// pairs whose agent identities differ, and aggregate RED metrics per 60s
+/// window. Anchored like the service derivation on the caller: the parent side
+/// is bounded to the source window and stamps `observed_at`, the child side
+/// widens by the time-proximity allowance and supplies status/duration.
+fn agent_calls_branch(
+    traces: &[CallsSource],
+    window: &GraphQueryWindow,
+) -> DfResult<Option<DataFrame>> {
+    let mut parents: Option<DataFrame> = None;
+    let mut children: Option<DataFrame> = None;
+    for trace in traces {
+        let Some(agent) = &trace.agent else {
+            continue;
+        };
+        let parent = trace
+            .scan
+            .clone()
+            .filter(span_predicate(agent, window, true))?
+            .select(vec![
+                ident(TRACE_TIMESTAMP_COLUMN),
+                ident(TRACE_ID_COLUMN),
+                ident(SPAN_ID_COLUMN),
+                entity_id_expr(&agent.id_columns, &|c| ident(c)).alias("src_id"),
+            ])?;
+        let child = trace
+            .scan
+            .clone()
+            .filter(span_predicate(agent, window, false))?
+            .select(vec![
+                ident(TRACE_TIMESTAMP_COLUMN),
+                ident(TRACE_ID_COLUMN),
+                ident(PARENT_SPAN_ID_COLUMN),
+                entity_id_expr(&agent.id_columns, &|c| ident(c)).alias("dst_id"),
+                ident(SPAN_STATUS_CODE_COLUMN),
+                ident(DURATION_NANO_COLUMN),
+            ])?;
+        parents = union_all(parents, parent)?;
+        children = union_all(children, child)?;
+    }
+    let (Some(parents), Some(children)) = (parents, children) else {
+        return Ok(None);
+    };
+
+    let parent = parents.alias("parent")?;
+    let child = children.alias("child")?;
+    let join_conditions = vec![
+        qcol("parent", TRACE_ID_COLUMN).eq(qcol("child", TRACE_ID_COLUMN)),
+        qcol("child", PARENT_SPAN_ID_COLUMN).eq(qcol("parent", SPAN_ID_COLUMN)),
+        qcol("child", TRACE_TIMESTAMP_COLUMN)
+            .gt_eq(qcol("parent", TRACE_TIMESTAMP_COLUMN) - interval(CHILD_SPAN_EARLY_NANOS)),
+        qcol("child", TRACE_TIMESTAMP_COLUMN)
+            .lt_eq(qcol("parent", TRACE_TIMESTAMP_COLUMN) + interval(CHILD_SPAN_LATE_NANOS)),
+    ];
+
+    let df = parent
+        .join_on(child, JoinType::Inner, join_conditions)?
+        .select(vec![
+            bin_ms(qcol("parent", TRACE_TIMESTAMP_COLUMN)).alias("observed_at"),
+            qcol("parent", "src_id").alias("src_id"),
+            qcol("child", "dst_id").alias("dst_id"),
+            qcol("child", SPAN_STATUS_CODE_COLUMN).alias("status_code"),
+            qcol("child", DURATION_NANO_COLUMN).alias("duration_nano"),
+        ])?
+        // A sub-span of the same agent is internal structure, not a call
+        // between two agents.
+        .filter(ident("src_id").not_eq(ident("dst_id")))?
+        .aggregate(
+            vec![ident("observed_at"), ident("src_id"), ident("dst_id")],
+            vec![
+                count(lit(1)).alias("request_count"),
+                count(lit(1))
+                    .filter(ident("status_code").eq(lit(SPAN_STATUS_ERROR)))
+                    .build()?
+                    .alias("error_count"),
+                sum(ident("duration_nano")).alias("duration_nano_sum"),
+            ],
+        )?
+        .select(vec![
+            ident("observed_at"),
+            ident("observed_at").alias("window_start"),
+            (ident("observed_at") + bin_interval()).alias("window_end"),
+            (ident("observed_at") + bin_interval()).alias("fresh_until"),
+            lit("agent").alias("src_type"),
+            ident("src_id"),
+            lit("agent").alias("dst_type"),
+            ident("dst_id"),
+            lit("calls").alias("rel_type"),
+            lit("trace").alias("provenance"),
+            lit(1.0_f64).alias("confidence"),
+            ident("request_count"),
+            ident("error_count"),
+            (cast(ident("duration_nano_sum"), DataType::Float64) / lit(1e9_f64))
+                .alias("duration_sum"),
+            ident("request_count").alias("duration_count"),
+            null_json().alias("attributes"),
+        ])?;
+    Ok(Some(df))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -738,6 +845,7 @@ mod tests {
         let plan = build_relationships_plan_for_test(
             vec![CallsSource {
                 service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                agent: None,
                 scan: trace,
             }],
             &test_window(),
@@ -821,11 +929,12 @@ mod tests {
             .value(row)
     }
 
-    fn sources(traces: &[(&str, DataFrame)]) -> Vec<CallsSource> {
-        traces
+    fn sources(scans: &[DataFrame]) -> Vec<CallsSource> {
+        scans
             .iter()
-            .map(|(_, scan)| CallsSource {
+            .map(|scan| CallsSource {
                 service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                agent: None,
                 scan: scan.clone(),
             })
             .collect()
@@ -873,10 +982,9 @@ mod tests {
         );
         let a = ctx.table("trace_a").await.unwrap();
         let b = ctx.table("trace_b").await.unwrap();
-        let plan =
-            build_relationships_plan_for_test(sources(&[("a", a), ("b", b)]), &test_window())
-                .unwrap()
-                .unwrap();
+        let plan = build_relationships_plan_for_test(sources(&[a, b]), &test_window())
+            .unwrap()
+            .unwrap();
 
         let batches = collect(&ctx, plan).await;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -913,10 +1021,9 @@ mod tests {
         );
         let a = ctx.table("trace_a").await.unwrap();
         let b = ctx.table("trace_b").await.unwrap();
-        let plan =
-            build_relationships_plan_for_test(sources(&[("a", a), ("b", b)]), &test_window())
-                .unwrap()
-                .unwrap();
+        let plan = build_relationships_plan_for_test(sources(&[a, b]), &test_window())
+            .unwrap()
+            .unwrap();
 
         let batches = collect(&ctx, plan).await;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -934,12 +1041,9 @@ mod tests {
         register_trace_table(&ctx, "trace_empty", &[], &[]);
         let base = ctx.table("opentelemetry_traces").await.unwrap();
         let empty = ctx.table("trace_empty").await.unwrap();
-        let plan = build_relationships_plan_for_test(
-            sources(&[("base", base), ("empty", empty)]),
-            &test_window(),
-        )
-        .unwrap()
-        .unwrap();
+        let plan = build_relationships_plan_for_test(sources(&[base, empty]), &test_window())
+            .unwrap()
+            .unwrap();
 
         let batches = collect(&ctx, plan).await;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -978,7 +1082,7 @@ mod tests {
             ],
         );
         let a = ctx.table("trace_a").await.unwrap();
-        let plan = build_relationships_plan_for_test(sources(&[("a", a)]), &test_window())
+        let plan = build_relationships_plan_for_test(sources(&[a]), &test_window())
             .unwrap()
             .unwrap();
 
@@ -1013,7 +1117,7 @@ mod tests {
             &[(1_000, "t1", "c1", None, CLIENT, UNSET, "frontend", 100)],
         );
         let a = ctx.table("trace_a").await.unwrap();
-        let plan = build_relationships_plan_for_test(sources(&[("a", a)]), &test_window())
+        let plan = build_relationships_plan_for_test(sources(&[a]), &test_window())
             .unwrap()
             .unwrap();
 
@@ -1024,6 +1128,130 @@ mod tests {
             json_texts(batch, 15),
             vec![Some(r#"{"connection_type":"database"}"#.to_string())]
         );
+    }
+
+    #[tokio::test]
+    async fn agent_calls_from_parent_child_spans() {
+        let ctx = SessionContext::new();
+        const INTERNAL: &str = "SPAN_KIND_INTERNAL";
+        register_trace_table(
+            &ctx,
+            "agent_traces",
+            &[(
+                "agent_id",
+                &[
+                    Some("orchestrator"),
+                    Some("researcher"),
+                    Some("researcher"),
+                    Some("researcher"),
+                ],
+            )],
+            &[
+                // orchestrator delegates to researcher twice (one errored);
+                // the researcher's own sub-span is same-agent structure.
+                (1_000, "t1", "p1", None, INTERNAL, UNSET, "app", 0),
+                (
+                    1_010,
+                    "t1",
+                    "a1",
+                    Some("p1"),
+                    INTERNAL,
+                    ERROR,
+                    "app",
+                    2_000_000_000,
+                ),
+                (
+                    2_000,
+                    "t1",
+                    "a2",
+                    Some("p1"),
+                    INTERNAL,
+                    UNSET,
+                    "app",
+                    1_000_000_000,
+                ),
+                (1_020, "t1", "a3", Some("a1"), INTERNAL, UNSET, "app", 100),
+            ],
+        );
+        let scan = ctx.table("agent_traces").await.unwrap();
+        let plan = build_relationships_plan(
+            RelationshipSources {
+                traces: vec![CallsSource {
+                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                    agent: Some(co_decl("agent", &["agent_id"])),
+                    scan,
+                }],
+                co_declared: vec![],
+                declared: None,
+            },
+            &test_window(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let batches = collect(&ctx, plan).await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        // INTERNAL spans feed no service-calls pairs; the same-agent child
+        // (a3 under a1) is excluded. One agent edge remains.
+        assert_eq!(total, 1);
+        let batch = &batches[0];
+        assert_eq!(strings(batch, 4), vec!["agent"]);
+        assert_eq!(strings(batch, 5), vec!["orchestrator"]);
+        assert_eq!(strings(batch, 6), vec!["agent"]);
+        assert_eq!(strings(batch, 7), vec!["researcher"]);
+        assert_eq!(strings(batch, 8), vec!["calls"]);
+        assert_eq!(strings(batch, 9), vec!["trace"]);
+        assert_eq!(confidence(batch, 0), 1.0);
+        assert_eq!(red_metrics(batch, 0), (2, 1, 3.0, 2));
+    }
+
+    #[tokio::test]
+    async fn agent_calls_anchor_on_the_parent_span() {
+        let ctx = SessionContext::new();
+        const INTERNAL: &str = "SPAN_KIND_INTERNAL";
+        // The parent is inside the queried window; the child starts after its
+        // end but within the proximity allowance and must still pair.
+        register_trace_table(
+            &ctx,
+            "agent_traces",
+            &[("agent_id", &[Some("orchestrator"), Some("researcher")])],
+            &[
+                (599_000, "t1", "p1", None, INTERNAL, UNSET, "app", 0),
+                (
+                    601_000,
+                    "t1",
+                    "a1",
+                    Some("p1"),
+                    INTERNAL,
+                    UNSET,
+                    "app",
+                    500_000_000,
+                ),
+            ],
+        );
+        let scan = ctx.table("agent_traces").await.unwrap();
+        let plan = build_relationships_plan(
+            RelationshipSources {
+                traces: vec![CallsSource {
+                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                    agent: Some(co_decl("agent", &["agent_id"])),
+                    scan,
+                }],
+                co_declared: vec![],
+                declared: None,
+            },
+            &test_window(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let batches = collect(&ctx, plan).await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1);
+        let batch = &batches[0];
+        // observed_at is the parent's bin.
+        assert_eq!(ts_values(batch, 0), vec![540_000]);
+        assert_eq!(red_metrics(batch, 0), (1, 0, 0.5, 1));
     }
 
     /// A metric-like declaring table: ms timestamps, one row with a NULL
@@ -1250,7 +1478,7 @@ mod tests {
             ],
         );
         let a = ctx.table("trace_a").await.unwrap();
-        let plan = build_relationships_plan_for_test(sources(&[("a", a)]), &test_window())
+        let plan = build_relationships_plan_for_test(sources(&[a]), &test_window())
             .unwrap()
             .unwrap();
 
@@ -1273,6 +1501,7 @@ mod tests {
         let plan = build_relationships_plan_for_test(
             vec![CallsSource {
                 service: trace_service_decl(&[SERVICE_NAME_COLUMN, "service_namespace"]),
+                agent: None,
                 scan: trace,
             }],
             &test_window(),
@@ -1639,6 +1868,7 @@ mod tests {
             RelationshipSources {
                 traces: vec![CallsSource {
                     service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                    agent: None,
                     scan: trace,
                 }],
                 co_declared: vec![],

--- a/src/operator/src/statement/semantic_graph/relationships.rs
+++ b/src/operator/src/statement/semantic_graph/relationships.rs
@@ -142,11 +142,11 @@ const ATTRIBUTE_EDGE_VOCABULARY: [(&str, &str, &str); 6] = [
 ];
 
 /// The agent-edge vocabulary, applied only to trace sources: the RFC derives
-/// `agent uses model` / `agent invoked tool` from span structure (an LLM- or
+/// `agent uses model` / `agent invokes tool` from span structure (an LLM- or
 /// tool-call span carries both identities), so a non-trace table co-declaring
 /// these types must not fabricate invocations.
 const AGENT_EDGE_VOCABULARY: [(&str, &str, &str); 2] =
-    [("agent", "model", "uses"), ("agent", "tool", "invoked")];
+    [("agent", "model", "uses"), ("agent", "tool", "invokes")];
 
 const CO_DECLARED_VALID_COLUMN: &str = "__edge_valid";
 
@@ -313,11 +313,16 @@ fn declared_edges(scan: DataFrame, window: &GraphQueryWindow) -> DfResult<DataFr
 }
 
 /// Span-attribute columns naming an uninstrumented peer, in precedence order,
-/// each with the `connection_type` its match implies. Attribute columns are
-/// dynamic in `greptime_trace_v1` (created on first use), so only columns
-/// present in a table's schema participate.
-const VIRTUAL_DST_CANDIDATES: [(&str, &str); 3] = [
+/// each with the `connection_type` its match implies: current OTel names
+/// first (`service.peer.name` and `db.namespace` replaced the deprecated
+/// `peer.service` and `db.name` in semconv 1.39/1.26, kept for existing
+/// telemetry), the bare network endpoint last. Attribute columns are dynamic
+/// in `greptime_trace_v1` (created on first use), so only columns present in
+/// a table's schema participate.
+const VIRTUAL_DST_CANDIDATES: [(&str, &str); 5] = [
+    ("span_attributes.service.peer.name", "virtual_node"),
     ("span_attributes.peer.service", "virtual_node"),
+    ("span_attributes.db.namespace", "database"),
     ("span_attributes.db.name", "database"),
     ("span_attributes.server.address", "virtual_node"),
 ];
@@ -1099,10 +1104,10 @@ mod tests {
             &ctx,
             "trace_a",
             &[
-                // An empty peer.service must fall through to db.name, whose
-                // match maps connection_type to `database`.
-                ("span_attributes.peer.service", &[Some("")]),
-                ("span_attributes.db.name", &[Some("mysql")]),
+                // An empty high-precedence value must fall through to the next
+                // candidate, whose match maps connection_type to `database`.
+                ("span_attributes.service.peer.name", &[Some("")]),
+                ("span_attributes.db.namespace", &[Some("mysql")]),
             ],
             &[(1_000, "t1", "c1", None, CLIENT, UNSET, "frontend", 100)],
         );
@@ -1469,7 +1474,7 @@ mod tests {
                     "agent-1".to_string(),
                     "tool".to_string(),
                     "search".to_string(),
-                    "invoked".to_string(),
+                    "invokes".to_string(),
                     "trace".to_string(),
                 ),
             ]

--- a/src/operator/src/statement/semantic_graph/relationships.rs
+++ b/src/operator/src/statement/semantic_graph/relationships.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 //! The `semantic_relationships` derivation: the plan builders for every edge
-//! branch (trace-derived `calls`, the declared-edge union) behind the computed
-//! table. Shared expression helpers and the entity registry live in the parent
-//! module.
+//! branch behind the computed table — trace-derived service `calls` (with
+//! virtual-node edges for unmatched clients), agent `calls` from span
+//! structure, same-row co-declared edges, and the declared-edge union. Shared
+//! expression helpers and the entity registry live in the parent module.
 
 use common_catalog::consts::{
     DURATION_NANO_COLUMN, PARENT_SPAN_ID_COLUMN, SPAN_ID_COLUMN, SPAN_KIND_CLIENT,
@@ -98,10 +99,10 @@ pub struct RelationshipSources {
     pub declared: Option<DeclaredSource>,
 }
 
-/// Builds the `semantic_relationships` plan: the trace-derived `calls` branch,
-/// the same-row co-declared branch, and the declared-edge branch unioned and
-/// re-projected to the 16-column contract. Returns `None` when no source can
-/// contribute edges, so the computed table streams empty.
+/// Builds the `semantic_relationships` plan: the service-calls, agent-calls,
+/// co-declared, and declared-edge branches unioned and re-projected to the
+/// 16-column contract. Returns `None` when no source can contribute edges, so
+/// the computed table streams empty.
 pub fn build_relationships_plan(
     sources: RelationshipSources,
     window: &GraphQueryWindow,

--- a/src/operator/src/statement/semantic_graph/relationships.rs
+++ b/src/operator/src/statement/semantic_graph/relationships.rs
@@ -69,11 +69,13 @@ const RELATIONSHIP_COLUMNS: [&str; 16] = [
 const CHILD_SPAN_EARLY_NANOS: i64 = 5 * 60 * 1_000_000_000;
 const CHILD_SPAN_LATE_NANOS: i64 = 60 * 60 * 1_000_000_000;
 
-/// A trace table's scan paired with the `service` declaration it derives
-/// `calls` edges for — a unit of `build_relationships_plan`. A table that
-/// also declares an `agent` entity feeds the agent-calls derivation.
+/// A trace table's scan paired with the entity declarations its derivations
+/// key on — a unit of `build_relationships_plan`. The `service` declaration
+/// feeds service calls, the `agent` declaration agent calls; the two are
+/// independent, so a table whose service declaration is unusable still
+/// derives agent edges (and vice versa).
 pub struct CallsSource {
-    pub service: EntityDeclaration,
+    pub service: Option<EntityDeclaration>,
     pub agent: Option<EntityDeclaration>,
     pub scan: DataFrame,
 }
@@ -227,7 +229,10 @@ fn co_declared_branch(
         )?;
         union_df = union_all(union_df, branch)?;
     }
-    Ok(union_df)
+    // The per-source DISTINCT inside `unnest_rows` cannot see other sources:
+    // two tables witnessing the same edge in the same window must still fold
+    // into one row per (window, edge).
+    union_df.map(DataFrame::distinct).transpose()
 }
 
 /// Ranking column used to pick the latest declared-edge revision per edge key.
@@ -328,7 +333,8 @@ const VIRTUAL_NODE_CONFIDENCE: f64 = 0.5;
 /// the plan form of the Tempo servicegraph connector. Unioning spans before
 /// the join pairs a client with a server stored in a *different* trace table
 /// (`x-greptime-trace-table-name` routing); with a single table it degenerates
-/// to the previous self-join. Returns `None` when there is no trace table.
+/// to the previous self-join. Returns `None` when no trace table has a
+/// usable `service` declaration.
 ///
 /// A client with no matching server span is an edge to a **virtual node**
 /// named by [`VIRTUAL_DST_CANDIDATES`], with the client's own status/duration
@@ -340,11 +346,11 @@ fn calls_branch(traces: &[CallsSource], window: &GraphQueryWindow) -> DfResult<O
     let mut clients: Option<DataFrame> = None;
     let mut servers: Option<DataFrame> = None;
     for trace in traces {
-        clients = union_all(clients, client_spans(trace, window)?)?;
-        servers = union_all(
-            servers,
-            server_spans(&trace.service, trace.scan.clone(), window)?,
-        )?;
+        let Some(service) = &trace.service else {
+            continue;
+        };
+        clients = union_all(clients, client_spans(service, &trace.scan, window)?)?;
+        servers = union_all(servers, server_spans(service, trace.scan.clone(), window)?)?;
     }
     let (Some(clients), Some(servers)) = (clients, servers) else {
         return Ok(None);
@@ -381,9 +387,8 @@ fn calls_branch(traces: &[CallsSource], window: &GraphQueryWindow) -> DfResult<O
             qcol("client", DURATION_NANO_COLUMN).alias("client_duration_nano"),
             qcol("client", "virtual_conn").alias("virtual_conn"),
         ])?
-        // An unmatched client without a peer-naming attribute observes no edge;
-        // a self-call (on either the paired or the attribute-named identity) is
-        // not an edge between two distinct entities.
+        // No destination means no edge; a self-call is not an edge between
+        // two distinct entities.
         .filter(
             ident("dst_id")
                 .is_not_null()
@@ -509,11 +514,14 @@ fn span_predicate(service: &EntityDeclaration, window: &GraphQueryWindow, strict
 /// declaration, so edges land on exactly the entity ids the registry emits (a
 /// composite identity renders the same sorted `k=v` form); the per-table
 /// projection is what lets tables with different declarations union.
-fn client_spans(source: &CallsSource, window: &GraphQueryWindow) -> DfResult<DataFrame> {
-    // Peer-naming candidates present in this table's schema, normalized so an
-    // empty value falls through to the next candidate.
+fn client_spans(
+    service: &EntityDeclaration,
+    scan: &DataFrame,
+    window: &GraphQueryWindow,
+) -> DfResult<DataFrame> {
+    // NULLIF('') lets an empty value fall through to the next candidate.
     let present: Vec<(Expr, &str)> = {
-        let schema = source.scan.schema();
+        let schema = scan.schema();
         VIRTUAL_DST_CANDIDATES
             .iter()
             .filter(|(column, _)| schema.has_column_with_unqualified_name(column))
@@ -535,13 +543,11 @@ fn client_spans(source: &CallsSource, window: &GraphQueryWindow) -> DfResult<Dat
         virtual_conn = when(value.is_not_null(), lit(conn)).otherwise(virtual_conn)?;
     }
 
-    source
-        .scan
-        .clone()
+    scan.clone()
         .filter(
             ident(SPAN_KIND_COLUMN)
                 .eq(lit(SPAN_KIND_CLIENT))
-                .and(span_predicate(&source.service, window, true)),
+                .and(span_predicate(service, window, true)),
         )?
         .select(vec![
             ident(TRACE_TIMESTAMP_COLUMN),
@@ -549,7 +555,7 @@ fn client_spans(source: &CallsSource, window: &GraphQueryWindow) -> DfResult<Dat
             ident(SPAN_ID_COLUMN),
             // The cast inside entity_id_expr also normalizes tag columns, which
             // come out of the storage engine dictionary-encoded.
-            entity_id_expr(&source.service.id_columns, &|c| ident(c)).alias("src_id"),
+            entity_id_expr(&service.id_columns, &|c| ident(c)).alias("src_id"),
             ident(SPAN_STATUS_CODE_COLUMN),
             ident(DURATION_NANO_COLUMN),
             virtual_dst.alias("virtual_dst"),
@@ -846,7 +852,7 @@ mod tests {
         let trace = ctx.table("opentelemetry_traces").await.unwrap();
         let plan = build_relationships_plan_for_test(
             vec![CallsSource {
-                service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                service: Some(trace_service_decl(&[SERVICE_NAME_COLUMN])),
                 agent: None,
                 scan: trace,
             }],
@@ -935,7 +941,7 @@ mod tests {
         scans
             .iter()
             .map(|scan| CallsSource {
-                service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                service: Some(trace_service_decl(&[SERVICE_NAME_COLUMN])),
                 agent: None,
                 scan: scan.clone(),
             })
@@ -990,7 +996,6 @@ mod tests {
 
         let batches = collect(&ctx, plan).await;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-        // One edge row with the RED metrics of both tables' pairs.
         assert_eq!(total, 1);
         assert_eq!(red_metrics(&batches[0], 0), (2, 1, 2.0, 2));
     }
@@ -1035,23 +1040,6 @@ mod tests {
         assert_eq!(strings(batch, 7), vec!["cart"]);
         assert_eq!(confidence(batch, 0), 1.0);
         assert_eq!(red_metrics(batch, 0), (1, 0, 0.5, 1));
-    }
-
-    #[tokio::test]
-    async fn empty_trace_table_does_not_change_edges() {
-        let ctx = trace_table_ctx();
-        register_trace_table(&ctx, "trace_empty", &[], &[]);
-        let base = ctx.table("opentelemetry_traces").await.unwrap();
-        let empty = ctx.table("trace_empty").await.unwrap();
-        let plan = build_relationships_plan_for_test(sources(&[base, empty]), &test_window())
-            .unwrap()
-            .unwrap();
-
-        let batches = collect(&ctx, plan).await;
-        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-        // Same single edge, same RED numbers as the single-table derivation.
-        assert_eq!(total, 1);
-        assert_eq!(red_metrics(&batches[0], 0), (2, 1, 2.0, 2));
     }
 
     #[tokio::test]
@@ -1179,7 +1167,7 @@ mod tests {
         let plan = build_relationships_plan(
             RelationshipSources {
                 traces: vec![CallsSource {
-                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                    service: None,
                     agent: Some(co_decl("agent", &["agent_id"])),
                     scan,
                 }],
@@ -1193,8 +1181,8 @@ mod tests {
 
         let batches = collect(&ctx, plan).await;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-        // INTERNAL spans feed no service-calls pairs; the same-agent child
-        // (a3 under a1) is excluded. One agent edge remains.
+        // The same-agent child (a3 under a1) is excluded; agent edges need
+        // no service declaration.
         assert_eq!(total, 1);
         let batch = &batches[0];
         assert_eq!(strings(batch, 4), vec!["agent"]);
@@ -1235,7 +1223,7 @@ mod tests {
         let plan = build_relationships_plan(
             RelationshipSources {
                 traces: vec![CallsSource {
-                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                    service: None,
                     agent: Some(co_decl("agent", &["agent_id"])),
                     scan,
                 }],
@@ -1287,11 +1275,13 @@ mod tests {
         )
         .unwrap();
         let ctx = SessionContext::new();
-        ctx.register_table(
-            "co_metrics",
-            Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap()),
-        )
-        .unwrap();
+        for name in ["co_metrics", "co_metrics_2"] {
+            ctx.register_table(
+                name,
+                Arc::new(MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap()),
+            )
+            .unwrap();
+        }
         ctx
     }
 
@@ -1395,6 +1385,40 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn co_declared_edge_folds_across_sources() {
+        let ctx = co_declared_ctx();
+        let declarations = || {
+            vec![
+                co_decl("service.instance", &["instance"]),
+                co_decl("host", &["host"]),
+            ]
+        };
+        let source = |scan| CoDeclaredSource {
+            declarations: declarations(),
+            is_trace: false,
+            scan,
+        };
+        let a = ctx.table("co_metrics").await.unwrap();
+        let b = ctx.table("co_metrics_2").await.unwrap();
+        let plan = build_relationships_plan(
+            RelationshipSources {
+                traces: vec![],
+                co_declared: vec![source(a), source(b)],
+                declared: None,
+            },
+            &test_window(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let batches = collect(&ctx, plan).await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        // Both tables witness the same runs_on edge in the same window: one
+        // row per (window, edge), not one per source.
+        assert_eq!(total, 1);
     }
 
     #[tokio::test]
@@ -1502,7 +1526,10 @@ mod tests {
         let trace = ctx.table("opentelemetry_traces").await.unwrap();
         let plan = build_relationships_plan_for_test(
             vec![CallsSource {
-                service: trace_service_decl(&[SERVICE_NAME_COLUMN, "service_namespace"]),
+                service: Some(trace_service_decl(&[
+                    SERVICE_NAME_COLUMN,
+                    "service_namespace",
+                ])),
                 agent: None,
                 scan: trace,
             }],
@@ -1869,7 +1896,7 @@ mod tests {
         let plan = build_relationships_plan(
             RelationshipSources {
                 traces: vec![CallsSource {
-                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                    service: Some(trace_service_decl(&[SERVICE_NAME_COLUMN])),
                     agent: None,
                     scan: trace,
                 }],

--- a/src/operator/src/statement/semantic_graph/relationships.rs
+++ b/src/operator/src/statement/semantic_graph/relationships.rs
@@ -74,23 +74,41 @@ pub struct CallsSource {
     pub scan: DataFrame,
 }
 
+/// A declaring table's scan paired with its entity declarations, from which
+/// the same-row co-declaration rules derive edges. `is_trace` gates the
+/// agent-edge vocabulary, which the RFC ties to span structure.
+pub struct CoDeclaredSource {
+    pub declarations: Vec<EntityDeclaration>,
+    pub is_trace: bool,
+    pub scan: DataFrame,
+}
+
 /// The declared-edge table's scan (`semantic_relationships_declared`), whose
 /// rows `build_relationships_plan` unions into the edge set.
 pub struct DeclaredSource {
     pub scan: DataFrame,
 }
 
-/// Builds the `semantic_relationships` plan: the trace-derived `calls` branch
-/// unioned with the declared-edge branch, re-projected to the 16-column
-/// contract. Returns `None` when there is neither a trace table nor a
-/// declared-edge table, so the computed table streams empty.
+/// Everything `build_relationships_plan` derives edges from.
+pub struct RelationshipSources {
+    pub traces: Vec<CallsSource>,
+    pub co_declared: Vec<CoDeclaredSource>,
+    pub declared: Option<DeclaredSource>,
+}
+
+/// Builds the `semantic_relationships` plan: the trace-derived `calls` branch,
+/// the same-row co-declared branch, and the declared-edge branch unioned and
+/// re-projected to the 16-column contract. Returns `None` when no source can
+/// contribute edges, so the computed table streams empty.
 pub fn build_relationships_plan(
-    traces: Vec<CallsSource>,
-    declared: Option<DeclaredSource>,
+    sources: RelationshipSources,
     window: &GraphQueryWindow,
 ) -> DfResult<Option<LogicalPlan>> {
-    let mut union_df = calls_branch(traces, window)?;
-    if let Some(declared) = declared {
+    let mut union_df = calls_branch(sources.traces, window)?;
+    if let Some(co_declared) = co_declared_branch(sources.co_declared, window)? {
+        union_df = union_all(union_df, co_declared)?;
+    }
+    if let Some(declared) = sources.declared {
         union_df = union_all(union_df, declared_edges(declared.scan, window)?)?;
     }
     union_df
@@ -100,6 +118,109 @@ pub fn build_relationships_plan(
                 .into_unoptimized_plan())
         })
         .transpose()
+}
+
+/// The same-row co-declaration vocabulary open to any declaring table: a row
+/// carrying both identities witnesses the edge, and the built-in direction is
+/// `src -> dst`. Rows are `(src_type, dst_type, rel_type)`.
+const ATTRIBUTE_EDGE_VOCABULARY: [(&str, &str, &str); 6] = [
+    ("service.instance", "host", "runs_on"),
+    ("process", "host", "runs_on"),
+    ("k8s.pod", "k8s.node", "runs_on"),
+    ("k8s.pod", "k8s.container", "contains"),
+    ("service.instance", "service", "part_of"),
+    ("k8s.pod", "k8s.workload", "part_of"),
+];
+
+/// The agent-edge vocabulary, applied only to trace sources: the RFC derives
+/// `agent uses model` / `agent invoked tool` from span structure (an LLM- or
+/// tool-call span carries both identities), so a non-trace table co-declaring
+/// these types must not fabricate invocations.
+const AGENT_EDGE_VOCABULARY: [(&str, &str, &str); 2] =
+    [("agent", "model", "uses"), ("agent", "tool", "invoked")];
+
+const CO_DECLARED_VALID_COLUMN: &str = "__edge_valid";
+
+/// The same-row co-declared branch: for each source table, every vocabulary
+/// pair whose two entity types the table declares yields an edge projection,
+/// expanded from one scan via `unnest_rows` (the registry idiom). Attribute
+/// edges carry `provenance = 'attribute'`; agent edges are span-structure
+/// observations and carry `provenance = 'trace'`.
+fn co_declared_branch(
+    sources: Vec<CoDeclaredSource>,
+    window: &GraphQueryWindow,
+) -> DfResult<Option<DataFrame>> {
+    let mut union_df: Option<DataFrame> = None;
+    for source in sources {
+        let find = |ty: &str| source.declarations.iter().find(|d| d.entity_type == ty);
+        let mut pairs = Vec::new();
+        for (src_type, dst_type, rel_type) in ATTRIBUTE_EDGE_VOCABULARY {
+            if let (Some(src), Some(dst)) = (find(src_type), find(dst_type)) {
+                pairs.push((src, dst, rel_type, "attribute"));
+            }
+        }
+        if source.is_trace {
+            for (src_type, dst_type, rel_type) in AGENT_EDGE_VOCABULARY {
+                if let (Some(src), Some(dst)) = (find(src_type), find(dst_type)) {
+                    pairs.push((src, dst, rel_type, "trace"));
+                }
+            }
+        }
+        let Some((first, _, _, _)) = pairs.first() else {
+            continue;
+        };
+
+        let ts = ident(&first.time_index);
+        let bin = bin_ms(ts.clone());
+        let window_predicate = ts
+            .clone()
+            .gt_eq(window.source_start())
+            .and(ts.lt(window.source_end()));
+        let null_i64 = || lit(ScalarValue::Int64(None));
+        let rows = pairs
+            .iter()
+            .map(|(src, dst, rel_type, provenance)| {
+                // Both endpoints must identify something on the row for the
+                // row to witness the edge.
+                let valid = src
+                    .id_columns
+                    .iter()
+                    .chain(&dst.id_columns)
+                    .fold(lit(true), |predicate, id| {
+                        predicate.and(ident(id).is_not_null())
+                    });
+                vec![
+                    valid,
+                    bin.clone(),
+                    bin.clone(),
+                    bin.clone() + bin_interval(),
+                    bin.clone() + bin_interval(),
+                    lit(src.entity_type.as_str()),
+                    entity_id_expr(&src.id_columns, &|c| ident(c)),
+                    lit(dst.entity_type.as_str()),
+                    entity_id_expr(&dst.id_columns, &|c| ident(c)),
+                    lit(*rel_type),
+                    lit(*provenance),
+                    lit(1.0_f64),
+                    null_i64(),
+                    null_i64(),
+                    lit(ScalarValue::Float64(None)),
+                    null_i64(),
+                    null_json(),
+                ]
+            })
+            .collect();
+
+        let branch = super::unnest_rows(
+            source.scan,
+            window_predicate,
+            CO_DECLARED_VALID_COLUMN,
+            &RELATIONSHIP_COLUMNS,
+            rows,
+        )?;
+        union_df = union_all(union_df, branch)?;
+    }
+    Ok(union_df)
 }
 
 /// Ranking column used to pick the latest declared-edge revision per edge key.
@@ -458,8 +579,8 @@ mod tests {
 
     use common_catalog::consts::{SEMANTIC_RELATIONSHIPS_DECLARED_TABLE_NAME, SERVICE_NAME_COLUMN};
     use datafusion::arrow::array::{
-        ArrayRef, BinaryArray, Float64Array, Int64Array, StringArray, TimestampMillisecondArray,
-        TimestampNanosecondArray, UInt64Array,
+        Array, ArrayRef, BinaryArray, Float64Array, Int64Array, StringArray,
+        TimestampMillisecondArray, TimestampNanosecondArray, UInt64Array,
     };
     use datafusion::arrow::datatypes::{Field, Schema, TimeUnit};
     use datafusion::arrow::record_batch::RecordBatch;
@@ -905,6 +1026,202 @@ mod tests {
         );
     }
 
+    /// A metric-like declaring table: ms timestamps, one row with a NULL
+    /// `instance` (witnessing nothing for instance edges), two rows duplicating
+    /// the same identities inside one bin (collapsed by DISTINCT).
+    fn co_declared_ctx() -> SessionContext {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("instance", DataType::Utf8, true),
+            Field::new("host", DataType::Utf8, false),
+            Field::new("service", DataType::Utf8, false),
+            Field::new("agent_id", DataType::Utf8, false),
+            Field::new("model_name", DataType::Utf8, false),
+            Field::new("tool_name", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![1_000, 2_000, 3_000])) as ArrayRef,
+                Arc::new(StringArray::from(vec![Some("i-1"), Some("i-1"), None])),
+                Arc::new(StringArray::from(vec!["h-1", "h-1", "h-2"])),
+                Arc::new(StringArray::from(vec!["svc", "svc", "svc"])),
+                Arc::new(StringArray::from(vec!["agent-1"; 3])),
+                Arc::new(StringArray::from(vec!["gpt"; 3])),
+                Arc::new(StringArray::from(vec!["search"; 3])),
+            ],
+        )
+        .unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table(
+            "co_metrics",
+            Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap()),
+        )
+        .unwrap();
+        ctx
+    }
+
+    fn co_decl(entity_type: &str, id_columns: &[&str]) -> EntityDeclaration {
+        EntityDeclaration {
+            schema: "public".to_string(),
+            table: "co_metrics".to_string(),
+            time_index: "ts".to_string(),
+            entity_type: entity_type.to_string(),
+            id_columns: id_columns.iter().map(|s| s.to_string()).collect(),
+            descriptive_columns: vec![],
+            scope_columns: vec![],
+        }
+    }
+
+    async fn co_declared_edges(
+        ctx: &SessionContext,
+        declarations: Vec<EntityDeclaration>,
+        is_trace: bool,
+    ) -> Option<Vec<(String, String, String, String, String, String)>> {
+        let scan = ctx.table("co_metrics").await.unwrap();
+        let plan = build_relationships_plan(
+            RelationshipSources {
+                traces: vec![],
+                co_declared: vec![CoDeclaredSource {
+                    declarations,
+                    is_trace,
+                    scan,
+                }],
+                declared: None,
+            },
+            &test_window(),
+        )
+        .unwrap()?;
+        assert_eq!(
+            plan.schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            RELATIONSHIP_COLUMNS
+        );
+        let batches = collect(ctx, plan).await;
+        let mut rows = vec![];
+        for batch in &batches {
+            for i in 0..batch.num_rows() {
+                rows.push((
+                    strings(batch, 4)[i].clone(),
+                    strings(batch, 5)[i].clone(),
+                    strings(batch, 6)[i].clone(),
+                    strings(batch, 7)[i].clone(),
+                    strings(batch, 8)[i].clone(),
+                    strings(batch, 9)[i].clone(),
+                ));
+                assert_eq!(confidence(batch, i), 1.0);
+                // Co-declared edges carry no RED metrics or attributes.
+                for column in 11..=15 {
+                    assert!(batch.column(column).is_null(i));
+                }
+            }
+        }
+        rows.sort();
+        Some(rows)
+    }
+
+    #[tokio::test]
+    async fn co_declared_direction_follows_vocabulary() {
+        let ctx = co_declared_ctx();
+        // Declaration order must not matter: the vocabulary fixes direction.
+        let rows = co_declared_edges(
+            &ctx,
+            vec![
+                co_decl("host", &["host"]),
+                co_decl("service", &["service"]),
+                co_decl("service.instance", &["instance"]),
+            ],
+            false,
+        )
+        .await
+        .unwrap();
+        // The two non-NULL-instance rows share one 60s bin, so DISTINCT folds
+        // them into one row per edge; the NULL-instance row witnesses nothing.
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "service.instance".to_string(),
+                    "i-1".to_string(),
+                    "host".to_string(),
+                    "h-1".to_string(),
+                    "runs_on".to_string(),
+                    "attribute".to_string(),
+                ),
+                (
+                    "service.instance".to_string(),
+                    "i-1".to_string(),
+                    "service".to_string(),
+                    "svc".to_string(),
+                    "part_of".to_string(),
+                    "attribute".to_string(),
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn co_declared_ignores_types_outside_the_vocabulary() {
+        let ctx = co_declared_ctx();
+        // (service, host) is not a vocabulary pair: no edge, no plan.
+        let rows = co_declared_edges(
+            &ctx,
+            vec![co_decl("service", &["service"]), co_decl("host", &["host"])],
+            false,
+        )
+        .await;
+        assert!(rows.is_none());
+    }
+
+    #[tokio::test]
+    async fn agent_edges_require_a_trace_source() {
+        let ctx = co_declared_ctx();
+        let declarations = || {
+            vec![
+                co_decl("agent", &["agent_id"]),
+                co_decl("model", &["model_name"]),
+                co_decl("tool", &["tool_name"]),
+            ]
+        };
+        // A non-trace table co-declaring agent/model/tool must not fabricate
+        // invocations.
+        assert!(
+            co_declared_edges(&ctx, declarations(), false)
+                .await
+                .is_none()
+        );
+
+        let rows = co_declared_edges(&ctx, declarations(), true).await.unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "agent".to_string(),
+                    "agent-1".to_string(),
+                    "model".to_string(),
+                    "gpt".to_string(),
+                    "uses".to_string(),
+                    "trace".to_string(),
+                ),
+                (
+                    "agent".to_string(),
+                    "agent-1".to_string(),
+                    "tool".to_string(),
+                    "search".to_string(),
+                    "invoked".to_string(),
+                    "trace".to_string(),
+                ),
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn real_pair_suppresses_virtual_edge() {
         let ctx = SessionContext::new();
@@ -983,7 +1300,14 @@ mod tests {
         traces: Vec<CallsSource>,
         window: &GraphQueryWindow,
     ) -> DfResult<Option<LogicalPlan>> {
-        build_relationships_plan(traces, None, window)
+        build_relationships_plan(
+            RelationshipSources {
+                traces,
+                co_declared: vec![],
+                declared: None,
+            },
+            window,
+        )
     }
 
     /// Registers a declared-edge table holding:
@@ -1139,9 +1463,16 @@ mod tests {
 
         // Queried window [120s, 600s).
         let window = GraphQueryWindow::from_observed(120_000, 600_000);
-        let plan = build_relationships_plan(vec![], Some(DeclaredSource { scan }), &window)
-            .unwrap()
-            .unwrap();
+        let plan = build_relationships_plan(
+            RelationshipSources {
+                traces: vec![],
+                co_declared: vec![],
+                declared: Some(DeclaredSource { scan }),
+            },
+            &window,
+        )
+        .unwrap()
+        .unwrap();
         let names = plan
             .schema()
             .fields()
@@ -1255,9 +1586,16 @@ mod tests {
         // the first revision was the edge's state then and must not be hidden
         // by the newer one.
         let window = GraphQueryWindow::from_observed(0, 150_000);
-        let plan = build_relationships_plan(vec![], Some(DeclaredSource { scan }), &window)
-            .unwrap()
-            .unwrap();
+        let plan = build_relationships_plan(
+            RelationshipSources {
+                traces: vec![],
+                co_declared: vec![],
+                declared: Some(DeclaredSource { scan }),
+            },
+            &window,
+        )
+        .unwrap()
+        .unwrap();
 
         let batches = collect(&ctx, plan).await;
         let mut rows: Vec<(String, f64)> = vec![];
@@ -1298,11 +1636,14 @@ mod tests {
             .unwrap();
 
         let plan = build_relationships_plan(
-            vec![CallsSource {
-                service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
-                scan: trace,
-            }],
-            Some(DeclaredSource { scan: declared }),
+            RelationshipSources {
+                traces: vec![CallsSource {
+                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                    scan: trace,
+                }],
+                co_declared: vec![],
+                declared: Some(DeclaredSource { scan: declared }),
+            },
             &test_window(),
         )
         .unwrap()

--- a/src/operator/src/statement/semantic_graph/relationships.rs
+++ b/src/operator/src/statement/semantic_graph/relationships.rs
@@ -25,14 +25,14 @@ use common_catalog::consts::{
 use datafusion::arrow::datatypes::DataType;
 use datafusion::dataframe::DataFrame;
 use datafusion::functions::core as core_fns;
-use datafusion::functions_aggregate::expr_fn::{count, sum};
+use datafusion::functions_aggregate::expr_fn::{bool_or, count, min, sum};
 use datafusion::functions_window::expr_fn::row_number;
-use datafusion_common::Result as DfResult;
-use datafusion_expr::{ExprFunctionExt, JoinType, LogicalPlan, cast, ident, lit};
+use datafusion_common::{Result as DfResult, ScalarValue};
+use datafusion_expr::{Expr, ExprFunctionExt, JoinType, LogicalPlan, cast, ident, lit, when};
 
 use crate::statement::semantic_graph::{
     DECLARED_EDGE_IDENTITY_COLUMNS, EntityDeclaration, GraphQueryWindow, OBSERVED_AT_COLUMN,
-    bin_interval, bin_ms, entity_id_expr, interval, null_json, qcol, union_all,
+    bin_interval, bin_ms, entity_id_expr, interval, null_json, parse_json_expr, qcol, union_all,
 };
 
 /// The projected columns of `semantic_relationships`, in order. Every derived
@@ -179,36 +179,131 @@ fn declared_edges(scan: DataFrame, window: &GraphQueryWindow) -> DfResult<DataFr
         ])
 }
 
-/// The `calls` derivation: pair each client span with its child server span on
-/// `trace_id` + `parent_span_id`, project to `service`, union the pairs of all
-/// trace tables, and aggregate RED metrics per 60s window in one pass — an edge
-/// observed across several trace tables yields one row, not per-table
-/// fragments (the plan form of the Tempo servicegraph connector). Column names
-/// are the fixed `greptime_trace_v1` schema, the reason
-/// `table_data_model = greptime_trace_v1` is required. Returns `None` when
-/// there is no trace table.
+/// Span-attribute columns naming an uninstrumented peer, in precedence order,
+/// each with the `connection_type` its match implies. Attribute columns are
+/// dynamic in `greptime_trace_v1` (created on first use), so only columns
+/// present in a table's schema participate.
+const VIRTUAL_DST_CANDIDATES: [(&str, &str); 3] = [
+    ("span_attributes.peer.service", "virtual_node"),
+    ("span_attributes.db.name", "database"),
+    ("span_attributes.server.address", "virtual_node"),
+];
+
+/// Confidence of a virtual-node edge: the peer was named by a client-side
+/// attribute, not witnessed by a server span (the RFC requires `< 1.0`).
+const VIRTUAL_NODE_CONFIDENCE: f64 = 0.5;
+
+/// The `calls` derivation: union the client spans and the server spans of all
+/// trace tables (each projected to a normalized shape with its own table's
+/// `service` identity), left-join clients to their child server spans on
+/// `trace_id` + `parent_span_id`, and aggregate RED metrics per 60s window —
+/// the plan form of the Tempo servicegraph connector. Unioning spans before
+/// the join pairs a client with a server stored in a *different* trace table
+/// (`x-greptime-trace-table-name` routing); with a single table it degenerates
+/// to the previous self-join. Returns `None` when there is no trace table.
+///
+/// A client with no matching server span is an edge to a **virtual node**
+/// named by [`VIRTUAL_DST_CANDIDATES`], with the client's own status/duration
+/// and `confidence < 1.0`. Real pairs win: when a window's edge key holds any
+/// pair, the edge reports only the pair population (the RFC pins RED metrics
+/// to observed span pairs) and the unmatched clients are suppressed, so one
+/// `(window, edge)` never yields two rows.
 fn calls_branch(
     traces: Vec<CallsSource>,
     window: &GraphQueryWindow,
 ) -> DfResult<Option<DataFrame>> {
-    let mut union_df: Option<DataFrame> = None;
+    let mut clients: Option<DataFrame> = None;
+    let mut servers: Option<DataFrame> = None;
     for trace in traces {
-        union_df = union_all(union_df, calls_pairs(&trace.service, trace.scan, window)?)?;
+        clients = union_all(clients, client_spans(&trace, window)?)?;
+        servers = union_all(servers, server_spans(&trace.service, trace.scan, window)?)?;
     }
-    let Some(pairs) = union_df else {
+    let (Some(clients), Some(servers)) = (clients, servers) else {
         return Ok(None);
     };
 
-    let df = pairs
+    let client = clients.alias("client")?;
+    let server = servers.alias("server")?;
+    let join_conditions = vec![
+        qcol("client", TRACE_ID_COLUMN).eq(qcol("server", TRACE_ID_COLUMN)),
+        qcol("server", PARENT_SPAN_ID_COLUMN).eq(qcol("client", SPAN_ID_COLUMN)),
+        qcol("server", TRACE_TIMESTAMP_COLUMN)
+            .gt_eq(qcol("client", TRACE_TIMESTAMP_COLUMN) - interval(CHILD_SPAN_EARLY_NANOS)),
+        qcol("server", TRACE_TIMESTAMP_COLUMN)
+            .lt_eq(qcol("client", TRACE_TIMESTAMP_COLUMN) + interval(CHILD_SPAN_LATE_NANOS)),
+    ];
+
+    let observations = client
+        .join_on(server, JoinType::Left, join_conditions)?
+        .select(vec![
+            bin_ms(qcol("client", TRACE_TIMESTAMP_COLUMN)).alias("observed_at"),
+            qcol("client", "src_id").alias("src_id"),
+            core_fns::coalesce()
+                .call(vec![
+                    qcol("server", "dst_id"),
+                    qcol("client", "virtual_dst"),
+                ])
+                .alias("dst_id"),
+            qcol("server", TRACE_ID_COLUMN)
+                .is_not_null()
+                .alias("paired"),
+            qcol("server", SPAN_STATUS_CODE_COLUMN).alias("server_status"),
+            qcol("server", DURATION_NANO_COLUMN).alias("server_duration_nano"),
+            qcol("client", SPAN_STATUS_CODE_COLUMN).alias("client_status"),
+            qcol("client", DURATION_NANO_COLUMN).alias("client_duration_nano"),
+            qcol("client", "virtual_conn").alias("virtual_conn"),
+        ])?
+        // An unmatched client without a peer-naming attribute observes no edge;
+        // a self-call (on either the paired or the attribute-named identity) is
+        // not an edge between two distinct entities.
+        .filter(
+            ident("dst_id")
+                .is_not_null()
+                .and(ident("src_id").not_eq(ident("dst_id"))),
+        )?;
+
+    let paired = ident("paired");
+    let df = observations
         .aggregate(
             vec![ident("observed_at"), ident("src_id"), ident("dst_id")],
             vec![
-                count(lit(1)).alias("request_count"),
                 count(lit(1))
-                    .filter(ident("status_code").eq(lit(SPAN_STATUS_ERROR)))
+                    .filter(paired.clone())
                     .build()?
-                    .alias("error_count"),
-                sum(ident("duration_nano")).alias("duration_nano_sum"),
+                    .alias("pair_count"),
+                count(lit(1))
+                    .filter(
+                        paired
+                            .clone()
+                            .and(ident("server_status").eq(lit(SPAN_STATUS_ERROR))),
+                    )
+                    .build()?
+                    .alias("pair_errors"),
+                sum(ident("server_duration_nano"))
+                    .filter(paired.clone())
+                    .build()?
+                    .alias("pair_duration_nano"),
+                count(lit(1))
+                    .filter(!paired.clone())
+                    .build()?
+                    .alias("unmatched_count"),
+                count(lit(1))
+                    .filter(
+                        (!paired.clone()).and(ident("client_status").eq(lit(SPAN_STATUS_ERROR))),
+                    )
+                    .build()?
+                    .alias("unmatched_errors"),
+                sum(ident("client_duration_nano"))
+                    .filter(!paired.clone())
+                    .build()?
+                    .alias("unmatched_duration_nano"),
+                bool_or(paired.clone()).alias("has_pair"),
+                // `min` makes a mixed-provenance virtual edge deterministic
+                // (`database` sorts before `virtual_node`).
+                min(ident("virtual_conn"))
+                    .filter(!paired)
+                    .build()?
+                    .alias("virtual_conn"),
             ],
         )?
         .select(vec![
@@ -222,76 +317,139 @@ fn calls_branch(
             ident("dst_id"),
             lit("calls").alias("rel_type"),
             lit("trace").alias("provenance"),
-            lit(1.0_f64).alias("confidence"),
-            ident("request_count"),
-            ident("error_count"),
-            // duration_nano sums in nanoseconds; the contract column is seconds.
-            (cast(ident("duration_nano_sum"), DataType::Float64) / lit(1e9_f64))
-                .alias("duration_sum"),
-            ident("request_count").alias("duration_count"),
-            null_json().alias("attributes"),
+            real_wins(lit(1.0_f64), lit(VIRTUAL_NODE_CONFIDENCE))?.alias("confidence"),
+            real_wins(ident("pair_count"), ident("unmatched_count"))?.alias("request_count"),
+            real_wins(ident("pair_errors"), ident("unmatched_errors"))?.alias("error_count"),
+            // duration sums in nanoseconds; the contract column is seconds.
+            (cast(
+                real_wins(
+                    ident("pair_duration_nano"),
+                    ident("unmatched_duration_nano"),
+                )?,
+                DataType::Float64,
+            ) / lit(1e9_f64))
+            .alias("duration_sum"),
+            real_wins(ident("pair_count"), ident("unmatched_count"))?.alias("duration_count"),
+            real_wins(null_json(), virtual_attrs_expr()?)?.alias("attributes"),
         ])?;
     Ok(Some(df))
 }
 
-/// One trace table's client/server span pairs, projected to the aggregation
-/// inputs `(observed_at, src_id, dst_id, status_code, duration_nano)`.
-/// Endpoint ids are built from the table's `service` entity declaration, so
-/// edges land on exactly the entity ids the registry emits (a composite
-/// service identity renders the same sorted `k=v` form on both sides).
-fn calls_pairs(
+/// `CASE WHEN has_pair THEN real ELSE virtual END` — the real-wins projection
+/// over the mixed aggregate.
+fn real_wins(real: Expr, r#virtual: Expr) -> DfResult<Expr> {
+    when(ident("has_pair"), real).otherwise(r#virtual)
+}
+
+/// The `attributes` JSON of a virtual edge, from the aggregated
+/// `connection_type`.
+fn virtual_attrs_expr() -> DfResult<Expr> {
+    when(
+        ident("virtual_conn").eq(lit("database")),
+        parse_json_expr(lit(r#"{"connection_type":"database"}"#)),
+    )
+    .otherwise(parse_json_expr(lit(
+        r#"{"connection_type":"virtual_node"}"#,
+    )))
+}
+
+/// The window + span-kind + identity predicate shared by both join sides.
+/// `strict` bounds the scan to the source window; the non-strict side widens
+/// by the join's time-proximity allowance (the join bounds reference the other
+/// side's timestamp and cannot prune this side's scan on their own).
+fn span_predicate(service: &EntityDeclaration, window: &GraphQueryWindow, strict: bool) -> Expr {
+    let ts = ident(TRACE_TIMESTAMP_COLUMN);
+    let mut predicate = if strict {
+        ts.clone()
+            .gt_eq(window.source_start())
+            .and(ts.lt(window.source_end()))
+    } else {
+        ts.clone()
+            .gt_eq(window.source_start() - interval(CHILD_SPAN_EARLY_NANOS))
+            .and(ts.lt(window.source_end() + interval(CHILD_SPAN_LATE_NANOS)))
+    };
+    // A NULL identity component identifies nothing, on either endpoint.
+    for id in &service.id_columns {
+        predicate = predicate.and(ident(id).is_not_null());
+    }
+    predicate
+}
+
+/// One trace table's client spans, normalized to
+/// `(timestamp, trace_id, span_id, src_id, status_code, duration_nano,
+/// virtual_dst, virtual_conn)`. `src_id` is built from the table's `service`
+/// declaration, so edges land on exactly the entity ids the registry emits (a
+/// composite identity renders the same sorted `k=v` form); the per-table
+/// projection is what lets tables with different declarations union.
+fn client_spans(source: &CallsSource, window: &GraphQueryWindow) -> DfResult<DataFrame> {
+    // Peer-naming candidates present in this table's schema, normalized so an
+    // empty value falls through to the next candidate.
+    let present: Vec<(Expr, &str)> = {
+        let schema = source.scan.schema();
+        VIRTUAL_DST_CANDIDATES
+            .iter()
+            .filter(|(column, _)| schema.has_column_with_unqualified_name(column))
+            .map(|(column, conn)| {
+                let value =
+                    core_fns::nullif().call(vec![cast(ident(*column), DataType::Utf8), lit("")]);
+                (value, *conn)
+            })
+            .collect()
+    };
+    let null_utf8 = || lit(ScalarValue::Utf8(None));
+    let virtual_dst = if present.is_empty() {
+        null_utf8()
+    } else {
+        core_fns::coalesce().call(present.iter().map(|(value, _)| value.clone()).collect())
+    };
+    let mut virtual_conn = null_utf8();
+    for (value, conn) in present.into_iter().rev() {
+        virtual_conn = when(value.is_not_null(), lit(conn)).otherwise(virtual_conn)?;
+    }
+
+    source
+        .scan
+        .clone()
+        .filter(
+            ident(SPAN_KIND_COLUMN)
+                .eq(lit(SPAN_KIND_CLIENT))
+                .and(span_predicate(&source.service, window, true)),
+        )?
+        .select(vec![
+            ident(TRACE_TIMESTAMP_COLUMN),
+            ident(TRACE_ID_COLUMN),
+            ident(SPAN_ID_COLUMN),
+            // The cast inside entity_id_expr also normalizes tag columns, which
+            // come out of the storage engine dictionary-encoded.
+            entity_id_expr(&source.service.id_columns, &|c| ident(c)).alias("src_id"),
+            ident(SPAN_STATUS_CODE_COLUMN),
+            ident(DURATION_NANO_COLUMN),
+            virtual_dst.alias("virtual_dst"),
+            virtual_conn.alias("virtual_conn"),
+        ])
+}
+
+/// One trace table's server spans, normalized to
+/// `(timestamp, trace_id, parent_span_id, dst_id, status_code, duration_nano)`.
+fn server_spans(
     service: &EntityDeclaration,
     trace: DataFrame,
     window: &GraphQueryWindow,
 ) -> DfResult<DataFrame> {
-    let mut client_pred = ident(SPAN_KIND_COLUMN)
-        .eq(lit(SPAN_KIND_CLIENT))
-        .and(ident(TRACE_TIMESTAMP_COLUMN).gt_eq(window.source_start()))
-        .and(ident(TRACE_TIMESTAMP_COLUMN).lt(window.source_end()));
-    let mut server_pred = ident(SPAN_KIND_COLUMN)
-        .eq(lit(SPAN_KIND_SERVER))
-        // Static bounds implied by the window and the join's time-proximity
-        // conditions below; the join bounds reference client.timestamp and
-        // cannot prune the server-side scan.
-        .and(
-            ident(TRACE_TIMESTAMP_COLUMN)
-                .gt_eq(window.source_start() - interval(CHILD_SPAN_EARLY_NANOS)),
-        )
-        .and(
-            ident(TRACE_TIMESTAMP_COLUMN).lt(window.source_end() + interval(CHILD_SPAN_LATE_NANOS)),
-        );
-    // A NULL identity component identifies nothing, on either endpoint.
-    for id in &service.id_columns {
-        client_pred = client_pred.and(ident(id).is_not_null());
-        server_pred = server_pred.and(ident(id).is_not_null());
-    }
-
-    let client = trace.clone().filter(client_pred)?.alias("client")?;
-    let server = trace.filter(server_pred)?.alias("server")?;
-
-    let join_conditions = vec![
-        qcol("client", TRACE_ID_COLUMN).eq(qcol("server", TRACE_ID_COLUMN)),
-        qcol("server", PARENT_SPAN_ID_COLUMN).eq(qcol("client", SPAN_ID_COLUMN)),
-        qcol("server", TRACE_TIMESTAMP_COLUMN)
-            .gt_eq(qcol("client", TRACE_TIMESTAMP_COLUMN) - interval(CHILD_SPAN_EARLY_NANOS)),
-        qcol("server", TRACE_TIMESTAMP_COLUMN)
-            .lt_eq(qcol("client", TRACE_TIMESTAMP_COLUMN) + interval(CHILD_SPAN_LATE_NANOS)),
-    ];
-
-    client
-        .join_on(server, JoinType::Inner, join_conditions)?
+    trace
+        .filter(
+            ident(SPAN_KIND_COLUMN)
+                .eq(lit(SPAN_KIND_SERVER))
+                .and(span_predicate(service, window, false)),
+        )?
         .select(vec![
-            bin_ms(qcol("client", TRACE_TIMESTAMP_COLUMN)).alias("observed_at"),
-            // The cast inside entity_id_expr also normalizes tag columns, which
-            // come out of the storage engine dictionary-encoded.
-            entity_id_expr(&service.id_columns, &|c| qcol("client", c)).alias("src_id"),
-            entity_id_expr(&service.id_columns, &|c| qcol("server", c)).alias("dst_id"),
-            qcol("server", SPAN_STATUS_CODE_COLUMN).alias("status_code"),
-            qcol("server", DURATION_NANO_COLUMN).alias("duration_nano"),
-        ])?
-        // Exclude self-calls on the composed identity: an edge needs two
-        // distinct service entities.
-        .filter(ident("src_id").not_eq(ident("dst_id")))
+            ident(TRACE_TIMESTAMP_COLUMN),
+            ident(TRACE_ID_COLUMN),
+            ident(PARENT_SPAN_ID_COLUMN),
+            entity_id_expr(&service.id_columns, &|c| ident(c)).alias("dst_id"),
+            ident(SPAN_STATUS_CODE_COLUMN),
+            ident(DURATION_NANO_COLUMN),
+        ])
 }
 
 #[cfg(test)]
@@ -315,9 +473,29 @@ mod tests {
         GraphQueryWindow::from_observed(0, 10 * 60 * 1000)
     }
 
-    /// A trace-like table in the fixed `greptime_trace_v1` shape (ns timestamps).
-    fn trace_table_ctx() -> SessionContext {
-        let schema = Arc::new(Schema::new(vec![
+    /// One span row of the fixed `greptime_trace_v1` shape:
+    /// `(ts_ms, trace_id, span_id, parent_span_id, span_kind, status_code,
+    /// service_name, duration_nano)`.
+    type Span<'a> = (
+        i64,
+        &'a str,
+        &'a str,
+        Option<&'a str>,
+        &'a str,
+        &'a str,
+        &'a str,
+        u64,
+    );
+
+    /// Registers a trace-v1-shaped table (ns timestamps) plus optional dynamic
+    /// string columns (`extra`), one value per span.
+    fn register_trace_table(
+        ctx: &SessionContext,
+        name: &str,
+        extra: &[(&str, &[Option<&str>])],
+        spans: &[Span<'_>],
+    ) {
+        let mut fields = vec![
             Field::new(
                 TRACE_TIMESTAMP_COLUMN,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
@@ -329,84 +507,94 @@ mod tests {
             Field::new(SPAN_KIND_COLUMN, DataType::Utf8, false),
             Field::new(SPAN_STATUS_CODE_COLUMN, DataType::Utf8, false),
             Field::new(SERVICE_NAME_COLUMN, DataType::Utf8, false),
-            Field::new("service_namespace", DataType::Utf8, false),
             Field::new(DURATION_NANO_COLUMN, DataType::UInt64, false),
-        ]));
+        ];
+        for (column, _) in extra {
+            fields.push(Field::new(*column, DataType::Utf8, true));
+        }
+        let schema = Arc::new(Schema::new(fields));
         const MS: i64 = 1_000_000;
-        // Two client->server pairs frontend->cart (one errored), one pair
-        // cart->cart (self-call, excluded), one unmatched client span.
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(TimestampNanosecondArray::from(vec![
-                    1_000 * MS, // client frontend->cart
-                    1_010 * MS, //   server cart
-                    2_000 * MS, // client frontend->cart (error)
-                    2_010 * MS, //   server cart (error)
-                    3_000 * MS, // client cart->cart (self-call)
-                    3_010 * MS, //   server cart
-                    4_000 * MS, // client with no matching server
-                ])) as ArrayRef,
-                Arc::new(StringArray::from(vec![
-                    "t1", "t1", "t2", "t2", "t3", "t3", "t4",
-                ])),
-                Arc::new(StringArray::from(vec![
-                    "c1", "s1", "c2", "s2", "c3", "s3", "c4",
-                ])),
-                Arc::new(StringArray::from(vec![
-                    None,
-                    Some("c1"),
-                    None,
-                    Some("c2"),
-                    None,
-                    Some("c3"),
-                    None,
-                ])),
-                Arc::new(StringArray::from(vec![
-                    "SPAN_KIND_CLIENT",
-                    "SPAN_KIND_SERVER",
-                    "SPAN_KIND_CLIENT",
-                    "SPAN_KIND_SERVER",
-                    "SPAN_KIND_CLIENT",
-                    "SPAN_KIND_SERVER",
-                    "SPAN_KIND_CLIENT",
-                ])),
-                Arc::new(StringArray::from(vec![
-                    "STATUS_CODE_UNSET",
-                    "STATUS_CODE_UNSET",
-                    "STATUS_CODE_UNSET",
-                    "STATUS_CODE_ERROR",
-                    "STATUS_CODE_UNSET",
-                    "STATUS_CODE_UNSET",
-                    "STATUS_CODE_UNSET",
-                ])),
-                Arc::new(StringArray::from(vec![
-                    "frontend", "cart", "frontend", "cart", "cart", "cart", "frontend",
-                ])),
-                Arc::new(StringArray::from(vec!["ns1"; 7])),
-                Arc::new(UInt64Array::from(vec![
-                    0,
-                    500_000_000, // 0.5s
-                    0,
-                    1_500_000_000, // 1.5s
-                    0,
-                    100,
-                    0,
-                ])),
-            ],
-        )
-        .unwrap();
-        let ctx = SessionContext::new();
+        let mut columns: Vec<ArrayRef> = vec![
+            Arc::new(TimestampNanosecondArray::from(
+                spans.iter().map(|s| s.0 * MS).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                spans.iter().map(|s| s.1).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                spans.iter().map(|s| s.2).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                spans.iter().map(|s| s.3).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                spans.iter().map(|s| s.4).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                spans.iter().map(|s| s.5).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                spans.iter().map(|s| s.6).collect::<Vec<_>>(),
+            )),
+            Arc::new(UInt64Array::from(
+                spans.iter().map(|s| s.7).collect::<Vec<_>>(),
+            )),
+        ];
+        for (_, values) in extra {
+            columns.push(Arc::new(StringArray::from(values.to_vec())));
+        }
+        let batch = RecordBatch::try_new(schema.clone(), columns).unwrap();
         ctx.register_table(
-            "opentelemetry_traces",
-            Arc::new(MemTable::try_new(schema.clone(), vec![vec![batch.clone()]]).unwrap()),
-        )
-        .unwrap();
-        ctx.register_table(
-            "opentelemetry_traces_2",
+            name,
             Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap()),
         )
         .unwrap();
+    }
+
+    const UNSET: &str = "STATUS_CODE_UNSET";
+    const ERROR: &str = "STATUS_CODE_ERROR";
+    const CLIENT: &str = "SPAN_KIND_CLIENT";
+    const SERVER: &str = "SPAN_KIND_SERVER";
+
+    /// Two client->server pairs frontend->cart (one errored), one pair
+    /// cart->cart (self-call, excluded), one unmatched client span.
+    const BASE_SPANS: [Span<'static>; 7] = [
+        (1_000, "t1", "c1", None, CLIENT, UNSET, "frontend", 0),
+        (
+            1_010,
+            "t1",
+            "s1",
+            Some("c1"),
+            SERVER,
+            UNSET,
+            "cart",
+            500_000_000,
+        ),
+        (2_000, "t2", "c2", None, CLIENT, UNSET, "frontend", 0),
+        (
+            2_010,
+            "t2",
+            "s2",
+            Some("c2"),
+            SERVER,
+            ERROR,
+            "cart",
+            1_500_000_000,
+        ),
+        (3_000, "t3", "c3", None, CLIENT, UNSET, "cart", 0),
+        (3_010, "t3", "s3", Some("c3"), SERVER, UNSET, "cart", 100),
+        (4_000, "t4", "c4", None, CLIENT, UNSET, "frontend", 0),
+    ];
+
+    fn trace_table_ctx() -> SessionContext {
+        let ctx = SessionContext::new();
+        let namespaces = [Some("ns1"); 7];
+        register_trace_table(
+            &ctx,
+            "opentelemetry_traces",
+            &[("service_namespace", &namespaces)],
+            &BASE_SPANS,
+        );
         ctx
     }
 
@@ -483,22 +671,150 @@ mod tests {
         assert!(json_texts(batch, 15)[0].is_none());
     }
 
+    /// RED columns of one output row: `(request_count, error_count,
+    /// duration_sum, duration_count)`.
+    fn red_metrics(batch: &RecordBatch, row: usize) -> (i64, i64, f64, i64) {
+        let i64_at = |column: usize| {
+            batch
+                .column(column)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(row)
+        };
+        let duration_sum = batch
+            .column(13)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .value(row);
+        (i64_at(11), i64_at(12), duration_sum, i64_at(14))
+    }
+
+    fn confidence(batch: &RecordBatch, row: usize) -> f64 {
+        batch
+            .column(10)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap()
+            .value(row)
+    }
+
+    fn sources(traces: &[(&str, DataFrame)]) -> Vec<CallsSource> {
+        traces
+            .iter()
+            .map(|(_, scan)| CallsSource {
+                service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
+                scan: scan.clone(),
+            })
+            .collect()
+    }
+
     #[tokio::test]
     async fn calls_plan_merges_edges_across_trace_tables() {
-        let ctx = trace_table_ctx();
-        let t1 = ctx.table("opentelemetry_traces").await.unwrap();
-        let t2 = ctx.table("opentelemetry_traces_2").await.unwrap();
-        let plan = build_relationships_plan_for_test(
-            vec![
-                CallsSource {
-                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
-                    scan: t1,
-                },
-                CallsSource {
-                    service: trace_service_decl(&[SERVICE_NAME_COLUMN]),
-                    scan: t2,
-                },
+        let ctx = SessionContext::new();
+        // Distinct traces observing the same frontend->cart edge, one per table.
+        register_trace_table(
+            &ctx,
+            "trace_a",
+            &[],
+            &[
+                (1_000, "t1", "c1", None, CLIENT, UNSET, "frontend", 0),
+                (
+                    1_010,
+                    "t1",
+                    "s1",
+                    Some("c1"),
+                    SERVER,
+                    UNSET,
+                    "cart",
+                    500_000_000,
+                ),
             ],
+        );
+        register_trace_table(
+            &ctx,
+            "trace_b",
+            &[],
+            &[
+                (2_000, "t2", "c2", None, CLIENT, UNSET, "frontend", 0),
+                (
+                    2_010,
+                    "t2",
+                    "s2",
+                    Some("c2"),
+                    SERVER,
+                    ERROR,
+                    "cart",
+                    1_500_000_000,
+                ),
+            ],
+        );
+        let a = ctx.table("trace_a").await.unwrap();
+        let b = ctx.table("trace_b").await.unwrap();
+        let plan =
+            build_relationships_plan_for_test(sources(&[("a", a), ("b", b)]), &test_window())
+                .unwrap()
+                .unwrap();
+
+        let batches = collect(&ctx, plan).await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        // One edge row with the RED metrics of both tables' pairs.
+        assert_eq!(total, 1);
+        assert_eq!(red_metrics(&batches[0], 0), (2, 1, 2.0, 2));
+    }
+
+    #[tokio::test]
+    async fn calls_pair_split_across_trace_tables() {
+        let ctx = SessionContext::new();
+        // The client span and its child server span land in different tables
+        // (per-table trace routing): the union-then-join pairing must find it.
+        register_trace_table(
+            &ctx,
+            "trace_a",
+            &[],
+            &[(1_000, "t1", "c1", None, CLIENT, UNSET, "frontend", 0)],
+        );
+        register_trace_table(
+            &ctx,
+            "trace_b",
+            &[],
+            &[(
+                1_010,
+                "t1",
+                "s1",
+                Some("c1"),
+                SERVER,
+                UNSET,
+                "cart",
+                500_000_000,
+            )],
+        );
+        let a = ctx.table("trace_a").await.unwrap();
+        let b = ctx.table("trace_b").await.unwrap();
+        let plan =
+            build_relationships_plan_for_test(sources(&[("a", a), ("b", b)]), &test_window())
+                .unwrap()
+                .unwrap();
+
+        let batches = collect(&ctx, plan).await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1);
+        let batch = &batches[0];
+        assert_eq!(strings(batch, 5), vec!["frontend"]);
+        assert_eq!(strings(batch, 7), vec!["cart"]);
+        assert_eq!(confidence(batch, 0), 1.0);
+        assert_eq!(red_metrics(batch, 0), (1, 0, 0.5, 1));
+    }
+
+    #[tokio::test]
+    async fn empty_trace_table_does_not_change_edges() {
+        let ctx = trace_table_ctx();
+        register_trace_table(&ctx, "trace_empty", &[], &[]);
+        let base = ctx.table("opentelemetry_traces").await.unwrap();
+        let empty = ctx.table("trace_empty").await.unwrap();
+        let plan = build_relationships_plan_for_test(
+            sources(&[("base", base), ("empty", empty)]),
             &test_window(),
         )
         .unwrap()
@@ -506,28 +822,131 @@ mod tests {
 
         let batches = collect(&ctx, plan).await;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
-        // The same frontend->cart edge from both tables folds into one row with
-        // summed RED metrics.
+        // Same single edge, same RED numbers as the single-table derivation.
+        assert_eq!(total, 1);
+        assert_eq!(red_metrics(&batches[0], 0), (2, 1, 2.0, 2));
+    }
+
+    #[tokio::test]
+    async fn virtual_node_edge_from_unmatched_client() {
+        let ctx = SessionContext::new();
+        register_trace_table(
+            &ctx,
+            "trace_a",
+            &[(
+                "span_attributes.peer.service",
+                &[Some("redis"), None, Some("frontend")],
+            )],
+            &[
+                // Unmatched client naming its peer: a virtual-node edge with
+                // the client's own status and duration.
+                (
+                    1_000,
+                    "t1",
+                    "c1",
+                    None,
+                    CLIENT,
+                    ERROR,
+                    "frontend",
+                    250_000_000,
+                ),
+                // Unmatched client without a peer attribute: no edge.
+                (2_000, "t2", "c2", None, CLIENT, UNSET, "frontend", 0),
+                // Peer attribute naming the client's own service: excluded.
+                (3_000, "t3", "c3", None, CLIENT, UNSET, "frontend", 0),
+            ],
+        );
+        let a = ctx.table("trace_a").await.unwrap();
+        let plan = build_relationships_plan_for_test(sources(&[("a", a)]), &test_window())
+            .unwrap()
+            .unwrap();
+
+        let batches = collect(&ctx, plan).await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 1);
         let batch = &batches[0];
-        let request_count = batch
-            .column(11)
-            .as_any()
-            .downcast_ref::<Int64Array>()
+        assert_eq!(strings(batch, 5), vec!["frontend"]);
+        assert_eq!(strings(batch, 7), vec!["redis"]);
+        assert_eq!(strings(batch, 8), vec!["calls"]);
+        assert_eq!(strings(batch, 9), vec!["trace"]);
+        assert_eq!(confidence(batch, 0), VIRTUAL_NODE_CONFIDENCE);
+        assert_eq!(red_metrics(batch, 0), (1, 1, 0.25, 1));
+        assert_eq!(
+            json_texts(batch, 15),
+            vec![Some(r#"{"connection_type":"virtual_node"}"#.to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn virtual_endpoint_fallback_and_connection_type() {
+        let ctx = SessionContext::new();
+        register_trace_table(
+            &ctx,
+            "trace_a",
+            &[
+                // An empty peer.service must fall through to db.name, whose
+                // match maps connection_type to `database`.
+                ("span_attributes.peer.service", &[Some("")]),
+                ("span_attributes.db.name", &[Some("mysql")]),
+            ],
+            &[(1_000, "t1", "c1", None, CLIENT, UNSET, "frontend", 100)],
+        );
+        let a = ctx.table("trace_a").await.unwrap();
+        let plan = build_relationships_plan_for_test(sources(&[("a", a)]), &test_window())
+            .unwrap()
             .unwrap();
-        assert_eq!(request_count.value(0), 4);
-        let error_count = batch
-            .column(12)
-            .as_any()
-            .downcast_ref::<Int64Array>()
+
+        let batches = collect(&ctx, plan).await;
+        let batch = &batches[0];
+        assert_eq!(strings(batch, 7), vec!["mysql"]);
+        assert_eq!(
+            json_texts(batch, 15),
+            vec![Some(r#"{"connection_type":"database"}"#.to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn real_pair_suppresses_virtual_edge() {
+        let ctx = SessionContext::new();
+        register_trace_table(
+            &ctx,
+            "trace_a",
+            &[(
+                "span_attributes.peer.service",
+                &[Some("cart"), None, Some("cart")],
+            )],
+            &[
+                // A sampled-out server: the client names the same peer an
+                // actual pair witnesses in the same window.
+                (1_000, "t1", "c1", None, CLIENT, ERROR, "frontend", 999),
+                (
+                    2_010,
+                    "t2",
+                    "s2",
+                    Some("c2"),
+                    SERVER,
+                    UNSET,
+                    "cart",
+                    500_000_000,
+                ),
+                (2_000, "t2", "c2", None, CLIENT, UNSET, "frontend", 0),
+            ],
+        );
+        let a = ctx.table("trace_a").await.unwrap();
+        let plan = build_relationships_plan_for_test(sources(&[("a", a)]), &test_window())
+            .unwrap()
             .unwrap();
-        assert_eq!(error_count.value(0), 2);
-        let duration_sum = batch
-            .column(13)
-            .as_any()
-            .downcast_ref::<Float64Array>()
-            .unwrap();
-        assert!((duration_sum.value(0) - 4.0).abs() < 1e-9);
+
+        let batches = collect(&ctx, plan).await;
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        // One (window, edge) row: the pair population wins; the unmatched
+        // client neither adds a second row nor inflates the pair RED metrics.
+        assert_eq!(total, 1);
+        let batch = &batches[0];
+        assert_eq!(strings(batch, 7), vec!["cart"]);
+        assert_eq!(confidence(batch, 0), 1.0);
+        assert_eq!(red_metrics(batch, 0), (1, 0, 0.5, 1));
+        assert!(json_texts(batch, 15)[0].is_none());
     }
 
     #[tokio::test]

--- a/tests-integration/src/instance.rs
+++ b/tests-integration/src/instance.rs
@@ -563,7 +563,9 @@ mod tests {
             ) -> auth::error::Result<auth::PermissionResp> {
                 if matches!(req, auth::PermissionReq::Action(auth::SEMANTIC_GRAPH_QUERY))
                     && let auth::PermissionTableTargets::Resolved(targets) = targets
-                    && targets.iter().any(|target| target.table == "secret_traces")
+                    && targets
+                        .iter()
+                        .any(|target| target.table.starts_with("secret_"))
                 {
                     return Ok(auth::PermissionResp::Reject);
                 }
@@ -580,7 +582,7 @@ mod tests {
             .await;
         let instance = standalone.fe_instance().clone();
 
-        for table in ["open_traces", "secret_traces"] {
+        for (table, trace_id) in [("open_traces", "t0"), ("secret_traces", "t1")] {
             let create = format!(
                 r#"create table {table} (
                     "timestamp" timestamp(9) time index,
@@ -597,14 +599,59 @@ mod tests {
             create_table(&instance, &create).await;
             let insert = format!(
                 "insert into {table} values \
-                 (now(), 't0', 'c1', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'client-{table}', 0), \
-                 (now(), 't0', 's1', 'c1', 'SPAN_KIND_SERVER', 'STATUS_CODE_UNSET', 'server-{table}', 100)"
+                 (now(), '{trace_id}', 'c1', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'client-{table}', 0), \
+                 (now(), '{trace_id}', 's1', 'c1', 'SPAN_KIND_SERVER', 'STATUS_CODE_UNSET', 'server-{table}', 100)"
             );
             let output = query(&instance, &insert).await;
             let OutputData::AffectedRows(x) = output.data else {
                 unreachable!()
             };
             assert_eq!(x, 2);
+        }
+
+        // A pair split across tables (client here, server in a denied table):
+        // a join-derived edge needs read access to all of its input tables.
+        create_table(
+            &instance,
+            r#"create table cross_clients (
+                "timestamp" timestamp(9) time index,
+                trace_id string,
+                span_id string,
+                parent_span_id string,
+                span_kind string,
+                span_status_code string,
+                service_name string,
+                duration_nano bigint unsigned,
+                primary key (service_name)
+            ) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true')"#,
+        )
+        .await;
+        create_table(
+            &instance,
+            r#"create table secret_cross_servers (
+                "timestamp" timestamp(9) time index,
+                trace_id string,
+                span_id string,
+                parent_span_id string,
+                span_kind string,
+                span_status_code string,
+                service_name string,
+                duration_nano bigint unsigned,
+                primary key (service_name)
+            ) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true')"#,
+        )
+        .await;
+        for insert in [
+            "insert into cross_clients values \
+             (now(), 't9', 'c9', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'client-cross', 0)",
+            "insert into secret_cross_servers values \
+             (now(), 't9', 's9', 'c9', 'SPAN_KIND_SERVER', 'STATUS_CODE_UNSET', 'server-cross', 100)",
+        ] {
+            let output = query(&instance, insert).await;
+            let OutputData::AffectedRows(x) = output.data else {
+                unreachable!()
+            };
+            assert_eq!(x, 1);
         }
 
         let sql = "select src_id, dst_id from greptime_private.semantic_relationships \
@@ -623,6 +670,10 @@ mod tests {
             !pretty_print.contains("secret_traces"),
             "denied source leaked into edges:\n{pretty_print}"
         );
+        assert!(
+            !pretty_print.contains("client-cross"),
+            "edge with a denied join side leaked:\n{pretty_print}"
+        );
 
         let sql = "select entity_id from greptime_private.semantic_entities order by entity_id";
         let output = query(&instance, sql).await;
@@ -636,7 +687,7 @@ mod tests {
             "allowed entity missing:\n{pretty_print}"
         );
         assert!(
-            !pretty_print.contains("secret_traces"),
+            !pretty_print.contains("secret_traces") && !pretty_print.contains("server-cross"),
             "denied source leaked into entities:\n{pretty_print}"
         );
     }

--- a/tests/cases/standalone/common/system/semantic_graph.result
+++ b/tests/cases/standalone/common/system/semantic_graph.result
@@ -431,7 +431,7 @@ drop table graph_traces_virtual;
 Affected Rows: 0
 
 -- Agent edges: span structure derives parent_agent calls agent, and span rows
--- co-declaring agent+model / agent+tool witness uses / invoked.
+-- co-declaring agent+model / agent+tool witness uses / invokes.
 create table graph_agent_traces (
   "timestamp" timestamp(9) time index,
   trace_id string,
@@ -470,7 +470,7 @@ order by rel_type, dst_id;
 | src_type | src_id       | dst_type | dst_id     | rel_type | provenance |
 +----------+--------------+----------+------------+----------+------------+
 | agent    | orchestrator | agent    | researcher | calls    | trace      |
-| agent    | researcher   | tool     | web_search | invoked  | trace      |
+| agent    | researcher   | tool     | web_search | invokes  | trace      |
 | agent    | researcher   | model    | gpt-5      | uses     | trace      |
 +----------+--------------+----------+------------+----------+------------+
 

--- a/tests/cases/standalone/common/system/semantic_graph.result
+++ b/tests/cases/standalone/common/system/semantic_graph.result
@@ -277,3 +277,204 @@ drop table greptime_private.semantic_relationships_declared;
 
 Affected Rows: 0
 
+-- Same-row co-declaration: a table declaring both entity types of a built-in
+-- vocabulary pair witnesses the edge on every row carrying both identities;
+-- the vocabulary fixes the direction.
+create table graph_pod_metrics (
+  ts timestamp time index,
+  instance string,
+  host string,
+  "service" string,
+  cpu double,
+  primary key (instance, host, "service")
+) with (
+  'greptime.semantic.entity.service.instance.id' = 'instance',
+  'greptime.semantic.entity.host.id' = 'host',
+  'greptime.semantic.entity.service.id' = 'service'
+);
+
+Affected Rows: 0
+
+insert into graph_pod_metrics values (now(), 'cart-0', 'node-1', 'cart', 0.5);
+
+Affected Rows: 1
+
+select src_type, src_id, dst_type, dst_id, rel_type, provenance, confidence
+from greptime_private.semantic_relationships
+order by rel_type, src_id;
+
++------------------+--------+----------+--------+----------+------------+------------+
+| src_type         | src_id | dst_type | dst_id | rel_type | provenance | confidence |
++------------------+--------+----------+--------+----------+------------+------------+
+| service.instance | cart-0 | service  | cart   | part_of  | attribute  | 1.0        |
+| service.instance | cart-0 | host     | node-1 | runs_on  | attribute  | 1.0        |
++------------------+--------+----------+--------+----------+------------+------------+
+
+drop table graph_pod_metrics;
+
+Affected Rows: 0
+
+-- Cross-table calls pairing: the client span and its child server span land in
+-- different trace tables and must still pair into one edge. A trace-model
+-- table that lost the fixed span columns is skipped instead of failing the
+-- scan.
+create table graph_traces_a (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  primary key (service_name)
+) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true');
+
+Affected Rows: 0
+
+create table graph_traces_b (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  primary key (service_name)
+) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true');
+
+Affected Rows: 0
+
+create table graph_traces_malformed (
+  ts timestamp time index,
+  note string
+) with ('table_data_model' = 'greptime_trace_v1');
+
+Affected Rows: 0
+
+insert into graph_traces_a values
+  (now(), 't1', 'c1', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'frontend', 0);
+
+Affected Rows: 1
+
+insert into graph_traces_b values
+  (now(), 't1', 's1', 'c1', 'SPAN_KIND_SERVER', 'STATUS_CODE_ERROR', 'cart', 1500000000);
+
+Affected Rows: 1
+
+insert into graph_traces_malformed values (now(), 'not a trace');
+
+Affected Rows: 1
+
+select src_id, dst_id, rel_type, provenance, confidence, request_count, error_count
+from greptime_private.semantic_relationships
+order by src_id;
+
++----------+--------+----------+------------+------------+---------------+-------------+
+| src_id   | dst_id | rel_type | provenance | confidence | request_count | error_count |
++----------+--------+----------+------------+------------+---------------+-------------+
+| frontend | cart   | calls    | trace      | 1.0        | 1             | 1           |
++----------+--------+----------+------------+------------+---------------+-------------+
+
+drop table graph_traces_a;
+
+Affected Rows: 0
+
+drop table graph_traces_b;
+
+Affected Rows: 0
+
+drop table graph_traces_malformed;
+
+Affected Rows: 0
+
+-- Virtual nodes: a client span with no matching server span names its peer
+-- through span attributes; the edge carries confidence < 1.0 and the
+-- connection type.
+create table graph_traces_virtual (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  "span_attributes.peer.service" string,
+  "span_attributes.db.name" string,
+  primary key (service_name)
+) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true');
+
+Affected Rows: 0
+
+insert into graph_traces_virtual values
+  (now(), 't1', 'c1', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'frontend', 250000000, 'redis', NULL),
+  (now(), 't2', 'c2', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'frontend', 100000000, NULL, 'orders-db');
+
+Affected Rows: 2
+
+-- SQLNESS PROTOCOL MYSQL
+select src_id, dst_id, rel_type, confidence, request_count, attributes
+from greptime_private.semantic_relationships
+order by dst_id;
+
++----------+-----------+----------+------------+---------------+------------------------------------+
+| src_id   | dst_id    | rel_type | confidence | request_count | attributes                         |
++----------+-----------+----------+------------+---------------+------------------------------------+
+| frontend | orders-db | calls    | 0.5        | 1             | {"connection_type":"database"}     |
+| frontend | redis     | calls    | 0.5        | 1             | {"connection_type":"virtual_node"} |
++----------+-----------+----------+------------+---------------+------------------------------------+
+
+drop table graph_traces_virtual;
+
+Affected Rows: 0
+
+-- Agent edges: span structure derives parent_agent calls agent, and span rows
+-- co-declaring agent+model / agent+tool witness uses / invoked.
+create table graph_agent_traces (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  agent_id string,
+  model_name string,
+  tool_name string,
+  primary key (service_name, agent_id, model_name, tool_name)
+) with (
+  'table_data_model' = 'greptime_trace_v1',
+  'append_mode' = 'true',
+  'greptime.semantic.entity.agent.id' = 'agent_id',
+  'greptime.semantic.entity.model.id' = 'model_name',
+  'greptime.semantic.entity.tool.id' = 'tool_name'
+);
+
+Affected Rows: 0
+
+insert into graph_agent_traces values
+  (now(), 't1', 'p1', NULL, 'SPAN_KIND_INTERNAL', 'STATUS_CODE_UNSET', 'app', 0, 'orchestrator', NULL, NULL),
+  (now(), 't1', 'a1', 'p1', 'SPAN_KIND_INTERNAL', 'STATUS_CODE_UNSET', 'app', 2000000000, 'researcher', 'gpt-5', NULL),
+  (now(), 't1', 'a2', 'a1', 'SPAN_KIND_INTERNAL', 'STATUS_CODE_UNSET', 'app', 500000000, 'researcher', NULL, 'web_search');
+
+Affected Rows: 3
+
+select src_type, src_id, dst_type, dst_id, rel_type, provenance
+from greptime_private.semantic_relationships
+order by rel_type, dst_id;
+
++----------+--------------+----------+------------+----------+------------+
+| src_type | src_id       | dst_type | dst_id     | rel_type | provenance |
++----------+--------------+----------+------------+----------+------------+
+| agent    | orchestrator | agent    | researcher | calls    | trace      |
+| agent    | researcher   | tool     | web_search | invoked  | trace      |
+| agent    | researcher   | model    | gpt-5      | uses     | trace      |
++----------+--------------+----------+------------+----------+------------+
+
+drop table graph_agent_traces;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/system/semantic_graph.sql
+++ b/tests/cases/standalone/common/system/semantic_graph.sql
@@ -266,7 +266,7 @@ order by dst_id;
 drop table graph_traces_virtual;
 
 -- Agent edges: span structure derives parent_agent calls agent, and span rows
--- co-declaring agent+model / agent+tool witness uses / invoked.
+-- co-declaring agent+model / agent+tool witness uses / invokes.
 create table graph_agent_traces (
   "timestamp" timestamp(9) time index,
   trace_id string,

--- a/tests/cases/standalone/common/system/semantic_graph.sql
+++ b/tests/cases/standalone/common/system/semantic_graph.sql
@@ -161,3 +161,140 @@ values (now(), 'service', 'reborn', 'depends_on', 'service', 'db', 'declared', '
 select src_id from greptime_private.semantic_relationships order by src_id;
 
 drop table greptime_private.semantic_relationships_declared;
+
+-- Same-row co-declaration: a table declaring both entity types of a built-in
+-- vocabulary pair witnesses the edge on every row carrying both identities;
+-- the vocabulary fixes the direction.
+create table graph_pod_metrics (
+  ts timestamp time index,
+  instance string,
+  host string,
+  "service" string,
+  cpu double,
+  primary key (instance, host, "service")
+) with (
+  'greptime.semantic.entity.service.instance.id' = 'instance',
+  'greptime.semantic.entity.host.id' = 'host',
+  'greptime.semantic.entity.service.id' = 'service'
+);
+
+insert into graph_pod_metrics values (now(), 'cart-0', 'node-1', 'cart', 0.5);
+
+select src_type, src_id, dst_type, dst_id, rel_type, provenance, confidence
+from greptime_private.semantic_relationships
+order by rel_type, src_id;
+
+drop table graph_pod_metrics;
+
+-- Cross-table calls pairing: the client span and its child server span land in
+-- different trace tables and must still pair into one edge. A trace-model
+-- table that lost the fixed span columns is skipped instead of failing the
+-- scan.
+create table graph_traces_a (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  primary key (service_name)
+) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true');
+
+create table graph_traces_b (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  primary key (service_name)
+) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true');
+
+create table graph_traces_malformed (
+  ts timestamp time index,
+  note string
+) with ('table_data_model' = 'greptime_trace_v1');
+
+insert into graph_traces_a values
+  (now(), 't1', 'c1', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'frontend', 0);
+
+insert into graph_traces_b values
+  (now(), 't1', 's1', 'c1', 'SPAN_KIND_SERVER', 'STATUS_CODE_ERROR', 'cart', 1500000000);
+
+insert into graph_traces_malformed values (now(), 'not a trace');
+
+select src_id, dst_id, rel_type, provenance, confidence, request_count, error_count
+from greptime_private.semantic_relationships
+order by src_id;
+
+drop table graph_traces_a;
+
+drop table graph_traces_b;
+
+drop table graph_traces_malformed;
+
+-- Virtual nodes: a client span with no matching server span names its peer
+-- through span attributes; the edge carries confidence < 1.0 and the
+-- connection type.
+create table graph_traces_virtual (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  "span_attributes.peer.service" string,
+  "span_attributes.db.name" string,
+  primary key (service_name)
+) with ('table_data_model' = 'greptime_trace_v1', 'append_mode' = 'true');
+
+insert into graph_traces_virtual values
+  (now(), 't1', 'c1', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'frontend', 250000000, 'redis', NULL),
+  (now(), 't2', 'c2', NULL, 'SPAN_KIND_CLIENT', 'STATUS_CODE_UNSET', 'frontend', 100000000, NULL, 'orders-db');
+
+-- SQLNESS PROTOCOL MYSQL
+select src_id, dst_id, rel_type, confidence, request_count, attributes
+from greptime_private.semantic_relationships
+order by dst_id;
+
+drop table graph_traces_virtual;
+
+-- Agent edges: span structure derives parent_agent calls agent, and span rows
+-- co-declaring agent+model / agent+tool witness uses / invoked.
+create table graph_agent_traces (
+  "timestamp" timestamp(9) time index,
+  trace_id string,
+  span_id string,
+  parent_span_id string,
+  span_kind string,
+  span_status_code string,
+  service_name string,
+  duration_nano bigint unsigned,
+  agent_id string,
+  model_name string,
+  tool_name string,
+  primary key (service_name, agent_id, model_name, tool_name)
+) with (
+  'table_data_model' = 'greptime_trace_v1',
+  'append_mode' = 'true',
+  'greptime.semantic.entity.agent.id' = 'agent_id',
+  'greptime.semantic.entity.model.id' = 'model_name',
+  'greptime.semantic.entity.tool.id' = 'tool_name'
+);
+
+insert into graph_agent_traces values
+  (now(), 't1', 'p1', NULL, 'SPAN_KIND_INTERNAL', 'STATUS_CODE_UNSET', 'app', 0, 'orchestrator', NULL, NULL),
+  (now(), 't1', 'a1', 'p1', 'SPAN_KIND_INTERNAL', 'STATUS_CODE_UNSET', 'app', 2000000000, 'researcher', 'gpt-5', NULL),
+  (now(), 't1', 'a2', 'a1', 'SPAN_KIND_INTERNAL', 'STATUS_CODE_UNSET', 'app', 500000000, 'researcher', NULL, 'web_search');
+
+select src_type, src_id, dst_type, dst_id, rel_type, provenance
+from greptime_private.semantic_relationships
+order by rel_type, dst_id;
+
+drop table graph_agent_traces;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#8609. Follows #8841 (mechanical module split, merged); each commit is one derivation.

## What's changed and what's your intention?

Completes the derived-edge vocabulary of the read-time entity graph (#8794), per the [entity-relationships RFC](https://github.com/GreptimeTeam/greptimedb/blob/main/docs/rfcs/2026-06-25-entity-relationships-and-graph-query.md). Four derivations, all inside the existing 16-column `semantic_relationships` contract and `GraphQueryWindow` semantics:

- **Cross-table `calls` pairing.** The service-graph join previously self-joined each trace table, so a client span and its server span stored in different tables (`x-greptime-trace-table-name` routing) never paired. The derivation now projects every trace table's client and server spans to a normalized shape (with each table's own `service` identity expression), unions them, and joins once. A single table degenerates to the previous self-join.
- **Virtual-node edges.** A client span with no matching server span becomes a `calls` edge to a peer named by span attributes (`service.peer.name` / `db.namespace` first, the deprecated `peer.service` / `db.name` kept for existing telemetry, `server.address` last; empty values fall through), with `confidence = 0.5` and `attributes.connection_type` (`database` when named by `db.name`, else `virtual_node`). Real pairs win: when a window's edge key has any pair, the edge reports only the pair population (the RFC pins RED metrics to observed span pairs) and unmatched clients are suppressed, so one `(window, edge)` never yields two rows. Implemented as one left join with filtered aggregates — no extra scans over the trace tables.
- **Same-row co-declared edges.** A table declaring both entity types of a built-in vocabulary pair witnesses the edge on every row carrying both identities; the vocabulary fixes the direction: `service.instance|process -> host` and `k8s.pod -> k8s.node` (`runs_on`), `k8s.pod -> k8s.container` (`contains`), `service.instance -> service` and `k8s.pod -> k8s.workload` (`part_of`), with `provenance = 'attribute'`. The agent rules `agent -> model` (`uses`) and `agent -> tool` (`invokes`) apply only to trace sources — the RFC derives them from span structure, so a non-trace table co-declaring these types must not fabricate invocations — and carry `provenance = 'trace'`.
- **`parent_agent calls agent`.** Trace tables declaring an `agent` entity pair each span with its child span (no span-kind filter), keep pairs whose agent identities differ, and aggregate RED metrics, anchored on the parent span like the service derivation anchors on the client.

Also: `enumerate` now validates the fixed trace-v1 columns (names + ingest types) and derives around a malformed trace-model table with a warning instead of failing every relationships scan (closes the TODO left by #8794; the RFC requires schema drift never to poison a scan).

Limitations:

- A whole trace duplicated into several tables (fan-out ingestion) inflates pair counts quadratically, since the same spans appear on both join sides. Span identity for dedup (and its conflict rules) is deliberately not defined here; a single table keeps exactly the previous semantics.
- When the caller may read a client table but not the table holding the matching server spans, the unmatched clients can surface as virtual-node edges. These derive only from the readable table and leak nothing from the denied one.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
