### PR TITLE
ci: update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,8 @@
 
 ## [Module] Database Engine
 /src/index @evenyag @discord9 @WenyXu 
-/src/mito2 @evenyag @v0y4g3r @waynexia
-/src/query @evenyag @waynexia @discord9
+/src/mito2 @evenyag @v0y4g3r
+/src/query @evenyag @discord9
 
 ## [Module] Distributed
 /src/common/meta @MichaelScofield @WenyXu
@@ -20,8 +20,8 @@
 /src/store-api @v0y4g3r @evenyag
 
 ## [Module] Metrics Engine
-/src/metric-engine @waynexia @WenyXu
-/src/promql @waynexia @evenyag @discord9
+/src/metric-engine @WenyXu @v0y4g3r
+/src/promql @evenyag @discord9
 
 ## [Module] Flow
-/src/flow @discord9 @waynexia
+/src/flow @discord9 @WenyXu


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## What's changed and what's your intention?

Remove `@waynexia` from the CODEOWNERS rules and assign active maintainers where a replacement is needed to preserve the repository's minimum of two owners per module:

- Add `@v0y4g3r` to `metric-engine`.
- Add `@WenyXu` to `flow`.
- Keep the existing owners for `mito2`, `query`, and `promql`.

This only changes automatic reviewer assignment. It does not affect runtime behavior, APIs, schemas, or stored data.

Validation:

- `git diff --check`
- Confirmed `@waynexia` no longer appears in `.github/CODEOWNERS`.
- Confirmed every module rule retains at least two owners.

## PR Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
