### PR TITLE
fix(ci): grant pull-requests write and stop counting drafts

### DIFF
--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -1,7 +1,8 @@
 // Warns when a repository member has too many open pull requests.
 //
 // Review capacity is the bottleneck, so authors are expected to land or close
-// existing work before opening more. Drafts count: they still occupy attention.
+// existing work before opening more. Drafts are not counted and never warned
+// about: they are not asking for review yet.
 // This is advisory only — it never closes a pull request or fails the job.
 
 import { appendFileSync } from "node:fs";
@@ -47,7 +48,7 @@ async function isTeamMember(octokit, owner, repo, username) {
 function buildComment(author, total, limit, openPrs) {
   const listed = openPrs
     .slice(0, MAX_LISTED_PRS)
-    .map((pr) => `- #${pr.number} ${pr.title}${pr.draft ? " _(draft)_" : ""}`);
+    .map((pr) => `- #${pr.number} ${pr.title}`);
   const hidden = openPrs.length - listed.length;
   const list = hidden > 0 ? `${listed.join("\n")}\n- ...and ${hidden} more` : listed.join("\n");
 
@@ -99,6 +100,11 @@ async function upsertComment(octokit, params, body) {
     return;
   }
 
+  if (process.env.PR_IS_DRAFT === "true") {
+    summary(`Skipping #${prNumber}: draft.`);
+    return;
+  }
+
   const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
   if (!(await isTeamMember(octokit, owner, repo, author))) {
@@ -117,7 +123,7 @@ async function upsertComment(octokit, params, body) {
   // The pull request that triggered this run is already open, so exclude it and
   // report the total separately.
   const others = allOpen.filter(
-    (pr) => pr.user?.login === author && pr.number !== prNumber
+    (pr) => pr.user?.login === author && pr.number !== prNumber && !pr.draft
   );
   const total = others.length + 1;
 

--- a/.github/workflows/pr-open-limit.yml
+++ b/.github/workflows/pr-open-limit.yml
@@ -5,15 +5,15 @@ on:
     types:
       - opened
       - reopened
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# The warning comment goes through the issues API, hence `issues: write`.
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:
@@ -44,4 +44,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_IS_DRAFT: ${{ github.event.pull_request.draft }}
           MAX_OPEN_PRS: ${{ vars.MAX_OPEN_PRS_PER_AUTHOR || 5 }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8813 and #8822.

## What's changed and what's your intention?

The warning comment has never been posted. Every run fails with `403 Resource not accessible by integration` on `POST /repos/{owner}/{repo}/issues/{n}/comments`.

The permissions block grants `issues: write` on the grounds that the comment goes through the issues API. The path does, but GitHub authorizes it against the target object, and that object is a pull request, so it needs `pull-requests: write`. Granting it fixes the 403.

Also in this change:

- Drafts no longer count toward the limit and no longer trigger a warning. They are not asking for review yet, so they should not consume the author's budget.
- `ready_for_review` is added to the trigger types. Without it, opening as a draft and flipping to ready would skip the check entirely.

Verified end to end on a scratch repository running this exact workflow, with a real limit and drafts open alongside regular pull requests: going over the limit posts the comment and lists only the non-draft pull requests, drafts neither inflate the count nor appear in the list, staying under the limit posts nothing, opening a draft is skipped, marking it ready fires the check, and reopening updates the existing comment instead of adding a second one.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.