### PR TITLE
feat(promql): support native histogram aggregations

### DIFF
--- a/src/common/query/src/native_histogram.rs
+++ b/src/common/query/src/native_histogram.rs
@@ -247,6 +247,25 @@ pub struct NativeHistogram {
     pub negative_buckets: Vec<f64>,
 }
 
+/// Formats a histogram component like Prometheus's default `%g` formatter.
+fn format_promql_histogram_float(value: f64) -> String {
+    let abs = value.abs();
+    if !value.is_finite() || value == 0.0 || (1e-4..1e6).contains(&abs) {
+        return format_prometheus_float(value);
+    }
+
+    let scientific = format!("{value:e}");
+    let Some((mantissa, exponent)) = scientific.rsplit_once('e') else {
+        return scientific;
+    };
+    let (sign, exponent) = if let Some(exponent) = exponent.strip_prefix('-') {
+        ('-', exponent)
+    } else {
+        ('+', exponent.strip_prefix('+').unwrap_or(exponent))
+    };
+    format!("{mantissa}e{sign}{exponent:0>2}")
+}
+
 impl NativeHistogram {
     fn uses_custom_buckets(&self) -> bool {
         self.schema == CUSTOM_BUCKETS_SCHEMA
@@ -378,7 +397,10 @@ impl NativeHistogram {
 
     /// Formats this histogram using PromQL native histogram sample notation.
     pub fn promql_string(&self) -> String {
-        let mut parts = vec![format!("count:{}", self.count), format!("sum:{}", self.sum)];
+        let mut parts = vec![
+            format!("count:{}", format_promql_histogram_float(self.count)),
+            format!("sum:{}", format_promql_histogram_float(self.sum)),
+        ];
         if let Some(buckets) = self.all_buckets() {
             parts.extend(
                 buckets
@@ -392,7 +414,11 @@ impl NativeHistogram {
                         };
                         format!(
                             "{}{},{}{}:{}",
-                            left, bucket.lower, bucket.upper, right, bucket.count
+                            left,
+                            format_promql_histogram_float(bucket.lower),
+                            format_promql_histogram_float(bucket.upper),
+                            right,
+                            format_promql_histogram_float(bucket.count)
                         )
                     }),
             );
@@ -1615,6 +1641,35 @@ mod tests {
             positive_buckets,
             negative_buckets: Vec::new(),
         }
+    }
+
+    #[test]
+    fn promql_string_matches_prometheus_float_format() {
+        assert_eq!(format_promql_histogram_float(0.0001), "0.0001");
+        assert_eq!(format_promql_histogram_float(1_000_000.0), "1e+06");
+
+        let histogram = NativeHistogram {
+            schema: CUSTOM_BUCKETS_SCHEMA,
+            zero_threshold: 0.0,
+            sum: 2_349_209.324,
+            reset_hint: CounterResetHint::Unknown,
+            start_timestamp: None,
+            custom_values: vec![0.00001],
+            positive_spans: vec![Span {
+                offset: 0,
+                length: 2,
+            }],
+            negative_spans: Vec::new(),
+            count: 3.0,
+            zero_count: 0.0,
+            positive_buckets: vec![1.0, 2.0],
+            negative_buckets: Vec::new(),
+        };
+
+        assert_eq!(
+            histogram.promql_string(),
+            "{count:3, sum:2.349209324e+06, [-Inf,1e-05]:1, (1e-05,+Inf]:2}"
+        );
     }
 
     #[test]

--- a/src/promql/src/functions.rs
+++ b/src/promql/src/functions.rs
@@ -54,7 +54,7 @@ pub use native_histogram::{
     NativeHistogramNotEq, NativeHistogramPresentOverTime, NativeHistogramQuantile,
     NativeHistogramRate, NativeHistogramResets, NativeHistogramScalarMul, NativeHistogramStddev,
     NativeHistogramStdvar, NativeHistogramSub, NativeHistogramSum, NativeHistogramSumOverTime,
-    NativeHistogramToString,
+    NativeHistogramToString, PromqlFloatToString,
 };
 pub use predict_linear::PredictLinear;
 pub use quantile::QuantileOverTime;

--- a/src/promql/src/functions/native_histogram.rs
+++ b/src/promql/src/functions/native_histogram.rs
@@ -405,10 +405,8 @@ fn histogram_pair_udf_with_collector(
                     match (read_histogram(lhs, row)?, read_histogram(rhs, row)?) {
                         (Some(lhs), Some(rhs)) => {
                             record_custom_reconciliation(&collector, name, &lhs, &rhs);
+                            record_counter_reset_contradiction(&collector, name, &lhs, &rhs);
                             let result = op(&lhs, &rhs);
-                            if result.is_some() {
-                                record_counter_reset_contradiction(&collector, name, &lhs, &rhs);
-                            }
                             if result.is_none() {
                                 record_warning(
                                     &collector,
@@ -926,9 +924,6 @@ impl NativeHistogramAggregateAccumulator {
     }
 
     fn push_histogram(&mut self, histogram: NativeHistogram, count: u64) -> DfResult<()> {
-        if self.dropped_incompatible {
-            return Ok(());
-        }
         if self.kind.needs_count() && count == 0 {
             return Ok(());
         }
@@ -937,6 +932,9 @@ impl NativeHistogramAggregateAccumulator {
             histogram.reset_hint == COUNTER_RESET_HINT,
             histogram.reset_hint == NOT_COUNTER_RESET_HINT,
         );
+        if self.dropped_incompatible {
+            return Ok(());
+        }
         let combined_count = if self.kind.needs_count() {
             self.count.checked_add(count).ok_or_else(|| {
                 DataFusionError::Execution(format!(
@@ -1009,16 +1007,19 @@ fn range_fold_histograms(
     name: &'static str,
     collector: &Option<PromqlAnnotationCollector>,
 ) -> Option<NativeHistogram> {
+    if samples
+        .iter()
+        .any(|histogram| histogram.reset_hint == COUNTER_RESET_HINT)
+        && samples
+            .iter()
+            .any(|histogram| histogram.reset_hint == NOT_COUNTER_RESET_HINT)
+    {
+        record_counter_reset_contradiction_warning(collector, name);
+    }
+
     let mut value = None;
     let mut count = 0u64;
-    let mut counter_reset_seen = false;
-    let mut not_counter_reset_seen = false;
     for histogram in samples {
-        counter_reset_seen |= histogram.reset_hint == COUNTER_RESET_HINT;
-        not_counter_reset_seen |= histogram.reset_hint == NOT_COUNTER_RESET_HINT;
-        if counter_reset_seen && not_counter_reset_seen {
-            record_counter_reset_contradiction_warning(collector, name);
-        }
         value = match value {
             Some(value) => {
                 record_custom_reconciliation(collector, name, &value, &histogram);
@@ -2340,17 +2341,16 @@ impl DfAccumulator for NativeHistogramAggregateAccumulator {
             })?;
 
         for row in 0..histograms.len() {
-            if dropped.value(row) {
-                self.mark_incompatible();
-                continue;
-            }
-            if self.dropped_incompatible {
-                continue;
-            }
             self.observe_reset_hints(
                 counter_reset_seen.value(row),
                 not_counter_reset_seen.value(row),
             );
+            if dropped.value(row) {
+                self.mark_incompatible();
+            }
+            if self.dropped_incompatible {
+                continue;
+            }
             let Some(histogram) = read_histogram(histograms, row)? else {
                 continue;
             };
@@ -3520,25 +3520,32 @@ mod tests {
     }
 
     #[test]
-    fn subtraction_records_reset_hint_contradictions() {
-        let mut left = sample_histogram(2.0, 2.0, vec![2.0]);
-        left.reset_hint = COUNTER_RESET_HINT;
-        let mut right = sample_histogram(1.0, 1.0, vec![1.0]);
-        right.reset_hint = NOT_COUNTER_RESET_HINT;
-        let collector = PromqlAnnotationCollector::default();
+    fn subtraction_records_reset_hint_contradictions_for_incompatible_histograms() {
+        for incompatible in [false, true] {
+            let mut left = sample_histogram(2.0, 2.0, vec![2.0]);
+            left.reset_hint = COUNTER_RESET_HINT;
+            let mut right = sample_histogram(1.0, 1.0, vec![1.0]);
+            right.reset_hint = NOT_COUNTER_RESET_HINT;
+            if incompatible {
+                right.schema = CUSTOM_BUCKETS_SCHEMA;
+                right.custom_values = vec![1.0];
+            }
+            let collector = PromqlAnnotationCollector::default();
 
-        run_histogram_udf(
-            NativeHistogramSub::scalar_udf_with_collector(Some(collector.clone())),
-            vec![
-                ColumnarValue::Array(build_histogram_array(&[Some(left)])),
-                ColumnarValue::Array(build_histogram_array(&[Some(right)])),
-            ],
-        );
+            run_udf(
+                NativeHistogramSub::scalar_udf_with_collector(Some(collector.clone())),
+                vec![
+                    ColumnarValue::Array(build_histogram_array(&[Some(left)])),
+                    ColumnarValue::Array(build_histogram_array(&[Some(right)])),
+                ],
+                native_histogram_arrow_type(),
+            );
 
-        assert!(collected_warnings(&collector).contains(&format!(
-            "{}: native histogram counter reset hints contradict",
-            NativeHistogramSub::name()
-        )));
+            assert!(collected_warnings(&collector).contains(&format!(
+                "{}: native histogram counter reset hints contradict",
+                NativeHistogramSub::name()
+            )));
+        }
     }
 
     #[test]
@@ -3596,6 +3603,115 @@ mod tests {
             assert!(collected_warnings(&collector).contains(&format!(
                 "{}: native histogram counter reset hints contradict",
                 kind.name()
+            )));
+        }
+    }
+
+    #[test]
+    fn incompatible_aggregates_do_not_hide_reset_hint_contradictions() {
+        let mut reset = sample_histogram(1.0, 1.0, vec![1.0]);
+        reset.reset_hint = COUNTER_RESET_HINT;
+        let mut incompatible_reset = sample_histogram(2.0, 2.0, vec![2.0]);
+        incompatible_reset.schema = CUSTOM_BUCKETS_SCHEMA;
+        incompatible_reset.custom_values = vec![1.0];
+        incompatible_reset.reset_hint = COUNTER_RESET_HINT;
+        let mut not_reset = sample_histogram(3.0, 3.0, vec![3.0]);
+        not_reset.reset_hint = NOT_COUNTER_RESET_HINT;
+
+        for kind in [
+            NativeHistogramAggregateKind::Sum,
+            NativeHistogramAggregateKind::Avg,
+        ] {
+            for histograms in [
+                [reset.clone(), incompatible_reset.clone(), not_reset.clone()],
+                [reset.clone(), not_reset.clone(), incompatible_reset.clone()],
+            ] {
+                let collector = PromqlAnnotationCollector::default();
+                let mut aggregate =
+                    NativeHistogramAggregateAccumulator::new(kind, Some(collector.clone()));
+                for histogram in histograms {
+                    aggregate.push_histogram(histogram, 1).unwrap();
+                }
+
+                assert!(aggregate.dropped_incompatible);
+                let warnings = collected_warnings(&collector);
+                assert!(warnings.contains(&format!(
+                    "{}: dropped native histogram aggregate with incompatible schemas",
+                    kind.name()
+                )));
+                assert!(warnings.contains(&format!(
+                    "{}: native histogram counter reset hints contradict",
+                    kind.name()
+                )));
+            }
+
+            let mut dropped_partial = NativeHistogramAggregateAccumulator::new(kind, None);
+            dropped_partial.push_histogram(reset.clone(), 1).unwrap();
+            dropped_partial
+                .push_histogram(incompatible_reset.clone(), 1)
+                .unwrap();
+            let dropped_states = dropped_partial
+                .state()
+                .unwrap()
+                .into_iter()
+                .map(|value| value.to_array_of_size(1).unwrap())
+                .collect::<Vec<_>>();
+
+            let mut opposing_partial = NativeHistogramAggregateAccumulator::new(kind, None);
+            opposing_partial
+                .push_histogram(not_reset.clone(), 1)
+                .unwrap();
+            let opposing_states = opposing_partial
+                .state()
+                .unwrap()
+                .into_iter()
+                .map(|value| value.to_array_of_size(1).unwrap())
+                .collect::<Vec<_>>();
+
+            for (first, second) in [
+                (&dropped_states, &opposing_states),
+                (&opposing_states, &dropped_states),
+            ] {
+                let collector = PromqlAnnotationCollector::default();
+                let mut merged =
+                    NativeHistogramAggregateAccumulator::new(kind, Some(collector.clone()));
+                merged.merge_batch(first).unwrap();
+                merged.merge_batch(second).unwrap();
+
+                assert!(merged.dropped_incompatible);
+                assert!(collected_warnings(&collector).contains(&format!(
+                    "{}: native histogram counter reset hints contradict",
+                    kind.name()
+                )));
+            }
+        }
+
+        for (kind, name) in [
+            (
+                NativeHistogramAggregateKind::Sum,
+                NativeHistogramSumOverTime::name(),
+            ),
+            (
+                NativeHistogramAggregateKind::Avg,
+                NativeHistogramAvgOverTime::name(),
+            ),
+        ] {
+            let collector = PromqlAnnotationCollector::default();
+            assert!(
+                range_fold_histograms(
+                    vec![reset.clone(), incompatible_reset.clone(), not_reset.clone()],
+                    kind,
+                    name,
+                    &Some(collector.clone()),
+                )
+                .is_none()
+            );
+            let warnings = collected_warnings(&collector);
+            assert!(warnings.contains(&format!(
+                "{name}: dropped native histogram range with incompatible schemas"
+            )));
+            assert!(warnings.contains(&format!(
+                "{name}: native histogram counter reset hints contradict"
             )));
         }
     }

--- a/src/promql/src/functions/native_histogram.rs
+++ b/src/promql/src/functions/native_histogram.rs
@@ -20,6 +20,7 @@ use std::mem::size_of;
 use std::sync::Arc;
 
 use common_query::native_histogram::*;
+use common_query::prometheus::format_prometheus_float;
 use common_query::promql_annotations::PromqlAnnotationCollector;
 use datafusion::arrow::array::{
     Array, ArrayRef, BooleanArray, Float64Array, Float64Builder, Int64Array, StringBuilder,
@@ -740,6 +741,39 @@ impl NativeHistogramStdvar {
         scalar_histogram_udf(Self::name(), vec![], |histogram, _, _, _, _| {
             Ok(histogram.estimated_stdvar())
         })
+    }
+}
+
+/// Formats float samples as PromQL label values.
+pub struct PromqlFloatToString;
+
+impl PromqlFloatToString {
+    pub const fn name() -> &'static str {
+        "prom_float_to_string"
+    }
+
+    pub fn scalar_udf() -> ScalarUDF {
+        create_udf(
+            Self::name(),
+            vec![DataType::Float64],
+            DataType::Utf8,
+            Volatility::Volatile,
+            Arc::new(|input: &[ColumnarValue]| {
+                let values = extract_array(&input[0])?;
+                let values = values
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .expect("validated Float64 input");
+                let mut result = StringBuilder::new();
+                for value in values.iter() {
+                    match value {
+                        Some(value) => result.append_value(format_prometheus_float(value)),
+                        None => result.append_null(),
+                    }
+                }
+                Ok(ColumnarValue::Array(Arc::new(result.finish())))
+            }),
+        )
     }
 }
 

--- a/src/promql/src/functions/native_histogram.rs
+++ b/src/promql/src/functions/native_histogram.rs
@@ -92,20 +92,28 @@ fn read_scalar_f64_arg(
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum AnnotationReturn {
     FloatNull,
+    BooleanTrue,
     BooleanFalse,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum AnnotationLevel {
+    Info,
+    Warning,
 }
 
 impl AnnotationReturn {
     fn data_type(self) -> DataType {
         match self {
             Self::FloatNull => DataType::Float64,
-            Self::BooleanFalse => DataType::Boolean,
+            Self::BooleanTrue | Self::BooleanFalse => DataType::Boolean,
         }
     }
 
     fn scalar_value(self) -> ScalarValue {
         match self {
             Self::FloatNull => ScalarValue::Float64(None),
+            Self::BooleanTrue => ScalarValue::Boolean(Some(true)),
             Self::BooleanFalse => ScalarValue::Boolean(Some(false)),
         }
     }
@@ -116,6 +124,7 @@ struct NativeHistogramAnnotationUdf {
     name: &'static str,
     signature: Signature,
     return_kind: AnnotationReturn,
+    level: AnnotationLevel,
     message: String,
     collector: Option<PromqlAnnotationCollector>,
 }
@@ -124,6 +133,7 @@ impl NativeHistogramAnnotationUdf {
     fn new(
         name: &'static str,
         return_kind: AnnotationReturn,
+        level: AnnotationLevel,
         message: String,
         collector: Option<PromqlAnnotationCollector>,
     ) -> Self {
@@ -131,6 +141,7 @@ impl NativeHistogramAnnotationUdf {
             name,
             signature: Signature::variadic_any(Volatility::Volatile),
             return_kind,
+            level,
             message,
             collector,
         }
@@ -141,6 +152,7 @@ impl PartialEq for NativeHistogramAnnotationUdf {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
             && self.return_kind == other.return_kind
+            && self.level == other.level
             && self.message == other.message
     }
 }
@@ -151,6 +163,7 @@ impl Hash for NativeHistogramAnnotationUdf {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name.hash(state);
         self.return_kind.hash(state);
+        self.level.hash(state);
         self.message.hash(state);
     }
 }
@@ -188,7 +201,10 @@ impl ScalarUDFImpl for NativeHistogramAnnotationUdf {
                 .cloned()
                 .or_else(|| self.collector.clone())
         {
-            collector.record_info(self.message.clone());
+            match self.level {
+                AnnotationLevel::Info => collector.record_info(self.message.clone()),
+                AnnotationLevel::Warning => collector.record_warning(self.message.clone()),
+            }
         }
         Ok(ColumnarValue::Scalar(self.return_kind.scalar_value()))
     }
@@ -205,6 +221,10 @@ impl NativeHistogramDrop {
         "prom_native_histogram_drop_bool"
     }
 
+    const fn bool_true_name() -> &'static str {
+        "prom_native_histogram_keep_bool"
+    }
+
     pub fn float_null_udf(
         message: String,
         collector: Option<PromqlAnnotationCollector>,
@@ -212,6 +232,7 @@ impl NativeHistogramDrop {
         ScalarUDF::new_from_impl(NativeHistogramAnnotationUdf::new(
             Self::float_null_name(),
             AnnotationReturn::FloatNull,
+            AnnotationLevel::Info,
             message,
             collector,
         ))
@@ -224,14 +245,39 @@ impl NativeHistogramDrop {
         ScalarUDF::new_from_impl(NativeHistogramAnnotationUdf::new(
             Self::bool_false_name(),
             AnnotationReturn::BooleanFalse,
+            AnnotationLevel::Info,
+            message,
+            collector,
+        ))
+    }
+
+    pub fn bool_true_udf(
+        message: String,
+        collector: Option<PromqlAnnotationCollector>,
+    ) -> ScalarUDF {
+        ScalarUDF::new_from_impl(NativeHistogramAnnotationUdf::new(
+            Self::bool_true_name(),
+            AnnotationReturn::BooleanTrue,
+            AnnotationLevel::Info,
+            message,
+            collector,
+        ))
+    }
+
+    pub fn warning_bool_false_udf(
+        message: String,
+        collector: Option<PromqlAnnotationCollector>,
+    ) -> ScalarUDF {
+        ScalarUDF::new_from_impl(NativeHistogramAnnotationUdf::new(
+            Self::bool_false_name(),
+            AnnotationReturn::BooleanFalse,
+            AnnotationLevel::Warning,
             message,
             collector,
         ))
     }
 }
 
-// Synthetic drop UDFs only cover info-level invalid PromQL combinations.
-// Warning annotations stay in the histogram UDFs that actually drop samples.
 fn record_info(collector: &Option<PromqlAnnotationCollector>, message: impl Into<String>) {
     if let Some(collector) = collector {
         collector.record_info(message);
@@ -845,19 +891,38 @@ impl NativeHistogramAggregateAccumulator {
         }
     }
 
-    fn push_histogram(&mut self, histogram: NativeHistogram, count: u64) {
+    fn push_histogram(&mut self, histogram: NativeHistogram, count: u64) -> DfResult<()> {
         if self.dropped_incompatible {
-            return;
+            return Ok(());
+        }
+        if self.kind.needs_count() && count == 0 {
+            return Ok(());
         }
 
         self.observe_reset_hints(
             histogram.reset_hint == COUNTER_RESET_HINT,
             histogram.reset_hint == NOT_COUNTER_RESET_HINT,
         );
+        let combined_count = if self.kind.needs_count() {
+            self.count.checked_add(count).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "{}: native histogram sample count overflow",
+                    self.kind.name()
+                ))
+            })?
+        } else {
+            self.count
+        };
         let value = match self.value.take() {
             Some(value) => {
                 record_custom_reconciliation(&self.collector, self.kind.name(), &value, &histogram);
-                match value.add(&histogram) {
+                let combined = match self.kind {
+                    NativeHistogramAggregateKind::Sum => value.add(&histogram),
+                    NativeHistogramAggregateKind::Avg => {
+                        weighted_histogram_mean(value, self.count, histogram, count, combined_count)
+                    }
+                };
+                match combined {
                     Some(value) => Some(value),
                     None => {
                         self.record_incompatible();
@@ -869,8 +934,9 @@ impl NativeHistogramAggregateAccumulator {
         };
         if !self.dropped_incompatible {
             self.value = value;
-            self.count += count;
+            self.count = combined_count;
         }
+        Ok(())
     }
 
     fn mark_incompatible(&mut self) {
@@ -891,12 +957,26 @@ impl NativeHistogramAggregateAccumulator {
     }
 }
 
-fn range_sum_histograms(
+fn weighted_histogram_mean(
+    left: NativeHistogram,
+    left_count: u64,
+    right: NativeHistogram,
+    right_count: u64,
+    total_count: u64,
+) -> Option<NativeHistogram> {
+    let total_count = total_count as f64;
+    left.scale(left_count as f64 / total_count)
+        .add(&right.scale(right_count as f64 / total_count))
+}
+
+fn range_fold_histograms(
     samples: Vec<NativeHistogram>,
+    kind: NativeHistogramAggregateKind,
     name: &'static str,
     collector: &Option<PromqlAnnotationCollector>,
 ) -> Option<NativeHistogram> {
     let mut value = None;
+    let mut count = 0u64;
     let mut counter_reset_seen = false;
     let mut not_counter_reset_seen = false;
     for histogram in samples {
@@ -908,7 +988,14 @@ fn range_sum_histograms(
         value = match value {
             Some(value) => {
                 record_custom_reconciliation(collector, name, &value, &histogram);
-                match value.add(&histogram) {
+                let next_count = count.checked_add(1)?;
+                let combined = match kind {
+                    NativeHistogramAggregateKind::Sum => value.add(&histogram),
+                    NativeHistogramAggregateKind::Avg => {
+                        weighted_histogram_mean(value, count, histogram, 1, next_count)
+                    }
+                };
+                match combined {
                     Some(value) => Some(value),
                     None => {
                         record_warning(
@@ -923,6 +1010,7 @@ fn range_sum_histograms(
             }
             None => Some(histogram),
         };
+        count = count.checked_add(1)?;
     }
     value
 }
@@ -1016,14 +1104,18 @@ fn native_histogram_range_histogram(
             continue;
         };
         let histogram = match kind {
-            NativeHistogramRangeHistogramKind::Sum => {
-                range_sum_histograms(samples, func_name, &collector)
-            }
-            NativeHistogramRangeHistogramKind::Avg => {
-                let count = samples.len();
-                range_sum_histograms(samples, func_name, &collector)
-                    .map(|histogram| histogram.divide_by(count as f64))
-            }
+            NativeHistogramRangeHistogramKind::Sum => range_fold_histograms(
+                samples,
+                NativeHistogramAggregateKind::Sum,
+                func_name,
+                &collector,
+            ),
+            NativeHistogramRangeHistogramKind::Avg => range_fold_histograms(
+                samples,
+                NativeHistogramAggregateKind::Avg,
+                func_name,
+                &collector,
+            ),
             NativeHistogramRangeHistogramKind::Last => samples.last().cloned(),
         };
         result.push(histogram);
@@ -2113,7 +2205,7 @@ impl DfAccumulator for NativeHistogramAggregateAccumulator {
             let Some(histogram) = read_histogram(histograms, row)? else {
                 continue;
             };
-            self.push_histogram(histogram, 1);
+            self.push_histogram(histogram, 1)?;
         }
 
         Ok(())
@@ -2125,7 +2217,7 @@ impl DfAccumulator for NativeHistogramAggregateAccumulator {
             (_, false, None) => None,
             (NativeHistogramAggregateKind::Sum, false, value) => value,
             (NativeHistogramAggregateKind::Avg, false, Some(value)) if self.count > 0 => {
-                Some(value.divide_by(self.count as f64))
+                Some(value)
             }
             (NativeHistogramAggregateKind::Avg, _, _) => None,
         };
@@ -2229,7 +2321,7 @@ impl DfAccumulator for NativeHistogramAggregateAccumulator {
                 continue;
             };
             let count = counts.map(|counts| counts.value(row)).unwrap_or(1);
-            self.push_histogram(histogram, count);
+            self.push_histogram(histogram, count)?;
         }
 
         Ok(())
@@ -2799,6 +2891,15 @@ mod tests {
         read_histogram(&array, 0).unwrap().unwrap()
     }
 
+    fn evaluated_histogram(
+        accumulator: &mut NativeHistogramAggregateAccumulator,
+    ) -> NativeHistogram {
+        let ScalarValue::Struct(array) = accumulator.evaluate().unwrap() else {
+            panic!("native histogram accumulator returned a non-struct value");
+        };
+        read_histogram(&array, 0).unwrap().unwrap()
+    }
+
     fn histogram_range_input(values: Vec<Option<NativeHistogram>>) -> Vec<ColumnarValue> {
         let timestamps = Arc::new(TimestampMillisecondArray::from_iter(
             (0..values.len()).map(|idx| Some((idx as i64 + 1) * 1000)),
@@ -3196,6 +3297,80 @@ mod tests {
     }
 
     #[test]
+    fn histogram_averages_avoid_sum_overflow() {
+        let large = sample_histogram(1.0e308, 1.0e308, vec![1.0e308]);
+
+        let range_average = run_histogram_range_udf(
+            NativeHistogramAvgOverTime::scalar_udf(),
+            vec![large.clone(), large.clone()],
+        );
+        assert_eq!(range_average.count, 1.0e308);
+        assert_eq!(range_average.sum, 1.0e308);
+        assert_eq!(range_average.positive_buckets, vec![1.0e308]);
+
+        let mut aggregate =
+            NativeHistogramAggregateAccumulator::new(NativeHistogramAggregateKind::Avg, None);
+        aggregate.push_histogram(large.clone(), 1).unwrap();
+        aggregate.push_histogram(large, 1).unwrap();
+        let aggregate_average = evaluated_histogram(&mut aggregate);
+        assert_eq!(aggregate_average.count, 1.0e308);
+        assert_eq!(aggregate_average.sum, 1.0e308);
+        assert_eq!(aggregate_average.positive_buckets, vec![1.0e308]);
+    }
+
+    #[test]
+    fn histogram_average_partial_states_are_weighted() {
+        let mut first =
+            NativeHistogramAggregateAccumulator::new(NativeHistogramAggregateKind::Avg, None);
+        first
+            .push_histogram(sample_histogram(1.0, 1.0, vec![1.0]), 1)
+            .unwrap();
+        first
+            .push_histogram(sample_histogram(3.0, 3.0, vec![3.0]), 1)
+            .unwrap();
+        let first_state = first
+            .state()
+            .unwrap()
+            .into_iter()
+            .map(|value| value.to_array_of_size(1).unwrap())
+            .collect::<Vec<_>>();
+
+        let mut second =
+            NativeHistogramAggregateAccumulator::new(NativeHistogramAggregateKind::Avg, None);
+        second
+            .push_histogram(sample_histogram(8.0, 8.0, vec![8.0]), 1)
+            .unwrap();
+        let second_state = second
+            .state()
+            .unwrap()
+            .into_iter()
+            .map(|value| value.to_array_of_size(1).unwrap())
+            .collect::<Vec<_>>();
+
+        let mut merged =
+            NativeHistogramAggregateAccumulator::new(NativeHistogramAggregateKind::Avg, None);
+        merged.merge_batch(&first_state).unwrap();
+        merged.merge_batch(&second_state).unwrap();
+        let average = evaluated_histogram(&mut merged);
+        assert_eq!(average.count, 4.0);
+        assert_eq!(average.sum, 4.0);
+        assert_eq!(average.positive_buckets, vec![4.0]);
+    }
+
+    #[test]
+    fn histogram_average_rejects_sample_count_overflow() {
+        let mut aggregate =
+            NativeHistogramAggregateAccumulator::new(NativeHistogramAggregateKind::Avg, None);
+        aggregate.value = Some(sample_histogram(1.0, 1.0, vec![1.0]));
+        aggregate.count = u64::MAX;
+
+        let error = aggregate
+            .push_histogram(sample_histogram(1.0, 1.0, vec![1.0]), 1)
+            .unwrap_err();
+        assert!(error.to_string().contains("sample count overflow"));
+    }
+
+    #[test]
     fn presence_only_range_functions_preserve_null_semantics() {
         let first = sample_histogram(1.0, 1.0, vec![1.0]);
         let second = sample_histogram(2.0, 2.0, vec![2.0]);
@@ -3343,8 +3518,9 @@ mod tests {
 
         let range_collector = PromqlAnnotationCollector::default();
         assert!(
-            range_sum_histograms(
+            range_fold_histograms(
                 vec![reset.clone(), unknown.clone(), not_reset.clone()],
+                NativeHistogramAggregateKind::Sum,
                 NativeHistogramSumOverTime::name(),
                 &Some(range_collector.clone()),
             )
@@ -3360,8 +3536,8 @@ mod tests {
             NativeHistogramAggregateKind::Avg,
         ] {
             let mut first_partial = NativeHistogramAggregateAccumulator::new(kind, None);
-            first_partial.push_histogram(reset.clone(), 1);
-            first_partial.push_histogram(unknown.clone(), 1);
+            first_partial.push_histogram(reset.clone(), 1).unwrap();
+            first_partial.push_histogram(unknown.clone(), 1).unwrap();
             let first_states = first_partial
                 .state()
                 .unwrap()
@@ -3370,7 +3546,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             let mut second_partial = NativeHistogramAggregateAccumulator::new(kind, None);
-            second_partial.push_histogram(not_reset.clone(), 1);
+            second_partial.push_histogram(not_reset.clone(), 1).unwrap();
             let second_states = second_partial
                 .state()
                 .unwrap()
@@ -3402,7 +3578,7 @@ mod tests {
             NativeHistogramAggregateAccumulator::new(NativeHistogramAggregateKind::Sum, None);
         let empty_size = accumulator.size();
 
-        accumulator.push_histogram(histogram, 1);
+        accumulator.push_histogram(histogram, 1).unwrap();
 
         assert!(heap_size > 0);
         assert_eq!(accumulator.size(), empty_size + heap_size);

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -74,8 +74,8 @@ use promql::functions::{
     NativeHistogramNotEq, NativeHistogramPresentOverTime, NativeHistogramQuantile,
     NativeHistogramRate, NativeHistogramResets, NativeHistogramScalarMul, NativeHistogramStddev,
     NativeHistogramStdvar, NativeHistogramSub, NativeHistogramSum, NativeHistogramSumOverTime,
-    NativeHistogramToString, PredictLinear, PresentOverTime, QuantileOverTime, Rate, Resets, Round,
-    StddevOverTime, StdvarOverTime, SumOverTime, quantile_udaf,
+    NativeHistogramToString, PredictLinear, PresentOverTime, PromqlFloatToString, QuantileOverTime,
+    Rate, Resets, Round, StddevOverTime, StdvarOverTime, SumOverTime, quantile_udaf,
 };
 use promql_parser::label::{METRIC_NAME, MatchOp, Matcher, Matchers};
 use promql_parser::parser::token::TokenType;
@@ -4343,9 +4343,9 @@ impl PromPlanner {
             DfExpr::ScalarFunction(ScalarFunction {
                 func: coalesce(),
                 args: vec![
-                    DfExpr::Cast(Cast {
-                        expr: Box::new(float_input.clone()),
-                        data_type: ArrowDataType::Utf8,
+                    DfExpr::ScalarFunction(ScalarFunction {
+                        func: Arc::new(PromqlFloatToString::scalar_udf()),
+                        args: vec![float_input.clone()],
                     }),
                     DfExpr::ScalarFunction(ScalarFunction {
                         func: Arc::new(NativeHistogramToString::scalar_udf()),
@@ -12825,6 +12825,28 @@ Projection: count(prometheus_tsdb_head_series.greptime_value) AS my_series, prom
             let mut actual = numeric_values(&batches, &value_column);
             actual.sort_by(f64::total_cmp);
             assert_eq!(actual, expected, "{query}");
+
+            if query.starts_with("count_values") {
+                let mut sample_labels = batches
+                    .iter()
+                    .flat_map(|batch| {
+                        batch
+                            .column_by_name("sample")
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<StringArray>()
+                            .unwrap()
+                            .iter()
+                            .flatten()
+                            .map(str::to_string)
+                    })
+                    .collect::<Vec<_>>();
+                sample_labels.sort();
+                let mut expected_labels =
+                    vec!["2".to_string(), direct_or_histogram().promql_string()];
+                expected_labels.sort();
+                assert_eq!(sample_labels, expected_labels);
+            }
         }
     }
 

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -48,6 +48,7 @@ use datafusion::sql::TableReference;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
 use datafusion_common::{DFSchema, NullEquality};
 use datafusion_expr::expr::WindowFunctionParams;
+use datafusion_expr::expr_fn::when;
 use datafusion_expr::utils::{conjunction, disjunction};
 use datafusion_expr::{
     ExprSchemable, Literal, Projection, SortExpr, TableScan, TableSource, col, lit,
@@ -64,17 +65,17 @@ use promql::extension_plan::{
 use promql::functions::{
     AbsentOverTime, AvgOverTime, Changes, CountOverTime, Delta, Deriv, DoubleExponentialSmoothing,
     IDelta, Increase, LastOverTime, MaxOverTime, MinOverTime, MixedRange,
-    NativeHistogramAbsentOverTime, NativeHistogramAdd, NativeHistogramAvg,
-    NativeHistogramAvgOverTime, NativeHistogramChanges, NativeHistogramCount,
-    NativeHistogramCountOverTime, NativeHistogramDelta, NativeHistogramDivScalar,
-    NativeHistogramDrop, NativeHistogramEq, NativeHistogramFraction, NativeHistogramIDelta,
-    NativeHistogramIRate, NativeHistogramIncrease, NativeHistogramLastOverTime,
-    NativeHistogramMulScalar, NativeHistogramNeg, NativeHistogramNotEq,
-    NativeHistogramPresentOverTime, NativeHistogramQuantile, NativeHistogramRate,
-    NativeHistogramResets, NativeHistogramScalarMul, NativeHistogramStddev, NativeHistogramStdvar,
-    NativeHistogramSub, NativeHistogramSum, NativeHistogramSumOverTime, PredictLinear,
-    PresentOverTime, QuantileOverTime, Rate, Resets, Round, StddevOverTime, StdvarOverTime,
-    SumOverTime, quantile_udaf,
+    NativeHistogramAbsentOverTime, NativeHistogramAdd, NativeHistogramAggAvg,
+    NativeHistogramAggSum, NativeHistogramAvg, NativeHistogramAvgOverTime, NativeHistogramChanges,
+    NativeHistogramCount, NativeHistogramCountOverTime, NativeHistogramDelta,
+    NativeHistogramDivScalar, NativeHistogramDrop, NativeHistogramEq, NativeHistogramFraction,
+    NativeHistogramIDelta, NativeHistogramIRate, NativeHistogramIncrease,
+    NativeHistogramLastOverTime, NativeHistogramMulScalar, NativeHistogramNeg,
+    NativeHistogramNotEq, NativeHistogramPresentOverTime, NativeHistogramQuantile,
+    NativeHistogramRate, NativeHistogramResets, NativeHistogramScalarMul, NativeHistogramStddev,
+    NativeHistogramStdvar, NativeHistogramSub, NativeHistogramSum, NativeHistogramSumOverTime,
+    NativeHistogramToString, PredictLinear, PresentOverTime, QuantileOverTime, Rate, Resets, Round,
+    StddevOverTime, StdvarOverTime, SumOverTime, quantile_udaf,
 };
 use promql_parser::label::{METRIC_NAME, MatchOp, Matcher, Matchers};
 use promql_parser::parser::token::TokenType;
@@ -654,6 +655,16 @@ impl PromPlanner {
                 // calculate columns to group by
                 // Need to append time index column into group by columns
                 let mut group_exprs = self.agg_modifier_to_col(input.schema(), modifier, true)?;
+                let mixed_sample_columns =
+                    Self::alternative_sample_columns(input.schema(), &self.ctx.field_columns)
+                        .map(|(float, histogram)| (float.to_string(), histogram.to_string()));
+                // Aggregates over native histogram inputs may drop every sample in a group
+                // (e.g. `min` over histogram-only samples, or `sum` over histograms with
+                // incompatible schemas) and leave a NULL-valued group row behind. Compute this
+                // before `create_aggregate_exprs` mutates `ctx.field_columns`.
+                let preserve_any_value = mixed_sample_columns.is_some();
+                let has_native_histogram = preserve_any_value
+                    || self.all_field_columns_are_native_histograms(input.schema());
                 // convert op and value columns to aggregate exprs
                 let (mut aggr_exprs, prev_field_exprs) =
                     self.create_aggregate_exprs(*op, param, &input)?;
@@ -699,6 +710,59 @@ impl PromPlanner {
                         .context(DataFusionPlanningSnafu)?
                 };
 
+                let builder = if let Some((float, histogram)) = mixed_sample_columns {
+                    let builder = match op.id() {
+                        token::T_SUM | token::T_AVG => builder
+                            .filter(self.mixed_aggregate_filter_expr(*op, &float, &histogram)?)
+                            .context(DataFusionPlanningSnafu)?,
+                        token::T_MIN
+                        | token::T_MAX
+                        | token::T_STDDEV
+                        | token::T_STDVAR
+                        | token::T_QUANTILE => builder
+                            .filter(self.mixed_ignored_histogram_filter_expr(*op, &histogram)?)
+                            .context(DataFusionPlanningSnafu)?,
+                        _ => builder,
+                    };
+
+                    match op.id() {
+                        token::T_SUM
+                        | token::T_AVG
+                        | token::T_MIN
+                        | token::T_MAX
+                        | token::T_STDDEV
+                        | token::T_STDVAR
+                        | token::T_QUANTILE => {
+                            let project_fields = self
+                                .create_field_column_exprs()?
+                                .into_iter()
+                                .chain(self.create_tag_column_exprs()?)
+                                .chain(self.ctx.use_tsid.then_some(DfExpr::Column(
+                                    Column::from_name(DATA_SCHEMA_TSID_COLUMN_NAME),
+                                )))
+                                .chain(Some(self.create_time_index_column_expr()?));
+                            builder
+                                .project(project_fields)
+                                .context(DataFusionPlanningSnafu)?
+                        }
+                        _ => builder,
+                    }
+                } else {
+                    builder
+                };
+
+                // Drop group rows whose every aggregated sample was discarded (NULL), so that
+                // e.g. `group(min(native_histogram))` doesn't resurrect groups Prometheus
+                // considers unseen. For alternative float/histogram fields keep the row if any
+                // field survived.
+                let builder = if has_native_histogram {
+                    builder
+                        .filter(self.create_empty_values_filter_expr(preserve_any_value)?)
+                        .context(DataFusionPlanningSnafu)?
+                } else {
+                    builder
+                };
+
                 let sort_expr = group_exprs.into_iter().map(|expr| expr.sort(true, false));
 
                 builder
@@ -730,6 +794,32 @@ impl PromPlanner {
         self.ctx.use_tsid = input_has_tsid;
 
         let group_exprs = self.agg_modifier_to_col(input.schema(), modifier, false)?;
+
+        let mut input = input;
+        if let Some((float_column, histogram_column)) =
+            Self::alternative_sample_columns(input.schema(), &self.ctx.field_columns)
+                .map(|(float, histogram)| (float.to_string(), histogram.to_string()))
+        {
+            let drop_histogram = DfExpr::ScalarFunction(ScalarFunction {
+                func: Arc::new(NativeHistogramDrop::bool_false_udf(
+                    format!(
+                        "{}: dropped native histogram samples because this aggregation is not supported for native histograms",
+                        op
+                    ),
+                    self.promql_annotations.clone(),
+                )),
+                args: vec![col(&histogram_column)],
+            });
+            let keep_float = when(col(&histogram_column).is_not_null(), drop_histogram)
+                .otherwise(col(&float_column).is_not_null())
+                .context(DataFusionPlanningSnafu)?;
+            input = LogicalPlanBuilder::from(input)
+                .filter(keep_float)
+                .context(DataFusionPlanningSnafu)?
+                .build()
+                .context(DataFusionPlanningSnafu)?;
+            self.ctx.field_columns = vec![float_column];
+        }
 
         if self.all_field_columns_are_native_histograms(input.schema()) {
             let promql_annotations = self.promql_annotations.clone();
@@ -4123,9 +4213,11 @@ impl PromPlanner {
         param: &Option<Box<PromExpr>>,
         input_plan: &LogicalPlan,
     ) -> Result<(Vec<DfExpr>, Vec<DfExpr>)> {
-        let mut non_col_args = Vec::new();
+        let mixed_sample_columns =
+            Self::alternative_sample_columns(input_plan.schema(), &self.ctx.field_columns)
+                .map(|(float, histogram)| (float.to_string(), histogram.to_string()));
         let is_group_agg = op.id() == token::T_GROUP;
-        if is_group_agg {
+        if is_group_agg && mixed_sample_columns.is_none() {
             ensure!(
                 self.ctx.field_columns.len() == 1,
                 MultiFieldsNotSupportedSnafu {
@@ -4133,46 +4225,28 @@ impl PromPlanner {
                 }
             );
         }
-        let aggr = match op.id() {
-            token::T_SUM => sum_udaf(),
-            token::T_QUANTILE => {
-                let q =
-                    Self::get_param_as_literal_expr(param, Some(op), Some(ArrowDataType::Float64))?;
-                non_col_args.push(q);
-                quantile_udaf()
-            }
-            token::T_AVG => avg_udaf(),
-            token::T_COUNT_VALUES | token::T_COUNT => count_udaf(),
-            token::T_MIN => min_udaf(),
-            token::T_MAX => max_udaf(),
-            // PromQL's `group()` aggregator produces 1 for each group.
-            // Use `max(1.0)` (per-group) to match semantics and output type (Float64).
-            token::T_GROUP => max_udaf(),
-            token::T_STDDEV => stddev_pop_udaf(),
-            token::T_STDVAR => var_pop_udaf(),
-            token::T_TOPK | token::T_BOTTOMK => UnsupportedExprSnafu {
-                name: format!("{op:?}"),
-            }
-            .fail()?,
-            _ => UnexpectedTokenSnafu { token: op }.fail()?,
-        };
+
+        if let Some((float, histogram)) = mixed_sample_columns {
+            return self.create_mixed_aggregate_exprs(op, param, &float, &histogram);
+        }
+
+        if self.all_field_columns_are_native_histograms(input_plan.schema()) {
+            return self.create_native_histogram_aggregate_exprs(op, input_plan);
+        }
 
         // perform aggregate operation to each value column
-        let exprs: Vec<DfExpr> = self
+        let exprs = self
             .ctx
             .field_columns
             .iter()
             .map(|col| {
-                if is_group_agg {
-                    aggr.call(vec![lit(1_f64)])
-                } else {
-                    non_col_args.push(DfExpr::Column(Column::from_name(col)));
-                    let expr = aggr.call(non_col_args.clone());
-                    non_col_args.pop();
-                    expr
-                }
+                Self::create_numeric_aggregate_expr(
+                    op,
+                    param,
+                    DfExpr::Column(Column::from_name(col)),
+                )
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
 
         // if the aggregator is `count_values`, it must be grouped by current fields.
         let prev_field_exprs = if op.id() == token::T_COUNT_VALUES {
@@ -4204,6 +4278,273 @@ impl PromPlanner {
             new_field_columns.push(expr.schema_name().to_string());
         }
         self.ctx.field_columns = new_field_columns;
+
+        Ok((exprs, prev_field_exprs))
+    }
+
+    fn create_numeric_aggregate_expr(
+        op: TokenType,
+        param: &Option<Box<PromExpr>>,
+        input: DfExpr,
+    ) -> Result<DfExpr> {
+        let expr = match op.id() {
+            token::T_SUM => sum_udaf().call(vec![input]),
+            token::T_QUANTILE => {
+                let q =
+                    Self::get_param_as_literal_expr(param, Some(op), Some(ArrowDataType::Float64))?;
+                quantile_udaf().call(vec![q, input])
+            }
+            token::T_AVG => avg_udaf().call(vec![input]),
+            token::T_COUNT_VALUES | token::T_COUNT => count_udaf().call(vec![input]),
+            token::T_MIN => min_udaf().call(vec![input]),
+            token::T_MAX => max_udaf().call(vec![input]),
+            // PromQL's `group()` aggregator produces 1 for each group.
+            // Use `max(1.0)` (per-group) to match semantics and output type (Float64).
+            token::T_GROUP => max_udaf().call(vec![lit(1_f64)]),
+            token::T_STDDEV => stddev_pop_udaf().call(vec![input]),
+            token::T_STDVAR => var_pop_udaf().call(vec![input]),
+            token::T_TOPK | token::T_BOTTOMK => {
+                return UnsupportedExprSnafu {
+                    name: format!("{op:?}"),
+                }
+                .fail();
+            }
+            _ => return UnexpectedTokenSnafu { token: op }.fail(),
+        };
+        Ok(expr)
+    }
+
+    fn create_mixed_aggregate_exprs(
+        &mut self,
+        op: TokenType,
+        param: &Option<Box<PromExpr>>,
+        float_column: &str,
+        histogram_column: &str,
+    ) -> Result<(Vec<DfExpr>, Vec<DfExpr>)> {
+        let float_input = DfExpr::Column(Column::from_name(float_column));
+        let histogram_input = DfExpr::Column(Column::from_name(histogram_column));
+        let float_count = count_udaf().call(vec![float_input.clone()]);
+        let histogram_count = count_udaf().call(vec![histogram_input.clone()]);
+
+        let (exprs, prev_field_exprs, field_columns) = match op.id() {
+            token::T_SUM | token::T_AVG => (
+                vec![
+                    Self::create_numeric_aggregate_expr(op, param, float_input)?
+                        .alias(float_column),
+                    self.create_native_histogram_aggregate_expr(op, histogram_column)?,
+                    float_count.alias(Self::mixed_sample_count_name(float_column)),
+                    histogram_count.alias(Self::mixed_sample_count_name(histogram_column)),
+                ],
+                vec![],
+                vec![float_column.to_string(), histogram_column.to_string()],
+            ),
+            token::T_COUNT => (
+                vec![
+                    DfExpr::BinaryExpr(BinaryExpr {
+                        left: Box::new(float_count),
+                        op: Operator::Plus,
+                        right: Box::new(histogram_count),
+                    })
+                    .alias(float_column),
+                ],
+                vec![],
+                vec![float_column.to_string()],
+            ),
+            token::T_GROUP => (
+                vec![max_udaf().call(vec![lit(1_f64)]).alias(float_column)],
+                vec![],
+                vec![float_column.to_string()],
+            ),
+            token::T_COUNT_VALUES => {
+                let value = DfExpr::ScalarFunction(ScalarFunction {
+                    func: coalesce(),
+                    args: vec![
+                        DfExpr::Cast(Cast {
+                            expr: Box::new(float_input.clone()),
+                            data_type: ArrowDataType::Utf8,
+                        }),
+                        DfExpr::ScalarFunction(ScalarFunction {
+                            func: Arc::new(NativeHistogramToString::scalar_udf()),
+                            args: vec![histogram_input.clone()],
+                        }),
+                    ],
+                });
+                (
+                    vec![
+                        DfExpr::BinaryExpr(BinaryExpr {
+                            left: Box::new(float_count),
+                            op: Operator::Plus,
+                            right: Box::new(histogram_count),
+                        })
+                        .alias(float_column),
+                    ],
+                    vec![value],
+                    vec![float_column.to_string()],
+                )
+            }
+            token::T_MIN | token::T_MAX | token::T_STDDEV | token::T_STDVAR | token::T_QUANTILE => {
+                (
+                    vec![
+                        Self::create_numeric_aggregate_expr(op, param, float_input)?
+                            .alias(float_column),
+                        histogram_count.alias(Self::mixed_sample_count_name(histogram_column)),
+                    ],
+                    vec![],
+                    vec![float_column.to_string()],
+                )
+            }
+            token::T_TOPK | token::T_BOTTOMK => {
+                return UnsupportedExprSnafu {
+                    name: format!("{op:?}"),
+                }
+                .fail();
+            }
+            _ => return UnexpectedTokenSnafu { token: op }.fail(),
+        };
+
+        self.ctx.field_columns = field_columns;
+        Ok((exprs, prev_field_exprs))
+    }
+
+    fn mixed_sample_count_column(column: &str) -> DfExpr {
+        DfExpr::Column(Column::from_name(Self::mixed_sample_count_name(column)))
+    }
+
+    fn mixed_sample_count_name(column: &str) -> String {
+        format!("__promql_sample_count({column})")
+    }
+
+    fn mixed_aggregate_filter_expr(
+        &self,
+        op: TokenType,
+        float_column: &str,
+        histogram_column: &str,
+    ) -> Result<DfExpr> {
+        let float_count = Self::mixed_sample_count_column(float_column);
+        let histogram_count = Self::mixed_sample_count_column(histogram_column);
+        let mixed = float_count
+            .clone()
+            .gt(lit(0_i64))
+            .and(histogram_count.clone().gt(lit(0_i64)));
+        let drop_mixed = DfExpr::ScalarFunction(ScalarFunction {
+            func: Arc::new(NativeHistogramDrop::warning_bool_false_udf(
+                format!(
+                    "{op}: dropped aggregation result containing both float and native histogram samples"
+                ),
+                self.promql_annotations.clone(),
+            )),
+            args: vec![float_count, histogram_count],
+        });
+
+        when(mixed, drop_mixed)
+            .otherwise(lit(true))
+            .context(DataFusionPlanningSnafu)
+    }
+
+    fn mixed_ignored_histogram_filter_expr(
+        &self,
+        op: TokenType,
+        histogram_column: &str,
+    ) -> Result<DfExpr> {
+        let histogram_count = Self::mixed_sample_count_column(histogram_column);
+        let has_histograms = histogram_count.clone().gt(lit(0_i64));
+        let record_info = DfExpr::ScalarFunction(ScalarFunction {
+            func: Arc::new(NativeHistogramDrop::bool_true_udf(
+                format!(
+                    "{op}: dropped native histogram samples because this aggregation is not supported for native histograms"
+                ),
+                self.promql_annotations.clone(),
+            )),
+            args: vec![histogram_count],
+        });
+
+        when(has_histograms, record_info)
+            .otherwise(lit(true))
+            .context(DataFusionPlanningSnafu)
+    }
+
+    fn create_native_histogram_aggregate_expr(
+        &self,
+        op: TokenType,
+        column: &str,
+    ) -> Result<DfExpr> {
+        let input = DfExpr::Column(Column::from_name(column));
+        let expr = match op.id() {
+            token::T_SUM => Arc::new(NativeHistogramAggSum::aggregate_udf_with_collector(
+                self.promql_annotations.clone(),
+            ))
+            .call(vec![input])
+            .alias(column),
+            token::T_AVG => Arc::new(NativeHistogramAggAvg::aggregate_udf_with_collector(
+                self.promql_annotations.clone(),
+            ))
+            .call(vec![input])
+            .alias(column),
+            token::T_COUNT_VALUES | token::T_COUNT => {
+                count_udaf().call(vec![input]).alias(column)
+            }
+            token::T_GROUP => max_udaf().call(vec![lit(1_f64)]).alias(column),
+            token::T_MIN
+            | token::T_MAX
+            | token::T_STDDEV
+            | token::T_STDVAR
+            | token::T_QUANTILE
+            | token::T_TOPK
+            | token::T_BOTTOMK => sum_udaf()
+                .call(vec![DfExpr::ScalarFunction(ScalarFunction {
+                    func: Arc::new(NativeHistogramDrop::float_null_udf(
+                        format!(
+                            "{op}: dropped native histogram samples because this aggregation is not supported for native histograms"
+                        ),
+                        self.promql_annotations.clone(),
+                    )),
+                    args: vec![input],
+                })])
+                .alias(column),
+            _ => return UnexpectedTokenSnafu { token: op }.fail(),
+        };
+        Ok(expr)
+    }
+
+    fn create_native_histogram_aggregate_exprs(
+        &mut self,
+        op: TokenType,
+        input_plan: &LogicalPlan,
+    ) -> Result<(Vec<DfExpr>, Vec<DfExpr>)> {
+        let prev_field_exprs = if op.id() == token::T_COUNT_VALUES {
+            ensure!(
+                self.ctx.field_columns.len() == 1,
+                UnsupportedExprSnafu {
+                    name: "count_values on multi-value input"
+                }
+            );
+            self.ctx
+                .field_columns
+                .iter()
+                .map(|col| {
+                    DfExpr::ScalarFunction(ScalarFunction {
+                        func: Arc::new(NativeHistogramToString::scalar_udf()),
+                        args: vec![DfExpr::Column(Column::from_name(col))],
+                    })
+                })
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        };
+
+        let exprs = self
+            .ctx
+            .field_columns
+            .iter()
+            .map(|col| self.create_native_histogram_aggregate_expr(op, col))
+            .collect::<Result<Vec<_>>>()?;
+
+        let normalized_exprs =
+            normalize_cols(exprs.iter().cloned(), input_plan).context(DataFusionPlanningSnafu)?;
+        self.ctx.field_columns = normalized_exprs
+            .into_iter()
+            .map(|expr| expr.schema_name().to_string())
+            .collect();
 
         Ok((exprs, prev_field_exprs))
     }
@@ -6346,7 +6687,7 @@ mod test {
     use common_base::Plugins;
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use common_query::native_histogram::{
-        CounterResetHint, NativeHistogram, build_histogram_array,
+        CUSTOM_BUCKETS_SCHEMA, CounterResetHint, NativeHistogram, build_histogram_array,
     };
     use common_query::prelude::{greptime_native_histogram, greptime_timestamp, greptime_value};
     use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
@@ -6877,6 +7218,65 @@ mod test {
                 &or_modifier("lhs or on(k) rhs"),
             )
             .unwrap();
+        (planner, plan)
+    }
+
+    async fn mixed_aggregate_input(histograms: Vec<NativeHistogram>) -> (PromPlanner, LogicalPlan) {
+        let float_field = format!("{OR_FLOAT_FIELD_PREFIX}0");
+        let histogram_field = format!("{OR_HISTOGRAM_FIELD_PREFIX}0");
+        let row_count = histograms.len() + 1;
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(
+                "ts",
+                ArrowDataType::Timestamp(ArrowTimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("k", ArrowDataType::Utf8, false),
+            Field::new(&float_field, ArrowDataType::Float64, true),
+            Field::new(
+                &histogram_field,
+                native_histogram_value_type().as_arrow_type(),
+                true,
+            ),
+        ]));
+        let mut histogram_values = Vec::with_capacity(row_count);
+        histogram_values.push(None);
+        histogram_values.extend(histograms.into_iter().map(Some));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![1; row_count])),
+                Arc::new(StringArray::from_iter_values(
+                    (0..row_count).map(|row| format!("kind_{row}")),
+                )),
+                Arc::new(Float64Array::from_iter(
+                    (0..row_count).map(|row| (row == 0).then_some(1.25)),
+                )),
+                build_histogram_array(&histogram_values),
+            ],
+        )
+        .unwrap();
+        let table = Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap());
+        let plan = LogicalPlanBuilder::scan("mixed", provider_as_source(table), None)
+            .unwrap()
+            .build()
+            .unwrap();
+        let table_provider = build_test_table_provider_with_fields(
+            &[(DEFAULT_SCHEMA_NAME.to_string(), "dummy".to_string())],
+            &[],
+        )
+        .await;
+        let planner = PromPlanner {
+            table_provider,
+            ctx: PromPlannerContext {
+                table_name: Some("mixed".to_string()),
+                time_index_column: Some("ts".to_string()),
+                field_columns: vec![float_field, histogram_field],
+                tag_columns: vec!["k".to_string()],
+                ..Default::default()
+            },
+            promql_annotations: None,
+        };
         (planner, plan)
     }
 
@@ -9813,6 +10213,50 @@ mod test {
     }
 
     #[tokio::test]
+    async fn mixed_or_topk_bottomk_ignore_native_histograms() {
+        for op in ["topk", "bottomk"] {
+            let collector = PromqlAnnotationCollector::default();
+            let state = build_query_engine_state();
+            let plan = PromPlanner::stmt_to_plan_with_annotations(
+                operator_table_provider(),
+                &operator_eval_stmt(&format!("{op}(1, lf or on(tag) lh)")),
+                &state,
+                Some(collector.clone()),
+            )
+            .await
+            .unwrap();
+            let float_field = plan
+                .schema()
+                .fields()
+                .iter()
+                .find(|field| field.data_type() == &ArrowDataType::Float64)
+                .unwrap()
+                .name()
+                .clone();
+            assert!(
+                plan.schema()
+                    .fields()
+                    .iter()
+                    .all(|field| field.data_type() != &PromPlanner::native_histogram_arrow_type()),
+                "{plan:?}"
+            );
+
+            let (_, batches) = execute(plan, &state).await;
+            assert_eq!(values(&batches, &float_field), vec![2.0], "{op}");
+            let mut warnings = vec![];
+            let mut infos = vec![];
+            collector.append_to(&mut warnings, &mut infos);
+            assert!(warnings.is_empty());
+            assert_eq!(
+                infos,
+                vec![format!(
+                    "{op}: dropped native histogram samples because this aggregation is not supported for native histograms"
+                )]
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn native_histogram_scalar_is_ignored_before_scalar_calculate() {
         let plan = native_histogram_plan("scalar(some_metric)").await;
 
@@ -10142,9 +10586,9 @@ mod test {
 
     #[tokio::test]
     async fn native_histogram_mixed_field_table_behaves() {
-        // Metric Engine exposes float and histogram samples as alternative nullable fields.
-        // Histogram functions must select the histogram field without adding a NULL float
-        // field that would make the empty-value filter reject every row.
+        // Exercise function planning after float and histogram samples have already been
+        // represented as alternative nullable fields. Histogram functions must select the
+        // histogram field without adding a NULL float field that would reject every row.
         let table_provider = build_test_mixed_native_histogram_table_provider("some_metric").await;
         let plan = PromPlanner::stmt_to_plan(
             table_provider,
@@ -11562,6 +12006,7 @@ Projection: count(prometheus_tsdb_head_series.greptime_value) AS my_series, prom
                 .contains("OR value fields have incompatible types")
         );
     }
+
     #[tokio::test]
     async fn test_or_with_histogram_quantile_missing_le_column() {
         let case = r#"histogram_quantile(0.99, non_existent_histogram_bucket) or normal_metric"#;
@@ -11899,6 +12344,55 @@ Projection: count(prometheus_tsdb_head_series.greptime_value) AS my_series, prom
     }
 
     #[tokio::test]
+    async fn test_histogram_only_min_drops_empty_aggregate_group() {
+        // `min` over native-histogram-only input drops every sample in the group, so the
+        // NULL-valued aggregate row must be filtered out. Otherwise an outer expression
+        // like `group()` resurrects the group Prometheus considers unseen.
+        let state = build_query_engine_state();
+        for query in ["min(lh)", "group(min(lh))"] {
+            let plan = PromPlanner::stmt_to_plan(
+                operator_table_provider(),
+                &operator_eval_stmt(query),
+                &state,
+            )
+            .await
+            .unwrap();
+            let (_, batches) = execute(plan, &state).await;
+            assert_eq!(
+                batches.iter().map(RecordBatch::num_rows).sum::<usize>(),
+                0,
+                "{query}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mixed_min_drops_histogram_only_group() {
+        // With alternative float/histogram fields, `min by (tag)` keeps float-only groups
+        // (tag=a from `lf`) and drops histogram-only groups (tag=b from `lh`) instead of
+        // emitting a NULL-valued row for them.
+        let state = build_query_engine_state();
+        let plan = PromPlanner::stmt_to_plan(
+            operator_table_provider(),
+            &operator_eval_stmt("min by (tag) (lf or on(tag) lh)"),
+            &state,
+        )
+        .await
+        .unwrap();
+        let float_field = plan
+            .schema()
+            .fields()
+            .iter()
+            .find(|field| field.data_type() == &ArrowDataType::Float64)
+            .unwrap()
+            .name()
+            .clone();
+        let (_, batches) = execute(plan, &state).await;
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        assert_eq!(values(&batches, &float_field), vec![2.0]);
+    }
+
+    #[tokio::test]
     async fn test_mixed_or_can_feed_another_or() {
         let state = build_query_engine_state();
         let plan = PromPlanner::stmt_to_plan(
@@ -12168,6 +12662,176 @@ Projection: count(prometheus_tsdb_head_series.greptime_value) AS my_series, prom
             assert_eq!(histogram.count, -1.0);
             assert_eq!(histogram.sum, -1.0);
             assert_eq!(histogram.reset_hint, CounterResetHint::Gauge);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_mixed_or_sum_aggregates_each_sample_type() {
+        let PromExpr::Aggregate(AggregateExpr { op, param, .. }) =
+            parser::parse("sum(lhs)").unwrap()
+        else {
+            unreachable!()
+        };
+
+        let collector = PromqlAnnotationCollector::default();
+        let (mut planner, input) = mixed_direct_or(false).await;
+        planner.promql_annotations = Some(collector.clone());
+        let float_column = planner.ctx.field_columns[0].clone();
+        let histogram_column = planner.ctx.field_columns[1].clone();
+        let (aggregate_exprs, _) = planner.create_aggregate_exprs(op, &param, &input).unwrap();
+        let plan = LogicalPlanBuilder::from(input)
+            .aggregate(vec![col("ts"), col("k")], aggregate_exprs)
+            .unwrap()
+            .filter(
+                planner
+                    .mixed_aggregate_filter_expr(op, &float_column, &histogram_column)
+                    .unwrap(),
+            )
+            .unwrap()
+            .project([
+                col(&float_column),
+                col(&histogram_column),
+                col("ts"),
+                col("k"),
+            ])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let (_, batches) = execute(plan, &build_query_engine_state()).await;
+        assert_eq!(values(&batches, &float_column), vec![1.25]);
+        let histogram = batches
+            .iter()
+            .find_map(|batch| {
+                let values = batch
+                    .column_by_name(&histogram_column)?
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::StructArray>()?;
+                (0..values.len()).find_map(|row| {
+                    common_query::native_histogram::read_histogram(values, row).unwrap()
+                })
+            })
+            .unwrap();
+        assert_eq!(histogram.count, 1.0);
+        let mut warnings = vec![];
+        let mut infos = vec![];
+        collector.append_to(&mut warnings, &mut infos);
+        assert!(warnings.is_empty());
+
+        let collector = PromqlAnnotationCollector::default();
+        let (mut planner, input) = mixed_direct_or(false).await;
+        planner.promql_annotations = Some(collector.clone());
+        let float_column = planner.ctx.field_columns[0].clone();
+        let histogram_column = planner.ctx.field_columns[1].clone();
+        let (aggregate_exprs, _) = planner.create_aggregate_exprs(op, &param, &input).unwrap();
+        let plan = LogicalPlanBuilder::from(input)
+            .aggregate(vec![col("ts")], aggregate_exprs)
+            .unwrap()
+            .filter(
+                planner
+                    .mixed_aggregate_filter_expr(op, &float_column, &histogram_column)
+                    .unwrap(),
+            )
+            .unwrap()
+            .project([col(&float_column), col(&histogram_column), col("ts")])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let (_, batches) = execute(plan, &build_query_engine_state()).await;
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0);
+        let mut warnings = vec![];
+        let mut infos = vec![];
+        collector.append_to(&mut warnings, &mut infos);
+        assert_eq!(
+            warnings,
+            vec![
+                "sum: dropped aggregation result containing both float and native histogram samples"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mixed_or_sum_drops_incompatible_mixed_group() {
+        let PromExpr::Aggregate(AggregateExpr { op, param, .. }) =
+            parser::parse("sum(lhs)").unwrap()
+        else {
+            unreachable!()
+        };
+        let mut custom = direct_or_histogram();
+        custom.schema = CUSTOM_BUCKETS_SCHEMA;
+        custom.custom_values = vec![1.0];
+        let collector = PromqlAnnotationCollector::default();
+        let (mut planner, input) = mixed_aggregate_input(vec![direct_or_histogram(), custom]).await;
+        planner.promql_annotations = Some(collector.clone());
+        let float_column = planner.ctx.field_columns[0].clone();
+        let histogram_column = planner.ctx.field_columns[1].clone();
+        let (aggregate_exprs, _) = planner.create_aggregate_exprs(op, &param, &input).unwrap();
+        let plan = LogicalPlanBuilder::from(input)
+            .aggregate(vec![col("ts")], aggregate_exprs)
+            .unwrap()
+            .filter(
+                planner
+                    .mixed_aggregate_filter_expr(op, &float_column, &histogram_column)
+                    .unwrap(),
+            )
+            .unwrap()
+            .project([col(&float_column), col(&histogram_column), col("ts")])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let (_, batches) = execute(plan, &build_query_engine_state()).await;
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0);
+        let mut warnings = vec![];
+        let mut infos = vec![];
+        collector.append_to(&mut warnings, &mut infos);
+        assert!(warnings.iter().any(|warning| {
+            warning
+                == "sum: dropped aggregation result containing both float and native histogram samples"
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_mixed_or_min_records_only_present_histograms() {
+        let PromExpr::Aggregate(AggregateExpr { op, param, .. }) =
+            parser::parse("min(lhs)").unwrap()
+        else {
+            unreachable!()
+        };
+        let expected_info = "min: dropped native histogram samples because this aggregation is not supported for native histograms";
+
+        for (histograms, expected_infos) in [
+            (vec![], vec![]),
+            (vec![direct_or_histogram()], vec![expected_info]),
+        ] {
+            let collector = PromqlAnnotationCollector::default();
+            let (mut planner, input) = mixed_aggregate_input(histograms).await;
+            planner.promql_annotations = Some(collector.clone());
+            let float_column = planner.ctx.field_columns[0].clone();
+            let histogram_column = planner.ctx.field_columns[1].clone();
+            let (aggregate_exprs, _) = planner.create_aggregate_exprs(op, &param, &input).unwrap();
+            let plan = LogicalPlanBuilder::from(input)
+                .aggregate(vec![col("ts")], aggregate_exprs)
+                .unwrap()
+                .filter(
+                    planner
+                        .mixed_ignored_histogram_filter_expr(op, &histogram_column)
+                        .unwrap(),
+                )
+                .unwrap()
+                .project([col(&float_column), col("ts")])
+                .unwrap()
+                .build()
+                .unwrap();
+
+            let (_, batches) = execute(plan, &build_query_engine_state()).await;
+            assert_eq!(values(&batches, &float_column), vec![1.25]);
+            let mut warnings = vec![];
+            let mut infos = vec![];
+            collector.append_to(&mut warnings, &mut infos);
+            assert!(warnings.is_empty());
+            assert_eq!(infos, expected_infos);
         }
     }
 

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -668,6 +668,8 @@ impl PromPlanner {
                 // convert op and value columns to aggregate exprs
                 let (mut aggr_exprs, prev_field_exprs) =
                     self.create_aggregate_exprs(*op, param, &input)?;
+                let prev_field_exprs =
+                    normalize_cols(prev_field_exprs, &input).context(DataFusionPlanningSnafu)?;
 
                 let keep_tsid = op.id() != token::T_COUNT_VALUES
                     && input_has_tsid
@@ -691,16 +693,28 @@ impl PromPlanner {
                     let label = Self::get_param_value_as_str(*op, param)?;
                     // `count_values` must be grouped by fields,
                     // and project the fields to the new label.
-                    group_exprs.extend(prev_field_exprs.clone());
+                    let count_value_exprs = prev_field_exprs.iter().map(|expr| {
+                        match expr {
+                            DfExpr::Column(column) => DfExpr::Column(column.clone()),
+                            _ => DfExpr::Column(Column::from_name(expr.schema_name().to_string())),
+                        }
+                        .alias(label)
+                    });
+                    let aggregate_group_exprs = group_exprs
+                        .iter()
+                        .cloned()
+                        .chain(prev_field_exprs.clone())
+                        .collect::<Vec<_>>();
+                    group_exprs.push(col(label));
                     let project_fields = self
                         .create_field_column_exprs()?
                         .into_iter()
                         .chain(self.create_tag_column_exprs()?)
                         .chain(Some(self.create_time_index_column_expr()?))
-                        .chain(prev_field_exprs.into_iter().map(|expr| expr.alias(label)));
+                        .chain(count_value_exprs);
 
                     builder
-                        .aggregate(group_exprs.clone(), aggr_exprs)
+                        .aggregate(aggregate_group_exprs, aggr_exprs)
                         .context(DataFusionPlanningSnafu)?
                         .project(project_fields)
                         .context(DataFusionPlanningSnafu)?
@@ -4325,6 +4339,21 @@ impl PromPlanner {
         let histogram_input = DfExpr::Column(Column::from_name(histogram_column));
         let float_count = count_udaf().call(vec![float_input.clone()]);
         let histogram_count = count_udaf().call(vec![histogram_input.clone()]);
+        let mixed_sample_value = || {
+            DfExpr::ScalarFunction(ScalarFunction {
+                func: coalesce(),
+                args: vec![
+                    DfExpr::Cast(Cast {
+                        expr: Box::new(float_input.clone()),
+                        data_type: ArrowDataType::Utf8,
+                    }),
+                    DfExpr::ScalarFunction(ScalarFunction {
+                        func: Arc::new(NativeHistogramToString::scalar_udf()),
+                        args: vec![histogram_input.clone()],
+                    }),
+                ],
+            })
+        };
 
         let (exprs, prev_field_exprs, field_columns) = match op.id() {
             token::T_SUM | token::T_AVG => (
@@ -4338,46 +4367,31 @@ impl PromPlanner {
                 vec![],
                 vec![float_column.to_string(), histogram_column.to_string()],
             ),
-            token::T_COUNT => (
-                vec![
-                    DfExpr::BinaryExpr(BinaryExpr {
-                        left: Box::new(float_count),
-                        op: Operator::Plus,
-                        right: Box::new(histogram_count),
-                    })
-                    .alias(float_column),
-                ],
-                vec![],
-                vec![float_column.to_string()],
-            ),
+            token::T_COUNT => {
+                let present = when(
+                    float_input
+                        .clone()
+                        .is_not_null()
+                        .or(histogram_input.clone().is_not_null()),
+                    lit(1_i64),
+                )
+                .otherwise(lit(ScalarValue::Int64(None)))
+                .context(DataFusionPlanningSnafu)?;
+                (
+                    vec![count_udaf().call(vec![present]).alias(float_column)],
+                    vec![],
+                    vec![float_column.to_string()],
+                )
+            }
             token::T_GROUP => (
                 vec![max_udaf().call(vec![lit(1_f64)]).alias(float_column)],
                 vec![],
                 vec![float_column.to_string()],
             ),
             token::T_COUNT_VALUES => {
-                let value = DfExpr::ScalarFunction(ScalarFunction {
-                    func: coalesce(),
-                    args: vec![
-                        DfExpr::Cast(Cast {
-                            expr: Box::new(float_input.clone()),
-                            data_type: ArrowDataType::Utf8,
-                        }),
-                        DfExpr::ScalarFunction(ScalarFunction {
-                            func: Arc::new(NativeHistogramToString::scalar_udf()),
-                            args: vec![histogram_input.clone()],
-                        }),
-                    ],
-                });
+                let value = mixed_sample_value();
                 (
-                    vec![
-                        DfExpr::BinaryExpr(BinaryExpr {
-                            left: Box::new(float_count),
-                            op: Operator::Plus,
-                            right: Box::new(histogram_count),
-                        })
-                        .alias(float_column),
-                    ],
+                    vec![count_udaf().call(vec![value.clone()]).alias(float_column)],
                     vec![value],
                     vec![float_column.to_string()],
                 )
@@ -7306,6 +7320,26 @@ mod test {
             .collect()
     }
 
+    fn numeric_values(batches: &[RecordBatch], column: &str) -> Vec<f64> {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                let values = datafusion::arrow::compute::cast(
+                    batch.column_by_name(column).unwrap(),
+                    &ArrowDataType::Float64,
+                )
+                .unwrap();
+                values
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .unwrap()
+                    .iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
     fn histograms(batches: &[RecordBatch], column: &str) -> Vec<NativeHistogram> {
         batches
             .iter()
@@ -7725,18 +7759,41 @@ mod test {
         ];
         let schema = Arc::new(Schema::new(columns));
         let table_meta = TableMetaBuilder::empty()
-            .schema(schema)
+            .schema(schema.clone())
             .primary_key_indices(vec![0])
             .value_indices(vec![2, 3])
             .next_column_id(1024)
             .build()
             .unwrap();
-        let table_info = TableInfoBuilder::default()
-            .name(table_name)
-            .meta(table_meta)
-            .build()
-            .unwrap();
-        let table = EmptyTable::from_table_info(&table_info);
+        let table_info = Arc::new(
+            TableInfoBuilder::default()
+                .name(table_name)
+                .meta(table_meta)
+                .build()
+                .unwrap(),
+        );
+        let batch = RecordBatch::try_new(
+            schema.arrow_schema().clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["float", "histogram"])),
+                Arc::new(TimestampMillisecondArray::from(vec![1_000, 1_000])),
+                build_histogram_array(&[None, Some(direct_or_histogram())]),
+                Arc::new(Float64Array::from(vec![Some(2.0), None])),
+            ],
+        )
+        .unwrap();
+        let backing = GreptimeMemTable::new_with_catalog(
+            table_name,
+            GreptimeRecordBatch::from_df_record_batch(schema, batch),
+            1024,
+            DEFAULT_CATALOG_NAME.to_string(),
+            DEFAULT_SCHEMA_NAME.to_string(),
+        );
+        let table = Arc::new(Table::new(
+            table_info,
+            FilterPushDownType::Unsupported,
+            backing.data_source(),
+        ));
 
         assert!(
             catalog_list
@@ -11570,15 +11627,14 @@ Filter: up.field_0 IS NOT NULL [timestamp:Timestamp(ms), field_0:Float64;N, foo:
             PromPlanner::stmt_to_plan(table_provider, &eval_stmt, &build_query_engine_state())
                 .await
                 .unwrap();
-        let expected = "Projection: count(prometheus_tsdb_head_series.greptime_value), prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, series [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N]\
-        \n  Sort: prometheus_tsdb_head_series.ip ASC NULLS LAST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS LAST, prometheus_tsdb_head_series.greptime_value ASC NULLS LAST [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N, greptime_value:Float64;N]\
-        \n    Projection: count(prometheus_tsdb_head_series.greptime_value), prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value AS series, prometheus_tsdb_head_series.greptime_value [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N, greptime_value:Float64;N]\
-        \n      Aggregate: groupBy=[[prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value]], aggr=[[count(prometheus_tsdb_head_series.greptime_value)]] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N, count(prometheus_tsdb_head_series.greptime_value):Int64]\
-        \n        PromInstantManipulate: range=[0..100000000], lookback=[1000], interval=[5000], time index=[greptime_timestamp] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
-        \n          PromSeriesDivide: tags=[\"ip\"] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
-        \n            Sort: prometheus_tsdb_head_series.ip ASC NULLS FIRST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS FIRST [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
-        \n              Filter: prometheus_tsdb_head_series.ip ~ Utf8(\"^(?:(10.0.160.237:8080|10.0.160.237:9090))$\") AND prometheus_tsdb_head_series.greptime_timestamp >= TimestampMillisecond(-999, None) AND prometheus_tsdb_head_series.greptime_timestamp <= TimestampMillisecond(100000000, None) [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
-        \n                TableScan: prometheus_tsdb_head_series [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]";
+        let expected = "Sort: prometheus_tsdb_head_series.ip ASC NULLS LAST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS LAST, series ASC NULLS LAST [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N]\
+        \n  Projection: count(prometheus_tsdb_head_series.greptime_value), prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value AS series [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N]\
+        \n    Aggregate: groupBy=[[prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value]], aggr=[[count(prometheus_tsdb_head_series.greptime_value)]] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N, count(prometheus_tsdb_head_series.greptime_value):Int64]\
+        \n      PromInstantManipulate: range=[0..100000000], lookback=[1000], interval=[5000], time index=[greptime_timestamp] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
+        \n        PromSeriesDivide: tags=[\"ip\"] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
+        \n          Sort: prometheus_tsdb_head_series.ip ASC NULLS FIRST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS FIRST [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
+        \n            Filter: prometheus_tsdb_head_series.ip ~ Utf8(\"^(?:(10.0.160.237:8080|10.0.160.237:9090))$\") AND prometheus_tsdb_head_series.greptime_timestamp >= TimestampMillisecond(-999, None) AND prometheus_tsdb_head_series.greptime_timestamp <= TimestampMillisecond(100000000, None) [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]\
+        \n              TableScan: prometheus_tsdb_head_series [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]";
 
         assert_eq!(plan.display_indent_schema().to_string(), expected);
     }
@@ -11620,15 +11676,14 @@ Filter: up.field_0 IS NOT NULL [timestamp:Timestamp(ms), field_0:Float64;N, foo:
                 .unwrap();
         let expected = r#"
 Projection: count(prometheus_tsdb_head_series.greptime_value) AS my_series, prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp [my_series:Int64, ip:Utf8, greptime_timestamp:Timestamp(ms)]
-  Projection: count(prometheus_tsdb_head_series.greptime_value), prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, series [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N]
-    Sort: prometheus_tsdb_head_series.ip ASC NULLS LAST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS LAST, prometheus_tsdb_head_series.greptime_value ASC NULLS LAST [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N, greptime_value:Float64;N]
-      Projection: count(prometheus_tsdb_head_series.greptime_value), prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value AS series, prometheus_tsdb_head_series.greptime_value [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N, greptime_value:Float64;N]
-        Aggregate: groupBy=[[prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value]], aggr=[[count(prometheus_tsdb_head_series.greptime_value)]] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N, count(prometheus_tsdb_head_series.greptime_value):Int64]
-          PromInstantManipulate: range=[0..100000000], lookback=[1000], interval=[5000], time index=[greptime_timestamp] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
-            PromSeriesDivide: tags=["ip"] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
-              Sort: prometheus_tsdb_head_series.ip ASC NULLS FIRST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS FIRST [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
-                Filter: prometheus_tsdb_head_series.ip ~ Utf8("^(?:(10.0.160.237:8080|10.0.160.237:9090))$") AND prometheus_tsdb_head_series.greptime_timestamp >= TimestampMillisecond(-999, None) AND prometheus_tsdb_head_series.greptime_timestamp <= TimestampMillisecond(100000000, None) [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
-                  TableScan: prometheus_tsdb_head_series [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]"#;
+  Sort: prometheus_tsdb_head_series.ip ASC NULLS LAST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS LAST, series ASC NULLS LAST [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N]
+    Projection: count(prometheus_tsdb_head_series.greptime_value), prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value AS series [count(prometheus_tsdb_head_series.greptime_value):Int64, ip:Utf8, greptime_timestamp:Timestamp(ms), series:Float64;N]
+      Aggregate: groupBy=[[prometheus_tsdb_head_series.ip, prometheus_tsdb_head_series.greptime_timestamp, prometheus_tsdb_head_series.greptime_value]], aggr=[[count(prometheus_tsdb_head_series.greptime_value)]] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N, count(prometheus_tsdb_head_series.greptime_value):Int64]
+        PromInstantManipulate: range=[0..100000000], lookback=[1000], interval=[5000], time index=[greptime_timestamp] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
+          PromSeriesDivide: tags=["ip"] [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
+            Sort: prometheus_tsdb_head_series.ip ASC NULLS FIRST, prometheus_tsdb_head_series.greptime_timestamp ASC NULLS FIRST [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
+              Filter: prometheus_tsdb_head_series.ip ~ Utf8("^(?:(10.0.160.237:8080|10.0.160.237:9090))$") AND prometheus_tsdb_head_series.greptime_timestamp >= TimestampMillisecond(-999, None) AND prometheus_tsdb_head_series.greptime_timestamp <= TimestampMillisecond(100000000, None) [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]
+                TableScan: prometheus_tsdb_head_series [ip:Utf8, greptime_timestamp:Timestamp(ms), greptime_value:Float64;N]"#;
         assert_eq!(format!("\n{}", plan.display_indent_schema()), expected);
     }
 
@@ -12662,6 +12717,114 @@ Projection: count(prometheus_tsdb_head_series.greptime_value) AS my_series, prom
             assert_eq!(histogram.count, -1.0);
             assert_eq!(histogram.sum, -1.0);
             assert_eq!(histogram.reset_hint, CounterResetHint::Gauge);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_native_histogram_sum_and_avg_execute_real_batches() {
+        for op_name in ["sum", "avg"] {
+            for incompatible in [false, true] {
+                let mut second = direct_or_histogram();
+                if incompatible {
+                    second.schema = CUSTOM_BUCKETS_SCHEMA;
+                    second.custom_values = vec![1.0];
+                }
+                let collector = PromqlAnnotationCollector::default();
+                let (mut planner, input) =
+                    mixed_aggregate_input(vec![direct_or_histogram(), second]).await;
+                planner.promql_annotations = Some(collector.clone());
+                let histogram_column = planner.ctx.field_columns[1].clone();
+                planner.ctx.field_columns = vec![histogram_column.clone()];
+                let input = LogicalPlanBuilder::from(input)
+                    .project([col("ts"), col(&histogram_column)])
+                    .unwrap()
+                    .build()
+                    .unwrap();
+                let PromExpr::Aggregate(AggregateExpr { op, param, .. }) =
+                    parser::parse(&format!("{op_name}(mixed)")).unwrap()
+                else {
+                    unreachable!()
+                };
+                let (aggregate_exprs, _) =
+                    planner.create_aggregate_exprs(op, &param, &input).unwrap();
+                let plan = LogicalPlanBuilder::from(input)
+                    .aggregate(vec![col("ts")], aggregate_exprs)
+                    .unwrap()
+                    .filter(planner.create_empty_values_filter_expr(false).unwrap())
+                    .unwrap()
+                    .build()
+                    .unwrap();
+
+                let (_, batches) = execute(plan, &build_query_engine_state()).await;
+                let mut warnings = vec![];
+                let mut infos = vec![];
+                collector.append_to(&mut warnings, &mut infos);
+                assert!(infos.is_empty());
+                if incompatible {
+                    assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0);
+                    assert!(warnings.iter().any(|warning| {
+                        warning
+                            == &format!(
+                                "prom_native_histogram_agg_{op_name}: dropped native histogram aggregate with incompatible schemas"
+                            )
+                    }));
+                } else {
+                    let histograms = histograms(&batches, &histogram_column);
+                    assert_eq!(histograms.len(), 1);
+                    let expected = if op_name == "sum" { 2.0 } else { 1.0 };
+                    assert_eq!(histograms[0].count, expected);
+                    assert_eq!(histograms[0].sum, expected);
+                    assert!(warnings.is_empty());
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_canonical_mixed_count_group_and_count_values_execute() {
+        let state = build_query_engine_state();
+        for (query, expected) in [
+            ("count(some_metric)", vec![2.0]),
+            ("group(some_metric)", vec![1.0]),
+            (r#"count_values("sample", some_metric)"#, vec![1.0, 1.0]),
+        ] {
+            let plan = PromPlanner::stmt_to_plan(
+                build_test_mixed_native_histogram_table_provider("some_metric").await,
+                &operator_eval_stmt(query),
+                &state,
+            )
+            .await
+            .unwrap();
+            assert!(
+                plan.schema()
+                    .fields()
+                    .iter()
+                    .all(|field| !field.name().starts_with("__promql_sample_count")),
+                "{query}: {plan:?}"
+            );
+            let value_fields = plan
+                .schema()
+                .fields()
+                .iter()
+                .filter(|field| {
+                    matches!(
+                        field.data_type(),
+                        ArrowDataType::Float64 | ArrowDataType::Int64 | ArrowDataType::UInt64
+                    ) || field.data_type() == &native_histogram_value_type().as_arrow_type()
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(value_fields.len(), 1, "{query}: {plan:?}");
+            assert_ne!(
+                value_fields[0].data_type(),
+                &native_histogram_value_type().as_arrow_type(),
+                "{query}: {plan:?}"
+            );
+            let value_column = value_fields[0].name().clone();
+
+            let (_, batches) = execute(plan, &state).await;
+            let mut actual = numeric_values(&batches, &value_column);
+            actual.sort_by(f64::total_cmp);
+            assert_eq!(actual, expected, "{query}");
         }
     }
 

--- a/src/query/src/query_engine/default_serializer.rs
+++ b/src/query/src/query_engine/default_serializer.rs
@@ -40,8 +40,8 @@ use promql::functions::{
     NativeHistogramNotEq, NativeHistogramPresentOverTime, NativeHistogramQuantile,
     NativeHistogramRate, NativeHistogramResets, NativeHistogramScalarMul, NativeHistogramStddev,
     NativeHistogramStdvar, NativeHistogramSub, NativeHistogramSum, NativeHistogramSumOverTime,
-    NativeHistogramToString, PredictLinear, PresentOverTime, QuantileOverTime, Rate, Resets, Round,
-    StddevOverTime, StdvarOverTime, SumOverTime, quantile_udaf,
+    NativeHistogramToString, PredictLinear, PresentOverTime, PromqlFloatToString, QuantileOverTime,
+    Rate, Resets, Round, StddevOverTime, StdvarOverTime, SumOverTime, quantile_udaf,
 };
 use prost::Message;
 use session::context::QueryContextRef;
@@ -212,6 +212,7 @@ impl SubstraitPlanDecoder for DefaultPlanDecoder {
             NativeHistogramSum::scalar_udf(),
             NativeHistogramSumOverTime::scalar_udf(),
             NativeHistogramToString::scalar_udf(),
+            PromqlFloatToString::scalar_udf(),
         ] {
             let _ = session_state.register_udf(Arc::new(udf));
         }
@@ -374,6 +375,10 @@ mod tests {
                 )),
                 args: vec![col("sum")],
             }),
+            Expr::ScalarFunction(ScalarFunction {
+                func: Arc::new(PromqlFloatToString::scalar_udf()),
+                args: vec![lit(2.0)],
+            }),
         ])
         .unwrap()
         .build()
@@ -403,6 +408,7 @@ mod tests {
         assert!(decoded.contains("prom_native_histogram_drop_float"));
         assert!(decoded.contains(NativeHistogramAggSum::name()));
         assert!(decoded.contains(NativeHistogramAggAvg::name()));
+        assert!(decoded.contains(PromqlFloatToString::name()));
 
         let schema = Arc::new(Schema::new(vec![
             Field::new(

--- a/src/query/src/query_engine/default_serializer.rs
+++ b/src/query/src/query_engine/default_serializer.rs
@@ -188,6 +188,7 @@ impl SubstraitPlanDecoder for DefaultPlanDecoder {
             NativeHistogramDelta::scalar_udf(),
             NativeHistogramDivScalar::scalar_udf(),
             NativeHistogramDrop::bool_false_udf(String::new(), None),
+            NativeHistogramDrop::bool_true_udf(String::new(), None),
             NativeHistogramDrop::float_null_udf(String::new(), None),
             NativeHistogramEq::scalar_udf(),
             NativeHistogramFraction::scalar_udf(),
@@ -348,6 +349,13 @@ mod tests {
                 args: vec![col("histogram")],
             }),
             Expr::ScalarFunction(ScalarFunction {
+                func: Arc::new(NativeHistogramDrop::bool_true_udf(
+                    "ignored annotation".to_string(),
+                    None,
+                )),
+                args: vec![col("histogram")],
+            }),
+            Expr::ScalarFunction(ScalarFunction {
                 func: Arc::new(NativeHistogramDrop::float_null_udf(
                     "ignored annotation".to_string(),
                     None,
@@ -379,6 +387,7 @@ mod tests {
         let decoded = decoded.to_string();
         assert!(decoded.contains("prom_native_histogram_count"));
         assert!(decoded.contains("prom_native_histogram_drop_bool"));
+        assert!(decoded.contains("prom_native_histogram_keep_bool"));
         assert!(decoded.contains("prom_native_histogram_drop_float"));
 
         let schema = Arc::new(Schema::new(vec![

--- a/src/query/src/query_engine/default_serializer.rs
+++ b/src/query/src/query_engine/default_serializer.rs
@@ -336,31 +336,43 @@ mod tests {
             None,
         )
         .unwrap()
+        .aggregate(
+            Vec::<Expr>::new(),
+            vec![
+                Arc::new(NativeHistogramAggSum::aggregate_udf())
+                    .call(vec![col("histogram")])
+                    .alias("sum"),
+                Arc::new(NativeHistogramAggAvg::aggregate_udf())
+                    .call(vec![col("histogram")])
+                    .alias("avg"),
+            ],
+        )
+        .unwrap()
         .project(vec![
             Expr::ScalarFunction(ScalarFunction {
                 func: Arc::new(NativeHistogramCount::scalar_udf()),
-                args: vec![col("histogram")],
+                args: vec![col("sum")],
             }),
             Expr::ScalarFunction(ScalarFunction {
                 func: Arc::new(NativeHistogramDrop::bool_false_udf(
                     "ignored annotation".to_string(),
                     None,
                 )),
-                args: vec![col("histogram")],
+                args: vec![col("sum")],
             }),
             Expr::ScalarFunction(ScalarFunction {
                 func: Arc::new(NativeHistogramDrop::bool_true_udf(
                     "ignored annotation".to_string(),
                     None,
                 )),
-                args: vec![col("histogram")],
+                args: vec![col("sum")],
             }),
             Expr::ScalarFunction(ScalarFunction {
                 func: Arc::new(NativeHistogramDrop::float_null_udf(
                     "ignored annotation".to_string(),
                     None,
                 )),
-                args: vec![col("histogram")],
+                args: vec![col("sum")],
             }),
         ])
         .unwrap()
@@ -389,6 +401,8 @@ mod tests {
         assert!(decoded.contains("prom_native_histogram_drop_bool"));
         assert!(decoded.contains("prom_native_histogram_keep_bool"));
         assert!(decoded.contains("prom_native_histogram_drop_float"));
+        assert!(decoded.contains(NativeHistogramAggSum::name()));
+        assert!(decoded.contains(NativeHistogramAggAvg::name()));
 
         let schema = Arc::new(Schema::new(vec![
             Field::new(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This is the 5th PR of the 6 PRs for native histogram.

This pull request adds PromQL aggregation support for native histograms.
- Supports histogram-aware `sum`, `avg`, `count`, `group`, and `count_values` planning for histogram-only and mixed inputs.
- Drops incompatible mixed results or unsupported histogram samples with appropriate warnings and info annotations, while filtering empty groups.
- Registers histogram aggregate functions for distributed plan decoding and preserves overflow-safe, correctly weighted averages across partial states.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
