### PR TITLE
feat(servers): expose native histograms over Prometheus HTTP

### DIFF
--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -134,12 +134,19 @@ impl PrometheusGatewayService {
             }
         };
         let (metric_name, mut result_type) = retrieve_metric_name_and_result_type(query.expr());
+        let query_id = ctx.remote_query_id().map(str::to_string);
         let result = self.handler.do_query_parsed(query, ctx).await;
         // range query only returns matrix
         if is_range_query {
             result_type = ValueType::Matrix;
         };
 
-        PrometheusJsonResponse::from_query_result(result, metric_name, result_type).await
+        PrometheusJsonResponse::from_query_result(
+            result,
+            metric_name,
+            result_type,
+            query_id.as_deref(),
+        )
+        .await
     }
 }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -60,8 +60,8 @@ use crate::http::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, i
 use crate::http::otlp::OtlpState;
 use crate::http::prom_store::PromStoreState;
 use crate::http::prometheus::{
-    build_info_query, format_query, instant_query, label_values_query, labels_query, parse_query,
-    range_query, series_query,
+    build_info_query, format_query, instant_query, label_values_query, labels_query,
+    metadata_query, parse_query, range_query, series_query,
 };
 use crate::http::result::arrow_result::ArrowResponse;
 use crate::http::result::csv_result::CsvResponse;
@@ -1341,6 +1341,7 @@ impl HttpServer {
             .route("/query", routing::post(instant_query).get(instant_query))
             .route("/query_range", routing::post(range_query).get(range_query))
             .route("/labels", routing::post(labels_query).get(labels_query))
+            .route("/metadata", routing::get(metadata_query))
             .route("/series", routing::post(series_query).get(series_query))
             .route("/parse_query", routing::post(parse_query).get(parse_query))
             .route(

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -2048,6 +2048,7 @@ fn prometheus_metadata_from_table(table_info: &TableInfo) -> PromMetadata {
     PromMetadata {
         metric_type,
         unit,
+        // TODO: Persist and return Prometheus help text and OTLP metric descriptions.
         help: String::new(),
     }
 }
@@ -3480,6 +3481,7 @@ mod tests {
         for (metric_type, temporality, expected) in [
             ("updown_counter", None, "gauge"),
             ("gauge_histogram", None, "gaugehistogram"),
+            ("summary", None, "summary"),
             ("mixed", None, "unknown"),
             ("counter", Some("delta"), "unknown"),
             ("histogram", Some("delta"), "unknown"),

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -34,6 +34,7 @@ use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_decimal::Decimal128;
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
+use common_query::native_histogram::is_native_histogram_value_type;
 use common_query::{Output, OutputData};
 use common_recordbatch::{RecordBatch, RecordBatches};
 use common_telemetry::{debug, tracing};
@@ -64,6 +65,8 @@ use store_api::metric_engine_consts::{
     DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, LOGICAL_TABLE_METADATA_KEY,
 };
 use table::TableRef;
+use table::metadata::TableInfo;
+use table::requests::{SEMANTIC_METRIC_TEMPORALITY, SEMANTIC_METRIC_TYPE, SEMANTIC_METRIC_UNIT};
 
 pub use super::result::prometheus_resp::PrometheusJsonResponse;
 use crate::error::{
@@ -136,6 +139,14 @@ pub struct PromData {
     pub result: PromQueryResult,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromMetadata {
+    #[serde(rename = "type")]
+    pub metric_type: String,
+    pub unit: String,
+    pub help: String,
+}
+
 /// A "holder" for the reference([Arc]) to a column name,
 /// to help avoiding cloning [String]s when used as a [HashMap] key.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -153,6 +164,7 @@ pub enum PrometheusResponse {
     PromData(PromData),
     Labels(Vec<String>),
     Series(Vec<HashMap<Column, String>>),
+    Metadata(BTreeMap<String, Vec<PromMetadata>>),
     LabelValues(Vec<String>),
     FormatQuery(String),
     BuildInfo(OwnedBuildInfo),
@@ -166,7 +178,7 @@ impl PrometheusResponse {
     /// Append the other [`PrometheusResponse]`.
     /// # NOTE
     ///   Only append matrix and vector results, otherwise just ignore the other response.
-    fn append(&mut self, other: PrometheusResponse) {
+    pub(super) fn append(&mut self, other: PrometheusResponse) {
         match (self, other) {
             (
                 PrometheusResponse::PromData(PromData {
@@ -209,6 +221,13 @@ pub struct FormatQuery {
     query: Option<String>,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct MetadataQuery {
+    db: Option<String>,
+    limit: Option<usize>,
+    metric: Option<String>,
+}
+
 #[axum_macros::debug_handler]
 #[tracing::instrument(
     skip_all,
@@ -244,6 +263,67 @@ pub struct BuildInfoQuery {}
 pub async fn build_info_query() -> PrometheusJsonResponse {
     let build_info = common_version::build_info().clone();
     PrometheusJsonResponse::success(PrometheusResponse::BuildInfo(build_info.into()))
+}
+
+#[axum_macros::debug_handler]
+#[tracing::instrument(
+    skip_all,
+    fields(protocol = "prometheus", request_type = "metadata_query")
+)]
+pub async fn metadata_query(
+    State(handler): State<PrometheusHandlerRef>,
+    Query(params): Query<MetadataQuery>,
+    Extension(mut query_ctx): Extension<QueryContext>,
+) -> PrometheusJsonResponse {
+    let (catalog, schema) = get_catalog_schema(&params.db, &query_ctx);
+    try_update_catalog_schema(&mut query_ctx, &catalog, &schema);
+    let query_ctx = Arc::new(query_ctx);
+
+    if let Err(err) = handler.check_query_permission(&[], &query_ctx).await {
+        return PrometheusJsonResponse::error(err.status_code(), err.to_string());
+    }
+    if let Some(metric) = &params.metric
+        && let Err(err) = handler
+            .check_query_target_permission(
+                current_schema_metric_targets(&query_ctx, std::slice::from_ref(metric)),
+                &query_ctx,
+            )
+            .await
+    {
+        return PrometheusJsonResponse::error(err.status_code(), err.to_string());
+    }
+
+    let mut metadata =
+        match retrieve_metric_metadata(&query_ctx, handler.catalog_manager(), &params).await {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                return PrometheusJsonResponse::error(
+                    StatusCode::InvalidArguments,
+                    err.to_string(),
+                );
+            }
+        };
+    let allowed_metric_names = match handler
+        .filter_metadata_metric_names(
+            metadata.keys().cloned().collect(),
+            query_ctx.current_schema().as_str(),
+            &query_ctx,
+        )
+        .await
+    {
+        Ok(metric_names) => metric_names,
+        Err(err) => {
+            return PrometheusJsonResponse::error(err.status_code(), err.to_string());
+        }
+    }
+    .into_iter()
+    .collect::<HashSet<_>>();
+    metadata.retain(|metric, _| allowed_metric_names.contains(metric));
+    if let Some(limit) = params.limit {
+        metadata = metadata.into_iter().take(limit).collect();
+    }
+
+    PrometheusJsonResponse::success(PrometheusResponse::Metadata(metadata))
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -391,7 +471,7 @@ pub async fn instant_query(
         responses
             .into_iter()
             .reduce(|mut acc, resp| {
-                acc.data.append(resp.data);
+                acc.append_query_response(resp);
                 acc
             })
             .unwrap()
@@ -407,8 +487,10 @@ async fn do_instant_query(
     query_ctx: QueryContextRef,
 ) -> PrometheusJsonResponse {
     let (metric_name, result_type) = retrieve_metric_name_and_result_type(prom_query.expr());
+    let query_id = query_ctx.remote_query_id().map(str::to_string);
     let result = handler.do_query_parsed(prom_query, query_ctx).await;
-    PrometheusJsonResponse::from_query_result(result, metric_name, result_type).await
+    PrometheusJsonResponse::from_query_result(result, metric_name, result_type, query_id.as_deref())
+        .await
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -519,7 +601,7 @@ pub async fn range_query(
         responses
             .into_iter()
             .reduce(|mut acc, resp| {
-                acc.data.append(resp.data);
+                acc.append_query_response(resp);
                 acc
             })
             .unwrap()
@@ -535,8 +617,15 @@ async fn do_range_query(
     query_ctx: QueryContextRef,
 ) -> PrometheusJsonResponse {
     let (metric_name, _) = retrieve_metric_name_and_result_type(prom_query.expr());
+    let query_id = query_ctx.remote_query_id().map(str::to_string);
     let result = handler.do_query_parsed(prom_query, query_ctx).await;
-    PrometheusJsonResponse::from_query_result(result, metric_name, ValueType::Matrix).await
+    PrometheusJsonResponse::from_query_result(
+        result,
+        metric_name,
+        ValueType::Matrix,
+        query_id.as_deref(),
+    )
+    .await
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -1165,15 +1254,15 @@ fn record_batches_to_labels_name(
     labels: &mut HashSet<String>,
 ) -> Result<()> {
     let mut column_indices = Vec::new();
-    let mut field_column_indices = Vec::new();
+    let mut value_column_indices = Vec::new();
     for (i, column) in batches.schema().column_schemas().iter().enumerate() {
-        if let ConcreteDataType::Float64(_) = column.data_type {
-            field_column_indices.push(i);
+        if is_prometheus_value_column(&column.data_type) {
+            value_column_indices.push(i);
         }
         column_indices.push(i);
     }
 
-    if field_column_indices.is_empty() {
+    if value_column_indices.is_empty() {
         return Err(Error::Internal {
             err_msg: "no value column found".to_string(),
         });
@@ -1185,21 +1274,18 @@ fn record_batches_to_labels_name(
             .map(|c| batches.schema().column_name_by_index(*c).to_string())
             .collect::<Vec<_>>();
 
-        let field_columns = field_column_indices
+        let value_columns = value_column_indices
             .iter()
-            .map(|i| {
-                let column = batch.column(*i);
-                column.as_primitive::<Float64Type>()
-            })
+            .map(|i| batch.column(*i))
             .collect::<Vec<_>>();
 
         for row_index in 0..batch.num_rows() {
-            // if all field columns are null, skip this row
-            if field_columns.iter().all(|c| c.is_null(row_index)) {
+            // if all value columns are null, skip this row
+            if value_columns.iter().all(|c| c.is_null(row_index)) {
                 continue;
             }
 
-            // if a field is not null, record the tag name and return
+            // if a value is not null, record the tag name and return
             names.iter().for_each(|name| {
                 let _ = labels.insert(name.clone());
             });
@@ -1207,6 +1293,10 @@ fn record_batches_to_labels_name(
         }
     }
     Ok(())
+}
+
+fn is_prometheus_value_column(data_type: &ConcreteDataType) -> bool {
+    matches!(data_type, ConcreteDataType::Float64(_)) || is_native_histogram_value_type(data_type)
 }
 
 pub(crate) fn retrieve_metric_name_and_result_type(
@@ -1869,6 +1959,94 @@ async fn retrieve_table_names(
     Ok(table_names)
 }
 
+async fn retrieve_metric_metadata(
+    query_ctx: &QueryContext,
+    manager: CatalogManagerRef,
+    params: &MetadataQuery,
+) -> Result<BTreeMap<String, Vec<PromMetadata>>> {
+    let mut metadata = BTreeMap::new();
+    if params.limit == Some(0) {
+        return Ok(metadata);
+    }
+
+    let catalog = query_ctx.current_catalog();
+    let schema = query_ctx.current_schema();
+    let mut tables_stream = manager.tables(catalog, &schema, Some(query_ctx));
+
+    while let Some(table) = tables_stream.next().await {
+        let table = table?;
+        let table_info = table.table_info();
+        if !is_prometheus_metric_table(table_info.as_ref()) {
+            continue;
+        }
+
+        if let Some(metric) = &params.metric
+            && table_info.name.as_str() != metric
+        {
+            continue;
+        }
+
+        metadata.insert(
+            table_info.name.clone(),
+            vec![prometheus_metadata_from_table(table_info.as_ref())],
+        );
+    }
+
+    Ok(metadata)
+}
+
+fn is_prometheus_metric_table(table_info: &TableInfo) -> bool {
+    table_info
+        .meta
+        .options
+        .extra_options
+        .contains_key(LOGICAL_TABLE_METADATA_KEY)
+}
+
+fn prometheus_metadata_from_table(table_info: &TableInfo) -> PromMetadata {
+    let options = &table_info.meta.options.extra_options;
+    let metric_type = match options.get(SEMANTIC_METRIC_TYPE) {
+        Some(metric_type)
+            if options
+                .get(SEMANTIC_METRIC_TEMPORALITY)
+                .is_some_and(|temporality| temporality == "delta")
+                && matches!(
+                    metric_type.as_str(),
+                    "counter" | "histogram" | "updown_counter"
+                ) =>
+        {
+            "unknown".to_string()
+        }
+        Some(metric_type) => match metric_type.as_str() {
+            "updown_counter" => "gauge".to_string(),
+            "gauge_histogram" => "gaugehistogram".to_string(),
+            "mixed" => "unknown".to_string(),
+            metric_type => metric_type.to_string(),
+        },
+        None if table_has_native_histogram_value(table_info) => "histogram".to_string(),
+        None => String::new(),
+    };
+    let unit = options
+        .get(SEMANTIC_METRIC_UNIT)
+        .cloned()
+        .unwrap_or_default();
+
+    PromMetadata {
+        metric_type,
+        unit,
+        help: String::new(),
+    }
+}
+
+fn table_has_native_histogram_value(table_info: &TableInfo) -> bool {
+    table_info
+        .meta
+        .schema
+        .column_schemas()
+        .iter()
+        .any(|column| is_native_histogram_value_type(&column.data_type))
+}
+
 async fn retrieve_field_names(
     query_ctx: &QueryContext,
     manager: CatalogManagerRef,
@@ -2170,11 +2348,15 @@ mod tests {
     use catalog::memory::MemoryCatalogManager;
     use catalog::{RegisterSchemaRequest, RegisterTableRequest};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use common_query::native_histogram::native_histogram_value_type;
+    use common_query::prelude::greptime_native_histogram;
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema};
     use promql_parser::parser::value::ValueType;
     use table::metadata::{TableInfoBuilder, TableMetaBuilder, TableType, TableVersion};
-    use table::requests::TableOptions;
+    use table::requests::{
+        SEMANTIC_METRIC_TEMPORALITY, SEMANTIC_METRIC_TYPE, SEMANTIC_METRIC_UNIT, TableOptions,
+    };
     use table::test_util::EmptyTable;
     use table::test_util::table_info::test_table_info;
 
@@ -2191,6 +2373,7 @@ mod tests {
 
     struct TestPrometheusHandler {
         catalog_manager: CatalogManagerRef,
+        deny_operation: bool,
         denied_table: Option<&'static str>,
         metric_names: Vec<String>,
         queries: Mutex<Vec<String>>,
@@ -2215,6 +2398,11 @@ mod tests {
         }
 
         async fn check_query_permission(&self, _: &[PromQuery], _: &QueryContextRef) -> Result<()> {
+            if self.deny_operation {
+                return auth::error::PermissionDeniedSnafu
+                    .fail()
+                    .context(crate::error::AuthSnafu);
+            }
             Ok(())
         }
 
@@ -2320,6 +2508,7 @@ mod tests {
     async fn test_promql_timer_records_parse_errors() {
         let handler: PrometheusHandlerRef = Arc::new(TestPrometheusHandler {
             catalog_manager: MemoryCatalogManager::new(),
+            deny_operation: false,
             denied_table: None,
             metric_names: Vec::new(),
             queries: Mutex::new(Vec::new()),
@@ -2402,6 +2591,7 @@ mod tests {
         let response = label_values_query(
             State(Arc::new(TestPrometheusHandler {
                 catalog_manager: manager,
+                deny_operation: false,
                 denied_table: Some("denied"),
                 metric_names: Vec::new(),
                 queries: Mutex::new(Vec::new()),
@@ -2444,6 +2634,7 @@ mod tests {
 
         let handler = Arc::new(TestPrometheusHandler {
             catalog_manager: manager,
+            deny_operation: false,
             denied_table: None,
             metric_names: vec!["cpu_user".to_string(), "cpu_system".to_string()],
             queries: Mutex::new(Vec::new()),
@@ -3145,5 +3336,177 @@ mod tests {
             static_promql_targets(&expr, &ctx).unwrap(),
             (PermissionTableTargets::resolved(Vec::new()), 2)
         );
+    }
+
+    #[test]
+    fn test_record_batches_to_labels_name_accepts_native_histogram_value() {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new("host", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(
+                greptime_native_histogram(),
+                native_histogram_value_type().clone(),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::new_empty(schema.clone());
+        let batches = RecordBatches::try_new(schema, vec![batch]).unwrap();
+        let mut labels = HashSet::new();
+
+        record_batches_to_labels_name(batches, &mut labels).unwrap();
+
+        assert!(labels.is_empty());
+    }
+
+    fn prometheus_metric_table_info(table_id: u32, name: &str) -> TableInfo {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new(
+                "greptime_timestamp",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+            ColumnSchema::new("host", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new("value", ConcreteDataType::float64_datatype(), true),
+        ]));
+        let mut options = TableOptions::default();
+        options.extra_options.insert(
+            LOGICAL_TABLE_METADATA_KEY.to_string(),
+            "greptime_physical_table".to_string(),
+        );
+        options
+            .extra_options
+            .insert(SEMANTIC_METRIC_TYPE.to_string(), "counter".to_string());
+        options
+            .extra_options
+            .insert(SEMANTIC_METRIC_UNIT.to_string(), "By".to_string());
+        let meta = TableMetaBuilder::empty()
+            .schema(schema)
+            .primary_key_indices(vec![1])
+            .engine("metric".to_string())
+            .next_column_id(3)
+            .options(options)
+            .build()
+            .unwrap();
+
+        TableInfoBuilder::default()
+            .table_id(table_id)
+            .table_version(0 as TableVersion)
+            .name(name)
+            .catalog_name(DEFAULT_CATALOG_NAME)
+            .schema_name(DEFAULT_SCHEMA_NAME)
+            .table_type(TableType::Base)
+            .meta(meta)
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_metric_metadata_uses_semantic_options() {
+        let table_info = prometheus_metric_table_info(1025, "http_requests_total");
+        let manager: CatalogManagerRef =
+            MemoryCatalogManager::new_with_table(EmptyTable::from_table_info(&table_info));
+        let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+
+        let metadata = retrieve_metric_metadata(&query_ctx, manager, &MetadataQuery::default())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            metadata.get("http_requests_total"),
+            Some(&vec![PromMetadata {
+                metric_type: "counter".to_string(),
+                unit: "By".to_string(),
+                help: String::new(),
+            }])
+        );
+
+        for (metric_type, temporality, expected) in [
+            ("updown_counter", None, "gauge"),
+            ("gauge_histogram", None, "gaugehistogram"),
+            ("mixed", None, "unknown"),
+            ("counter", Some("delta"), "unknown"),
+            ("histogram", Some("delta"), "unknown"),
+        ] {
+            let mut table_info = table_info.clone();
+            table_info
+                .meta
+                .options
+                .extra_options
+                .insert(SEMANTIC_METRIC_TYPE.to_string(), metric_type.to_string());
+            if let Some(temporality) = temporality {
+                table_info.meta.options.extra_options.insert(
+                    SEMANTIC_METRIC_TEMPORALITY.to_string(),
+                    temporality.to_string(),
+                );
+            }
+            assert_eq!(
+                prometheus_metadata_from_table(&table_info).metric_type,
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_metadata_query_checks_permissions_and_filters_tables() {
+        let allowed = prometheus_metric_table_info(1025, "allowed");
+        let denied = prometheus_metric_table_info(1026, "denied");
+        let manager = MemoryCatalogManager::new_with_table(EmptyTable::from_table_info(&allowed));
+        manager
+            .register_table_sync(RegisterTableRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: denied.name.clone(),
+                table_id: denied.table_id(),
+                table: EmptyTable::from_table_info(&denied),
+            })
+            .unwrap();
+        let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+
+        let response = metadata_query(
+            State(Arc::new(TestPrometheusHandler {
+                catalog_manager: manager.clone(),
+                deny_operation: true,
+                denied_table: None,
+                metric_names: Vec::new(),
+                queries: Mutex::new(Vec::new()),
+            })),
+            Query(MetadataQuery::default()),
+            Extension(query_ctx.clone()),
+        )
+        .await;
+        assert_eq!(Some(StatusCode::PermissionDenied), response.status_code);
+
+        let handler: PrometheusHandlerRef = Arc::new(TestPrometheusHandler {
+            catalog_manager: manager,
+            deny_operation: false,
+            denied_table: Some("denied"),
+            metric_names: Vec::new(),
+            queries: Mutex::new(Vec::new()),
+        });
+        let response = metadata_query(
+            State(handler.clone()),
+            Query(MetadataQuery::default()),
+            Extension(query_ctx.clone()),
+        )
+        .await;
+        assert!(response.status_code.is_none());
+        let PrometheusResponse::Metadata(metadata) = response.data else {
+            panic!("expected metadata response");
+        };
+        assert_eq!(
+            metadata.keys().cloned().collect::<Vec<_>>(),
+            vec!["allowed".to_string()]
+        );
+
+        let response = metadata_query(
+            State(handler),
+            Query(MetadataQuery {
+                metric: Some("denied".to_string()),
+                ..Default::default()
+            }),
+            Extension(query_ctx),
+        )
+        .await;
+        assert_eq!(Some(StatusCode::PermissionDenied), response.status_code);
     }
 }

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -74,6 +74,7 @@ use crate::error::{
     NotSupportedSnafu, Result, TableNotFoundSnafu, UnexpectedResultSnafu,
 };
 use crate::http::header::collect_plan_metrics;
+use crate::otlp::metrics::ucum_to_openmetrics_unit;
 use crate::prom_store::{FIELD_NAME_LABEL, METRIC_NAME_LABEL, is_database_selection_label};
 use crate::prometheus_handler::{
     ParsedPromQuery, PrometheusHandlerRef, resolve_schema_from_matchers,
@@ -2042,7 +2043,7 @@ fn prometheus_metadata_from_table(table_info: &TableInfo) -> PromMetadata {
     };
     let unit = options
         .get(SEMANTIC_METRIC_UNIT)
-        .cloned()
+        .map(|unit| ucum_to_openmetrics_unit(unit))
         .unwrap_or_default();
 
     PromMetadata {
@@ -3473,10 +3474,28 @@ mod tests {
             metadata.get("http_requests_total"),
             Some(&vec![PromMetadata {
                 metric_type: "counter".to_string(),
-                unit: "By".to_string(),
+                unit: "bytes".to_string(),
                 help: String::new(),
             }])
         );
+
+        for (ucum, openmetrics) in [
+            ("1", "ratios"),
+            ("ms", "milliseconds"),
+            ("m/s", "meters_per_second"),
+            ("USD", "USD"),
+        ] {
+            let mut table_info = table_info.clone();
+            table_info
+                .meta
+                .options
+                .extra_options
+                .insert(SEMANTIC_METRIC_UNIT.to_string(), ucum.to_string());
+            assert_eq!(
+                prometheus_metadata_from_table(&table_info).unit,
+                openmetrics
+            );
+        }
 
         for (metric_type, temporality, expected) in [
             ("updown_counter", None, "gauge"),

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -139,6 +139,7 @@ pub struct PromData {
     pub result: PromQueryResult,
 }
 
+/// Metadata for a Prometheus metric family.
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PromMetadata {
     #[serde(rename = "type")]
@@ -221,6 +222,7 @@ pub struct FormatQuery {
     query: Option<String>,
 }
 
+/// Query parameters for the Prometheus metric metadata endpoint.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct MetadataQuery {
     db: Option<String>,
@@ -1971,18 +1973,30 @@ async fn retrieve_metric_metadata(
 
     let catalog = query_ctx.current_catalog();
     let schema = query_ctx.current_schema();
+
+    if let Some(metric) = &params.metric {
+        let Some(table) = manager
+            .table(catalog, &schema, metric, Some(query_ctx))
+            .await?
+        else {
+            return Ok(metadata);
+        };
+        let table_info = table.table_info();
+        if is_prometheus_metric_table(table_info.as_ref()) {
+            metadata.insert(
+                table_info.name.clone(),
+                vec![prometheus_metadata_from_table(table_info.as_ref())],
+            );
+        }
+        return Ok(metadata);
+    }
+
     let mut tables_stream = manager.tables(catalog, &schema, Some(query_ctx));
 
     while let Some(table) = tables_stream.next().await {
         let table = table?;
         let table_info = table.table_info();
         if !is_prometheus_metric_table(table_info.as_ref()) {
-            continue;
-        }
-
-        if let Some(metric) = &params.metric
-            && table_info.name.as_str() != metric
-        {
             continue;
         }
 
@@ -2348,10 +2362,13 @@ mod tests {
     use catalog::memory::MemoryCatalogManager;
     use catalog::{RegisterSchemaRequest, RegisterTableRequest};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-    use common_query::native_histogram::native_histogram_value_type;
+    use common_query::native_histogram::{
+        CounterResetHint, NativeHistogram, build_histogram_array, native_histogram_value_type,
+    };
     use common_query::prelude::greptime_native_histogram;
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::{StringVector, StructVector};
     use promql_parser::parser::value::ValueType;
     use table::metadata::{TableInfoBuilder, TableMetaBuilder, TableType, TableVersion};
     use table::requests::{
@@ -3349,12 +3366,52 @@ mod tests {
             ),
         ]));
         let batch = RecordBatch::new_empty(schema.clone());
-        let batches = RecordBatches::try_new(schema, vec![batch]).unwrap();
+        let batches = RecordBatches::try_new(schema.clone(), vec![batch]).unwrap();
         let mut labels = HashSet::new();
 
         record_batches_to_labels_name(batches, &mut labels).unwrap();
 
         assert!(labels.is_empty());
+
+        let histogram = NativeHistogram {
+            schema: 0,
+            zero_threshold: 0.001,
+            sum: 1.0,
+            reset_hint: CounterResetHint::Unknown,
+            start_timestamp: None,
+            custom_values: vec![],
+            positive_spans: vec![],
+            negative_spans: vec![],
+            count: 1.0,
+            zero_count: 1.0,
+            positive_buckets: vec![],
+            negative_buckets: vec![],
+        };
+        let histogram_array = build_histogram_array(&[Some(histogram)]);
+        let histogram_array = histogram_array
+            .as_any()
+            .downcast_ref::<arrow::array::StructArray>()
+            .unwrap()
+            .clone();
+        let ConcreteDataType::Struct(histogram_type) = native_histogram_value_type().clone() else {
+            unreachable!("native histogram type must be a struct")
+        };
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![
+                Arc::new(StringVector::from(vec![Some("localhost")])) as _,
+                Arc::new(StructVector::try_new(histogram_type, histogram_array).unwrap()) as _,
+            ],
+        )
+        .unwrap();
+        let batches = RecordBatches::try_new(schema, vec![batch]).unwrap();
+
+        record_batches_to_labels_name(batches, &mut labels).unwrap();
+
+        assert_eq!(
+            labels,
+            HashSet::from(["host".to_string(), greptime_native_histogram().to_string(),])
+        );
     }
 
     fn prometheus_metric_table_info(table_id: u32, name: &str) -> TableInfo {
@@ -3461,6 +3518,19 @@ mod tests {
             })
             .unwrap();
         let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+
+        let metadata = retrieve_metric_metadata(
+            &query_ctx,
+            manager.clone(),
+            &MetadataQuery {
+                metric: Some("allowed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(metadata.len(), 1);
+        assert!(metadata.contains_key("allowed"));
 
         let response = metadata_query(
             State(Arc::new(TestPrometheusHandler {

--- a/src/servers/src/http/result/prometheus_resp.rs
+++ b/src/servers/src/http/result/prometheus_resp.rs
@@ -28,6 +28,9 @@ use common_query::native_histogram::{
     NativeHistogram, is_native_histogram_value_type, read_histogram,
 };
 use common_query::prometheus::{format_prometheus_float, is_prometheus_stale_nan};
+use common_query::promql_annotations::{
+    PromqlAnnotationCollector, get_promql_annotation_collector,
+};
 use common_query::{Output, OutputData};
 use common_recordbatch::RecordBatches;
 use datatypes::arrow_array::string_array_value_at_index;
@@ -80,6 +83,8 @@ pub struct PrometheusJsonResponse {
     pub error_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub infos: Option<Vec<String>>,
 
     #[serde(skip)]
     pub status_code: Option<StatusCode>,
@@ -124,6 +129,7 @@ impl PrometheusJsonResponse {
             error: Some(reason.into()),
             error_type: Some(error_type.to_string()),
             warnings: None,
+            infos: None,
             resp_metrics: Default::default(),
             status_code: Some(error_type),
         }
@@ -136,9 +142,26 @@ impl PrometheusJsonResponse {
             error: None,
             error_type: None,
             warnings: None,
+            infos: None,
             resp_metrics: Default::default(),
             status_code: None,
         }
+    }
+
+    /// Adds collected PromQL warnings and infos to the response.
+    fn append_promql_annotations(&mut self, collector: &PromqlAnnotationCollector) {
+        let mut warnings = self.warnings.take().unwrap_or_default();
+        let mut infos = self.infos.take().unwrap_or_default();
+        collector.append_to(&mut warnings, &mut infos);
+        self.warnings = (!warnings.is_empty()).then_some(warnings);
+        self.infos = (!infos.is_empty()).then_some(infos);
+    }
+
+    /// Merges data and annotations from another expanded PromQL query response.
+    pub(crate) fn append_query_response(&mut self, mut other: Self) {
+        self.data.append(other.data);
+        merge_annotations(&mut self.warnings, other.warnings.take());
+        merge_annotations(&mut self.infos, other.infos.take());
     }
 
     /// Convert from `Result<Output>`
@@ -146,7 +169,10 @@ impl PrometheusJsonResponse {
         result: Result<Output>,
         metric_name: Option<String>,
         result_type: ValueType,
+        query_id: Option<&str>,
     ) -> Self {
+        // Hold the collector while a streaming result is consumed.
+        let collector = query_id.and_then(get_promql_annotation_collector);
         let response: Result<Self> = try {
             let result = result?;
             let mut resp =
@@ -187,7 +213,7 @@ impl PrometheusJsonResponse {
 
         let result_type_string = result_type.to_string();
 
-        match response {
+        let mut response = match response {
             Ok(resp) => resp,
             Err(err) => {
                 // Prometheus won't report error if querying nonexist label and metric
@@ -202,7 +228,11 @@ impl PrometheusJsonResponse {
                     Self::error(err.status_code(), err.output_msg())
                 }
             }
+        };
+        if let Some(collector) = collector {
+            response.append_promql_annotations(&collector);
         }
+        response
     }
 
     /// Convert [RecordBatches] to [PromData]
@@ -435,6 +465,16 @@ impl PrometheusJsonResponse {
     }
 }
 
+fn merge_annotations(target: &mut Option<Vec<String>>, source: Option<Vec<String>>) {
+    let Some(source) = source else {
+        return;
+    };
+    let target = target.get_or_insert_default();
+    target.extend(source);
+    target.sort();
+    target.dedup();
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -444,6 +484,9 @@ mod tests {
         native_histogram_value_type,
     };
     use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
+    use common_query::promql_annotations::{
+        PromqlAnnotationCollector, promql_annotation_collector,
+    };
     use common_recordbatch::{RecordBatch, RecordBatches};
     use datatypes::data_type::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema};
@@ -452,6 +495,40 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn query_response_preserves_and_merges_promql_annotations() {
+        let query_id = "query_response_preserves_and_merges_promql_annotations";
+        let left = promql_annotation_collector(query_id);
+        left.record_warning("shared warning");
+        left.record_info("left info");
+        let mut response = PrometheusJsonResponse::from_query_result(
+            Ok(Output::new_with_record_batches(RecordBatches::empty())),
+            None,
+            ValueType::Vector,
+            Some(query_id),
+        )
+        .await;
+
+        let right = PromqlAnnotationCollector::default();
+        right.record_warning("shared warning");
+        right.record_info("right info");
+        let mut other = PrometheusJsonResponse::success(PrometheusResponse::None);
+        other.append_promql_annotations(&right);
+        response.append_query_response(other);
+
+        assert_eq!(response.warnings, Some(vec!["shared warning".to_string()]));
+        assert_eq!(
+            response.infos,
+            Some(vec!["left info".to_string(), "right info".to_string()])
+        );
+        let json = serde_json::to_value(response).unwrap();
+        assert_eq!(json["warnings"], serde_json::json!(["shared warning"]));
+        assert_eq!(
+            json["infos"],
+            serde_json::json!(["left info", "right info"])
+        );
+    }
 
     fn sample_histogram() -> NativeHistogram {
         NativeHistogram {

--- a/src/servers/src/otlp/metrics.rs
+++ b/src/servers/src/otlp/metrics.rs
@@ -38,6 +38,7 @@ use crate::semantic::{
 mod translator;
 
 pub use translator::legacy_normalize_otlp_name;
+pub(crate) use translator::ucum_to_openmetrics_unit;
 use translator::{translate_label_name, translate_metric_name};
 
 /// the default column count for table writer

--- a/src/servers/src/otlp/metrics/translator.rs
+++ b/src/servers/src/otlp/metrics/translator.rs
@@ -219,6 +219,20 @@ fn build_clean_unit_suffix(unit: &str) -> (Option<String>, Option<String>) {
     )
 }
 
+/// Converts a UCUM unit to its Prometheus/OpenMetrics unit word.
+pub(crate) fn ucum_to_openmetrics_unit(unit: &str) -> String {
+    if unit == "1" {
+        return "ratios".to_string();
+    }
+
+    match build_clean_unit_suffix(unit) {
+        (Some(main), Some(per)) => format!("{main}_per_{per}"),
+        (Some(main), None) => main,
+        (None, Some(per)) => format!("per_{per}"),
+        (None, None) => String::new(),
+    }
+}
+
 fn build_unit_suffixes(unit: &str) -> (String, String) {
     let (main, per) = unit.split_once('/').unwrap_or((unit, ""));
     let main_unit_suffix = unit_suffix(main, &UNIT_MAP);

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -980,6 +980,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
         error: None,
         error_type: None,
         warnings: None,
+        infos: None,
         resp_metrics: Default::default(),
         status_code: None,
     };

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2741,6 +2741,28 @@ pub async fn test_prometheus_remote_write_v2(store_type: StorageType) {
     )
     .await;
 
+    let res = client
+        .get("/v1/prometheus/api/v1/metadata?metric=remote_write_v2_typed_total")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = res.json::<PrometheusJsonResponse>().await;
+    assert_eq!(
+        serde_json::to_string_pretty(&body).unwrap(),
+        r#"{
+  "status": "success",
+  "data": {
+    "remote_write_v2_typed_total": [
+      {
+        "type": "counter",
+        "unit": "seconds",
+        "help": ""
+      }
+    ]
+  }
+}"#
+    );
+
     guard.remove_all().await;
 }
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2882,6 +2882,54 @@ pub async fn test_prometheus_remote_write_v2_native_histogram(store_type: Storag
     )
     .await;
 
+    let res = client
+        .get("/v1/prometheus/api/v1/query?query=histogram_count(remote_write_v2_latency_seconds)&time=4")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = serde_json::from_str::<Value>(&res.text().await).unwrap();
+    assert_eq!(body["status"], "success");
+    assert_eq!(body["data"]["resultType"], "vector");
+    let series = body["data"]["result"].as_array().unwrap();
+    assert_eq!(series.len(), 1);
+    let value = series[0]["value"].as_array().unwrap();
+    assert_eq!(value[0].as_f64(), Some(4.0));
+    assert_eq!(value[1], "6");
+
+    let res = client
+        .get("/v1/prometheus/api/v1/query?query=remote_write_v2_latency_seconds&time=4")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = serde_json::from_str::<Value>(&res.text().await).unwrap();
+    assert_eq!(body["status"], "success");
+    assert_eq!(body["data"]["resultType"], "vector");
+    let series = body["data"]["result"].as_array().unwrap();
+    assert_eq!(series.len(), 1);
+    assert!(series[0].get("value").is_none());
+    let histogram = series[0]["histogram"].as_array().unwrap();
+    assert_eq!(histogram[0].as_f64(), Some(4.0));
+    assert_eq!(histogram[1]["count"], "6");
+    assert_eq!(histogram[1]["sum"], "20");
+
+    let res = client
+        .get("/v1/prometheus/api/v1/query_range?query=remote_write_v2_latency_seconds&start=3&end=4&step=1")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = serde_json::from_str::<Value>(&res.text().await).unwrap();
+    assert_eq!(body["status"], "success");
+    assert_eq!(body["data"]["resultType"], "matrix");
+    let series = body["data"]["result"].as_array().unwrap();
+    assert_eq!(series.len(), 1);
+    assert!(series[0].get("values").is_none());
+    let histograms = series[0]["histograms"].as_array().unwrap();
+    assert_eq!(histograms.len(), 2);
+    assert_eq!(histograms[0][0].as_f64(), Some(3.0));
+    assert_eq!(histograms[0][1]["count"], "8");
+    assert_eq!(histograms[1][0].as_f64(), Some(4.0));
+    assert_eq!(histograms[1][1]["count"], "6");
+
     validate_data(
         "prometheus_remote_write_v2_native_histogram_table_created",
         &client,

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2883,6 +2883,28 @@ pub async fn test_prometheus_remote_write_v2_native_histogram(store_type: Storag
     .await;
 
     let res = client
+        .get("/v1/prometheus/api/v1/metadata?metric=remote_write_v2_latency_seconds")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = res.json::<PrometheusJsonResponse>().await;
+    assert_eq!(
+        serde_json::to_string_pretty(&body).unwrap(),
+        r#"{
+  "status": "success",
+  "data": {
+    "remote_write_v2_latency_seconds": [
+      {
+        "type": "histogram",
+        "unit": "",
+        "help": ""
+      }
+    ]
+  }
+}"#
+    );
+
+    let res = client
         .get("/v1/prometheus/api/v1/query?query=histogram_count(remote_write_v2_latency_seconds)&time=4")
         .send()
         .await;

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2887,48 +2887,174 @@ pub async fn test_prometheus_remote_write_v2_native_histogram(store_type: Storag
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
-    let body = serde_json::from_str::<Value>(&res.text().await).unwrap();
-    assert_eq!(body["status"], "success");
-    assert_eq!(body["data"]["resultType"], "vector");
-    let series = body["data"]["result"].as_array().unwrap();
-    assert_eq!(series.len(), 1);
-    let value = series[0]["value"].as_array().unwrap();
-    assert_eq!(value[0].as_f64(), Some(4.0));
-    assert_eq!(value[1], "6");
+    let body = res.json::<PrometheusJsonResponse>().await;
+    assert_eq!(
+        serde_json::to_string_pretty(&body).unwrap(),
+        r#"{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {
+          "__name__": "remote_write_v2_latency_seconds",
+          "instance": "localhost:9090",
+          "job": "api"
+        },
+        "value": [
+          4.0,
+          "6"
+        ]
+      }
+    ]
+  }
+}"#
+    );
 
     let res = client
         .get("/v1/prometheus/api/v1/query?query=remote_write_v2_latency_seconds&time=4")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
-    let body = serde_json::from_str::<Value>(&res.text().await).unwrap();
-    assert_eq!(body["status"], "success");
-    assert_eq!(body["data"]["resultType"], "vector");
-    let series = body["data"]["result"].as_array().unwrap();
-    assert_eq!(series.len(), 1);
-    assert!(series[0].get("value").is_none());
-    let histogram = series[0]["histogram"].as_array().unwrap();
-    assert_eq!(histogram[0].as_f64(), Some(4.0));
-    assert_eq!(histogram[1]["count"], "6");
-    assert_eq!(histogram[1]["sum"], "20");
+    let body = res.json::<PrometheusJsonResponse>().await;
+    assert_eq!(
+        serde_json::to_string_pretty(&body).unwrap(),
+        r#"{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {
+          "__name__": "remote_write_v2_latency_seconds",
+          "instance": "localhost:9090",
+          "job": "api"
+        },
+        "histogram": [
+          4.0,
+          {
+            "count": "6",
+            "sum": "20",
+            "buckets": [
+              [
+                3,
+                "-0.002",
+                "0.002",
+                "0.5"
+              ],
+              [
+                0,
+                "1.4142135623730951",
+                "1.681792830507429",
+                "2"
+              ],
+              [
+                0,
+                "1.681792830507429",
+                "2",
+                "3.5"
+              ]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}"#
+    );
 
     let res = client
         .get("/v1/prometheus/api/v1/query_range?query=remote_write_v2_latency_seconds&start=3&end=4&step=1")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
-    let body = serde_json::from_str::<Value>(&res.text().await).unwrap();
-    assert_eq!(body["status"], "success");
-    assert_eq!(body["data"]["resultType"], "matrix");
-    let series = body["data"]["result"].as_array().unwrap();
-    assert_eq!(series.len(), 1);
-    assert!(series[0].get("values").is_none());
-    let histograms = series[0]["histograms"].as_array().unwrap();
-    assert_eq!(histograms.len(), 2);
-    assert_eq!(histograms[0][0].as_f64(), Some(3.0));
-    assert_eq!(histograms[0][1]["count"], "8");
-    assert_eq!(histograms[1][0].as_f64(), Some(4.0));
-    assert_eq!(histograms[1][1]["count"], "6");
+    let body = res.json::<PrometheusJsonResponse>().await;
+    assert_eq!(
+        serde_json::to_string_pretty(&body).unwrap(),
+        r#"{
+  "status": "success",
+  "data": {
+    "resultType": "matrix",
+    "result": [
+      {
+        "metric": {
+          "__name__": "remote_write_v2_latency_seconds",
+          "instance": "localhost:9090",
+          "job": "api"
+        },
+        "histograms": [
+          [
+            3.0,
+            {
+              "count": "8",
+              "sum": "10",
+              "buckets": [
+                [
+                  1,
+                  "-0.5",
+                  "-0.3535533905932738",
+                  "1"
+                ],
+                [
+                  3,
+                  "-0.001",
+                  "0.001",
+                  "1"
+                ],
+                [
+                  0,
+                  "0.7071067811865476",
+                  "1",
+                  "1"
+                ],
+                [
+                  0,
+                  "1",
+                  "1.4142135623730951",
+                  "3"
+                ],
+                [
+                  0,
+                  "1.4142135623730951",
+                  "2",
+                  "2"
+                ]
+              ]
+            }
+          ],
+          [
+            4.0,
+            {
+              "count": "6",
+              "sum": "20",
+              "buckets": [
+                [
+                  3,
+                  "-0.002",
+                  "0.002",
+                  "0.5"
+                ],
+                [
+                  0,
+                  "1.4142135623730951",
+                  "1.681792830507429",
+                  "2"
+                ],
+                [
+                  0,
+                  "1.681792830507429",
+                  "2",
+                  "3.5"
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    ]
+  }
+}"#
+    );
 
     validate_data(
         "prometheus_remote_write_v2_native_histogram_table_created",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This is the 6th PR of the 6 PRs for native histogram.

This pull request adds the remaining Prometheus HTTP support for native histograms.
- Returns collected PromQL warnings and infos through HTTP and gRPC query paths, merging annotations from expanded queries.
- Makes label discovery recognize native-histogram values and covers scalar, instant, and range query responses.
- Adds a permission-aware `/metadata` endpoint using metric type, temporality, and unit metadata.

The changes are additive: existing float-only responses and persisted data remain unchanged. The branch is clean with no untracked files.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
