### PR TITLE
fix(mito2): publish committed sequence only after rows are installed

### DIFF
--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -908,6 +908,9 @@ where
         region_write_ctx.set_next_entry_id(last_entry_id + 1);
         region_write_ctx.write_memtable().await;
         region_write_ctx.write_bulk().await;
+        // Publish the replayed sequences only after all rows (including bulk
+        // parts) are installed, matching the write path ordering.
+        region_write_ctx.publish_sequence_and_entry_id();
     }
 
     // TODO(weny): We need to update `flushed_entry_id` in the region manifest

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -199,6 +199,12 @@ impl RegionWriteCtx {
         &self.version
     }
 
+    /// Returns the version control of the region.
+    #[cfg(test)]
+    pub(crate) fn version_control(&self) -> &VersionControlRef {
+        &self.version_control
+    }
+
     /// Returns whether writes in this context should skip WAL.
     pub(crate) fn skip_wal(&self) -> bool {
         self.provider == Provider::Noop || self.version.options.skip_wal
@@ -286,10 +292,6 @@ impl RegionWriteCtx {
             let bytes = new_memory_usage.saturating_sub(prev_memory_usage.unwrap_or_default());
             written_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
         }
-        // Updates region sequence and entry id. Since we stores last sequence and entry id in region, we need
-        // to decrease `next_sequence` and `next_entry_id` by 1.
-        self.version_control
-            .set_sequence_and_entry_id(self.next_sequence - 1, self.next_entry_id - 1);
     }
 
     pub(crate) fn push_bulk(
@@ -324,6 +326,8 @@ impl RegionWriteCtx {
         if self.failed || self.bulk_parts.is_empty() {
             return;
         }
+        #[cfg(test)]
+        test_hooks::pause_before_bulk_install(self.region_id, &self.version_control).await;
         let _timer = metrics::REGION_WORKER_HANDLE_WRITE_ELAPSED
             .with_label_values(&["write_bulk"])
             .start_timer();
@@ -369,8 +373,189 @@ impl RegionWriteCtx {
             let bytes = new_memory_usage.saturating_sub(prev_memory_usage.unwrap_or_default());
             written_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
         }
+    }
+
+    /// Publishes the sequences and entry id assigned by this context to the
+    /// region's committed watermark.
+    ///
+    /// Must be called after both [`write_memtable`](Self::write_memtable) and
+    /// [`write_bulk`](Self::write_bulk) have completed, so the committed
+    /// sequence never covers rows that are not yet physically installed in the
+    /// memtable (bulk part sequences are assigned in [`push_bulk`](Self::push_bulk)
+    /// before installation). Since we store the last sequence and entry id in
+    /// the region, we decrease `next_sequence` and `next_entry_id` by 1.
+    ///
+    /// If the write operation failed (e.g. the WAL entry could not be built),
+    /// no rows were installed and nothing must be published: advancing the
+    /// committed watermark here would make it cover rows that were never
+    /// written.
+    pub(crate) fn publish_sequence_and_entry_id(&self) {
+        if self.failed {
+            return;
+        }
         self.version_control
             .set_sequence_and_entry_id(self.next_sequence - 1, self.next_entry_id - 1);
+    }
+}
+
+/// Test-only hooks to make write ordering races deterministic.
+#[cfg(test)]
+pub(crate) mod test_hooks {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use store_api::storage::RegionId;
+    use tokio::sync::watch;
+
+    use super::VersionControlRef;
+
+    /// Channels of an armed bulk-install barrier.
+    ///
+    /// `reached` signals that a bulk write paused between ordinary-memtable
+    /// handling and bulk installation; `release` unblocks it. Dropping the
+    /// senders (by disarming the barrier) also unblocks paused writes because
+    /// their `wait_for` fails on a closed channel.
+    struct ActiveBarrier {
+        id: u64,
+        /// Only bulk writes for this region pause at the barrier; writes for
+        /// other regions pass through untouched, so concurrently running tests
+        /// can never satisfy (or be blocked by) each other's barrier.
+        target_region_id: RegionId,
+        /// The exact version control instance the owning test's write context
+        /// was created from. Matched by `Arc` identity (not content), so only
+        /// that context's bulk write pauses here: another write that merely
+        /// reuses the same `RegionId` (e.g. a concurrently running test) holds
+        /// a different `Arc` allocation and passes through untouched.
+        target_version_control: VersionControlRef,
+        reached: watch::Sender<bool>,
+        release: watch::Sender<bool>,
+    }
+
+    /// The currently armed barrier, if any. Wrapped in a `Mutex` so a test can
+    /// arm a fresh barrier after a previous one was released (or dropped), and
+    /// so a barrier can never leak past the test that owns it.
+    static ACTIVE_BARRIER: Mutex<Option<ActiveBarrier>> = Mutex::new(None);
+    static NEXT_BARRIER_ID: AtomicU64 = AtomicU64::new(1);
+
+    fn lock_active_barrier() -> std::sync::MutexGuard<'static, Option<ActiveBarrier>> {
+        // Never let a poisoned mutex (e.g. a panic in another test while
+        // holding the lock) hang or break unrelated tests.
+        ACTIVE_BARRIER
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// RAII guard for the bulk-install barrier.
+    ///
+    /// The guard owns the armed barrier. Releasing it — or dropping the guard,
+    /// e.g. when a test panics — unblocks any write paused at the barrier and
+    /// disarms it, so a paused write can never hang and later tests can arm a
+    /// fresh barrier.
+    pub(crate) struct BulkInstallBarrier {
+        id: u64,
+        reached_rx: watch::Receiver<bool>,
+        release_tx: watch::Sender<bool>,
+        released: bool,
+    }
+
+    impl BulkInstallBarrier {
+        /// Waits until a bulk write paused at the barrier.
+        pub(crate) async fn wait_until_reached(&mut self) {
+            if !*self.reached_rx.borrow() {
+                let _ = self.reached_rx.wait_for(|reached| *reached).await;
+            }
+        }
+
+        /// Unblocks the paused write and disarms the barrier.
+        pub(crate) fn release(&mut self) {
+            if self.released {
+                return;
+            }
+            self.released = true;
+            // Flip the release value so writes paused on this barrier proceed.
+            let _ = self.release_tx.send(true);
+            disarm_barrier(self.id);
+        }
+    }
+
+    impl Drop for BulkInstallBarrier {
+        fn drop(&mut self) {
+            self.release();
+        }
+    }
+
+    /// Arms the bulk-install barrier for `target_region_id`'s write context
+    /// identified by `target_version_control` and returns a guard that owns it.
+    ///
+    /// The barrier only pauses the bulk write whose context was created from
+    /// that exact `VersionControl` instance (`Arc` identity), so a write for a
+    /// different context reusing the same `RegionId` is never blocked by, and
+    /// can never satisfy, this barrier.
+    ///
+    /// Any previously armed barrier is replaced: its senders are dropped, which
+    /// unblocks writes that were paused on it instead of letting them hang.
+    pub(crate) fn arm_bulk_install_barrier(
+        target_region_id: RegionId,
+        target_version_control: VersionControlRef,
+    ) -> BulkInstallBarrier {
+        let (reached_tx, reached_rx) = watch::channel(false);
+        let (release_tx, _release_rx) = watch::channel(false);
+        let id = NEXT_BARRIER_ID.fetch_add(1, Ordering::Relaxed);
+        let mut active = lock_active_barrier();
+        *active = Some(ActiveBarrier {
+            id,
+            target_region_id,
+            target_version_control,
+            reached: reached_tx,
+            release: release_tx.clone(),
+        });
+        BulkInstallBarrier {
+            id,
+            reached_rx,
+            release_tx,
+            released: false,
+        }
+    }
+
+    /// Removes the barrier with `id` from the statics if it is still active.
+    fn disarm_barrier(id: u64) {
+        let mut active = lock_active_barrier();
+        if active.as_ref().is_some_and(|barrier| barrier.id == id) {
+            *active = None;
+        }
+    }
+
+    /// Pauses a bulk write for `region_id` whose context belongs to
+    /// `version_control` before installing its parts until the test releases
+    /// the barrier (or it is disarmed). The write only pauses when both the
+    /// region id and the version control instance (`Arc::ptr_eq`) match the
+    /// armed barrier; all other bulk writes return immediately, so a write
+    /// from another context reusing the same `RegionId` can neither satisfy
+    /// nor be blocked by the barrier.
+    pub(crate) async fn pause_before_bulk_install(
+        region_id: RegionId,
+        version_control: &VersionControlRef,
+    ) {
+        let (reached_tx, release_rx) = {
+            let active = lock_active_barrier();
+            match active.as_ref() {
+                Some(barrier)
+                    if barrier.target_region_id == region_id
+                        && Arc::ptr_eq(&barrier.target_version_control, version_control) =>
+                {
+                    (barrier.reached.clone(), barrier.release.subscribe())
+                }
+                _ => return,
+            }
+        };
+        // Signal that a bulk write reached the pause point.
+        let _ = reached_tx.send(true);
+        let mut release_rx = release_rx;
+        if !*release_rx.borrow() {
+            // The sender is dropped when the barrier is disarmed, which makes
+            // `wait_for` return an error instead of hanging forever.
+            let _ = release_rx.wait_for(|released| *released).await;
+        }
     }
 }
 

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -128,6 +128,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 let mut region_ctx = region_ctxs.into_values().next().unwrap();
                 region_ctx.write_memtable().await;
                 region_ctx.write_bulk().await;
+                // Publish only after all rows (including bulk parts) are
+                // physically installed, so a scan opening on the committed
+                // sequence can never bind H to invisible rows.
+                region_ctx.publish_sequence_and_entry_id();
                 put_rows += region_ctx.put_num;
                 delete_rows += region_ctx.delete_num;
             } else {
@@ -138,6 +142,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         common_runtime::spawn_global(async move {
                             region_ctx.write_memtable().await;
                             region_ctx.write_bulk().await;
+                            // The spawned task owns the moved ctx, so publish
+                            // inside the task after the memtable writes.
+                            region_ctx.publish_sequence_and_entry_id();
                             (region_ctx.put_num, region_ctx.delete_num)
                         })
                     })
@@ -734,7 +741,12 @@ fn check_partition_expr_version(
 
 #[cfg(test)]
 mod tests {
-    use api::v1::{Row, Rows};
+    use api::v1::helper::{tag_column_schema, time_index_column_schema};
+    use api::v1::value::ValueData;
+    use api::v1::{ColumnDataType, Row, Rows};
+    use common_recordbatch::DfRecordBatch;
+    use datatypes::arrow::array::{ArrayRef, StringArray, TimestampMillisecondArray};
+    use datatypes::arrow::datatypes::{DataType, Field, Schema};
     use futures::stream;
     use log_store::error::{
         Error as LogStoreError, IllegalStateSnafu, InvalidProviderSnafu, Result as LogStoreResult,
@@ -746,8 +758,41 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
+    use crate::memtable::bulk::part::BulkPart;
     use crate::request::OptionOutputTx;
+    use crate::test_util::ts_ms_value;
     use crate::test_util::version_util::VersionControlBuilder;
+
+    /// Creates a bulk part with `num_rows` rows. The schema carries the
+    /// builder metadata's columns (`tag_0` primary key + `ts` time index) so
+    /// the bulk-install conversion succeeds; `timestamp_index` points at the
+    /// `ts` column.
+    fn new_bulk_part(num_rows: i64) -> BulkPart {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("tag_0", DataType::Utf8, true),
+            Field::new(
+                "ts",
+                DataType::Timestamp(datatypes::arrow::datatypes::TimeUnit::Millisecond, None),
+                false,
+            ),
+        ]));
+        let tag = Arc::new(StringArray::from_iter_values(
+            (0..num_rows).map(|value| value.to_string()),
+        )) as ArrayRef;
+        let ts = Arc::new(TimestampMillisecondArray::from(
+            (0..num_rows).collect::<Vec<_>>(),
+        )) as ArrayRef;
+        let batch = DfRecordBatch::try_new(schema, vec![tag, ts]).unwrap();
+
+        BulkPart {
+            batch,
+            max_timestamp: num_rows - 1,
+            min_timestamp: 0,
+            sequence: 0,
+            timestamp_index: 1,
+            raw_data: None,
+        }
+    }
 
     /// A log store that fails to build entries for `failing_region` and fails the
     /// whole batch when `fail_append` is true.
@@ -857,8 +902,18 @@ mod tests {
         ctx.push_mutation(
             OpType::Put as i32,
             Some(Rows {
-                schema: vec![],
-                rows: vec![Row { values: vec![] }],
+                schema: vec![
+                    time_index_column_schema("ts", ColumnDataType::TimestampMillisecond),
+                    tag_column_schema("tag_0", ColumnDataType::String),
+                ],
+                rows: vec![Row {
+                    values: vec![
+                        ts_ms_value(0),
+                        api::v1::Value {
+                            value_data: Some(ValueData::StringValue("a".to_string())),
+                        },
+                    ],
+                }],
             }),
             None,
             OptionOutputTx::from(tx),
@@ -878,8 +933,10 @@ mod tests {
 
         let mut region_ctxs = HashMap::new();
         let (ctx, failing_rx) = new_region_ctx(failing_region);
+        let failing_committed_sequence = ctx.version_control().committed_sequence();
         region_ctxs.insert(failing_region, ctx);
         let (ctx, ok_rx) = new_region_ctx(ok_region);
+        let ok_committed_sequence = ctx.version_control().committed_sequence();
         region_ctxs.insert(ok_region, ctx);
         let entry_id = region_ctxs[&ok_region].next_entry_id();
 
@@ -890,10 +947,117 @@ mod tests {
         assert!(!region_ctxs[&ok_region].is_failed());
         assert_eq!(entry_id + 1, region_ctxs[&ok_region].next_entry_id());
 
+        // Run the memtable and publication phase the worker runs after `write_wal`.
+        // The failed region installed no rows, so its committed sequence must not
+        // advance; the successful sibling region advances normally.
+        for region_ctx in region_ctxs.values_mut() {
+            region_ctx.write_memtable().await;
+            region_ctx.write_bulk().await;
+            region_ctx.publish_sequence_and_entry_id();
+        }
+
+        assert_eq!(
+            failing_committed_sequence,
+            region_ctxs[&failing_region]
+                .version_control()
+                .committed_sequence()
+        );
+        assert_eq!(
+            ok_committed_sequence + 1,
+            region_ctxs[&ok_region]
+                .version_control()
+                .committed_sequence()
+        );
+
         // Waiters of the failed region get the error while others get the result.
         drop(region_ctxs);
         assert!(failing_rx.await.unwrap().is_err());
         assert_eq!(1, ok_rx.await.unwrap().unwrap());
+    }
+
+    // The committed sequence must not be published before the bulk part's rows
+    // are physically installed in the memtable: publication happens strictly
+    // after `write_bulk` returns. Armed with the bulk-install test barrier,
+    // this deterministically pauses the worker's memtable phase between the
+    // ordinary-memtable handling and the bulk installation and asserts the
+    // region's committed sequence is still its initial value (0) — read via
+    // the `version_control()` accessor, never through a scanner API. After the
+    // barrier is released, the committed sequence must advance to cover the
+    // bulk rows.
+    #[tokio::test]
+    async fn test_bulk_write_sequence_not_committed_before_install_worker_level() {
+        let region_id = RegionId::new(1, 1);
+        let version_control = Arc::new(VersionControlBuilder::new().build());
+        assert_eq!(
+            0,
+            version_control.committed_sequence(),
+            "the builder must start at sequence 0"
+        );
+
+        let mut region_ctxs = HashMap::new();
+        let mut ctx = RegionWriteCtx::new(
+            region_id,
+            &version_control,
+            Provider::raft_engine_provider(region_id.as_u64()),
+            None,
+        );
+        let (tx, rx) = oneshot::channel();
+        // Push a 3-row bulk part without an explicit sequence, exactly like the
+        // worker's `process_bulk_requests`.
+        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(3), None));
+        region_ctxs.insert(region_id, ctx);
+
+        // Run the WAL phase the worker runs before the memtable phase.
+        let wal = Wal::new(Arc::new(MockLogStore::default()));
+        assert!(write_wal(&wal, &mut region_ctxs).await);
+        assert!(!region_ctxs[&region_id].is_failed());
+
+        // Arm the bulk-install barrier: `write_bulk` pauses right before the
+        // parts are physically installed into the memtable. The barrier is
+        // bound to this test's version control instance (Arc identity), so a
+        // concurrently running test that happens to reuse the same region id
+        // can never satisfy (or be blocked by) it.
+        let mut barrier = crate::region_write_ctx::test_hooks::arm_bulk_install_barrier(
+            region_id,
+            version_control.clone(),
+        );
+
+        // Run the worker's memtable and publication phases in the background.
+        let write_handle = tokio::spawn(async move {
+            let mut region_ctx = region_ctxs.remove(&region_id).unwrap();
+            region_ctx.write_memtable().await;
+            region_ctx.write_bulk().await;
+            region_ctx.publish_sequence_and_entry_id();
+        });
+
+        // Wait until the write paused at the barrier: deterministic, no sleeps.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            barrier.wait_until_reached(),
+        )
+        .await
+        .expect("bulk write never reached the install barrier");
+
+        // The committed sequence must not have advanced yet: publication
+        // happens strictly after the bulk part is installed.
+        assert_eq!(
+            0,
+            version_control.committed_sequence(),
+            "committed sequence leaked before the bulk part was installed"
+        );
+
+        // Release the barrier: the bulk part installs and the committed
+        // sequence advances to cover all 3 bulk rows.
+        barrier.release();
+        write_handle.await.expect("bulk write should complete");
+        assert_eq!(
+            3,
+            version_control.committed_sequence(),
+            "committed sequence must cover the installed bulk rows"
+        );
+
+        // The bulk waiter is notified with the number of installed rows.
+        assert_eq!(3, rx.await.unwrap().unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

PR 1/5 of the incremental Flow data-plane series: #8862 → #8865 → #8866 (with #8863, #8864 in parallel).

## What's changed and what's your intention?

### Problem

The region's committed-sequence watermark was published inside `write_memtable()`, before bulk parts were installed into the memtable. A scan opening a snapshot could bind H to sequences whose rows were not yet physically visible: the checkpoint advances past them and the rows are permanently missed.

### Change

- Publish the watermark once, strictly after both ordinary and bulk memtable writes complete, on all three paths: the single-region fast path, the multi-region spawned tasks, and WAL replay.
- Failed write contexts (WAL entry could not be built) never publish.
- A `#[cfg(test)]` watch-channel barrier makes the race deterministic (region-targeted, empty-bulk early return hoisted); a worker-level regression test pins the ordering.

### Verification

- `cargo nextest run -p mito2`: 1113 passed (base 1112 + 1 new race test)
- `make fmt` / `git diff --check` clean

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

