### PR TITLE
feat(flow): mergeable UDDSketch state for incremental aggregation

### DIFF
--- a/src/common/function/src/aggrs/approximate/uddsketch.rs
+++ b/src/common/function/src/aggrs/approximate/uddsketch.rs
@@ -38,6 +38,13 @@ pub const UDDSKETCH_STATE_NAME: &str = "uddsketch_state";
 
 pub const UDDSKETCH_MERGE_NAME: &str = "uddsketch_merge";
 
+/// Name of the scalar function that merges exactly two UDDSketch states into
+/// one. It is used internally by the flow batching incremental rewrite to merge
+/// a delta state with the existing sink state of the same group, and is
+/// registered in the function registry so that the rewritten logical plan can
+/// round-trip through the Substrait codec (the frontend resolves it by name).
+pub const UDDSKETCH_MERGE_STATE_NAME: &str = "uddsketch_merge_state";
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UddSketchState {
     uddsketch: UDDSketch,
@@ -93,8 +100,15 @@ impl UddSketchState {
     fn merge(&mut self, raw: &[u8]) -> DfResult<()> {
         if let Ok(uddsketch) = bincode::deserialize::<Self>(raw) {
             if uddsketch.uddsketch.count() != 0 {
+                // Compare the serialized error rate exactly: the pinned
+                // `uddsketch` dependency derives `gamma` from the error rate
+                // and `merge_sketch` asserts that the reconstructed gammas
+                // differ by less than 1e-9. Two error rates within 1e-9 of
+                // each other (e.g. 0.01 and 0.0100000005) pass a tolerance
+                // check but still trip that assert, so accept only bitwise
+                // identical parameters.
                 if self.uddsketch.max_allowed_buckets() != uddsketch.uddsketch.max_allowed_buckets()
-                    || (self.error_rate - uddsketch.error_rate).abs() >= 1e-9
+                    || self.error_rate != uddsketch.error_rate
                 {
                     return Err(DataFusionError::Plan(format!(
                         "Merging UDDSketch with different parameters: arguments={:?} vs actual input={:?}",
@@ -105,7 +119,19 @@ impl UddSketchState {
                         )
                     )));
                 }
-                self.uddsketch.merge_sketch(&uddsketch.uddsketch);
+                // `merge_sketch` validates the reconstructed gammas with an
+                // assert rather than a Result, and a malformed/corrupt
+                // deserialized state can also hit internal asserts. Catch any
+                // panic so it becomes a DataFusionError instead of unwinding
+                // through query execution.
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    self.uddsketch.merge_sketch(&uddsketch.uddsketch);
+                }))
+                .map_err(|_| {
+                    DataFusionError::Execution(
+                        "UDDSketch panicked while merging state; the input state may be corrupt or have incompatible parameters".to_string(),
+                    )
+                })?;
             }
         } else {
             trace!("Warning: Failed to deserialize UDDSketch from {:?}", raw);
@@ -124,7 +150,16 @@ fn downcast_accumulator_args(args: AccumulatorArgs) -> DfResult<(u64, f64)> {
         .downcast_ref::<Literal>()
         .map(|lit| lit.value())
     {
-        Some(ScalarValue::Int64(Some(value))) => *value as u64,
+        Some(ScalarValue::Int64(Some(value))) => {
+            if *value <= 0 {
+                return not_impl_err!(
+                    "{} bucket size must be positive, got {}",
+                    UDDSKETCH_STATE_NAME,
+                    value
+                );
+            }
+            *value as u64
+        }
         _ => {
             return not_impl_err!(
                 "{} not supported for bucket size: {}",
@@ -139,7 +174,16 @@ fn downcast_accumulator_args(args: AccumulatorArgs) -> DfResult<(u64, f64)> {
         .downcast_ref::<Literal>()
         .map(|lit| lit.value())
     {
-        Some(ScalarValue::Float64(Some(value))) => *value,
+        Some(ScalarValue::Float64(Some(value))) => {
+            if !(1e-12..1.0).contains(value) {
+                return not_impl_err!(
+                    "{} error rate must be in [1e-12, 1.0), got {}",
+                    UDDSKETCH_STATE_NAME,
+                    value
+                );
+            }
+            *value
+        }
         _ => {
             return not_impl_err!(
                 "{} not supported for error rate: {}",
@@ -339,6 +383,62 @@ mod tests {
         } else {
             panic!("Expected binary scalar values");
         }
+    }
+
+    #[test]
+    fn test_uddsketch_merge_rejects_close_error_rate() {
+        // Error rates 0.01 and 0.0100000005 differ by 5e-10, which passes the
+        // old 1e-9 tolerance but trips the `uddsketch` dependency's assert on
+        // the reconstructed gammas. The merge must reject the state with an
+        // error instead of panicking through query execution.
+        let mut other = UddSketchState::new(10, 0.0100000005);
+        other.update(1.0);
+        let ScalarValue::Binary(Some(bytes)) = other.evaluate().unwrap() else {
+            unreachable!()
+        };
+
+        let mut state = UddSketchState::new(10, 0.01);
+        let result = state.merge(&bytes);
+        assert!(
+            result.is_err(),
+            "error rates within 1e-9 of each other must be rejected, got: {result:?}"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("different parameters"),
+            "mismatch error should mention the parameters"
+        );
+    }
+
+    #[test]
+    fn test_uddsketch_merge_rejects_corrupt_state() {
+        // Corrupt bytes must produce an error, never a panic.
+        let mut state = UddSketchState::new(10, 0.01);
+        let result = state.merge(b"definitely not a uddsketch state");
+        assert!(result.is_err(), "corrupt state bytes must fail loudly");
+    }
+
+    #[test]
+    fn test_uddsketch_merge_identical_params_still_merges() {
+        let mut other = UddSketchState::new(10, 0.01);
+        other.update(1.0);
+        other.update(2.0);
+        let ScalarValue::Binary(Some(bytes)) = other.evaluate().unwrap() else {
+            unreachable!()
+        };
+
+        let mut state = UddSketchState::new(10, 0.01);
+        state.update(3.0);
+        state.merge(&bytes).unwrap();
+
+        let ScalarValue::Binary(Some(merged_bytes)) = state.evaluate().unwrap() else {
+            unreachable!()
+        };
+        let deserialized: UddSketchState = bincode::deserialize(&merged_bytes).unwrap();
+        assert_eq!(deserialized.uddsketch.count(), 3);
+        assert!((deserialized.uddsketch.sum() - 6.0).abs() < 1e-10);
     }
 
     #[test]

--- a/src/common/function/src/function_registry.rs
+++ b/src/common/function/src/function_registry.rs
@@ -40,7 +40,7 @@ use crate::scalars::math::MathFunction;
 use crate::scalars::primary_key::DecodePrimaryKeyFunction;
 use crate::scalars::string::register_string_functions;
 use crate::scalars::timestamp::TimestampFunction;
-use crate::scalars::uddsketch_calc::UddSketchCalcFunction;
+use crate::scalars::uddsketch_calc::{UddSketchCalcFunction, UddSketchMergeStateFunction};
 use crate::scalars::vector::VectorFunction as VectorScalarFunction;
 use crate::system::SystemFunction;
 
@@ -209,6 +209,7 @@ pub static FUNCTION_REGISTRY: LazyLock<Arc<FunctionRegistry>> = LazyLock::new(||
     DateFunction::register(&function_registry);
     ExpressionFunction::register(&function_registry);
     UddSketchCalcFunction::register(&function_registry);
+    UddSketchMergeStateFunction::register(&function_registry);
     HllCalcFunction::register(&function_registry);
     DecodePrimaryKeyFunction::register(&function_registry);
 

--- a/src/common/function/src/scalars/uddsketch_calc.rs
+++ b/src/common/function/src/scalars/uddsketch_calc.rs
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Implementation of the scalar function `uddsketch_calc`.
+//! Implementation of the scalar functions `uddsketch_calc` and
+//! `uddsketch_merge_state`.
 
 use std::fmt;
 use std::fmt::Display;
 use std::sync::Arc;
 
+use datafusion::logical_expr::Accumulator as _;
 use datafusion_common::DataFusionError;
-use datafusion_common::arrow::array::{Array, AsArray, Float64Builder};
-use datafusion_common::arrow::datatypes::{DataType, Float64Type};
+use datafusion_common::arrow::array::{Array, AsArray, BinaryArray, BinaryBuilder, Float64Builder};
+use datafusion_common::arrow::datatypes::{DataType, Float64Type, Int64Type};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
 use uddsketch::UDDSketch;
 
+use crate::aggrs::approximate::uddsketch::{UDDSKETCH_MERGE_STATE_NAME, UddSketchState};
 use crate::function::{Function, extract_args};
 use crate::function_registry::FunctionRegistry;
 
@@ -131,9 +134,246 @@ impl Function for UddSketchCalcFunction {
                 builder.append_null();
                 continue;
             }
+            // `estimate_quantile` asserts the percentile is in [0, 1]; validate
+            // it up front so an out-of-range percentile is a query error
+            // instead of a panic.
+            if !(0.0..=1.0).contains(&perc) {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects percentile in [0.0, 1.0], got {perc}",
+                    self.name()
+                )));
+            }
             // Compute the estimated quantile from the sketch
             let result = sketch.estimate_quantile(perc);
             builder.append_value(result);
+        }
+
+        Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+    }
+}
+
+/// UddSketchMergeStateFunction implements the scalar function
+/// `uddsketch_merge_state`.
+///
+/// It accepts four arguments:
+/// 1. Bucket size (as int64), same as `uddsketch_state`'s first argument.
+/// 2. Error rate (as float64), same as `uddsketch_state`'s second argument.
+/// 3. The first serialized UDDSketch state (binary), e.g. a delta state.
+/// 4. The second serialized UDDSketch state (binary), e.g. an existing sink state.
+///
+/// It merges the two states into one and returns the merged state (binary).
+/// The bucket size and error rate must match the parameters used to create
+/// both input states; otherwise the merge fails loudly instead of silently
+/// producing a wrong state.
+#[derive(Debug)]
+pub(crate) struct UddSketchMergeStateFunction {
+    signature: Signature,
+}
+
+impl UddSketchMergeStateFunction {
+    pub fn register(registry: &FunctionRegistry) {
+        registry.register_scalar(UddSketchMergeStateFunction::default());
+    }
+}
+
+impl Default for UddSketchMergeStateFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![
+                    DataType::Int64,
+                    DataType::Float64,
+                    DataType::Binary,
+                    DataType::Binary,
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl Display for UddSketchMergeStateFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", UDDSKETCH_MERGE_STATE_NAME.to_ascii_uppercase())
+    }
+}
+
+impl Function for UddSketchMergeStateFunction {
+    fn name(&self) -> &str {
+        UDDSKETCH_MERGE_STATE_NAME
+    }
+
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(DataType::Binary)
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        let [arg0, arg1, arg2, arg3] = extract_args(self.name(), &args)?;
+
+        let bucket_size_arr = match arg0.as_primitive_opt::<Int64Type>() {
+            Some(arr) => arr,
+            None => {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects 1st argument to be Int64 datatype, got {}",
+                    self.name(),
+                    arg0.data_type()
+                )));
+            }
+        };
+        let error_rate_arr = match arg1.as_primitive_opt::<Float64Type>() {
+            Some(arr) => arr,
+            None => {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects 2nd argument to be Float64 datatype, got {}",
+                    self.name(),
+                    arg1.data_type()
+                )));
+            }
+        };
+        let Some(delta_states) = arg2.as_binary_opt::<i32>() else {
+            return Err(DataFusionError::Execution(format!(
+                "'{}' expects 3rd argument to be Binary datatype, got {}",
+                self.name(),
+                arg2.data_type()
+            )));
+        };
+        let Some(sink_states) = arg3.as_binary_opt::<i32>() else {
+            return Err(DataFusionError::Execution(format!(
+                "'{}' expects 4th argument to be Binary datatype, got {}",
+                self.name(),
+                arg3.data_type()
+            )));
+        };
+
+        let len = delta_states.len().max(sink_states.len());
+        if len == 0 {
+            // Empty batch: nothing to merge, no parameters to validate.
+            return Ok(ColumnarValue::Array(Arc::new(
+                BinaryBuilder::new().finish(),
+            )));
+        }
+
+        // The bucket size and error rate describe every state being merged, so
+        // they must be non-null, valid, and identical across all rows. Reading
+        // them per row keeps the function safe on arbitrary-length batches and
+        // rejects mixed parameters instead of silently merging mismatched
+        // states.
+        let mut bucket_size: i64 = 0;
+        let mut error_rate: f64 = 0.0;
+        let mut params_set = false;
+        for i in 0..len {
+            if i >= bucket_size_arr.len() || i >= error_rate_arr.len() {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects bucket size and error rate arguments to cover every row",
+                    self.name()
+                )));
+            }
+            if !bucket_size_arr.is_valid(i) || !error_rate_arr.is_valid(i) {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects non-null bucket size and error rate arguments",
+                    self.name()
+                )));
+            }
+            let row_bucket_size = bucket_size_arr.value(i);
+            let row_error_rate = error_rate_arr.value(i);
+            if row_bucket_size <= 0 {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects bucket size to be positive, got {row_bucket_size}",
+                    self.name()
+                )));
+            }
+            if !(1e-12..1.0).contains(&row_error_rate) {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects error rate in [1e-12, 1.0), got {row_error_rate}",
+                    self.name()
+                )));
+            }
+            if params_set && (row_bucket_size != bucket_size || row_error_rate != error_rate) {
+                return Err(DataFusionError::Execution(format!(
+                    "'{}' expects constant bucket size and error rate across all rows, got ({row_bucket_size}, {row_error_rate}) after ({bucket_size}, {error_rate})",
+                    self.name()
+                )));
+            }
+            if !params_set {
+                bucket_size = row_bucket_size;
+                error_rate = row_error_rate;
+                params_set = true;
+            }
+        }
+
+        // Validates non-null state bytes against the merge parameters by
+        // running them through the same deserialization and parameter check
+        // the two-state merge path uses. Single-side NULL rows used to pass
+        // their bytes through unchecked, letting corrupt or mismatched state
+        // slip into the sink; now they are validated exactly like a merge.
+        let validate_state = |state: &[u8]| -> datafusion_common::Result<()> {
+            let mut acc = UddSketchState::new(bucket_size as u64, error_rate);
+            let states = BinaryArray::from_opt_vec(vec![Some(state)]);
+            acc.merge_batch(&[Arc::new(states)]).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "'{}' failed to merge UDDSketch states: {}",
+                    self.name(),
+                    e
+                ))
+            })
+        };
+
+        let mut builder = BinaryBuilder::with_capacity(len, 0);
+        for i in 0..len {
+            let delta = if i < delta_states.len() {
+                delta_states.is_valid(i).then(|| delta_states.value(i))
+            } else {
+                None
+            };
+            let sink = if i < sink_states.len() {
+                sink_states.is_valid(i).then(|| sink_states.value(i))
+            } else {
+                None
+            };
+            match (delta, sink) {
+                (None, None) => builder.append_null(),
+                (Some(delta), None) => {
+                    validate_state(delta)?;
+                    builder.append_value(delta);
+                }
+                (None, Some(sink)) => {
+                    validate_state(sink)?;
+                    builder.append_value(sink);
+                }
+                (Some(delta), Some(sink)) => {
+                    let mut acc = UddSketchState::new(bucket_size as u64, error_rate);
+                    let states = BinaryArray::from_opt_vec(vec![Some(delta), Some(sink)]);
+                    acc.merge_batch(&[Arc::new(states)]).map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "'{}' failed to merge UDDSketch states: {}",
+                            self.name(),
+                            e
+                        ))
+                    })?;
+                    let datafusion_common::ScalarValue::Binary(Some(bytes)) =
+                        acc.evaluate().map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "'{}' failed to evaluate merged UDDSketch state: {}",
+                                self.name(),
+                                e
+                            ))
+                        })?
+                    else {
+                        return Err(DataFusionError::Execution(format!(
+                            "'{}' expected a binary merged UDDSketch state",
+                            self.name()
+                        )));
+                    };
+                    builder.append_value(&bytes);
+                }
+            }
         }
 
         Ok(ColumnarValue::Array(Arc::new(builder.finish())))
@@ -145,9 +385,47 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_schema::Field;
-    use datafusion_common::arrow::array::{BinaryArray, Float64Array};
+    use datafusion_common::ScalarValue;
+    use datafusion_common::arrow::array::{
+        ArrayRef, AsArray, BinaryArray, Float64Array, Int64Array,
+    };
+    use datafusion_common::arrow::datatypes::Float64Type;
 
     use super::*;
+
+    /// Builds a serialized `uddsketch_state` state from the given values.
+    fn make_state(bucket_size: u64, error_rate: f64, values: &[f64]) -> Vec<u8> {
+        let mut acc = UddSketchState::new(bucket_size, error_rate);
+        let values: ArrayRef = Arc::new(Float64Array::from(values.to_vec()));
+        acc.update_batch(&[values.clone(), values.clone(), values])
+            .unwrap();
+        let ScalarValue::Binary(Some(bytes)) = acc.evaluate().unwrap() else {
+            unreachable!()
+        };
+        bytes
+    }
+
+    /// Invokes `uddsketch_merge_state` on a single row.
+    fn invoke_merge_state(
+        function: &UddSketchMergeStateFunction,
+        bucket_size: i64,
+        error_rate: f64,
+        delta: Option<&[u8]>,
+        sink: Option<&[u8]>,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        function.invoke_with_args(ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(Int64Array::from(vec![bucket_size]))),
+                ColumnarValue::Array(Arc::new(Float64Array::from(vec![error_rate]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![delta]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![sink]))),
+            ],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("x", DataType::Binary, false)),
+            config_options: Arc::new(Default::default()),
+        })
+    }
 
     #[test]
     fn test_uddsketch_calc_function() {
@@ -208,6 +486,107 @@ mod tests {
     }
 
     #[test]
+    fn test_uddsketch_merge_state_function() {
+        use datafusion::logical_expr::Accumulator as _;
+
+        let mut state1 = UddSketchState::new(10, 0.01);
+        let values1: ArrayRef = Arc::new(Float64Array::from(vec![1.0]));
+        state1
+            .update_batch(&[values1.clone(), values1.clone(), values1])
+            .unwrap();
+        let state1_binary = state1.evaluate().unwrap();
+
+        let mut state2 = UddSketchState::new(10, 0.01);
+        let values2: ArrayRef = Arc::new(Float64Array::from(vec![2.0]));
+        state2
+            .update_batch(&[values2.clone(), values2.clone(), values2])
+            .unwrap();
+        let state2_binary = state2.evaluate().unwrap();
+
+        let function = UddSketchMergeStateFunction::default();
+        assert_eq!("uddsketch_merge_state", function.name());
+        assert_eq!(DataType::Binary, function.return_type(&[]).unwrap());
+
+        let ScalarValue::Binary(Some(state1_bytes)) = state1_binary else {
+            unreachable!()
+        };
+        let ScalarValue::Binary(Some(state2_bytes)) = state2_binary else {
+            unreachable!()
+        };
+        let args = vec![
+            ColumnarValue::Array(Arc::new(datafusion_common::arrow::array::Int64Array::from(
+                vec![10],
+            ))),
+            ColumnarValue::Array(Arc::new(Float64Array::from(vec![0.01]))),
+            ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                state1_bytes.as_slice(),
+            )]))),
+            ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                state2_bytes.as_slice(),
+            )]))),
+        ];
+
+        let result = function
+            .invoke_with_args(ScalarFunctionArgs {
+                args,
+                arg_fields: vec![],
+                number_rows: 1,
+                return_field: Arc::new(Field::new("x", DataType::Binary, false)),
+                config_options: Arc::new(Default::default()),
+            })
+            .unwrap();
+        let ColumnarValue::Array(result) = result else {
+            unreachable!()
+        };
+        let result = result.as_binary::<i32>();
+        assert_eq!(result.len(), 1);
+        let merged: uddsketch::UDDSketch = bincode::deserialize(result.value(0)).unwrap();
+        assert_eq!(merged.count(), 2);
+        assert!((merged.sum() - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_rejects_parameter_mismatch() {
+        use datafusion::logical_expr::Accumulator as _;
+
+        // state1 uses bucket size 10 while the merge call uses bucket size 20:
+        // the merge must fail loudly instead of silently producing a wrong state.
+        let mut state1 = UddSketchState::new(10, 0.01);
+        let values: ArrayRef = Arc::new(Float64Array::from(vec![1.0]));
+        state1
+            .update_batch(&[values.clone(), values.clone(), values])
+            .unwrap();
+        let ScalarValue::Binary(Some(state1_bytes)) = state1.evaluate().unwrap() else {
+            unreachable!()
+        };
+
+        let function = UddSketchMergeStateFunction::default();
+        let args = vec![
+            ColumnarValue::Array(Arc::new(datafusion_common::arrow::array::Int64Array::from(
+                vec![20],
+            ))),
+            ColumnarValue::Array(Arc::new(Float64Array::from(vec![0.01]))),
+            ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                state1_bytes.as_slice(),
+            )]))),
+            ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                state1_bytes.as_slice(),
+            )]))),
+        ];
+        let result = function.invoke_with_args(ScalarFunctionArgs {
+            args,
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("x", DataType::Binary, false)),
+            config_options: Arc::new(Default::default()),
+        });
+        assert!(
+            result.is_err(),
+            "merging states with different parameters must fail loudly"
+        );
+    }
+
+    #[test]
     fn test_uddsketch_calc_function_errors() {
         let function = UddSketchCalcFunction::default();
 
@@ -249,5 +628,464 @@ mod tests {
         let result = result.as_primitive::<Float64Type>();
         assert_eq!(result.len(), 1);
         assert!(result.is_null(0));
+    }
+
+    #[test]
+    fn test_uddsketch_calc_function_null_and_empty_sketch() {
+        let function = UddSketchCalcFunction::default();
+        let state = make_state(10, 0.01, &[1.0, 2.0]);
+        let empty = make_state(10, 0.01, &[]);
+
+        // NULL percentile, NULL state, and empty sketch all produce NULL;
+        // a valid percentile over a non-empty sketch produces a value.
+        let args = vec![
+            ColumnarValue::Array(Arc::new(Float64Array::from(vec![
+                Some(0.5),
+                None,
+                Some(0.5),
+                Some(0.5),
+            ]))),
+            ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![
+                Some(state.as_slice()),
+                Some(state.as_slice()),
+                None,
+                Some(empty.as_slice()),
+            ]))),
+        ];
+        let result = function
+            .invoke_with_args(ScalarFunctionArgs {
+                args,
+                arg_fields: vec![],
+                number_rows: 4,
+                return_field: Arc::new(Field::new("x", DataType::Float64, false)),
+                config_options: Arc::new(Default::default()),
+            })
+            .unwrap();
+        let ColumnarValue::Array(result) = result else {
+            unreachable!()
+        };
+        let result = result.as_primitive::<Float64Type>();
+        assert_eq!(result.len(), 4);
+        assert!(
+            result.is_valid(0),
+            "valid percentile should produce a value"
+        );
+        assert!(result.is_null(1), "NULL percentile should produce NULL");
+        assert!(result.is_null(2), "NULL state should produce NULL");
+        assert!(result.is_null(3), "empty sketch should produce NULL");
+    }
+
+    #[test]
+    fn test_uddsketch_calc_function_rejects_out_of_range_percentile() {
+        let function = UddSketchCalcFunction::default();
+        let state = make_state(10, 0.01, &[1.0, 2.0]);
+
+        for percentile in [-0.1f64, 1.1] {
+            let result = function.invoke_with_args(ScalarFunctionArgs {
+                args: vec![
+                    ColumnarValue::Array(Arc::new(Float64Array::from(vec![percentile]))),
+                    ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                        state.as_slice(),
+                    )]))),
+                ],
+                arg_fields: vec![],
+                number_rows: 1,
+                return_field: Arc::new(Field::new("x", DataType::Float64, false)),
+                config_options: Arc::new(Default::default()),
+            });
+            assert!(
+                result.is_err(),
+                "percentile {percentile} must be rejected instead of panicking"
+            );
+        }
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_empty_batch_is_safe() {
+        let function = UddSketchMergeStateFunction::default();
+        let result = function
+            .invoke_with_args(ScalarFunctionArgs {
+                args: vec![
+                    ColumnarValue::Array(Arc::new(Int64Array::from(Vec::<i64>::new()))),
+                    ColumnarValue::Array(Arc::new(Float64Array::from(Vec::<f64>::new()))),
+                    ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(
+                        Vec::<Option<&[u8]>>::new(),
+                    ))),
+                    ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(
+                        Vec::<Option<&[u8]>>::new(),
+                    ))),
+                ],
+                arg_fields: vec![],
+                number_rows: 0,
+                return_field: Arc::new(Field::new("x", DataType::Binary, false)),
+                config_options: Arc::new(Default::default()),
+            })
+            .unwrap();
+        let ColumnarValue::Array(result) = result else {
+            unreachable!()
+        };
+        let result = result.as_binary::<i32>();
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_null_handling() {
+        let function = UddSketchMergeStateFunction::default();
+        let state = make_state(10, 0.01, &[1.0, 2.0]);
+
+        // NULL/NULL -> NULL
+        let result = invoke_merge_state(&function, 10, 0.01, None, None)
+            .unwrap()
+            .into_array(1)
+            .unwrap();
+        let result = result.as_binary::<i32>();
+        assert_eq!(result.len(), 1);
+        assert!(result.is_null(0));
+
+        // delta NULL -> sink state passes through
+        let result = invoke_merge_state(&function, 10, 0.01, None, Some(state.as_slice()))
+            .unwrap()
+            .into_array(1)
+            .unwrap();
+        let result = result.as_binary::<i32>();
+        assert_eq!(result.value(0), state.as_slice());
+
+        // sink NULL -> delta state passes through
+        let result = invoke_merge_state(&function, 10, 0.01, Some(state.as_slice()), None)
+            .unwrap()
+            .into_array(1)
+            .unwrap();
+        let result = result.as_binary::<i32>();
+        assert_eq!(result.value(0), state.as_slice());
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_null_validates_present_state() {
+        let function = UddSketchMergeStateFunction::default();
+
+        // A single-side NULL must still validate the present state: corrupt
+        // bytes must error instead of passing through untouched.
+        let result = invoke_merge_state(&function, 10, 0.01, Some(b"corrupt"), None);
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("failed to merge UDDSketch states"),
+            "corrupt delta with NULL sink must fail loudly: {err}"
+        );
+        let result = invoke_merge_state(&function, 10, 0.01, None, Some(b"corrupt"));
+        assert!(
+            result.is_err(),
+            "corrupt sink with NULL delta must fail loudly"
+        );
+
+        // Mismatched parameters with a NULL side must error as well.
+        let mismatch_bucket = make_state(20, 0.01, &[1.0]);
+        let result =
+            invoke_merge_state(&function, 10, 0.01, Some(mismatch_bucket.as_slice()), None);
+        assert!(
+            result.is_err(),
+            "bucket size mismatch with NULL sink must fail loudly"
+        );
+        let result =
+            invoke_merge_state(&function, 10, 0.01, None, Some(mismatch_bucket.as_slice()));
+        assert!(
+            result.is_err(),
+            "bucket size mismatch with NULL delta must fail loudly"
+        );
+
+        let mismatch_error = make_state(10, 0.05, &[1.0]);
+        let result = invoke_merge_state(&function, 10, 0.01, Some(mismatch_error.as_slice()), None);
+        assert!(
+            result.is_err(),
+            "error rate mismatch with NULL sink must fail loudly"
+        );
+        let result = invoke_merge_state(&function, 10, 0.01, None, Some(mismatch_error.as_slice()));
+        assert!(
+            result.is_err(),
+            "error rate mismatch with NULL delta must fail loudly"
+        );
+
+        // A valid state with a NULL side returns the state's sketch: it must
+        // match merging the state with an empty sketch.
+        let state = make_state(10, 0.01, &[1.0, 2.0]);
+        let empty = make_state(10, 0.01, &[]);
+        for (delta, sink) in [
+            (Some(state.as_slice()), None),
+            (None, Some(state.as_slice())),
+        ] {
+            let result = invoke_merge_state(&function, 10, 0.01, delta, sink)
+                .unwrap()
+                .into_array(1)
+                .unwrap();
+            let result = result.as_binary::<i32>();
+            assert!(
+                result.is_valid(0),
+                "valid state with NULL side should produce a value"
+            );
+            let merged: uddsketch::UDDSketch = bincode::deserialize(result.value(0)).unwrap();
+            assert_eq!(merged.count(), 2);
+            assert!((merged.sum() - 3.0).abs() < 1e-10);
+
+            // Equal to merging the state with an empty sketch.
+            let expected = invoke_merge_state(
+                &function,
+                10,
+                0.01,
+                Some(state.as_slice()),
+                Some(empty.as_slice()),
+            )
+            .unwrap()
+            .into_array(1)
+            .unwrap();
+            let expected = expected.as_binary::<i32>();
+            let expected: uddsketch::UDDSketch = bincode::deserialize(expected.value(0)).unwrap();
+            assert_eq!(expected.count(), merged.count());
+            assert!((expected.sum() - merged.sum()).abs() < 1e-10);
+            for q in [0.1, 0.5, 0.9] {
+                assert!(
+                    (expected.estimate_quantile(q) - merged.estimate_quantile(q)).abs() < 1e-10,
+                    "quantile {q} mismatch: expected={}, got={}",
+                    expected.estimate_quantile(q),
+                    merged.estimate_quantile(q)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_merges_empty_and_nonempty() {
+        let function = UddSketchMergeStateFunction::default();
+        let empty = make_state(10, 0.01, &[]);
+        let nonempty = make_state(10, 0.01, &[3.0, 4.0]);
+
+        let result = invoke_merge_state(
+            &function,
+            10,
+            0.01,
+            Some(empty.as_slice()),
+            Some(nonempty.as_slice()),
+        )
+        .unwrap()
+        .into_array(1)
+        .unwrap();
+        let result = result.as_binary::<i32>();
+        let merged: uddsketch::UDDSketch = bincode::deserialize(result.value(0)).unwrap();
+        assert_eq!(merged.count(), 2);
+        assert!((merged.sum() - 7.0).abs() < 1e-10);
+
+        // Order must not matter.
+        let result = invoke_merge_state(
+            &function,
+            10,
+            0.01,
+            Some(nonempty.as_slice()),
+            Some(empty.as_slice()),
+        )
+        .unwrap()
+        .into_array(1)
+        .unwrap();
+        let result = result.as_binary::<i32>();
+        let merged: uddsketch::UDDSketch = bincode::deserialize(result.value(0)).unwrap();
+        assert_eq!(merged.count(), 2);
+        assert!((merged.sum() - 7.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_rejects_corrupt_state() {
+        let function = UddSketchMergeStateFunction::default();
+        let state = make_state(10, 0.01, &[1.0]);
+
+        let result = invoke_merge_state(
+            &function,
+            10,
+            0.01,
+            Some(b"corrupt"),
+            Some(state.as_slice()),
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("failed to merge UDDSketch states"),
+            "corrupt state bytes must fail loudly: {err}"
+        );
+
+        let result = invoke_merge_state(
+            &function,
+            10,
+            0.01,
+            Some(state.as_slice()),
+            Some(b"corrupt"),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_rejects_state_parameter_mismatch() {
+        let function = UddSketchMergeStateFunction::default();
+
+        // Left state built with bucket size 10, right state with bucket size 20.
+        let left = make_state(10, 0.01, &[1.0]);
+        let right = make_state(20, 0.01, &[2.0]);
+        let result = invoke_merge_state(
+            &function,
+            10,
+            0.01,
+            Some(left.as_slice()),
+            Some(right.as_slice()),
+        );
+        assert!(result.is_err(), "bucket size mismatch must fail loudly");
+        let result = invoke_merge_state(
+            &function,
+            20,
+            0.01,
+            Some(left.as_slice()),
+            Some(right.as_slice()),
+        );
+        assert!(result.is_err());
+
+        // Left state built with error rate 0.01, right state with 0.05.
+        let left = make_state(10, 0.01, &[1.0]);
+        let right = make_state(10, 0.05, &[2.0]);
+        let result = invoke_merge_state(
+            &function,
+            10,
+            0.01,
+            Some(left.as_slice()),
+            Some(right.as_slice()),
+        );
+        assert!(result.is_err(), "error rate mismatch must fail loudly");
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_rejects_invalid_params() {
+        let function = UddSketchMergeStateFunction::default();
+        let state = make_state(10, 0.01, &[1.0]);
+
+        // bucket size must be positive (a negative value would wrap to a huge
+        // u64 without the check)
+        for bucket_size in [0i64, -1, -100] {
+            let result = invoke_merge_state(
+                &function,
+                bucket_size,
+                0.01,
+                Some(state.as_slice()),
+                Some(state.as_slice()),
+            );
+            assert!(
+                result.is_err(),
+                "bucket size {bucket_size} must be rejected"
+            );
+            assert!(
+                result.unwrap_err().to_string().contains("bucket size"),
+                "bucket size error should mention bucket size"
+            );
+        }
+
+        // error rate must be in [1e-12, 1.0)
+        for error_rate in [0.0f64, -0.1, 1.0, 2.0] {
+            let result = invoke_merge_state(
+                &function,
+                10,
+                error_rate,
+                Some(state.as_slice()),
+                Some(state.as_slice()),
+            );
+            assert!(result.is_err(), "error rate {error_rate} must be rejected");
+            assert!(
+                result.unwrap_err().to_string().contains("error rate"),
+                "error rate error should mention error rate"
+            );
+        }
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_rejects_null_or_short_params() {
+        let function = UddSketchMergeStateFunction::default();
+        let state = make_state(10, 0.01, &[1.0]);
+
+        // NULL bucket size / error rate must be rejected, not interpreted.
+        let result = function.invoke_with_args(ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(Int64Array::from(vec![None]))),
+                ColumnarValue::Array(Arc::new(Float64Array::from(vec![Some(0.01)]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                    state.as_slice(),
+                )]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                    state.as_slice(),
+                )]))),
+            ],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("x", DataType::Binary, false)),
+            config_options: Arc::new(Default::default()),
+        });
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("non-null bucket size and error rate"),
+            "NULL parameters must be rejected"
+        );
+
+        // Parameters shorter than the state rows must be rejected without
+        // panicking. The DataFusion argument-coercion framework enforces this
+        // before `invoke_with_args` runs: `values_to_arrays` rejects argument
+        // arrays of mixed lengths.
+        let result = function.invoke_with_args(ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(Int64Array::from(Vec::<i64>::new()))),
+                ColumnarValue::Array(Arc::new(Float64Array::from(Vec::<f64>::new()))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                    state.as_slice(),
+                )]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![Some(
+                    state.as_slice(),
+                )]))),
+            ],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("x", DataType::Binary, false)),
+            config_options: Arc::new(Default::default()),
+        });
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("mixed length"),
+            "parameter arrays that do not cover every row must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_uddsketch_merge_state_function_rejects_non_constant_params() {
+        let function = UddSketchMergeStateFunction::default();
+        let state = make_state(10, 0.01, &[1.0]);
+
+        // Two rows with different bucket sizes must be rejected instead of
+        // silently merging with the first row's parameters.
+        let result = function.invoke_with_args(ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(Int64Array::from(vec![10, 20]))),
+                ColumnarValue::Array(Arc::new(Float64Array::from(vec![0.01, 0.01]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![
+                    Some(state.as_slice()),
+                    Some(state.as_slice()),
+                ]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_opt_vec(vec![
+                    Some(state.as_slice()),
+                    Some(state.as_slice()),
+                ]))),
+            ],
+            arg_fields: vec![],
+            number_rows: 2,
+            return_field: Arc::new(Field::new("x", DataType::Binary, false)),
+            config_options: Arc::new(Default::default()),
+        });
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("constant bucket size and error rate"),
+            "non-constant parameters must be rejected"
+        );
     }
 }

--- a/src/flow/src/batching_mode/utils.rs
+++ b/src/flow/src/batching_mode/utils.rs
@@ -20,21 +20,26 @@ use std::sync::Arc;
 use catalog::CatalogManagerRef;
 use common_error::ext::BoxedError;
 use common_function::aggrs::aggr_wrapper::get_aggr_func;
+use common_function::aggrs::approximate::uddsketch::UDDSKETCH_MERGE_STATE_NAME;
+use common_function::function::FunctionContext;
+use common_function::function_registry::FUNCTION_REGISTRY;
 use common_telemetry::debug;
 use datafusion::datasource::DefaultTableSource;
 use datafusion::error::Result as DfResult;
 use datafusion::logical_expr::Expr;
 use datafusion::sql::unparser::Unparser;
+use datafusion_common::arrow::datatypes::DataType;
 use datafusion_common::tree_node::{
     Transformed, TreeNode as _, TreeNodeRecursion, TreeNodeRewriter, TreeNodeVisitor,
 };
 use datafusion_common::{
     Column, DFSchema, DataFusionError, NullEquality, ScalarValue, TableReference,
 };
+use datafusion_expr::expr::{AggregateFunction, ScalarFunction};
 use datafusion_expr::logical_plan::{Aggregate, TableScan};
 use datafusion_expr::{
     Distinct, ExprSchemable, JoinType, LogicalPlan, LogicalPlanBuilder, Operator, Projection, and,
-    binary_expr, bitwise_and, bitwise_or, bitwise_xor, is_null, or, when,
+    binary_expr, bitwise_and, bitwise_or, bitwise_xor, is_null, lit, or, when,
 };
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, SchemaRef};
@@ -64,7 +69,7 @@ mod test;
 /// reference. It may contain dots or other non-identifier characters when the
 /// query keeps DataFusion's raw aggregate output name, e.g.
 /// `max(numbers_with_ts.number)`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct IncrementalAggregateMergeColumn {
     /// Final output/sink field name for the aggregate result/state column.
     ///
@@ -82,7 +87,7 @@ impl IncrementalAggregateMergeColumn {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum IncrementalAggregateMergeOp {
     Sum,
     Min,
@@ -92,6 +97,17 @@ pub enum IncrementalAggregateMergeOp {
     BitAnd,
     BitOr,
     BitXor,
+    /// Merge two UDDSketch aggregate states (both binary) with the given
+    /// `uddsketch_state`/`uddsketch_merge` parameters.
+    ///
+    /// The sink table stores one serialized state per group x window; the delta
+    /// query produces a state for the new rows and the incremental rewrite
+    /// merges the delta state with the existing sink state via
+    /// `uddsketch_merge_state`.
+    UddSketchState {
+        bucket_size: i64,
+        error_rate: f64,
+    },
 }
 
 /// Analysis result for an incremental aggregate plan.
@@ -101,7 +117,7 @@ pub enum IncrementalAggregateMergeOp {
 /// sink table before the left-join merge. They are not DataFusion logical-plan
 /// `Column` references; callers must attach qualifiers structurally instead of
 /// formatting qualified names as strings.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct IncrementalAggregateAnalysis {
     /// Final output/sink field names for group keys used as merge join keys.
     pub group_key_names: Vec<String>,
@@ -348,7 +364,10 @@ fn is_literal_or_cast_literal(expr: &Expr) -> bool {
     }
 }
 
-fn merge_op_for_aggregate_expr(aggr_expr: &Expr) -> Result<IncrementalAggregateMergeOp, String> {
+fn merge_op_for_aggregate_expr(
+    aggr_expr: &Expr,
+    input_schema: &DFSchema,
+) -> Result<IncrementalAggregateMergeOp, String> {
     let Some(aggr_func) = get_aggr_func(aggr_expr) else {
         return Err(aggr_expr.to_string());
     };
@@ -371,8 +390,93 @@ fn merge_op_for_aggregate_expr(aggr_expr: &Expr) -> Result<IncrementalAggregateM
         "bit_and" => Ok(IncrementalAggregateMergeOp::BitAnd),
         "bit_or" => Ok(IncrementalAggregateMergeOp::BitOr),
         "bit_xor" => Ok(IncrementalAggregateMergeOp::BitXor),
+        // Both `uddsketch_state` and `uddsketch_merge` produce a serialized
+        // UDDSketch state that can be pairwise-merged with the existing sink
+        // state of the same group x window.
+        "uddsketch_state" | "uddsketch_merge" => {
+            uddsketch_merge_op(aggr_func, aggr_expr, input_schema)
+        }
         _ => Err(aggr_expr.to_string()),
     }
+}
+
+/// Extracts the `(bucket_size, error_rate)` parameters and validates the value
+/// argument type of a `uddsketch_state`/`uddsketch_merge` aggregate expression.
+///
+/// The bucket size and error rate must be literals so that the generated merge
+/// expression can reproduce the same parameters; non-literal or type
+/// incompatible aggregates are reported as unsupported (which permanently
+/// disables incremental mode per the flow contract, falling back to safe full
+/// snapshots).
+fn uddsketch_merge_op(
+    aggr_func: &AggregateFunction,
+    aggr_expr: &Expr,
+    input_schema: &DFSchema,
+) -> Result<IncrementalAggregateMergeOp, String> {
+    let args = &aggr_func.params.args;
+    if args.len() != 3 {
+        return Err(format!(
+            "unsupported UDDSketch aggregate argument count: {aggr_expr}"
+        ));
+    }
+    let bucket_size = match &args[0] {
+        Expr::Literal(ScalarValue::Int64(Some(value)), _) => *value,
+        _ => {
+            return Err(format!(
+                "unsupported UDDSketch aggregate bucket size (must be an Int64 literal): {}",
+                args[0]
+            ));
+        }
+    };
+    let error_rate = match &args[1] {
+        Expr::Literal(ScalarValue::Float64(Some(value)), _) => *value,
+        _ => {
+            return Err(format!(
+                "unsupported UDDSketch aggregate error rate (must be a Float64 literal): {}",
+                args[1]
+            ));
+        }
+    };
+    let value_type = args[2]
+        .get_type(input_schema)
+        .map_err(|_| aggr_expr.to_string())?;
+    let is_state_fn = aggr_func
+        .func
+        .name()
+        .eq_ignore_ascii_case("uddsketch_state");
+    let value_type_ok = if is_state_fn {
+        // `uddsketch_state(bucket_size, error_rate, value)` values are numeric;
+        // the UDAF signature coerces them to Float64 at execution time.
+        matches!(
+            value_type,
+            DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float16
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Decimal128(_, _)
+                | DataType::Decimal256(_, _)
+        )
+    } else {
+        // `uddsketch_merge(bucket_size, error_rate, states)` merges a column of
+        // already-serialized states.
+        value_type == DataType::Binary
+    };
+    if !value_type_ok {
+        return Err(format!(
+            "unsupported UDDSketch aggregate value type {value_type:?}: {aggr_expr}"
+        ));
+    }
+    Ok(IncrementalAggregateMergeOp::UddSketchState {
+        bucket_size,
+        error_rate,
+    })
 }
 
 fn resolve_aggregate_output_field_name(
@@ -514,7 +618,7 @@ pub fn analyze_incremental_aggregate_plan(
     ));
     unsupported_exprs.extend(projection_info.duplicate_aggregate_aliases.iter().cloned());
     for aggr_expr in aggr_exprs {
-        let merge_op = match merge_op_for_aggregate_expr(&aggr_expr) {
+        let merge_op = match merge_op_for_aggregate_expr(&aggr_expr, aggregate.input.schema()) {
             Ok(merge_op) => merge_op,
             Err(reason) => {
                 unsupported_exprs.push(reason);
@@ -621,6 +725,28 @@ pub async fn rewrite_incremental_aggregate_with_sink_merge(
                 .to_string()
         }
     );
+
+    // UDDSketch state merge requires the sink's state column to be Binary (the
+    // serialized state). Report a clear error instead of letting the left-join
+    // merge fail with an obscure type-coercion error later.
+    let sink_table_info = sink_table.table_info();
+    let sink_columns = sink_table_info.meta.schema.column_schemas();
+    for merge_col in &analysis.merge_columns {
+        if let IncrementalAggregateMergeOp::UddSketchState { .. } = merge_col.merge_op
+            && let Some(sink_col) = sink_columns
+                .iter()
+                .find(|col| col.name == merge_col.output_field_name)
+            && sink_col.data_type != ConcreteDataType::binary_datatype()
+        {
+            return InvalidQuerySnafu {
+                reason: format!(
+                    "UNSUPPORTED_INCREMENTAL_AGG: UDDSketch state sink column '{}' must be Binary to merge states incrementally, found {}",
+                    merge_col.output_field_name, sink_col.data_type
+                ),
+            }
+            .fail();
+        }
+    }
 
     let delta_alias = "__flow_delta";
     let sink_alias = "__flow_sink";
@@ -838,8 +964,39 @@ fn build_left_join_merge_expr(
             .with_context(|_| DatafusionSnafu {
                 context: "Failed to build BIT_XOR merge expression".to_string(),
             })?,
+        IncrementalAggregateMergeOp::UddSketchState {
+            bucket_size,
+            error_rate,
+        } => uddsketch_merge_state_expr(bucket_size, error_rate, left.clone(), right.clone())?,
     };
     Ok(merged.alias(merge_col.output_field_name.clone()))
+}
+
+/// Builds a call to the registered `uddsketch_merge_state` scalar function that
+/// merges the delta state with the existing sink state of the same group.
+///
+/// The function is looked up from the common-function registry instead of being
+/// constructed locally so the rewritten plan survives the Substrait round trip:
+/// the frontend resolves the function by name from the same registry.
+fn uddsketch_merge_state_expr(
+    bucket_size: i64,
+    error_rate: f64,
+    delta_state: Expr,
+    sink_state: Expr,
+) -> Result<Expr, Error> {
+    let factory = FUNCTION_REGISTRY
+        .scalar_functions()
+        .into_iter()
+        .find(|func| func.name() == UDDSKETCH_MERGE_STATE_NAME)
+        .context(InvalidQuerySnafu {
+            reason: format!(
+                "UDDSketch merge state function {UDDSKETCH_MERGE_STATE_NAME} is not registered"
+            ),
+        })?;
+    Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
+        Arc::new(factory.provide(FunctionContext::default())),
+        vec![lit(bucket_size), lit(error_rate), delta_state, sink_state],
+    )))
 }
 
 pub async fn get_table_info_df_schema(

--- a/src/flow/src/batching_mode/utils/test.rs
+++ b/src/flow/src/batching_mode/utils/test.rs
@@ -22,7 +22,7 @@ use datafusion_expr::GroupingSet;
 use datatypes::prelude::{ConcreteDataType, MutableVector, Scalar, ScalarVectorBuilder, VectorRef};
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::timestamp::TimestampMillisecond;
-use datatypes::vectors::TimestampMillisecondVectorBuilder;
+use datatypes::vectors::{BinaryVectorBuilder, TimestampMillisecondVectorBuilder};
 use pretty_assertions::assert_eq;
 use query::query_engine::DefaultSerializer;
 use session::context::QueryContext;
@@ -79,6 +79,117 @@ fn time_window_u32_table(table_name: &str) -> TableRef {
     )
     .unwrap();
     MemTable::table(table_name, recordbatch)
+}
+
+/// A (ts: timestamp millisecond, state: binary) table used as the UDDSketch
+/// state sink / state source in tests.
+fn binary_state_table(table_name: &str, rows: &[(i64, Option<&[u8]>)]) -> TableRef {
+    let schema = Arc::new(Schema::new(vec![
+        ColumnSchema::new(
+            "ts",
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            false,
+        )
+        .with_time_index(true),
+        ColumnSchema::new("state", ConcreteDataType::binary_datatype(), true),
+    ]));
+
+    let mut ts_builder = TimestampMillisecondVectorBuilder::with_capacity(rows.len());
+    let mut state_builder = BinaryVectorBuilder::with_capacity(rows.len());
+    for (ts, state) in rows {
+        ts_builder.push(Some(TimestampMillisecond::new(*ts)));
+        state_builder.push(*state);
+    }
+    let recordbatch = RecordBatch::new(
+        schema,
+        vec![
+            ts_builder.to_vector_cloned(),
+            state_builder.to_vector_cloned(),
+        ],
+    )
+    .unwrap();
+    MemTable::table(table_name, recordbatch)
+}
+
+/// Serializes a UDDSketch state from the given values using the real
+/// `uddsketch_state` accumulator.
+fn make_uddsketch_state_bytes(bucket_size: u64, error_rate: f64, values: &[f64]) -> Vec<u8> {
+    use common_function::aggrs::approximate::uddsketch::UddSketchState;
+    use datafusion::logical_expr::Accumulator as _;
+    use datatypes::arrow::array::{ArrayRef, Float64Array};
+
+    let mut acc = UddSketchState::new(bucket_size, error_rate);
+    let values: ArrayRef = Arc::new(Float64Array::from(values.to_vec()));
+    acc.update_batch(&[values.clone(), values.clone(), values])
+        .unwrap();
+    let ScalarValue::Binary(Some(bytes)) = acc.evaluate().unwrap() else {
+        panic!("expected binary UDDSketch state")
+    };
+    bytes
+}
+
+/// Builds a call to the registered `uddsketch_calc` scalar function, resolved
+/// by name from the same registry the frontend uses at execution time.
+fn uddsketch_calc_expr(percentile: f64, state: Expr) -> Expr {
+    use common_function::function::FunctionContext;
+    use common_function::function_registry::FUNCTION_REGISTRY;
+    use datafusion_expr::expr::ScalarFunction;
+
+    let factory = FUNCTION_REGISTRY
+        .scalar_functions()
+        .into_iter()
+        .find(|func| func.name() == "uddsketch_calc")
+        .expect("uddsketch_calc must be registered");
+    Expr::ScalarFunction(ScalarFunction::new_udf(
+        Arc::new(factory.provide(FunctionContext::default())),
+        vec![lit(percentile), state],
+    ))
+}
+
+/// Computes the estimated quantile of a serialized UDDSketch state by invoking
+/// the registered `uddsketch_calc` scalar directly, so tests validate merged
+/// states through the public final result instead of bincode internals.
+fn uddsketch_calc_value(state_bytes: &[u8], percentile: f64) -> f64 {
+    use arrow_schema::Field;
+    use common_function::function::FunctionContext;
+    use common_function::function_registry::FUNCTION_REGISTRY;
+    use datafusion_common::arrow::array::{AsArray, BinaryArray, Float64Array};
+    use datafusion_common::arrow::datatypes::{DataType as ArrowDataType, Float64Type};
+    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs};
+
+    let factory = FUNCTION_REGISTRY
+        .scalar_functions()
+        .into_iter()
+        .find(|func| func.name() == "uddsketch_calc")
+        .expect("uddsketch_calc must be registered");
+    let udf = factory.provide(FunctionContext::default());
+    let result = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(Float64Array::from(vec![percentile]))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from(vec![state_bytes]))),
+            ],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("p", ArrowDataType::Float64, false)),
+            config_options: Arc::new(Default::default()),
+        })
+        .expect("uddsketch_calc must succeed on a valid state");
+    let ColumnarValue::Array(array) = result else {
+        panic!("expected array result from uddsketch_calc");
+    };
+    array.as_primitive::<Float64Type>().value(0)
+}
+
+fn uddsketch_merge_expr(field_name: &str, bucket_size: i64, error_rate: f64) -> Expr {
+    let left = qualified_col("__flow_delta", field_name);
+    let right = qualified_col("__flow_sink", field_name);
+    // The scalar itself validates the state bytes against the merge parameters
+    // and handles NULL sides, so the rewrite emits the merge call directly
+    // without NULL short-circuiting.
+    uddsketch_merge_state_expr(bucket_size, error_rate, left, right)
+        .unwrap()
+        .alias(field_name)
 }
 
 fn assert_same_logical_plan(actual: &LogicalPlan, expected: &LogicalPlan) {
@@ -1592,6 +1703,569 @@ async fn test_analyze_incremental_aggregate_plan_rejects_distinct() {
 
     let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
     assert!(!analysis.unsupported_exprs.is_empty());
+}
+
+#[tokio::test]
+async fn test_analyze_incremental_aggregate_plan_uddsketch_state() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let sql =
+        "SELECT uddsketch_state(10, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts";
+    let plan = sql_to_df_plan(ctx, query_engine, sql, false).await.unwrap();
+
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(
+        analysis.unsupported_exprs.is_empty(),
+        "uddsketch_state should be incrementally mergeable: {:?}",
+        analysis.unsupported_exprs
+    );
+    assert!(analysis.group_key_names.contains(&"ts".to_string()));
+    assert_eq!(analysis.merge_columns.len(), 1);
+    assert_eq!(analysis.merge_columns[0].output_field_name, "state");
+    assert_eq!(
+        analysis.merge_columns[0].merge_op,
+        IncrementalAggregateMergeOp::UddSketchState {
+            bucket_size: 10,
+            error_rate: 0.01,
+        }
+    );
+    assert_eq!(
+        analysis.output_field_names,
+        vec!["state".to_string(), "ts".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn test_analyze_incremental_aggregate_plan_uddsketch_merge_state_source() {
+    let query_engine = create_test_query_engine();
+    let catalog_manager = query_engine.engine_state().catalog_manager();
+    let memory_catalog = catalog_manager
+        .as_any()
+        .downcast_ref::<catalog::memory::MemoryCatalogManager>()
+        .unwrap();
+    memory_catalog
+        .register_table_sync(RegisterTableRequest {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table_name: "state_source".to_string(),
+            table_id: 9100,
+            table: binary_state_table("state_source", &[(1, Some(b"state"))]),
+        })
+        .unwrap();
+
+    let ctx = QueryContext::arc();
+    // `uddsketch_merge` merges a column of already-serialized states; its output
+    // is also a state that can be pairwise-merged with the sink state.
+    let sql = "SELECT uddsketch_merge(10, 0.01, state) AS state, ts FROM state_source GROUP BY ts";
+    let plan = sql_to_df_plan(ctx, query_engine, sql, false).await.unwrap();
+
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(
+        analysis.unsupported_exprs.is_empty(),
+        "uddsketch_merge over a binary state column should be mergeable: {:?}",
+        analysis.unsupported_exprs
+    );
+    assert_eq!(analysis.merge_columns.len(), 1);
+    assert_eq!(
+        analysis.merge_columns[0].merge_op,
+        IncrementalAggregateMergeOp::UddSketchState {
+            bucket_size: 10,
+            error_rate: 0.01,
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_analyze_incremental_aggregate_plan_rejects_incompatible_uddsketch() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let testcases = [
+        // bucket size is not an Int64 literal
+        "SELECT uddsketch_state(10.0, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts",
+        // bucket size is not a literal
+        "SELECT uddsketch_state(number, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts",
+        // error rate is not a Float64 literal
+        "SELECT uddsketch_state(10, number, number) AS state, ts FROM numbers_with_ts GROUP BY ts",
+        // value argument is not numeric (timestamp)
+        "SELECT uddsketch_state(10, 0.01, ts) AS state, ts FROM numbers_with_ts GROUP BY ts",
+        // uddsketch_merge requires a binary state column, not raw numbers
+        "SELECT uddsketch_merge(10, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts",
+    ];
+
+    for sql in testcases {
+        // Parameter/type incompatibility must surface before any incremental
+        // rewrite: either the planner clearly fails to plan the SQL (the
+        // exact-signature UDAF rejects the wrong types at plan time), or the
+        // plan succeeds but the flow analyzer marks the expression as
+        // unsupported (disabling incremental with the safe full-snapshot
+        // fallback). Both are acceptable per contract; never a silent rewrite.
+        match sql_to_df_plan(ctx.clone(), query_engine.clone(), sql, false).await {
+            Ok(plan) => {
+                let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+                assert!(
+                    !analysis.unsupported_exprs.is_empty(),
+                    "expected UDDSketch parameter/type incompatibility to be unsupported for SQL: {sql}"
+                );
+                assert!(
+                    analysis.merge_columns.is_empty(),
+                    "unsupported UDDSketch analysis should disable merge columns for SQL: {sql}"
+                );
+            }
+            Err(_) => {
+                // Planner rejected the SQL: incremental rewrite never happens.
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_analyze_incremental_aggregate_plan_rejects_non_literal_uddsketch_params() {
+    // Pin down the analyzer's own parameter-incompatibility path with a plan
+    // the SQL planner would never produce: the aggregate arguments already have
+    // the exact signature types (so no planner coercion error) but the bucket
+    // size is a column reference instead of an Int64 literal. The analyzer must
+    // mark it unsupported, disabling incremental mode with the safe
+    // full-snapshot fallback.
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let plan = sql_to_df_plan(
+        ctx,
+        query_engine,
+        "SELECT max(number) AS x, ts FROM numbers_with_ts GROUP BY ts",
+        false,
+    )
+    .await
+    .unwrap();
+    let LogicalPlan::Projection(projection) = plan else {
+        panic!("expected projection over aggregate");
+    };
+    let LogicalPlan::Aggregate(aggregate) = projection.input.as_ref() else {
+        panic!("expected aggregate below projection");
+    };
+
+    let state_udaf =
+        common_function::aggrs::approximate::uddsketch::UddSketchState::state_udf_impl();
+    let aggr_expr = Expr::AggregateFunction(datafusion_expr::expr::AggregateFunction::new_udf(
+        Arc::new(state_udaf),
+        vec![
+            unqualified_col("number"),
+            lit(0.01f64),
+            unqualified_col("number"),
+        ],
+        false,
+        None,
+        vec![],
+        None,
+    ))
+    .alias("state");
+    let aggregate = datafusion_expr::logical_plan::Aggregate::try_new(
+        aggregate.input.clone(),
+        aggregate.group_expr.clone(),
+        vec![aggr_expr],
+    )
+    .unwrap();
+    let plan = LogicalPlan::Aggregate(aggregate);
+
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert_unsupported(&analysis, "bucket size");
+}
+
+#[tokio::test]
+async fn test_analyze_incremental_aggregate_plan_rejects_uddsketch_calc_finalize() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    // A flow that finalizes the state (uddsketch_calc) stores plain quantiles,
+    // not mergeable states; it must not be incrementally rewritten.
+    let sql = "SELECT uddsketch_calc(0.95, uddsketch_state(10, 0.01, number)) AS p95, ts FROM numbers_with_ts GROUP BY ts";
+    let plan = sql_to_df_plan(ctx, query_engine, sql, false).await.unwrap();
+
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(
+        !analysis.unsupported_exprs.is_empty(),
+        "uddsketch_calc finalize output must not be incrementally mergeable: {:?}",
+        analysis.unsupported_exprs
+    );
+    assert!(analysis.merge_columns.is_empty());
+}
+
+#[tokio::test]
+async fn test_rewrite_incremental_aggregate_uddsketch_state() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let sql =
+        "SELECT uddsketch_state(10, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts";
+    let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), sql, false)
+        .await
+        .unwrap();
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(analysis.unsupported_exprs.is_empty());
+
+    let sink_table = binary_state_table("uddsketch_state_sink", &[(1, Some(b"existing"))]);
+    let sink_table_name = [
+        "greptime".to_string(),
+        "public".to_string(),
+        "uddsketch_state_sink".to_string(),
+    ];
+    let rewritten = rewrite_incremental_aggregate_with_sink_merge(
+        &plan,
+        &analysis,
+        sink_table.clone(),
+        &sink_table_name,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let expected = expected_left_join_rewrite(
+        &plan,
+        sink_table,
+        &sink_table_name,
+        vec![unqualified_col("ts"), unqualified_col("state")],
+        vec![unqualified_col("ts"), unqualified_col("state")],
+        (
+            vec![qualified_column("__flow_delta", "ts")],
+            vec![qualified_column("__flow_sink", "ts")],
+        ),
+        vec![
+            uddsketch_merge_expr("state", 10, 0.01),
+            qualified_col("__flow_delta", "ts").alias("ts"),
+        ],
+    );
+    assert_same_logical_plan(&rewritten, &expected);
+    let rewritten_fields = rewritten
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    assert_eq!(rewritten_fields, analysis.output_field_names);
+}
+
+#[tokio::test]
+async fn test_rewrite_incremental_aggregate_uddsketch_state_with_regular_aggregates() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let sql = "SELECT uddsketch_state(10, 0.01, number) AS state, max(number) AS max_num, ts FROM numbers_with_ts GROUP BY ts";
+    let plan = sql_to_df_plan(ctx, query_engine, sql, false).await.unwrap();
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(
+        analysis.unsupported_exprs.is_empty(),
+        "mixed UDDSketch and regular aggregates should be supported: {:?}",
+        analysis.unsupported_exprs
+    );
+    assert_eq!(analysis.merge_columns.len(), 2);
+    assert!(analysis.merge_columns.iter().any(|col| {
+        col.output_field_name == "state"
+            && col.merge_op
+                == IncrementalAggregateMergeOp::UddSketchState {
+                    bucket_size: 10,
+                    error_rate: 0.01,
+                }
+    }));
+    assert!(analysis.merge_columns.iter().any(|col| {
+        col.output_field_name == "max_num" && col.merge_op == IncrementalAggregateMergeOp::Max
+    }));
+
+    // sink table with a binary state column and a uint32 max column
+    let schema = Arc::new(Schema::new(vec![
+        ColumnSchema::new(
+            "ts",
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            false,
+        )
+        .with_time_index(true),
+        ColumnSchema::new("state", ConcreteDataType::binary_datatype(), true),
+        ColumnSchema::new("max_num", ConcreteDataType::uint32_datatype(), true),
+    ]));
+    let mut ts_builder = TimestampMillisecondVectorBuilder::with_capacity(1);
+    ts_builder.push(Some(TimestampMillisecond::new(0)));
+    let mut state_builder = BinaryVectorBuilder::with_capacity(1);
+    state_builder.push(Some(b"state"));
+    let max_builder: VectorRef = Arc::new(<u32 as Scalar>::VectorType::from_vec(vec![1_u32]));
+    let recordbatch = RecordBatch::new(
+        schema,
+        vec![
+            ts_builder.to_vector_cloned(),
+            state_builder.to_vector_cloned(),
+            max_builder,
+        ],
+    )
+    .unwrap();
+    let sink_table = MemTable::table("uddsketch_mixed_sink", recordbatch);
+    let sink_table_name = [
+        "greptime".to_string(),
+        "public".to_string(),
+        "uddsketch_mixed_sink".to_string(),
+    ];
+    let rewritten = rewrite_incremental_aggregate_with_sink_merge(
+        &plan,
+        &analysis,
+        sink_table,
+        &sink_table_name,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let rewritten_fields = rewritten
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    assert_eq!(rewritten_fields, analysis.output_field_names);
+}
+
+#[tokio::test]
+async fn test_rewrite_incremental_aggregate_rejects_uddsketch_non_binary_sink_state() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let sql =
+        "SELECT uddsketch_state(10, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts";
+    let plan = sql_to_df_plan(ctx, query_engine, sql, false).await.unwrap();
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(analysis.unsupported_exprs.is_empty());
+
+    // sink state column is Float64 instead of Binary -> the rewrite must fail
+    // clearly instead of producing a broken merge.
+    let schema = Arc::new(Schema::new(vec![
+        ColumnSchema::new(
+            "ts",
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            false,
+        )
+        .with_time_index(true),
+        ColumnSchema::new("state", ConcreteDataType::float64_datatype(), true),
+    ]));
+    let mut ts_builder = TimestampMillisecondVectorBuilder::with_capacity(1);
+    ts_builder.push(Some(TimestampMillisecond::new(0)));
+    let state_builder: VectorRef = Arc::new(<f64 as Scalar>::VectorType::from_vec(vec![1.0_f64]));
+    let recordbatch =
+        RecordBatch::new(schema, vec![ts_builder.to_vector_cloned(), state_builder]).unwrap();
+    let sink_table = MemTable::table("uddsketch_bad_sink", recordbatch);
+    let sink_table_name = [
+        "greptime".to_string(),
+        "public".to_string(),
+        "uddsketch_bad_sink".to_string(),
+    ];
+
+    let err = rewrite_incremental_aggregate_with_sink_merge(
+        &plan,
+        &analysis,
+        sink_table,
+        &sink_table_name,
+        None,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(
+        err.contains("must be Binary"),
+        "expected a clear sink state type error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_uddsketch_incremental_rewrite_survives_substrait_roundtrip() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let sql =
+        "SELECT uddsketch_state(10, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts";
+    let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), sql, false)
+        .await
+        .unwrap();
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(analysis.unsupported_exprs.is_empty());
+
+    // The sink must be registered in the catalog so the Substrait consumer can
+    // resolve the sink scan on decode.
+    let catalog_manager = query_engine.engine_state().catalog_manager();
+    let memory_catalog = catalog_manager
+        .as_any()
+        .downcast_ref::<catalog::memory::MemoryCatalogManager>()
+        .unwrap();
+    let sink_table = binary_state_table("uddsketch_roundtrip_sink", &[(1, Some(b"existing"))]);
+    memory_catalog
+        .register_table_sync(RegisterTableRequest {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table_name: "uddsketch_roundtrip_sink".to_string(),
+            table_id: 9101,
+            table: sink_table.clone(),
+        })
+        .unwrap();
+
+    let sink_table_name = [
+        "greptime".to_string(),
+        "public".to_string(),
+        "uddsketch_roundtrip_sink".to_string(),
+    ];
+    let rewritten = rewrite_incremental_aggregate_with_sink_merge(
+        &plan,
+        &analysis,
+        sink_table,
+        &sink_table_name,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // The rewritten plan travels from the flownode to the frontend as
+    // Substrait. Decode it exactly like the frontend's `handle_insert_plan`:
+    // a DefaultPlanDecoder whose session state registers the FUNCTION_REGISTRY
+    // functions, plus a DummyCatalogList that delegates table resolution to the
+    // real catalog manager (so both the source and the sink scans resolve).
+    // Replicate the production encode path (`BatchingTask::execute_logical_plan_unlocked`):
+    // every table scan is rewritten to a fully qualified reference
+    // ("catalog.schema.table") before the plan is encoded to Substrait, so the
+    // frontend's `DummyCatalogList` can resolve both the source and the sink
+    // scans against the real catalog manager on decode.
+    let rewritten = rewritten
+        .transform_down_with_subqueries(|plan| {
+            if let LogicalPlan::TableScan(mut table_scan) = plan {
+                let resolved = table_scan.table_name.resolve("greptime", "public");
+                table_scan.table_name = resolved.into();
+                Ok(Transformed::yes(LogicalPlan::TableScan(table_scan)))
+            } else {
+                Ok(Transformed::no(plan))
+            }
+        })
+        .unwrap()
+        .data;
+
+    let bytes = DFLogicalSubstraitConvertor {}
+        .encode(&rewritten, DefaultSerializer)
+        .unwrap();
+    let decoder = query_engine
+        .engine_context(ctx.clone())
+        .new_plan_decoder()
+        .unwrap();
+    let catalog_list = Arc::new(
+        catalog::table_source::dummy_catalog::DummyCatalogList::new_with_query_ctx(
+            catalog_manager.clone(),
+            ctx.clone(),
+        ),
+    );
+    let decoded = decoder.decode(bytes, catalog_list, false).await.unwrap();
+
+    let decoded_text = format!("{}", decoded.display_indent());
+    assert!(
+        decoded_text.contains("uddsketch_merge_state"),
+        "decoded plan should keep the uddsketch_merge_state call: {decoded_text}"
+    );
+    assert_eq!(
+        decoded.schema().fields().len(),
+        rewritten.schema().fields().len(),
+        "decoded plan schema field count should match: {decoded_text}"
+    );
+}
+
+#[tokio::test]
+async fn test_uddsketch_state_incremental_merge_executes() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+
+    // Existing sink state for ts=1 built from value 100.0.
+    let existing_state = make_uddsketch_state_bytes(10, 0.01, &[100.0]);
+    let sink_table = binary_state_table(
+        "uddsketch_exec_sink",
+        &[(1, Some(existing_state.as_slice()))],
+    );
+    let catalog_manager = query_engine.engine_state().catalog_manager();
+    let memory_catalog = catalog_manager
+        .as_any()
+        .downcast_ref::<catalog::memory::MemoryCatalogManager>()
+        .unwrap();
+    memory_catalog
+        .register_table_sync(RegisterTableRequest {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            table_name: "uddsketch_exec_sink".to_string(),
+            table_id: 9102,
+            table: sink_table.clone(),
+        })
+        .unwrap();
+
+    // Delta: numbers_with_ts has one value per ts (ts=i, number=i for i in 1..=10).
+    let sql =
+        "SELECT uddsketch_state(10, 0.01, number) AS state, ts FROM numbers_with_ts GROUP BY ts";
+    let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), sql, false)
+        .await
+        .unwrap();
+    let analysis = analyze_incremental_aggregate_plan(&plan).unwrap().unwrap();
+    assert!(analysis.unsupported_exprs.is_empty());
+    let sink_table_name = [
+        "greptime".to_string(),
+        "public".to_string(),
+        "uddsketch_exec_sink".to_string(),
+    ];
+    let rewritten = rewrite_incremental_aggregate_with_sink_merge(
+        &plan,
+        &analysis,
+        sink_table,
+        &sink_table_name,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Finalize the merged states through the registered `uddsketch_calc`
+    // scalar (the same registry the frontend resolves functions from), so the
+    // test validates the merged state via public final results instead of
+    // decoding bincode internals with a direct `uddsketch` dependency.
+    let finalize = LogicalPlanBuilder::from(rewritten)
+        .project(vec![
+            uddsketch_calc_expr(0.5, unqualified_col("state")).alias("p50"),
+            unqualified_col("ts"),
+        ])
+        .unwrap()
+        .build()
+        .unwrap();
+    let output = query_engine.execute(finalize, ctx).await.unwrap();
+    let common_query::OutputData::Stream(stream) = output.data else {
+        panic!("expected record stream output, got {:?}", output.data);
+    };
+    let batches = common_recordbatch::util::collect_batches(stream)
+        .await
+        .unwrap();
+
+    let mut rows = Vec::new();
+    for batch in batches.iter() {
+        let ts_col = batch.column_by_name("ts").unwrap();
+        let p50_col = batch.column_by_name("p50").unwrap();
+        let ts_arr = ts_col
+            .as_any()
+            .downcast_ref::<datatypes::arrow::array::TimestampMillisecondArray>()
+            .unwrap();
+        let p50_arr = p50_col
+            .as_any()
+            .downcast_ref::<datatypes::arrow::array::Float64Array>()
+            .unwrap();
+        for i in 0..ts_arr.len() {
+            rows.push((ts_arr.value(i), p50_arr.value(i)));
+        }
+    }
+
+    assert_eq!(rows.len(), 10, "merged plan should emit one row per group");
+    let mut p50_by_ts = std::collections::HashMap::new();
+    for (ts, p50) in rows {
+        p50_by_ts.insert(ts, p50);
+    }
+    // ts=1: delta value 1.0 merged with the existing sink state {100.0}; the
+    // merged state must match a state built directly from {1.0, 100.0}.
+    let expected_ts1 = make_uddsketch_state_bytes(10, 0.01, &[1.0, 100.0]);
+    assert!(
+        (p50_by_ts[&1] - uddsketch_calc_value(&expected_ts1, 0.5)).abs() < 1e-9,
+        "ts=1 p50 should match the {{1.0, 100.0}} reference state"
+    );
+    // Other groups only have their delta value.
+    for k in 2..=10 {
+        let expected = make_uddsketch_state_bytes(10, 0.01, &[k as f64]);
+        assert!(
+            (p50_by_ts[&k] - uddsketch_calc_value(&expected, 0.5)).abs() < 1e-9,
+            "ts={k} p50 should match the {{{k}}} reference state"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

PR 4/5 of the incremental Flow data-plane series. Depends on #8867 (UDDSketch implementation, upstream); will rebase and re-verify once it lands.

## What's changed and what's your intention?

### Problem

Per-window UDDSketch percentiles needed a mergeable state so incremental flow can maintain group state instead of rescanning full source history.

### Change

- new scalar `uddsketch_merge_state` (binary state merge) with fallible parameter validation (bucket size, error rate, percentile range) and empty/null/corrupt hardening
- Flow `IncrementalAggregateMergeOp::UddSketchState` merges `uddsketch_state`/`uddsketch_merge` deltas with existing sink state
- exact error-rate comparison before merging; dependency assert panics on malformed state converted to errors
- flow's direct bincode/uddsketch dev-deps removed

### Verification

- targeted uddsketch scalar + flow merge-op tests (utils/test.rs)
- `make fmt` / `git diff --check` clean

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

