### PR TITLE
feat: preserve row sequences and support exact sequence-range reads

### DIFF
--- a/src/cmd/src/bin/query_perf_fixture/direct_sst.rs
+++ b/src/cmd/src/bin/query_perf_fixture/direct_sst.rs
@@ -310,6 +310,7 @@ fn file_meta_from_sst_info(
         num_series: info.num_series,
         primary_key_min: None,
         primary_key_max: None,
+        preserve_row_sequence: false,
     }
 }
 

--- a/src/cmd/src/datanode/objbench.rs
+++ b/src/cmd/src/datanode/objbench.rs
@@ -208,6 +208,7 @@ impl ObjbenchCommand {
             inverted_index_config: MitoConfig::default().inverted_index,
             fulltext_index_config,
             bloom_filter_index_config: MitoConfig::default().bloom_filter_index,
+            preserve_row_sequence: false,
             #[cfg(feature = "vector_index")]
             vector_index_config: Default::default(),
         };

--- a/src/cmd/src/datanode/parquetbench.rs
+++ b/src/cmd/src/datanode/parquetbench.rs
@@ -356,6 +356,7 @@ impl ParquetbenchCommand {
                 num_series: 0,
                 primary_key_min: None,
                 primary_key_max: None,
+                preserve_row_sequence: false,
             },
             Arc::new(NoopFilePurger),
         );

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -342,6 +342,11 @@ impl AccessLayer {
         let region_id = request.metadata.region_id;
         let region_metadata = request.metadata.clone();
         let cache_manager = request.cache_manager.clone();
+        let override_sequence = if request.preserve_row_sequence {
+            None
+        } else {
+            request.max_sequence
+        };
 
         let sst_info = if let Some(write_cache) = cache_manager.write_cache() {
             // Write to the write cache.
@@ -397,14 +402,14 @@ impl AccessLayer {
                     writer
                         .write_all_flat_as_primary_key(
                             request.source,
-                            request.max_sequence,
+                            override_sequence,
                             write_opts,
                         )
                         .await?
                 }
                 FormatType::Flat => {
                     writer
-                        .write_all_flat(request.source, request.max_sequence, write_opts)
+                        .write_all_flat(request.source, override_sequence, write_opts)
                         .await?
                 }
             }
@@ -564,6 +569,8 @@ pub struct SstWriteRequest {
     pub storage: Option<String>,
     pub max_sequence: Option<SequenceNumber>,
     pub sst_write_format: FormatType,
+
+    pub preserve_row_sequence: bool,
 
     /// Configs for index
     pub index_options: IndexOptions,

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -2773,6 +2773,7 @@ mod tests {
                 append_mode: false,
                 filter_deleted: true,
                 merge_mode: crate::region::options::MergeMode::LastRow,
+                sequence_range: None,
                 partition_expr_version: 0,
             }
             .build(),

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -231,6 +231,11 @@ impl WriteCache {
         metrics: &mut Metrics,
     ) -> Result<SstInfoArray> {
         let region_id = write_request.metadata.region_id;
+        let override_sequence = if write_request.preserve_row_sequence {
+            None
+        } else {
+            write_request.max_sequence
+        };
 
         let store = self.file_cache.local_store();
         let path_provider = WriteCachePathProvider::new(self.file_cache.clone());
@@ -268,14 +273,14 @@ impl WriteCache {
                 writer
                     .write_all_flat_as_primary_key(
                         write_request.source,
-                        write_request.max_sequence,
+                        override_sequence,
                         write_opts,
                     )
                     .await?
             }
             crate::sst::FormatType::Flat => {
                 writer
-                    .write_all_flat(write_request.source, write_request.max_sequence, write_opts)
+                    .write_all_flat(write_request.source, override_sequence, write_opts)
                     .await?
             }
         };
@@ -631,6 +636,7 @@ mod tests {
             max_sequence: None,
             sst_write_format: Default::default(),
             cache_manager: Default::default(),
+            preserve_row_sequence: false,
             index_options: IndexOptions::default(),
             index_config: Default::default(),
             inverted_index_config: Default::default(),
@@ -735,6 +741,7 @@ mod tests {
             max_sequence: None,
             sst_write_format: Default::default(),
             cache_manager: cache_manager.clone(),
+            preserve_row_sequence: false,
             index_options: IndexOptions::default(),
             index_config: Default::default(),
             inverted_index_config: Default::default(),
@@ -829,6 +836,7 @@ mod tests {
             max_sequence: None,
             sst_write_format: Default::default(),
             cache_manager: cache_manager.clone(),
+            preserve_row_sequence: false,
             index_options: IndexOptions::default(),
             index_config: Default::default(),
             inverted_index_config: Default::default(),

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::{NonZero, NonZeroU64};
+use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -455,17 +455,49 @@ impl SstMerger for DefaultSstMerger {
             .iter()
             .map(|f| f.file_id().to_string())
             .join(",");
-        let max_sequence = known_max_input_sequence(&output.inputs);
+        let input_max_sequence = known_max_input_sequence(&output.inputs);
         // The compaction output can only preserve per-row sequences when the
         // region option is enabled AND every input file carries the
-        // preserved-sequence marker. Otherwise a legacy (unmarked) input would
-        // be laundered into a trusted output and exact sequence-range scans
-        // would silently skip or wrongly filter its normalized sequences.
+        // preserved-sequence marker. Otherwise, rewrite the untrusted input as
+        // a sequence-less file. `committed_sequence + 1` is the region-local
+        // admission barrier for this compacted SST: once Flow's cursor reaches
+        // it, the input rows (which were all flushed in this snapshot) have
+        // already been consumed.
         let output_preserves_sequence = compaction_region.region_options.preserve_row_sequence
             && output
                 .inputs
                 .iter()
                 .all(|f| f.meta_ref().preserve_row_sequence);
+        let output_sequence = if output_preserves_sequence {
+            input_max_sequence
+        } else {
+            // The manifest records the region's latest accepted sequence for
+            // edit paths and its flushed frontier otherwise. Compaction only
+            // rewrites the immutable SST snapshot, so this is the same
+            // region-local admission barrier used when accepting files.
+            let manifest = compaction_region
+                .manifest_ctx
+                .manifest_manager
+                .read()
+                .await
+                .manifest();
+            NonZeroU64::new(
+                manifest
+                    .committed_sequence
+                    .unwrap_or(manifest.flushed_sequence)
+                    + 1,
+            )
+        };
+        // The flat/primary-key parquet formats require their three internal
+        // columns. For a sequence-less output, write the sequence column as
+        // zero instead of its file barrier. The reader recognizes all-zero
+        // sequence columns and overrides them from FileMeta for legacy reads;
+        // exact reads skip this file at file level before row filtering.
+        let write_max_sequence = if output_preserves_sequence {
+            input_max_sequence.map(NonZeroU64::get)
+        } else {
+            Some(0)
+        };
         let builder = CompactionSstReaderBuilder {
             metadata: compaction_region.region_metadata.clone(),
             sst_layer: compaction_region.access_layer.clone(),
@@ -489,7 +521,7 @@ impl SstMerger for DefaultSstMerger {
                     source,
                     cache_manager: compaction_region.cache_manager.clone(),
                     storage,
-                    max_sequence: max_sequence.map(NonZero::get),
+                    max_sequence: write_max_sequence,
                     sst_write_format: if flat_format {
                         FormatType::Flat
                     } else {
@@ -544,7 +576,7 @@ impl SstMerger for DefaultSstMerger {
                     index_version: 0,
                     num_rows: sst_info.num_rows as u64,
                     num_row_groups: sst_info.num_row_groups,
-                    sequence: max_sequence,
+                    sequence: output_sequence,
                     partition_expr: partition_expr.clone(),
                     num_series: sst_info.num_series,
                     primary_key_min,

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -404,13 +404,10 @@ pub trait SstMerger: Send + Sync + 'static {
 #[derive(Clone)]
 pub struct DefaultSstMerger;
 
-/// Computes the maximum sequence bound of the output of merging `inputs`.
-///
-/// Returns `None` for empty inputs or if any input's sequence bound is unknown:
-/// a partial max over the known inputs would launder the unknown file's rows into a
-/// trusted sequence bound, letting exact sequence-range scans silently skip or
-/// wrongly filter rows from that file. Only when every input bound is known is
-/// the `max` computed.
+/// Computes the maximum target-domain sequence bound of the output of merging
+/// `inputs`. Foreign files are described by their target-local barrier; local
+/// trusted files use their physical sequence bound. Unknown bounds never become
+/// trusted through a partial maximum.
 fn known_max_input_sequence(inputs: &[FileHandle]) -> Option<NonZeroU64> {
     let mut max: Option<NonZeroU64> = None;
     for input in inputs {
@@ -456,18 +453,14 @@ impl SstMerger for DefaultSstMerger {
             .map(|f| f.file_id().to_string())
             .join(",");
         let input_max_sequence = known_max_input_sequence(&output.inputs);
-        // The compaction output can only preserve per-row sequences when the
-        // region option is enabled AND every input file carries the
-        // preserved-sequence marker. Otherwise, rewrite the untrusted input as
-        // a sequence-less file. `committed_sequence + 1` is the region-local
-        // admission barrier for this compacted SST: once Flow's cursor reaches
-        // it, the input rows (which were all flushed in this snapshot) have
-        // already been consumed.
+        // The output is trusted only when every input is trusted in the target
+        // domain. Foreign marker values describe the source and are ignored;
+        // their present FileMeta.sequence is the target-local barrier.
         let output_preserves_sequence = compaction_region.region_options.preserve_row_sequence
             && output
                 .inputs
                 .iter()
-                .all(|f| f.meta_ref().preserve_row_sequence);
+                .all(|f| f.is_effective_target_sequence_trusted(region_id));
         let output_sequence = if output_preserves_sequence {
             input_max_sequence
         } else {
@@ -488,16 +481,11 @@ impl SstMerger for DefaultSstMerger {
                     + 1,
             )
         };
-        // The flat/primary-key parquet formats require their three internal
-        // columns. For a sequence-less output, write the sequence column as
-        // zero instead of its file barrier. The reader recognizes all-zero
-        // sequence columns and overrides them from FileMeta for legacy reads;
-        // exact reads skip this file at file level before row filtering.
-        let write_max_sequence = if output_preserves_sequence {
-            input_max_sequence.map(NonZeroU64::get)
-        } else {
-            Some(0)
-        };
+        // For untrusted output, keep the physical sequence override compatible
+        // with the main write path: use the known maximum sequence of the
+        // inputs. The FileMeta sequence remains the admission barrier, but it
+        // must not be written into the rows (or replaced with zero).
+        let write_max_sequence = input_max_sequence.map(NonZeroU64::get);
         let builder = CompactionSstReaderBuilder {
             metadata: compaction_region.region_metadata.clone(),
             sst_layer: compaction_region.access_layer.clone(),
@@ -844,6 +832,36 @@ mod tests {
 
     fn new_file_handle(meta: FileMeta) -> FileHandle {
         FileHandle::new(meta, Arc::new(NoopFilePurger))
+    }
+
+    #[test]
+    fn test_effective_target_trust_and_max_sequence() {
+        let target = RegionId::new(1, 1);
+        let local_trusted = new_file_handle(FileMeta {
+            region_id: target,
+            sequence: NonZeroU64::new(3),
+            preserve_row_sequence: true,
+            ..dummy_file_meta()
+        });
+        let foreign_untrusted_marker = new_file_handle(FileMeta {
+            region_id: RegionId::new(1, 2),
+            sequence: NonZeroU64::new(9),
+            preserve_row_sequence: false,
+            ..dummy_file_meta()
+        });
+        let local_untrusted = new_file_handle(FileMeta {
+            region_id: target,
+            sequence: NonZeroU64::new(11),
+            preserve_row_sequence: false,
+            ..dummy_file_meta()
+        });
+        assert!(local_trusted.is_effective_target_sequence_trusted(target));
+        assert!(foreign_untrusted_marker.is_effective_target_sequence_trusted(target));
+        assert!(!local_untrusted.is_effective_target_sequence_trusted(target));
+        assert_eq!(
+            NonZeroU64::new(9),
+            known_max_input_sequence(&[local_trusted, foreign_untrusted_marker])
+        );
     }
 
     #[test]

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::NonZero;
+use std::num::{NonZero, NonZeroU64};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -52,7 +52,7 @@ use crate::region::version::VersionRef;
 use crate::region::{ManifestContext, RegionLeaderState, RegionRoleState};
 use crate::schedule::scheduler::LocalScheduler;
 use crate::sst::FormatType;
-use crate::sst::file::{FileMeta, UncommittedSsts};
+use crate::sst::file::{FileHandle, FileMeta, UncommittedSsts};
 use crate::sst::file_purger::LocalFilePurger;
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;
@@ -404,6 +404,22 @@ pub trait SstMerger: Send + Sync + 'static {
 #[derive(Clone)]
 pub struct DefaultSstMerger;
 
+/// Computes the maximum sequence bound of the output of merging `inputs`.
+///
+/// Returns `None` if any input's sequence bound is unknown (`None`): a partial
+/// max over the known inputs would launder the unknown file's rows into a
+/// trusted sequence bound, letting exact sequence-range scans silently skip or
+/// wrongly filter rows from that file. Only when every input bound is known is
+/// the `max` computed.
+fn max_input_sequence(inputs: &[FileHandle]) -> Option<NonZeroU64> {
+    let mut max: Option<NonZeroU64> = None;
+    for input in inputs {
+        let sequence = input.meta_ref().sequence?;
+        max = Some(max.map_or(sequence, |current| current.max(sequence)));
+    }
+    max
+}
+
 #[async_trait::async_trait]
 impl SstMerger for DefaultSstMerger {
     async fn merge_single_output(
@@ -439,12 +455,17 @@ impl SstMerger for DefaultSstMerger {
             .iter()
             .map(|f| f.file_id().to_string())
             .join(",");
-        let max_sequence = output
-            .inputs
-            .iter()
-            .map(|f| f.meta_ref().sequence)
-            .max()
-            .flatten();
+        let max_sequence = max_input_sequence(&output.inputs);
+        // The compaction output can only preserve per-row sequences when the
+        // region option is enabled AND every input file carries the
+        // preserved-sequence marker. Otherwise a legacy (unmarked) input would
+        // be laundered into a trusted output and exact sequence-range scans
+        // would silently skip or wrongly filter its normalized sequences.
+        let output_preserves_sequence = compaction_region.region_options.preserve_row_sequence
+            && output
+                .inputs
+                .iter()
+                .all(|f| f.meta_ref().preserve_row_sequence);
         let builder = CompactionSstReaderBuilder {
             metadata: compaction_region.region_metadata.clone(),
             sst_layer: compaction_region.access_layer.clone(),
@@ -474,6 +495,7 @@ impl SstMerger for DefaultSstMerger {
                     } else {
                         FormatType::PrimaryKey
                     },
+                    preserve_row_sequence: output_preserves_sequence,
                     index_options,
                     index_config,
                     inverted_index_config,
@@ -527,6 +549,7 @@ impl SstMerger for DefaultSstMerger {
                     num_series: sst_info.num_series,
                     primary_key_min,
                     primary_key_max,
+                    preserve_row_sequence: output_preserves_sequence,
                 }
             })
             .collect::<Vec<_>>();
@@ -789,6 +812,33 @@ mod tests {
 
     fn new_file_handle(meta: FileMeta) -> FileHandle {
         FileHandle::new(meta, Arc::new(NoopFilePurger))
+    }
+
+    #[test]
+    fn test_max_input_sequence() {
+        let meta_with = |sequence| FileMeta {
+            sequence,
+            ..dummy_file_meta()
+        };
+
+        // All inputs with known bounds yield their max.
+        let inputs = vec![
+            new_file_handle(meta_with(NonZeroU64::new(3))),
+            new_file_handle(meta_with(NonZeroU64::new(9))),
+            new_file_handle(meta_with(NonZeroU64::new(5))),
+        ];
+        assert_eq!(NonZeroU64::new(9), max_input_sequence(&inputs));
+
+        // A single unknown bound poisons the whole output: the known inputs'
+        // max must not be laundered onto the merged output.
+        let inputs = vec![
+            new_file_handle(meta_with(NonZeroU64::new(9))),
+            new_file_handle(meta_with(None)),
+        ];
+        assert_eq!(None, max_input_sequence(&inputs));
+
+        // No inputs at all yield `None`.
+        assert_eq!(None, max_input_sequence(&[]));
     }
 
     /// Build a minimal [`CompactionRegion`] suitable for tests where the

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -860,14 +860,12 @@ mod tests {
         ];
         assert_eq!(NonZeroU64::new(9), known_max_input_sequence(&inputs));
 
-        // Unknown input fails closed.
         let inputs = vec![
             new_file_handle(meta_with(NonZeroU64::new(9))),
             new_file_handle(meta_with(None)),
         ];
         assert_eq!(None, known_max_input_sequence(&inputs));
 
-        // Empty input has no bound.
         assert_eq!(None, known_max_input_sequence(&[]));
     }
 

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -406,12 +406,12 @@ pub struct DefaultSstMerger;
 
 /// Computes the maximum sequence bound of the output of merging `inputs`.
 ///
-/// Returns `None` if any input's sequence bound is unknown (`None`): a partial
-/// max over the known inputs would launder the unknown file's rows into a
+/// Returns `None` for empty inputs or if any input's sequence bound is unknown:
+/// a partial max over the known inputs would launder the unknown file's rows into a
 /// trusted sequence bound, letting exact sequence-range scans silently skip or
 /// wrongly filter rows from that file. Only when every input bound is known is
 /// the `max` computed.
-fn max_input_sequence(inputs: &[FileHandle]) -> Option<NonZeroU64> {
+fn known_max_input_sequence(inputs: &[FileHandle]) -> Option<NonZeroU64> {
     let mut max: Option<NonZeroU64> = None;
     for input in inputs {
         let sequence = input.meta_ref().sequence?;
@@ -455,7 +455,7 @@ impl SstMerger for DefaultSstMerger {
             .iter()
             .map(|f| f.file_id().to_string())
             .join(",");
-        let max_sequence = max_input_sequence(&output.inputs);
+        let max_sequence = known_max_input_sequence(&output.inputs);
         // The compaction output can only preserve per-row sequences when the
         // region option is enabled AND every input file carries the
         // preserved-sequence marker. Otherwise a legacy (unmarked) input would
@@ -815,30 +815,28 @@ mod tests {
     }
 
     #[test]
-    fn test_max_input_sequence() {
+    fn test_known_max_input_sequence() {
         let meta_with = |sequence| FileMeta {
             sequence,
             ..dummy_file_meta()
         };
 
-        // All inputs with known bounds yield their max.
         let inputs = vec![
             new_file_handle(meta_with(NonZeroU64::new(3))),
             new_file_handle(meta_with(NonZeroU64::new(9))),
             new_file_handle(meta_with(NonZeroU64::new(5))),
         ];
-        assert_eq!(NonZeroU64::new(9), max_input_sequence(&inputs));
+        assert_eq!(NonZeroU64::new(9), known_max_input_sequence(&inputs));
 
-        // A single unknown bound poisons the whole output: the known inputs'
-        // max must not be laundered onto the merged output.
+        // Unknown input fails closed.
         let inputs = vec![
             new_file_handle(meta_with(NonZeroU64::new(9))),
             new_file_handle(meta_with(None)),
         ];
-        assert_eq!(None, max_input_sequence(&inputs));
+        assert_eq!(None, known_max_input_sequence(&inputs));
 
-        // No inputs at all yield `None`.
-        assert_eq!(None, max_input_sequence(&[]));
+        // Empty input has no bound.
+        assert_eq!(None, known_max_input_sequence(&[]));
     }
 
     /// Build a minimal [`CompactionRegion`] suitable for tests where the

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -336,6 +336,7 @@ mod tests {
                 max_row_group_row_count: None,
                 primary_key_encoding: None,
                 write_buffer_size: None,
+                preserve_row_sequence: false,
             },
             compaction_time_window: None,
         }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -100,7 +100,7 @@ use common_meta::error::UnexpectedSnafu;
 use common_meta::key::SchemaMetadataManagerRef;
 use common_recordbatch::{QueryMemoryTracker, SendableRecordBatchStream};
 use common_stat::get_total_memory_bytes;
-use common_telemetry::{info, tracing, warn};
+use common_telemetry::{debug, info, tracing, warn};
 use common_wal::options::WalOptions;
 use datafusion::execution::memory_pool::{GreedyMemoryPool, MemoryPool, UnboundedMemoryPool};
 use futures::future::{join_all, try_join_all};
@@ -1061,15 +1061,15 @@ impl EngineInner {
             request.memtable_max_sequence = Some(version_data.committed_sequence);
         }
 
-        // Shared capability check used identically by the engine (fence
-        // relaxation) and the reader (row-level filtering) — see
-        // `read::scan_region::exact_sequence_range`. Only Flow's explicit
-        // `sequence_range` mode requests exactness; historical `memtable_only`
-        // scans never set `exact_sequence_range` and therefore keep every fence
-        // below regardless of region options.
-        let exact_sequence_range_files = exact_sequence_range_files(&request, &version);
-        let exact_sequence_range =
-            exact_sequence_range(&request, &version, &exact_sequence_range_files)?;
+        // Only exact requests need the capability check and its selected file
+        // list. Other requests keep the regular scan pruning path unchanged.
+        let selected_files = (request.exact_sequence_range && !request.skip_sst_files)
+            .then(|| exact_sequence_range_files(&request, &version));
+        let exact_sequence_range = exact_sequence_range(
+            &request,
+            &version,
+            selected_files.as_deref().unwrap_or_default(),
+        )?;
 
         // An extension range provider may contribute ranges on a follower
         // region, and extension streams are returned without a row-level
@@ -1089,6 +1089,13 @@ impl EngineInner {
             exact_sequence_range
         };
 
+        debug!(
+            "Scan region {} exact sequence range: requested={}, available={}, selected_files={}",
+            region_id,
+            request.exact_sequence_range,
+            exact_sequence_range.is_some(),
+            selected_files.as_ref().map_or(0, Vec::len),
+        );
         validate_sequence_fences(
             &request,
             &version,
@@ -1114,6 +1121,11 @@ impl EngineInner {
         .with_ignore_fulltext_index(self.config.fulltext_index.apply_on_query.disabled())
         .with_ignore_bloom_filter(self.config.bloom_filter_index.apply_on_query.disabled())
         .with_start_time(query_start);
+        let scan_region = if let Some(files) = selected_files {
+            scan_region.with_selected_files(files)
+        } else {
+            scan_region
+        };
 
         #[cfg(feature = "enterprise")]
         let scan_region = self.maybe_fill_extension_range_provider(scan_region, region);

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -148,7 +148,9 @@ use crate::metrics::{
     HANDLE_REQUEST_ELAPSED, SCAN_MEMORY_EXHAUSTED_TOTAL, SCAN_MEMORY_USAGE_BYTES,
     SCAN_REQUESTS_REJECTED_TOTAL,
 };
-use crate::read::scan_region::{ScanRegion, Scanner, exact_sequence_range};
+use crate::read::scan_region::{
+    ScanRegion, Scanner, exact_sequence_range, exact_sequence_range_files,
+};
 use crate::read::stream::ScanBatchStream;
 use crate::region::MitoRegionRef;
 use crate::region::opener::PartitionExprFetcherRef;
@@ -1065,7 +1067,9 @@ impl EngineInner {
         // `sequence_range` mode requests exactness; historical `memtable_only`
         // scans never set `exact_sequence_range` and therefore keep every fence
         // below regardless of region options.
-        let exact_sequence_range = exact_sequence_range(&request, &version)?;
+        let exact_sequence_range_files = exact_sequence_range_files(&request, &version);
+        let exact_sequence_range =
+            exact_sequence_range(&request, &version, &exact_sequence_range_files)?;
 
         // An extension range provider may contribute ranges on a follower
         // region, and extension streams are returned without a row-level

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -136,8 +136,8 @@ use crate::config::MitoConfig;
 use crate::engine::puffin_index::{IndexEntryContext, collect_index_entries_from_puffin};
 use crate::error::{
     IncrementalQueryStaleSnafu, InvalidRequestSnafu, JoinSnafu, MitoManifestInfoSnafu, RecvSnafu,
-    RegionNotFoundSnafu, Result, SerdeJsonSnafu, SerializeColumnMetadataSnafu,
-    SnapshotFenceStaleSnafu,
+    RegionNotFoundSnafu, Result, SequenceRangeUnsupportedSnafu, SerdeJsonSnafu,
+    SerializeColumnMetadataSnafu, SnapshotFenceStaleSnafu,
 };
 #[cfg(feature = "enterprise")]
 use crate::extension::BoxedExtensionRangeProviderFactory;
@@ -148,7 +148,7 @@ use crate::metrics::{
     HANDLE_REQUEST_ELAPSED, SCAN_MEMORY_EXHAUSTED_TOTAL, SCAN_MEMORY_USAGE_BYTES,
     SCAN_REQUESTS_REJECTED_TOTAL,
 };
-use crate::read::scan_region::{ScanRegion, Scanner};
+use crate::read::scan_region::{ScanRegion, Scanner, exact_sequence_range};
 use crate::read::stream::ScanBatchStream;
 use crate::region::MitoRegionRef;
 use crate::region::opener::PartitionExprFetcherRef;
@@ -1059,36 +1059,97 @@ impl EngineInner {
             request.memtable_max_sequence = Some(version_data.committed_sequence);
         }
 
-        if let Some(given_seq) = request.memtable_min_sequence {
-            let min_readable_seq = version.flushed_sequence;
-            ensure!(
-                given_seq >= min_readable_seq,
-                IncrementalQueryStaleSnafu {
-                    region_id,
-                    given_seq,
-                    min_readable_seq,
-                }
-            );
-        }
+        // Shared capability check used identically by the engine (fence
+        // relaxation) and the reader (row-level filtering) — see
+        // `read::scan_region::exact_sequence_range`. Only Flow's explicit
+        // `sequence_range` mode requests exactness; historical `memtable_only`
+        // scans never set `exact_sequence_range` and therefore keep every fence
+        // below regardless of region options.
+        let exact_sequence_range = exact_sequence_range(&request, &version);
 
-        if let Some(given_seq) = request.memtable_max_sequence
-            && !request.skip_sst_files
-        {
-            // Explicit snapshot fences that include SST reads are enforceable
-            // only while the requested upper bound is not older than the
-            // region's flushed frontier. If H has already been flushed into SST,
-            // mito cannot apply a memtable-only sequence upper bound to that
-            // SST scan, so fail and let Flow rebind the fenced repair instead
-            // of reading rows beyond H.
-            let min_enforceable_seq = version.flushed_sequence;
-            ensure!(
-                given_seq >= min_enforceable_seq,
-                SnapshotFenceStaleSnafu {
-                    region_id,
-                    given_seq,
-                    min_enforceable_seq,
+        if request.exact_sequence_range {
+            // Exact `sequence_range` mode: when the capability is available the
+            // requested (C, H] delta is enforced row-level on memtables and every
+            // SST, so the lower/upper fences can be relaxed. When it is not, we
+            // must fail with a structured stale/unsupported error so Flow falls
+            // back instead of silently reading an approximate superset.
+            if exact_sequence_range.is_none() {
+                if let Some(given_seq) = request.memtable_min_sequence {
+                    let min_readable_seq = version.flushed_sequence;
+                    ensure!(
+                        given_seq >= min_readable_seq,
+                        IncrementalQueryStaleSnafu {
+                            region_id,
+                            given_seq,
+                            min_readable_seq,
+                        }
+                    );
                 }
-            );
+
+                if let Some(given_seq) = request.memtable_max_sequence {
+                    let min_enforceable_seq = version.flushed_sequence;
+                    ensure!(
+                        given_seq >= min_enforceable_seq,
+                        SnapshotFenceStaleSnafu {
+                            region_id,
+                            given_seq,
+                            min_enforceable_seq,
+                        }
+                    );
+                }
+
+                // Both bounds are enforceable against the flushed frontier, yet the
+                // region cannot serve an exact row-level delta (preserve option off,
+                // or a file without the preserved-sequence marker). Main semantics
+                // would silently return rows outside (C, H], so fail instead.
+                return SequenceRangeUnsupportedSnafu {
+                    region_id,
+                    min_seq: request.memtable_min_sequence.unwrap_or_default(),
+                    max_seq: request.memtable_max_sequence.unwrap_or_default(),
+                    reason: if version.options.preserve_row_sequence {
+                        "region has files without preserved per-row sequences".to_string()
+                    } else {
+                        "region does not preserve per-row sequences (preserve_row_sequence is off)"
+                            .to_string()
+                    },
+                }
+                .fail();
+            }
+        } else {
+            // Non-exact mode (including historical `memtable_only` scans): keep
+            // main's fences exactly as-is. The preserve option never relaxes them
+            // because `exact_sequence_range` is the only explicit exact intent.
+            if let Some(given_seq) = request.memtable_min_sequence {
+                let min_readable_seq = version.flushed_sequence;
+                ensure!(
+                    given_seq >= min_readable_seq,
+                    IncrementalQueryStaleSnafu {
+                        region_id,
+                        given_seq,
+                        min_readable_seq,
+                    }
+                );
+            }
+
+            if let Some(given_seq) = request.memtable_max_sequence
+                && !request.skip_sst_files
+            {
+                // Explicit snapshot fences that include SST reads are enforceable
+                // only while the requested upper bound is not older than the
+                // region's flushed frontier. If H has already been flushed into SST,
+                // mito cannot apply a memtable-only sequence upper bound to that
+                // SST scan, so fail and let Flow rebind the fenced repair instead
+                // of reading rows beyond H.
+                let min_enforceable_seq = version.flushed_sequence;
+                ensure!(
+                    given_seq >= min_enforceable_seq,
+                    SnapshotFenceStaleSnafu {
+                        region_id,
+                        given_seq,
+                        min_enforceable_seq,
+                    }
+                );
+            }
         }
 
         // Get cache.

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -1061,15 +1061,35 @@ impl EngineInner {
             request.memtable_max_sequence = Some(version_data.committed_sequence);
         }
 
-        // Only exact requests need the capability check and its selected file
-        // list. Other requests keep the regular scan pruning path unchanged.
-        let selected_files = (request.exact_sequence_range && !request.skip_sst_files)
-            .then(|| exact_sequence_range_files(&request, &version));
-        let exact_sequence_range = exact_sequence_range(
-            &request,
-            &version,
-            selected_files.as_deref().unwrap_or_default(),
-        )?;
+        // Select the files and decide the exact capability from the same version
+        // snapshot. Keep them together so the reader cannot recompute either
+        // side from a different file set.
+        let exact_selection = if request.exact_sequence_range {
+            let files = if request.skip_sst_files {
+                Vec::new()
+            } else {
+                exact_sequence_range_files(&request, &version)
+            };
+            let selected_files = files.len();
+            match exact_sequence_range(&request, &version, &files) {
+                Ok(sequence_range) => Some((files, sequence_range)),
+                Err(err) => {
+                    debug!(
+                        "Scan region {} exact sequence range denied: min={:?}, max={:?}, selected_files={}, denial_reason=foreign_file_missing_barrier",
+                        region_id,
+                        request.memtable_min_sequence,
+                        request.memtable_max_sequence,
+                        selected_files,
+                    );
+                    return Err(err);
+                }
+            }
+        } else {
+            None
+        };
+        let exact_sequence_range = exact_selection
+            .as_ref()
+            .and_then(|(_, sequence_range)| *sequence_range);
 
         // An extension range provider may contribute ranges on a follower
         // region, and extension streams are returned without a row-level
@@ -1088,13 +1108,36 @@ impl EngineInner {
         } else {
             exact_sequence_range
         };
+        let exact_selection = exact_selection.map(|(files, _)| (files, exact_sequence_range));
+        let exact_denial_reason = if !request.exact_sequence_range {
+            "not_requested"
+        } else if request.skip_sst_files {
+            "sst_files_skipped"
+        } else if request.memtable_min_sequence.is_none() {
+            "missing_lower_bound"
+        } else if request.memtable_max_sequence.is_none() {
+            "missing_upper_bound"
+        } else if !version.options.preserve_row_sequence {
+            "preserve_row_sequence_disabled"
+        } else if extension_provider_blocks_exact {
+            "extension_provider"
+        } else if exact_sequence_range.is_none() {
+            "selected_file_barrier_not_admitted"
+        } else {
+            "none"
+        };
 
         debug!(
-            "Scan region {} exact sequence range: requested={}, available={}, selected_files={}",
+            "Scan region {} exact sequence range: requested={}, min={:?}, max={:?}, committed={}, flushed={}, available={}, selected_files={}, denial_reason={}",
             region_id,
             request.exact_sequence_range,
+            request.memtable_min_sequence,
+            request.memtable_max_sequence,
+            version_data.committed_sequence,
+            version.flushed_sequence,
             exact_sequence_range.is_some(),
-            selected_files.as_ref().map_or(0, Vec::len),
+            exact_selection.as_ref().map_or(0, |(files, _)| files.len()),
+            exact_denial_reason,
         );
         validate_sequence_fences(
             &request,
@@ -1121,8 +1164,8 @@ impl EngineInner {
         .with_ignore_fulltext_index(self.config.fulltext_index.apply_on_query.disabled())
         .with_ignore_bloom_filter(self.config.bloom_filter_index.apply_on_query.disabled())
         .with_start_time(query_start);
-        let scan_region = if let Some(files) = selected_files {
-            scan_region.with_selected_files(files)
+        let scan_region = if let Some(selection) = exact_selection {
+            scan_region.with_exact_selection(selection)
         } else {
             scan_region
         };

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -1065,7 +1065,7 @@ impl EngineInner {
         // `sequence_range` mode requests exactness; historical `memtable_only`
         // scans never set `exact_sequence_range` and therefore keep every fence
         // below regardless of region options.
-        let exact_sequence_range = exact_sequence_range(&request, &version);
+        let exact_sequence_range = exact_sequence_range(&request, &version)?;
 
         // An extension range provider may contribute ranges on a follower
         // region, and extension streams are returned without a row-level

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -1077,108 +1077,21 @@ impl EngineInner {
         let extension_provider_blocks_exact = region.is_follower()
             && self.extension_range_provider_factory.is_some()
             && exact_sequence_range.is_some();
-        #[cfg(feature = "enterprise")]
+        #[cfg(not(feature = "enterprise"))]
+        let extension_provider_blocks_exact = false;
         let exact_sequence_range = if extension_provider_blocks_exact {
             None
         } else {
             exact_sequence_range
         };
 
-        if request.exact_sequence_range {
-            // Exact `sequence_range` mode: when the capability is available the
-            // requested (C, H] delta is enforced row-level on memtables and every
-            // SST, so the lower/upper fences can be relaxed. When it is not, we
-            // must fail with a structured stale/unsupported error so Flow falls
-            // back instead of silently reading an approximate superset.
-            if exact_sequence_range.is_none() {
-                if let Some(given_seq) = request.memtable_min_sequence {
-                    let min_readable_seq = version.flushed_sequence;
-                    ensure!(
-                        given_seq >= min_readable_seq,
-                        IncrementalQueryStaleSnafu {
-                            region_id,
-                            given_seq,
-                            min_readable_seq,
-                        }
-                    );
-                }
-
-                if let Some(given_seq) = request.memtable_max_sequence {
-                    let min_enforceable_seq = version.flushed_sequence;
-                    ensure!(
-                        given_seq >= min_enforceable_seq,
-                        SnapshotFenceStaleSnafu {
-                            region_id,
-                            given_seq,
-                            min_enforceable_seq,
-                        }
-                    );
-                }
-
-                // Both bounds are enforceable against the flushed frontier, yet the
-                // region cannot serve an exact row-level delta (preserve option off,
-                // a file without the preserved-sequence marker, or a follower with
-                // an extension range provider). Main semantics would silently
-                // return rows outside (C, H], so fail instead.
-                return SequenceRangeUnsupportedSnafu {
-                    region_id,
-                    min_seq: request.memtable_min_sequence.unwrap_or_default(),
-                    max_seq: request.memtable_max_sequence.unwrap_or_default(),
-                    reason: {
-                        #[cfg(feature = "enterprise")]
-                        let extension_reason = extension_provider_blocks_exact.then(|| {
-                            "region is a follower with an extension range provider, whose streams cannot be filtered by sequence".to_string()
-                        });
-                        #[cfg(not(feature = "enterprise"))]
-                        let extension_reason = None::<String>;
-                        extension_reason.unwrap_or_else(|| {
-                            if version.options.preserve_row_sequence {
-                                "region has files without preserved per-row sequences".to_string()
-                            } else {
-                                "region does not preserve per-row sequences (preserve_row_sequence is off)"
-                                    .to_string()
-                            }
-                        })
-                    },
-                }
-                .fail();
-            }
-        } else {
-            // Non-exact mode (including historical `memtable_only` scans): keep
-            // main's fences exactly as-is. The preserve option never relaxes them
-            // because `exact_sequence_range` is the only explicit exact intent.
-            if let Some(given_seq) = request.memtable_min_sequence {
-                let min_readable_seq = version.flushed_sequence;
-                ensure!(
-                    given_seq >= min_readable_seq,
-                    IncrementalQueryStaleSnafu {
-                        region_id,
-                        given_seq,
-                        min_readable_seq,
-                    }
-                );
-            }
-
-            if let Some(given_seq) = request.memtable_max_sequence
-                && !request.skip_sst_files
-            {
-                // Explicit snapshot fences that include SST reads are enforceable
-                // only while the requested upper bound is not older than the
-                // region's flushed frontier. If H has already been flushed into SST,
-                // mito cannot apply a memtable-only sequence upper bound to that
-                // SST scan, so fail and let Flow rebind the fenced repair instead
-                // of reading rows beyond H.
-                let min_enforceable_seq = version.flushed_sequence;
-                ensure!(
-                    given_seq >= min_enforceable_seq,
-                    SnapshotFenceStaleSnafu {
-                        region_id,
-                        given_seq,
-                        min_enforceable_seq,
-                    }
-                );
-            }
-        }
+        validate_sequence_fences(
+            &request,
+            &version,
+            region_id,
+            exact_sequence_range.is_some(),
+            extension_provider_blocks_exact,
+        )?;
 
         // Get cache.
         let cache_manager = self.workers.cache_manager();
@@ -1282,6 +1195,110 @@ impl EngineInner {
         self.workers
             .get_region(region_id)
             .map(|region| region.region_role())
+    }
+}
+
+fn validate_sequence_fences(
+    request: &ScanRequest,
+    version: &crate::region::version::Version,
+    region_id: RegionId,
+    exact_sequence_range_available: bool,
+    extension_provider_blocks_exact: bool,
+) -> Result<()> {
+    if request.exact_sequence_range {
+        // Exact `sequence_range` mode: when the capability is available the
+        // requested (C, H] delta is enforced row-level on memtables and every
+        // SST, so the lower/upper fences can be relaxed. When it is not, we
+        // must fail with a structured stale/unsupported error so Flow falls
+        // back instead of silently reading an approximate superset.
+        if !exact_sequence_range_available {
+            if let Some(given_seq) = request.memtable_min_sequence {
+                let min_readable_seq = version.flushed_sequence;
+                ensure!(
+                    given_seq >= min_readable_seq,
+                    IncrementalQueryStaleSnafu {
+                        region_id,
+                        given_seq,
+                        min_readable_seq,
+                    }
+                );
+            }
+
+            if let Some(given_seq) = request.memtable_max_sequence {
+                let min_enforceable_seq = version.flushed_sequence;
+                ensure!(
+                    given_seq >= min_enforceable_seq,
+                    SnapshotFenceStaleSnafu {
+                        region_id,
+                        given_seq,
+                        min_enforceable_seq,
+                    }
+                );
+            }
+
+            // Both bounds are enforceable against the flushed frontier, yet the
+            // region cannot serve an exact row-level delta (preserve option off,
+            // a file without the preserved-sequence marker, or a follower with
+            // an extension range provider). Main semantics would silently
+            // return rows outside (C, H], so fail instead.
+            return SequenceRangeUnsupportedSnafu {
+                region_id,
+                min_seq: request.memtable_min_sequence.unwrap_or_default(),
+                max_seq: request.memtable_max_sequence.unwrap_or_default(),
+                reason: sequence_range_unsupported_reason(version, extension_provider_blocks_exact),
+            }
+            .fail();
+        }
+    } else {
+        // Non-exact mode (including historical `memtable_only` scans): keep
+        // main's fences exactly as-is. The preserve option never relaxes them
+        // because `exact_sequence_range` is the only explicit exact intent.
+        if let Some(given_seq) = request.memtable_min_sequence {
+            let min_readable_seq = version.flushed_sequence;
+            ensure!(
+                given_seq >= min_readable_seq,
+                IncrementalQueryStaleSnafu {
+                    region_id,
+                    given_seq,
+                    min_readable_seq,
+                }
+            );
+        }
+
+        if let Some(given_seq) = request.memtable_max_sequence
+            && !request.skip_sst_files
+        {
+            // Explicit snapshot fences that include SST reads are enforceable
+            // only while the requested upper bound is not older than the
+            // region's flushed frontier. If H has already been flushed into SST,
+            // mito cannot apply a memtable-only sequence upper bound to that
+            // SST scan, so fail and let Flow rebind the fenced repair instead
+            // of reading rows beyond H.
+            let min_enforceable_seq = version.flushed_sequence;
+            ensure!(
+                given_seq >= min_enforceable_seq,
+                SnapshotFenceStaleSnafu {
+                    region_id,
+                    given_seq,
+                    min_enforceable_seq,
+                }
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn sequence_range_unsupported_reason(
+    version: &crate::region::version::Version,
+    extension_provider_blocks_exact: bool,
+) -> String {
+    if extension_provider_blocks_exact {
+        "region is a follower with an extension range provider, whose streams cannot be filtered by sequence".to_string()
+    } else if version.options.preserve_row_sequence {
+        "region has files without preserved per-row sequences".to_string()
+    } else {
+        "region does not preserve per-row sequences (preserve_row_sequence is off)".to_string()
     }
 }
 

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -1067,6 +1067,23 @@ impl EngineInner {
         // below regardless of region options.
         let exact_sequence_range = exact_sequence_range(&request, &version);
 
+        // An extension range provider may contribute ranges on a follower
+        // region, and extension streams are returned without a row-level
+        // sequence filter (`scan_flat_extension_range`), so exactness cannot
+        // be proven when one is attached. Treat the capability as missing so
+        // the request fails closed below instead of emitting out-of-range
+        // rows. See the injection point in `ScanRegion::scan_input`.
+        #[cfg(feature = "enterprise")]
+        let extension_provider_blocks_exact = region.is_follower()
+            && self.extension_range_provider_factory.is_some()
+            && exact_sequence_range.is_some();
+        #[cfg(feature = "enterprise")]
+        let exact_sequence_range = if extension_provider_blocks_exact {
+            None
+        } else {
+            exact_sequence_range
+        };
+
         if request.exact_sequence_range {
             // Exact `sequence_range` mode: when the capability is available the
             // requested (C, H] delta is enforced row-level on memtables and every
@@ -1100,17 +1117,28 @@ impl EngineInner {
 
                 // Both bounds are enforceable against the flushed frontier, yet the
                 // region cannot serve an exact row-level delta (preserve option off,
-                // or a file without the preserved-sequence marker). Main semantics
-                // would silently return rows outside (C, H], so fail instead.
+                // a file without the preserved-sequence marker, or a follower with
+                // an extension range provider). Main semantics would silently
+                // return rows outside (C, H], so fail instead.
                 return SequenceRangeUnsupportedSnafu {
                     region_id,
                     min_seq: request.memtable_min_sequence.unwrap_or_default(),
                     max_seq: request.memtable_max_sequence.unwrap_or_default(),
-                    reason: if version.options.preserve_row_sequence {
-                        "region has files without preserved per-row sequences".to_string()
-                    } else {
-                        "region does not preserve per-row sequences (preserve_row_sequence is off)"
-                            .to_string()
+                    reason: {
+                        #[cfg(feature = "enterprise")]
+                        let extension_reason = extension_provider_blocks_exact.then(|| {
+                            "region is a follower with an extension range provider, whose streams cannot be filtered by sequence".to_string()
+                        });
+                        #[cfg(not(feature = "enterprise"))]
+                        let extension_reason = None::<String>;
+                        extension_reason.unwrap_or_else(|| {
+                            if version.options.preserve_row_sequence {
+                                "region has files without preserved per-row sequences".to_string()
+                            } else {
+                                "region does not preserve per-row sequences (preserve_row_sequence is off)"
+                                    .to_string()
+                            }
+                        })
                     },
                 }
                 .fail();

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -148,9 +148,7 @@ use crate::metrics::{
     HANDLE_REQUEST_ELAPSED, SCAN_MEMORY_EXHAUSTED_TOTAL, SCAN_MEMORY_USAGE_BYTES,
     SCAN_REQUESTS_REJECTED_TOTAL,
 };
-use crate::read::scan_region::{
-    ScanRegion, Scanner, exact_sequence_range, exact_sequence_range_files,
-};
+use crate::read::scan_region::{ScanRegion, Scanner, exact_sequence_range};
 use crate::read::stream::ScanBatchStream;
 use crate::region::MitoRegionRef;
 use crate::region::opener::PartitionExprFetcherRef;
@@ -1065,21 +1063,12 @@ impl EngineInner {
         // snapshot. Keep them together so the reader cannot recompute either
         // side from a different file set.
         let exact_selection = if request.exact_sequence_range {
-            let files = if request.skip_sst_files {
-                Vec::new()
-            } else {
-                exact_sequence_range_files(&request, &version)
-            };
-            let selected_files = files.len();
-            match exact_sequence_range(&request, &version, &files) {
-                Ok(sequence_range) => Some((files, sequence_range)),
+            match exact_sequence_range(&request, &version) {
+                Ok((files, sequence_range)) => Some((files, sequence_range)),
                 Err(err) => {
                     debug!(
-                        "Scan region {} exact sequence range denied: min={:?}, max={:?}, selected_files={}, denial_reason=foreign_file_missing_barrier",
-                        region_id,
-                        request.memtable_min_sequence,
-                        request.memtable_max_sequence,
-                        selected_files,
+                        "Scan region {} exact sequence range denied: min={:?}, max={:?}, denial_reason=foreign_file_missing_barrier",
+                        region_id, request.memtable_min_sequence, request.memtable_max_sequence,
                     );
                     return Err(err);
                 }

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -25,6 +25,7 @@ use api::v1::{
     ArrowIpc, BulkWalEntry, ColumnDataType, Row, Rows, SemanticType, Value, WalEntry, WriteHint,
 };
 use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use common_meta::ddl::utils::{parse_column_metadatas, parse_manifest_infos_from_extensions};
 use common_recordbatch::{DfRecordBatch, RecordBatches};
 use common_test_util::flight::encode_to_flight_data;
@@ -42,7 +43,7 @@ use store_api::region_engine::{RegionEngine, RegionManifestInfo, RegionRole};
 use store_api::region_request::{
     AddColumn, AddColumnLocation, AlterKind, ModifyColumnType, PathType, RegionAlterRequest,
     RegionBulkInsertsRequest, RegionCompactRequest, RegionOpenRequest, RegionPutRequest,
-    RegionRequest, SetIndexOption, SetRegionOption,
+    RegionRequest, SetIndexOption, SetRegionOption, UnsetRegionOption,
 };
 use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
 use store_api::storage::{ColumnId, RegionId, ScanRequest};
@@ -2611,6 +2612,287 @@ async fn test_alter_region_append_mode_invalid() {
 
     // append_mode should still be true
     check_append_mode(&engine, true);
+}
+
+#[tokio::test]
+async fn test_alter_region_preserve_row_sequence_lifecycle() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::with_prefix("test_alter_region_preserve_row_sequence_lifecycle").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .build();
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let alter = |kind: AlterKind| {
+        engine.handle_request(region_id, RegionRequest::Alter(RegionAlterRequest { kind }))
+    };
+
+    // Fill the memtable while preserve_row_sequence is disabled.
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: build_rows(0, 3),
+        },
+    )
+    .await;
+    let version = engine.get_region(region_id).unwrap().version();
+    assert!(version.memtables.num_rows() > 0);
+    let flushed_sequence = version.flushed_sequence;
+
+    // Enable alone on the non-empty memtable: applies in memory through the
+    // fast path, neither flushing nor losing rows.
+    alter(AlterKind::SetRegionOptions {
+        options: vec![SetRegionOption::PreserveRowSequence(true)],
+    })
+    .await
+    .unwrap();
+    let version = engine.get_region(region_id).unwrap().version();
+    assert!(version.options.preserve_row_sequence);
+    assert_eq!(0, version.ssts.levels()[0].files.len());
+    assert!(version.memtables.num_rows() > 0);
+    assert_eq!(flushed_sequence, version.flushed_sequence);
+
+    // Rows written after the ALTER share the pre-ALTER memtable; a later flush
+    // writes both into one SST marked with preserve_row_sequence.
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: build_rows(3, 5),
+        },
+    )
+    .await;
+    flush_region(&engine, region_id, None).await;
+    let version = engine.get_region(region_id).unwrap().version();
+    assert!(version.options.preserve_row_sequence);
+    let level0 = &version.ssts.levels()[0].files;
+    assert_eq!(1, level0.len());
+    assert!(
+        level0
+            .values()
+            .next()
+            .unwrap()
+            .meta_ref()
+            .preserve_row_sequence
+    );
+    let flushed_sequence = version.flushed_sequence;
+
+    // Exact scan (2, 5] returns pre-ALTER row "2" (seq 3) and post-ALTER rows
+    // "3" and "4" (seqs 4 and 5): distinct row sequences survive the flush.
+    let scan_exact = async |min: Option<u64>, max: Option<u64>| -> String {
+        let stream = engine
+            .scan_to_stream(
+                region_id,
+                ScanRequest {
+                    memtable_min_sequence: min,
+                    memtable_max_sequence: max,
+                    exact_sequence_range: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        sort_batches_and_print(&batches, &["tag_0", "ts"])
+    };
+    let expected = "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 2     | 2.0     | 1970-01-01T00:00:02 |
+| 3     | 3.0     | 1970-01-01T00:00:03 |
+| 4     | 4.0     | 1970-01-01T00:00:04 |
++-------+---------+---------------------+";
+    assert_eq!(expected, scan_exact(Some(2), Some(5)).await);
+
+    // Fill the memtable again and unset on the non-empty memtable: applies in
+    // memory without creating another SST.
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas,
+            rows: build_rows(5, 7),
+        },
+    )
+    .await;
+    alter(AlterKind::UnsetRegionOptions {
+        keys: vec![UnsetRegionOption::PreserveRowSequence],
+    })
+    .await
+    .unwrap();
+    let version = engine.get_region(region_id).unwrap().version();
+    assert!(!version.options.preserve_row_sequence);
+    assert_eq!(1, version.ssts.levels()[0].files.len());
+    assert!(version.memtables.num_rows() > 0);
+
+    // The exact capability is unsupported immediately: both bounds are still
+    // enforceable against the flushed frontier, yet row-level filtering is off.
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(flushed_sequence),
+                memtable_max_sequence: Some(flushed_sequence),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected sequence-range unsupported error");
+    assert!(matches!(err, error::Error::SequenceRangeUnsupported { .. }));
+
+    // A subsequent flush under the disabled state writes an unmarked SST while
+    // the earlier marked SST stays untouched.
+    flush_region(&engine, region_id, None).await;
+    let version = engine.get_region(region_id).unwrap().version();
+    let level0 = &version.ssts.levels()[0].files;
+    assert_eq!(2, level0.len());
+    let newest = level0
+        .values()
+        .max_by_key(|f| f.meta_ref().sequence)
+        .unwrap();
+    assert!(!newest.meta_ref().preserve_row_sequence);
+    assert_eq!(
+        1,
+        level0
+            .values()
+            .filter(|f| f.meta_ref().preserve_row_sequence)
+            .count()
+    );
+}
+
+#[tokio::test]
+async fn test_alter_region_append_mode_preserve_combined_flushes_in_both_orders() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::with_prefix(
+        "test_alter_region_append_mode_preserve_combined_flushes_in_both_orders",
+    )
+    .await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    // Both orders of the combined ALTER must behave identically: append_mode's
+    // requirement for an empty memtable is not bypassed by preserve_row_sequence.
+    for (region_id, options) in [
+        (
+            RegionId::new(1, 1),
+            vec![
+                SetRegionOption::AppendMode(true),
+                SetRegionOption::PreserveRowSequence(true),
+            ],
+        ),
+        (
+            RegionId::new(1, 2),
+            vec![
+                SetRegionOption::PreserveRowSequence(true),
+                SetRegionOption::AppendMode(true),
+            ],
+        ),
+    ] {
+        let request = CreateRequestBuilder::new().build();
+        let column_schemas = rows_schema(&request);
+        engine
+            .handle_request(region_id, RegionRequest::Create(request))
+            .await
+            .unwrap();
+
+        // Non-empty memtable: the combined ALTER must flush before applying.
+        put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: column_schemas,
+                rows: build_rows(0, 3),
+            },
+        )
+        .await;
+
+        engine
+            .handle_request(
+                region_id,
+                RegionRequest::Alter(RegionAlterRequest {
+                    kind: AlterKind::SetRegionOptions { options },
+                }),
+            )
+            .await
+            .unwrap();
+
+        let version = engine.get_region(region_id).unwrap().version();
+        assert!(version.options.append_mode && version.options.preserve_row_sequence);
+        // The append_mode change forced a flush: the memtable is now empty and
+        // the pre-ALTER rows live in the flushed SST.
+        assert_eq!(0, version.memtables.num_rows());
+
+        let request = ScanRequest::default();
+        let stream = engine.scan_to_stream(region_id, request).await.unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        assert_eq!(3, batches.iter().map(|b| b.num_rows()).sum::<usize>());
+    }
+}
+
+#[tokio::test]
+async fn test_alter_region_preserve_row_sequence_requires_append_mode() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env =
+        TestEnv::with_prefix("test_alter_region_preserve_row_sequence_requires_append_mode").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+
+    let alter = |options: Vec<SetRegionOption>| {
+        engine.handle_request(
+            region_id,
+            RegionRequest::Alter(RegionAlterRequest {
+                kind: AlterKind::SetRegionOptions { options },
+            }),
+        )
+    };
+
+    let err = alter(vec![SetRegionOption::PreserveRowSequence(true)])
+        .await
+        .unwrap_err();
+    let err = err.as_any().downcast_ref::<error::Error>().unwrap();
+    assert_matches!(
+        err,
+        error::Error::InvalidMetadata { source, .. }
+            if source.to_string().contains("preserve_row_sequence is only supported for append-only tables")
+    );
+    assert_eq!(err.status_code(), StatusCode::InvalidArguments);
+
+    // Disabling on a non-append region is a no-op success and leaves the
+    // option off.
+    alter(vec![SetRegionOption::PreserveRowSequence(false)])
+        .await
+        .unwrap();
+    assert!(
+        !engine
+            .get_region(region_id)
+            .unwrap()
+            .version()
+            .options
+            .preserve_row_sequence
+    );
 }
 
 /// Builds a batch against the schema before [add_nullable_field1]

--- a/src/mito2/src/engine/apply_staging_manifest_test.rs
+++ b/src/mito2/src/engine/apply_staging_manifest_test.rs
@@ -20,7 +20,7 @@ use api::v1::Rows;
 use api::v1::region::{StrictWindow, compact_request};
 use common_function::utils::partition_expr_version;
 use common_recordbatch::RecordBatches;
-use datatypes::arrow::array::AsArray;
+use datatypes::arrow::array::{AsArray, UInt64Array};
 use datatypes::arrow::datatypes::Float64Type;
 use datatypes::value::Value;
 use partition::expr::{PartitionExpr, col};
@@ -54,11 +54,16 @@ fn range_expr(col_name: &str, start: i64, end: i64) -> PartitionExpr {
 #[tokio::test]
 async fn test_apply_staging_manifest_sequence_domain() {
     common_telemetry::init_default_ut_logging();
-    test_apply_staging_manifest_sequence_domain_with_format(false).await;
-    test_apply_staging_manifest_sequence_domain_with_format(true).await;
+    for flat_format in [false, true] {
+        test_apply_staging_manifest_sequence_domain_with_format(flat_format, false).await;
+        test_apply_staging_manifest_sequence_domain_with_format(flat_format, true).await;
+    }
 }
 
-async fn test_apply_staging_manifest_sequence_domain_with_format(flat_format: bool) {
+async fn test_apply_staging_manifest_sequence_domain_with_format(
+    flat_format: bool,
+    preserve_row_sequence: bool,
+) {
     let mut env = TestEnv::with_prefix("apply-staging-sequence-domain").await;
     let engine = env
         .create_engine(MitoConfig {
@@ -68,23 +73,41 @@ async fn test_apply_staging_manifest_sequence_domain_with_format(flat_format: bo
         .await;
     let source = RegionId::new(1, 1);
     let target = RegionId::new(1, 2);
-    let request = CreateRequestBuilder::new().build();
+    let mut request_builder = CreateRequestBuilder::new();
+    if preserve_row_sequence {
+        request_builder = request_builder
+            .insert_option("append_mode", "true")
+            .insert_option("preserve_row_sequence", "true");
+    }
+    let request = request_builder.build();
     let schema = rows_schema(&request);
 
     engine
         .handle_request(source, RegionRequest::Create(request.clone()))
         .await
         .unwrap();
-    for value in 0..3 {
+    if preserve_row_sequence {
         put_rows(
             &engine,
             source,
             Rows {
                 schema: schema.clone(),
-                rows: build_rows_for_key("0", 0, 1, value),
+                rows: build_rows_for_key("0", 0, 3, 0),
             },
         )
         .await;
+    } else {
+        for value in 0..3 {
+            put_rows(
+                &engine,
+                source,
+                Rows {
+                    schema: schema.clone(),
+                    rows: build_rows_for_key("0", 0, 1, value),
+                },
+            )
+            .await;
+        }
     }
     engine
         .handle_request(source, RegionRequest::Flush(RegionFlushRequest::default()))
@@ -165,11 +188,18 @@ async fn test_apply_staging_manifest_sequence_domain_with_format(flat_format: bo
         target,
         Rows {
             schema: schema.clone(),
-            rows: build_rows_for_key("0", 0, 1, 99),
+            rows: build_rows_for_key(
+                if preserve_row_sequence { "1" } else { "0" },
+                if preserve_row_sequence { 3 } else { 0 },
+                if preserve_row_sequence { 4 } else { 1 },
+                99,
+            ),
         },
     )
     .await;
-    assert_target_value(&engine, target, 99.0).await;
+    if !preserve_row_sequence {
+        assert_target_value(&engine, target, 99.0).await;
+    }
 
     engine
         .handle_request(target, RegionRequest::Flush(RegionFlushRequest::default()))
@@ -216,7 +246,73 @@ async fn test_apply_staging_manifest_sequence_domain_with_format(flat_format: bo
         input_ids.iter().all(|id| !output_ids.contains(id)),
         "real compaction must replace both input SSTs"
     );
-    assert_target_value(&engine, target, 99.0).await;
+    if !preserve_row_sequence {
+        assert_target_value(&engine, target, 99.0).await;
+    }
+
+    if preserve_row_sequence {
+        let output = output_files
+            .iter()
+            .find(|file| output_ids.contains(&file.meta_ref().file_id))
+            .expect("target-owned compaction output");
+        assert!(output.meta_ref().preserve_row_sequence);
+        // The imported rows are virtualized at target barrier 1 and the local
+        // row has physical sequence 2, so the output frontier is 2.
+        assert_eq!(
+            Some(std::num::NonZeroU64::new(2).unwrap()),
+            output.meta_ref().sequence
+        );
+
+        let mut reader = engine
+            .get_region(target)
+            .unwrap()
+            .access_layer
+            .read_sst((**output).clone())
+            .build()
+            .await
+            .unwrap()
+            .expect("compaction output reader");
+        let batch = reader
+            .next_record_batch()
+            .await
+            .unwrap()
+            .expect("output batch");
+        let sequences = batch
+            .column(batch.num_columns() - 2)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("sequence column");
+        // The target partition excludes source field_0 = 0, leaving two
+        // imported rows at barrier 1 and the local row at sequence 2.
+        assert_eq!(
+            2,
+            sequences.values().iter().filter(|&&seq| seq == 1).count()
+        );
+        assert_eq!(
+            1,
+            sequences.values().iter().filter(|&&seq| seq == 2).count()
+        );
+
+        for (min, max, expected_rows) in [(0, 1, 2), (1, 2, 1)] {
+            let stream = engine
+                .scan_to_stream(
+                    target,
+                    ScanRequest {
+                        exact_sequence_range: true,
+                        memtable_min_sequence: Some(min),
+                        memtable_max_sequence: Some(max),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            let batches = RecordBatches::try_collect(stream).await.unwrap();
+            assert_eq!(
+                expected_rows,
+                batches.iter().map(|batch| batch.num_rows()).sum::<usize>()
+            );
+        }
+    }
 }
 
 fn current_file_ids(engine: &crate::engine::MitoEngine, region_id: RegionId) -> HashSet<FileId> {

--- a/src/mito2/src/engine/copy_region_from_test.rs
+++ b/src/mito2/src/engine/copy_region_from_test.rs
@@ -355,13 +355,13 @@ async fn test_engine_copy_region_unexpected_state_with_format(flat_format: bool)
     )
 }
 
-// Regression for #8865: `copy_region_from` must not carry the source region's
-// `FileMeta::preserve_row_sequence` trust marker into the target region, whose
-// sequence domain is independent. The copied file's physical per-row sequences
-// belong to the source region only; trusting them in the target would let an
-// exact sequence-range request replay source rows as if they were target
-// sequences. The marker must be cleared so the target fails closed with
-// `SequenceRangeUnsupported` instead.
+/// Regression for #8865: `copy_region_from` must not carry the source region's
+/// `FileMeta::preserve_row_sequence` trust marker into the target region, whose
+/// sequence domain is independent. The copied file's physical per-row sequences
+/// belong to the source region only; trusting them in the target would let an
+/// exact sequence-range request replay source rows as if they were target
+/// sequences. The marker must be cleared so the target fails closed with
+/// `SequenceRangeUnsupported` instead.
 #[tokio::test]
 async fn test_copy_region_from_clears_preserve_row_sequence_marker() {
     common_telemetry::init_default_ut_logging();

--- a/src/mito2/src/engine/copy_region_from_test.rs
+++ b/src/mito2/src/engine/copy_region_from_test.rs
@@ -430,6 +430,9 @@ async fn test_copy_region_from_clears_preserve_row_sequence_marker() {
 
     // The copied file in the target must NOT be trusted: its physical per-row
     // sequences belong to the source region's independent sequence domain.
+    // Both the `preserve_row_sequence` marker and the source-domain max
+    // `sequence` hint must be cleared, so exact reads fail closed instead of
+    // silently skipping the file as "proven disjoint".
     let target_manifest = engine
         .get_region(target_region_id)
         .unwrap()
@@ -443,6 +446,13 @@ async fn test_copy_region_from_clears_preserve_row_sequence_marker() {
             .values()
             .all(|meta| !meta.preserve_row_sequence),
         "copied files must have the preserve_row_sequence marker cleared"
+    );
+    assert!(
+        target_manifest
+            .files
+            .values()
+            .all(|meta| meta.sequence.is_none()),
+        "copied files must have their source-domain sequence hint cleared"
     );
 
     // An exact sequence-range request intersecting the copied rows' sequences

--- a/src/mito2/src/engine/copy_region_from_test.rs
+++ b/src/mito2/src/engine/copy_region_from_test.rs
@@ -18,10 +18,11 @@ use std::{assert_matches, fs};
 use api::v1::Rows;
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
+use common_recordbatch::RecordBatches;
 use object_store::layers::mock::{Error as MockError, ErrorKind, MockLayerBuilder};
 use store_api::region_engine::{MitoCopyRegionFromRequest, RegionEngine, RegionRole};
 use store_api::region_request::{RegionFlushRequest, RegionRequest};
-use store_api::storage::RegionId;
+use store_api::storage::{RegionId, ScanRequest};
 
 use crate::config::MitoConfig;
 use crate::error::Error;
@@ -352,4 +353,138 @@ async fn test_engine_copy_region_unexpected_state_with_format(flat_format: bool)
         err.as_any().downcast_ref::<Error>().unwrap(),
         Error::RegionState { .. }
     )
+}
+
+// Regression for #8865: `copy_region_from` must not carry the source region's
+// `FileMeta::preserve_row_sequence` trust marker into the target region, whose
+// sequence domain is independent. The copied file's physical per-row sequences
+// belong to the source region only; trusting them in the target would let an
+// exact sequence-range request replay source rows as if they were target
+// sequences. The marker must be cleared so the target fails closed with
+// `SequenceRangeUnsupported` instead.
+#[tokio::test]
+async fn test_copy_region_from_clears_preserve_row_sequence_marker() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::with_prefix("copy-region-from-preserve-sequence").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    // Source and target regions both preserve per-row sequences.
+    let source_region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = rows_schema(&request);
+
+    engine
+        .handle_request(source_region_id, RegionRequest::Create(request.clone()))
+        .await
+        .unwrap();
+    let rows = Rows {
+        schema: column_schemas,
+        rows: build_rows(0, 42),
+    };
+    put_rows(&engine, source_region_id, rows).await;
+    engine
+        .handle_request(
+            source_region_id,
+            RegionRequest::Flush(RegionFlushRequest::default()),
+        )
+        .await
+        .unwrap();
+
+    // The flushed source file keeps the trust marker: the source region's own
+    // sequence domain is intact.
+    let source_manifest = engine
+        .get_region(source_region_id)
+        .unwrap()
+        .manifest_ctx
+        .manifest()
+        .await;
+    assert_eq!(1, source_manifest.files.len());
+    assert!(
+        source_manifest
+            .files
+            .values()
+            .all(|meta| meta.preserve_row_sequence),
+        "source files must keep the preserve_row_sequence marker"
+    );
+
+    // Create a preserve-enabled target and copy the source files into it.
+    let target_region_id = RegionId::new(1, 2);
+    engine
+        .handle_request(target_region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    engine
+        .copy_region_from(
+            target_region_id,
+            MitoCopyRegionFromRequest {
+                source_region_id,
+                parallelism: 1,
+            },
+        )
+        .await
+        .unwrap();
+
+    // The copied file in the target must NOT be trusted: its physical per-row
+    // sequences belong to the source region's independent sequence domain.
+    let target_manifest = engine
+        .get_region(target_region_id)
+        .unwrap()
+        .manifest_ctx
+        .manifest()
+        .await;
+    assert_eq!(1, target_manifest.files.len());
+    assert!(
+        target_manifest
+            .files
+            .values()
+            .all(|meta| !meta.preserve_row_sequence),
+        "copied files must have the preserve_row_sequence marker cleared"
+    );
+
+    // An exact sequence-range request intersecting the copied rows' sequences
+    // (rows 3..=7 in the source domain) must fail closed with
+    // `SequenceRangeUnsupported` instead of replaying source-domain rows.
+    let err = engine
+        .scanner(
+            target_region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(2),
+                memtable_max_sequence: Some(7),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected sequence-range unsupported error");
+    assert!(
+        matches!(err, Error::SequenceRangeUnsupported { .. }),
+        "unexpected err: {err}"
+    );
+    assert_eq!(err.status_code(), StatusCode::Unsupported);
+
+    // Sanity: the source region keeps the marker and still serves the same
+    // exact range with its own row-level sequences (3..=7, 5 rows).
+    let stream = engine
+        .scan_to_stream(
+            source_region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(2),
+                memtable_max_sequence: Some(7),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        5, row_count,
+        "source exact range should return rows with sequence 3..=7"
+    );
 }

--- a/src/mito2/src/engine/copy_region_from_test.rs
+++ b/src/mito2/src/engine/copy_region_from_test.rs
@@ -411,7 +411,6 @@ async fn test_copy_region_from_clears_preserve_row_sequence_marker() {
         "source files must keep the preserve_row_sequence marker"
     );
 
-    // Create a preserve-enabled target and copy the source files into it.
     let target_region_id = RegionId::new(1, 2);
     engine
         .handle_request(target_region_id, RegionRequest::Create(request))

--- a/src/mito2/src/engine/edit_region_test.rs
+++ b/src/mito2/src/engine/edit_region_test.rs
@@ -563,6 +563,42 @@ async fn test_region_edit_with_file_sequence_is_not_merged() {
     assert_eq!(Some(3), region_file_sequence(&region, third_file_id));
 }
 
+#[tokio::test]
+async fn test_region_edit_clears_preserve_row_sequence() {
+    let mut env = TestEnv::new().await;
+    let (engine, _) = create_engine_with_request_listener(&mut env).await;
+
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+
+    let file_id = FileId::random();
+    let mut edit = test_region_edit(region.region_id, file_id);
+    // The caller claims the file preserves per-row sequences...
+    edit.files_to_add[0].preserve_row_sequence = true;
+
+    engine.edit_region(region.region_id, edit).await.unwrap();
+
+    // ...but a generic region edit assigns a new destination sequence domain
+    // without proving or rewriting the physical per-row sequence column, so the
+    // marker must be cleared while the assigned sequence stays committed + 1.
+    let version = region.version();
+    let file = version.ssts.levels()[0]
+        .files
+        .iter()
+        .find(|(id, _)| **id == file_id)
+        .unwrap()
+        .1;
+    assert!(!file.meta_ref().preserve_row_sequence);
+    assert_eq!(Some(1), file.meta_ref().sequence.map(|s| s.get()));
+}
+
 async fn wait_until_region_is_in_editing(region: &MitoRegionRef) {
     tokio::time::timeout(Duration::from_secs(3), async {
         while region.state() != RegionRoleState::Leader(RegionLeaderState::Editing) {

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -2933,7 +2933,7 @@ async fn test_exact_sequence_read_pk_format_compaction_multiple_inputs() {
         .insert_option("preserve_row_sequence", "true")
         .insert_option("sst_format", "primary_key")
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "100")
         .build();
     let column_schemas = test_util::rows_schema(&request);
 
@@ -2955,7 +2955,13 @@ async fn test_exact_sequence_read_pk_format_compaction_multiple_inputs() {
     engine
         .handle_request(
             region_id,
-            RegionRequest::Compact(RegionCompactRequest::default()),
+            RegionRequest::Compact(RegionCompactRequest {
+                options: compact_request::Options::StrictWindow(StrictWindow {
+                    window_seconds: 60,
+                }),
+                parallelism: None,
+                time_range: None,
+            }),
         )
         .await
         .unwrap();

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -1414,12 +1414,12 @@ async fn test_series_scan_flat_small_permits() {
     }
 }
 
-// Regression test: `ts = a OR ts = b` extracts to a `TimestampRange` that
-// `GenericRange::or` widens into `[min(a, b), max(a, b) + 1)`. Two such
-// predicates with different `a` values can both extract to ranges that cover
-// the same partition while selecting different (or no) rows. The previous
-// cover check would strip both predicates from the cache key, letting the
-// second scan return the first scan's cached row.
+/// Regression test: `ts = a OR ts = b` extracts to a `TimestampRange` that
+/// `GenericRange::or` widens into `[min(a, b), max(a, b) + 1)`. Two such
+/// predicates with different `a` values can both extract to ranges that cover
+/// the same partition while selecting different (or no) rows. The previous
+/// cover check would strip both predicates from the cache key, letting the
+/// second scan return the first scan's cached row.
 #[tokio::test]
 async fn test_range_cache_separates_or_equality_time_filters() {
     let mut env = TestEnv::new().await;
@@ -1588,11 +1588,11 @@ async fn test_exact_sequence_read_compacted_sst_with_preserve_row_sequence() {
     );
 }
 
-// P0 regression: historical MemtableOnly reads must keep every fence even when
-// the region preserves per-row sequences. The exact capability is only granted
-// to the explicit `sequence_range` mode; a memtable-only scan whose checkpoint
-// is behind the flushed frontier must stay stale instead of silently returning
-// an incomplete delta.
+/// P0 regression: historical MemtableOnly reads must keep every fence even when
+/// the region preserves per-row sequences. The exact capability is only granted
+/// to the explicit `sequence_range` mode; a memtable-only scan whose checkpoint
+/// is behind the flushed frontier must stay stale instead of silently returning
+/// an incomplete delta.
 #[tokio::test]
 async fn test_exact_sequence_read_memtable_only_keeps_fences_with_preserve_option() {
     let mut env = TestEnv::with_prefix("test_exact_sequence_read_memtable_only_keeps_fences").await;
@@ -1636,9 +1636,9 @@ async fn test_exact_sequence_read_memtable_only_keeps_fences_with_preserve_optio
     );
 }
 
-// SequenceRange mode on a region without preserve_row_sequence:
-// the exact capability is unavailable, both bounds are enforceable, so the
-// engine must return a structured unsupported error instead of approximating.
+/// SequenceRange mode on a region without preserve_row_sequence:
+/// the exact capability is unavailable, both bounds are enforceable, so the
+/// engine must return a structured unsupported error instead of approximating.
 #[tokio::test]
 async fn test_exact_sequence_range_unsupported_when_option_off() {
     let mut env = TestEnv::with_prefix("test_exact_sequence_range_unsupported_option_off").await;
@@ -1703,8 +1703,8 @@ async fn test_exact_sequence_range_unsupported_when_option_off() {
     );
 }
 
-// SequenceRange mode when a legacy file without the preserved-sequence marker
-// is present: exact capability unavailable -> structured unsupported error.
+/// SequenceRange mode when a legacy file without the preserved-sequence marker
+/// is present: exact capability unavailable -> structured unsupported error.
 #[tokio::test]
 async fn test_exact_sequence_range_unsupported_when_legacy_file() {
     let mut env = TestEnv::with_prefix("test_exact_sequence_range_unsupported_legacy_file").await;
@@ -1788,13 +1788,13 @@ async fn test_exact_sequence_range_unsupported_when_legacy_file() {
     assert_eq!(err.status_code(), StatusCode::Unsupported);
 }
 
-// Regression for #8865: a legacy (unmarked) SST written before the preserve
-// option was enabled must not permanently block exact scans. Once the option
-// is enabled, an exact `(C, H]` scan whose lower bound C is at/after the
-// unmarked file's max sequence is disjoint from it: the unmarked file is
-// pruned at file selection (its rows must never pass through unfiltered) and
-// only the new marked rows are returned, while normal scans still return
-// everything.
+/// Regression for #8865: a legacy (unmarked) SST written before the preserve
+/// option was enabled must not permanently block exact scans. Once the option
+/// is enabled, an exact `(C, H]` scan whose lower bound C is at/after the
+/// unmarked file's max sequence is disjoint from it: the unmarked file is
+/// pruned at file selection (its rows must never pass through unfiltered) and
+/// only the new marked rows are returned, while normal scans still return
+/// everything.
 #[tokio::test]
 async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
     let mut env =
@@ -1907,10 +1907,10 @@ async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
     assert_eq!(9, batches.iter().map(|b| b.num_rows()).sum::<usize>());
 }
 
-// Exact sequence-range mode must read every time-matching SST, so the legacy
-// `sst_min_sequence` file-pruning hint is incompatible: it could silently skip
-// a preserved file that still contains rows inside `(min, max]`. The request
-// must be rejected with the structured unsupported error, not approximated.
+/// Exact sequence-range mode must read every time-matching SST, so the legacy
+/// `sst_min_sequence` file-pruning hint is incompatible: it could silently skip
+/// a preserved file that still contains rows inside `(min, max]`. The request
+/// must be rejected with the structured unsupported error, not approximated.
 #[tokio::test]
 async fn test_exact_sequence_range_rejects_sst_min_sequence_hint() {
     let mut env =
@@ -1977,10 +1977,10 @@ async fn test_exact_sequence_range_rejects_sst_min_sequence_hint() {
     assert_eq!(1, row_count, "expected seq 1 only");
 }
 
-// Exact `(0, 1]` scans must not let the row-group-level `LastRow` shortcut drop
-// in-range rows: a series with seq 1 at t1 and seq 2 at t2 must return seq 1
-// (t1) instead of being reduced to seq 2 (t2) and then filtered out. Non-exact
-// `LastRow` scans keep their existing behavior (only the last row per series).
+/// Exact `(0, 1]` scans must not let the row-group-level `LastRow` shortcut drop
+/// in-range rows: a series with seq 1 at t1 and seq 2 at t2 must return seq 1
+/// (t1) instead of being reduced to seq 2 (t2) and then filtered out. Non-exact
+/// `LastRow` scans keep their existing behavior (only the last row per series).
 #[tokio::test]
 async fn test_exact_sequence_read_with_last_row_selector_keeps_in_range_rows() {
     let mut env = TestEnv::with_prefix("test_exact_sequence_read_with_last_row_selector").await;
@@ -2048,9 +2048,9 @@ async fn test_exact_sequence_read_with_last_row_selector_keeps_in_range_rows() {
     );
 }
 
-// Exact delta spanning both SSTs and the memtable: rows after C that are partly
-// flushed and partly still in the memtable must all be returned, with the H
-// watermark respected.
+/// Exact delta spanning both SSTs and the memtable: rows after C that are partly
+/// flushed and partly still in the memtable must all be returned, with the H
+/// watermark respected.
 #[tokio::test]
 async fn test_exact_sequence_read_partial_sst_partial_memtable() {
     let mut env =
@@ -2162,9 +2162,9 @@ fn build_bulk_insert_request(
     }
 }
 
-// Bulk parts fold per-part sequences (commit-unit granularity): an exact range
-// keeps or drops each whole part. The same set must hold before flush, after
-// flush, and after compaction.
+/// Bulk parts fold per-part sequences (commit-unit granularity): an exact range
+/// keeps or drops each whole part. The same set must hold before flush, after
+/// flush, and after compaction.
 #[tokio::test]
 async fn test_exact_sequence_read_bulk_parts() {
     let mut env = TestEnv::with_prefix("test_exact_sequence_read_bulk_parts").await;
@@ -2251,11 +2251,11 @@ async fn test_exact_sequence_read_bulk_parts() {
     assert_eq!(scan_exact(Some(2), Some(100)).await, scan);
 }
 
-// Bulk commit publication ordering: the committed sequence must never cover a
-// bulk part before its rows are physically installed in the memtable. A scan
-// opening in the window between ordinary-memtable handling and bulk
-// installation binds H to the pre-bulk committed sequence, sees no bulk rows,
-// and a follow-up exact scan over the fresh range returns the bulk rows once.
+/// Bulk commit publication ordering: the committed sequence must never cover a
+/// bulk part before its rows are physically installed in the memtable. A scan
+/// opening in the window between ordinary-memtable handling and bulk
+/// installation binds H to the pre-bulk committed sequence, sees no bulk rows,
+/// and a follow-up exact scan over the fresh range returns the bulk rows once.
 #[tokio::test]
 async fn test_bulk_write_sequence_not_committed_before_install() {
     let mut env =
@@ -2385,10 +2385,10 @@ async fn test_bulk_write_sequence_not_committed_before_install() {
     }
 }
 
-// Compaction must not launder a legacy (unmarked) input SST into a trusted
-// output: with the region option ON but an input lacking the preserved-sequence
-// marker, the rewritten output must stay unmarked and exact scans must keep
-// returning the structured unsupported error (never silent data).
+/// Compaction must not launder a legacy (unmarked) input SST into a trusted
+/// output: with the region option ON but an input lacking the preserved-sequence
+/// marker, the rewritten output must stay unmarked and exact scans must keep
+/// returning the structured unsupported error (never silent data).
 #[tokio::test]
 async fn test_compaction_output_not_laundered_from_legacy_input() {
     let mut env =
@@ -2541,9 +2541,9 @@ async fn test_compaction_output_not_laundered_from_legacy_input() {
     );
 }
 
-// Multi-input primary-key-format compaction: two preserved pk-format files
-// rewrite into one output that still carries the marker, and an exact scan
-// over the compacted output returns every row in range.
+/// Multi-input primary-key-format compaction: two preserved pk-format files
+/// rewrite into one output that still carries the marker, and an exact scan
+/// over the compacted output returns every row in range.
 #[tokio::test]
 async fn test_exact_sequence_read_pk_format_compaction_multiple_inputs() {
     let mut env =
@@ -2631,9 +2631,9 @@ async fn test_exact_sequence_read_pk_format_compaction_multiple_inputs() {
     );
 }
 
-// Exact sequence-range reads through the active production `PerSeries` series
-// scan path: row-level filtering must hold across the flushed SST and the
-// memtable regardless of the requested time-series distribution.
+/// Exact sequence-range reads through the active production `PerSeries` series
+/// scan path: row-level filtering must hold across the flushed SST and the
+/// memtable regardless of the requested time-series distribution.
 #[tokio::test]
 async fn test_exact_sequence_read_series_scan_per_series() {
     let mut env = TestEnv::with_prefix("test_exact_sequence_read_series_scan_per_series").await;
@@ -2705,9 +2705,9 @@ async fn test_exact_sequence_read_series_scan_per_series() {
     );
 }
 
-// Range-cache fingerprint: identical files and filters with different (C, H]
-// sequence ranges must never share a cache entry, otherwise the second scan
-// would replay the first scan's filtered rows.
+/// Range-cache fingerprint: identical files and filters with different (C, H]
+/// sequence ranges must never share a cache entry, otherwise the second scan
+/// would replay the first scan's filtered rows.
 #[tokio::test]
 async fn test_range_cache_key_separates_sequence_ranges() {
     let mut env = TestEnv::new().await;

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -61,7 +61,7 @@ use crate::error::Error;
 use crate::manifest::action::RegionEdit;
 use crate::read::read_columns::ReadColumns;
 use crate::read::scan_region::Scanner;
-use crate::sst::file::FileMeta;
+use crate::sst::file::{FileHandle, FileMeta};
 use crate::test_util;
 use crate::test_util::sst_util::{new_sparse_primary_key, sst_region_metadata_with_encoding};
 use crate::test_util::{CreateRequestBuilder, TestEnv, reopen_region};
@@ -1950,9 +1950,9 @@ async fn test_exact_sequence_range_ignores_time_pruned_unmarked_sst() {
 }
 
 /// Regression for #8865: a legacy (unmarked) SST written before the preserve
-/// option was enabled permanently disables exact scans. Its file sequence may
-/// be synthesized by an edit path and is never trusted for disjoint skipping;
-/// normal scans still return everything.
+/// option was enabled is excluded from exact scans once Flow's cursor reaches
+/// its admission barrier. A newer barrier still fails closed; normal scans
+/// continue to return every row.
 #[tokio::test]
 async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
     let mut env =
@@ -2022,9 +2022,9 @@ async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
     markers.sort_unstable();
     assert_eq!(vec![false, true, true], markers);
 
-    // Exact scans fail closed even though C=9 is after the unmarked file's
-    // apparent sequence (3).
-    let err = engine
+    // The legacy file's barrier is 3, so C=9 excludes it and the marked SSTs
+    // are row-level filtered normally.
+    let scanner = engine
         .scanner(
             region_id,
             ScanRequest {
@@ -2035,12 +2035,8 @@ async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
             },
         )
         .await
-        .err()
-        .expect("expected sequence-range unsupported error");
-    assert!(
-        matches!(err, Error::SequenceRangeUnsupported { .. }),
-        "unexpected err: {err}"
-    );
+        .expect("barrier should permit the exact scan");
+    assert_eq!(0, scanner.num_files(), "barrier file must be skipped");
 
     // Normal scans still return everything.
     let stream = engine
@@ -2529,10 +2525,9 @@ async fn test_bulk_write_sequence_not_committed_before_install() {
     }
 }
 
-/// Compaction must not launder a legacy (unmarked) input SST into a trusted
-/// output: with the region option ON but an input lacking the preserved-sequence
-/// marker, the rewritten output must stay unmarked and exact scans must keep
-/// returning the structured unsupported error (never silent data).
+/// Compaction rewrites a legacy (unmarked) input as a sequence-less output
+/// with the region-local admission barrier. Exact scans skip it once C reaches
+/// that barrier and fail closed while C is below it.
 #[tokio::test]
 async fn test_compaction_output_not_laundered_from_legacy_input() {
     let mut env =
@@ -2641,28 +2636,74 @@ async fn test_compaction_output_not_laundered_from_legacy_input() {
         "legacy input must not be laundered into a marked output"
     );
 
-    // The compacted output remains unmarked. Its sequence may have been
-    // synthesized by the region-edit handler, so exact scans fail closed for
-    // any lower bound.
-    for (min, max) in [(7, 8), (6, 7)] {
-        let err = engine
-            .scanner(
-                region_id,
-                ScanRequest {
-                    memtable_min_sequence: Some(min),
-                    memtable_max_sequence: Some(max),
-                    exact_sequence_range: true,
-                    ..Default::default()
-                },
-            )
-            .await
-            .err()
-            .expect("expected sequence-range unsupported error for unmarked file");
-        assert!(
-            matches!(err, Error::SequenceRangeUnsupported { .. }),
-            "unexpected err: {err}"
-        );
-    }
+    // The compacted output is sequence-less and carries the current region's
+    // admission barrier rather than any source-domain sequence.
+    let barrier = outputs[0]
+        .meta_ref()
+        .sequence
+        .expect("compaction output barrier")
+        .get();
+    assert_eq!(8, barrier);
+
+    // The sequence-less parquet is encoded as all zeroes. Its physical column
+    // therefore must not retain a source-domain sequence; legacy reads use the
+    // reader's existing all-zero compatibility override from FileMeta.
+    let mut sequence_less_meta = outputs[0].meta_ref().clone();
+    sequence_less_meta.sequence = None;
+    let sequence_less_handle = FileHandle::new(
+        sequence_less_meta,
+        Arc::new(crate::sst::file_purger::NoopFilePurger),
+    );
+    let mut reader = region
+        .access_layer
+        .read_sst(sequence_less_handle)
+        .build()
+        .await
+        .unwrap()
+        .expect("compaction output reader");
+    let batch = reader
+        .next_record_batch()
+        .await
+        .unwrap()
+        .expect("compaction output batch");
+    let sequence = batch
+        .column(batch.num_columns() - 2)
+        .as_any()
+        .downcast_ref::<datatypes::arrow::array::UInt64Array>()
+        .expect("sequence column");
+    assert!(sequence.values().iter().all(|sequence| *sequence == 0));
+
+    // A cursor before the barrier must fail closed.
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(barrier - 1),
+                memtable_max_sequence: Some(barrier),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("newer barrier must disable exact scanning");
+    assert!(matches!(err, Error::SequenceRangeUnsupported { .. }));
+
+    // Once C reaches the barrier the sequence-less file is skipped, so exact
+    // capability is restored without attempting row-level filtering.
+    let scanner = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(barrier),
+                memtable_max_sequence: Some(barrier + 1),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("barrier should restore exact capability");
+    assert_eq!(0, scanner.num_files());
 }
 
 /// Multi-input primary-key-format compaction: two preserved pk-format files

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -18,17 +18,23 @@ use std::sync::Arc;
 use api::helper::encode_json_value;
 use api::v1::helper::row;
 use api::v1::value::ValueData;
-use api::v1::{ColumnDataType, Rows, SemanticType, WriteHint};
+use api::v1::{ArrowIpc, ColumnDataType, Rows, SemanticType, WriteHint};
 use arrow_schema::extension::ExtensionType;
 use common_base::readable_size::ReadableSize;
 use common_error::ext::{ErrorExt, WhateverResult};
 use common_error::status_code::StatusCode;
-use common_recordbatch::RecordBatches;
+use common_recordbatch::{DfRecordBatch, RecordBatches};
+use common_test_util::flight::encode_to_flight_data;
+use common_time::Timestamp;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{col, lit};
-use datatypes::arrow::array::AsArray;
-use datatypes::arrow::datatypes::{Float64Type, TimestampMillisecondType, UInt64Type};
+use datatypes::arrow::array::{
+    ArrayRef, AsArray, Float64Array, StringArray, TimestampMillisecondArray,
+};
+use datatypes::arrow::datatypes::{
+    DataType, Field, Float64Type, Schema, TimeUnit, TimestampMillisecondType, UInt64Type,
+};
 use datatypes::extension::json::{Json2ExtensionType, JsonMetadata};
 use datatypes::json::JsonSettings;
 use datatypes::json::value::JsonValue;
@@ -41,14 +47,21 @@ use serde_json::json;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metric_engine_consts::PRIMARY_KEY_ENCODING;
 use store_api::region_engine::{PrepareRequest, RegionEngine, RegionScanner};
-use store_api::region_request::{RegionCompactRequest, RegionPutRequest, RegionRequest};
+use store_api::region_request::{
+    AlterKind, RegionAlterRequest, RegionBulkInsertsRequest, RegionCompactRequest,
+    RegionPutRequest, RegionRequest, SetRegionOption,
+};
 use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
-use store_api::storage::{RegionId, ScanRequest, TimeSeriesDistribution};
+use store_api::storage::{
+    FileId, RegionId, ScanRequest, TimeSeriesDistribution, TimeSeriesRowSelector,
+};
 
 use crate::config::MitoConfig;
 use crate::error::Error;
+use crate::manifest::action::RegionEdit;
 use crate::read::read_columns::ReadColumns;
 use crate::read::scan_region::Scanner;
+use crate::sst::file::FileMeta;
 use crate::test_util;
 use crate::test_util::sst_util::{new_sparse_primary_key, sst_region_metadata_with_encoding};
 use crate::test_util::{CreateRequestBuilder, TestEnv, reopen_region};
@@ -1492,5 +1505,1290 @@ async fn test_range_cache_separates_or_equality_time_filters() {
         row_count,
         "expected empty result, got: {}",
         batches.pretty_print().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_exact_sequence_read_compacted_sst_with_preserve_row_sequence() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Flush 3 SSTs so the twcs compaction (trigger file num 2) can merge them.
+    for (start, end) in [(0, 3), (3, 6), (6, 9)] {
+        let rows = Rows {
+            schema: column_schemas.clone(),
+            rows: test_util::build_rows(start, end),
+        };
+        test_util::put_rows(&engine, region_id, rows).await;
+        test_util::flush_region(&engine, region_id, None).await;
+    }
+
+    let output = engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest::default()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(output.affected_rows, 0);
+
+    // The compacted SST still preserves per-row sequences: the exact (2, 7] range
+    // returns rows with sequence 3..=7 even though C and H are older than the
+    // flushed frontier (which would normally fail the stale fences).
+    let stream = engine
+        .scan_to_stream(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(2),
+                memtable_max_sequence: Some(7),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        batches.pretty_print().unwrap(),
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 2     | 2.0     | 1970-01-01T00:00:02 |
+| 3     | 3.0     | 1970-01-01T00:00:03 |
+| 4     | 4.0     | 1970-01-01T00:00:04 |
+| 5     | 5.0     | 1970-01-01T00:00:05 |
+| 6     | 6.0     | 1970-01-01T00:00:06 |
++-------+---------+---------------------+"
+    );
+}
+
+// P0 regression: historical MemtableOnly reads must keep every fence even when
+// the region preserves per-row sequences. The exact capability is only granted
+// to the explicit `sequence_range` mode; a memtable-only scan whose checkpoint
+// is behind the flushed frontier must stay stale instead of silently returning
+// an incomplete delta.
+#[tokio::test]
+async fn test_exact_sequence_read_memtable_only_keeps_fences_with_preserve_option() {
+    let mut env = TestEnv::with_prefix("test_exact_sequence_read_memtable_only_keeps_fences").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(0),
+                memtable_max_sequence: Some(3),
+                skip_sst_files: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected stale cursor error for memtable-only after flush");
+    assert!(
+        matches!(err, Error::IncrementalQueryStale { .. }),
+        "unexpected err: {err}"
+    );
+}
+
+// SequenceRange mode on a region without preserve_row_sequence:
+// the exact capability is unavailable, both bounds are enforceable, so the
+// engine must return a structured unsupported error instead of approximating.
+#[tokio::test]
+async fn test_exact_sequence_range_unsupported_when_option_off() {
+    let mut env = TestEnv::with_prefix("test_exact_sequence_range_unsupported_option_off").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    // Bounds (3, 4] are both >= flushed frontier (3), so neither fence fires;
+    // the region still cannot serve exact row-level filtering -> unsupported.
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(3),
+                memtable_max_sequence: Some(4),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected sequence-range unsupported error");
+    assert!(
+        matches!(err, Error::SequenceRangeUnsupported { .. }),
+        "unexpected err: {err}"
+    );
+    assert_eq!(err.status_code(), StatusCode::Unsupported);
+
+    // A stale checkpoint still yields the structured stale error (rebind path).
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(0),
+                memtable_max_sequence: Some(4),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected stale cursor error");
+    assert!(
+        matches!(err, Error::IncrementalQueryStale { .. }),
+        "unexpected err: {err}"
+    );
+}
+
+// SequenceRange mode when a legacy file without the preserved-sequence marker
+// is present: exact capability unavailable -> structured unsupported error.
+#[tokio::test]
+async fn test_exact_sequence_range_unsupported_when_legacy_file() {
+    let mut env = TestEnv::with_prefix("test_exact_sequence_range_unsupported_legacy_file").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    // Inject a legacy file without the preserved-sequence marker. The region
+    // edit handler fills its max sequence with `committed + 1` (4), which is
+    // greater than C=3: the unmarked file may still contain in-range rows, so
+    // the exact capability is unavailable and the scan must fail with the
+    // structured unsupported error. (An unmarked file with an unknown max
+    // sequence fails closed in `files_allow_exact_sequence_range`, covered by
+    // the unit test.)
+    let edit = RegionEdit {
+        files_to_add: vec![FileMeta {
+            region_id,
+            file_id: FileId::random(),
+            time_range: (
+                Timestamp::new_millisecond(0),
+                Timestamp::new_millisecond(1000),
+            ),
+            level: 0,
+            file_size: 0,
+            max_row_group_uncompressed_size: 0,
+            available_indexes: Default::default(),
+            indexes: vec![],
+            index_file_size: 0,
+            index_version: 0,
+            num_rows: 0,
+            num_row_groups: 0,
+            sequence: None,
+            partition_expr: None,
+            num_series: 0,
+            preserve_row_sequence: false,
+            ..Default::default()
+        }],
+        files_to_remove: vec![],
+        timestamp_ms: None,
+        compaction_time_window: None,
+        flushed_entry_id: None,
+        flushed_sequence: None,
+        committed_sequence: None,
+    };
+    engine.edit_region(region_id, edit).await.unwrap();
+
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(3),
+                memtable_max_sequence: Some(4),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected sequence-range unsupported error");
+    assert!(
+        matches!(err, Error::SequenceRangeUnsupported { .. }),
+        "unexpected err: {err}"
+    );
+    assert_eq!(err.status_code(), StatusCode::Unsupported);
+}
+
+// Regression for #8865: a legacy (unmarked) SST written before the preserve
+// option was enabled must not permanently block exact scans. Once the option
+// is enabled, an exact `(C, H]` scan whose lower bound C is at/after the
+// unmarked file's max sequence is disjoint from it: the unmarked file is
+// pruned at file selection (its rows must never pass through unfiltered) and
+// only the new marked rows are returned, while normal scans still return
+// everything.
+#[tokio::test]
+async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
+    let mut env =
+        TestEnv::with_prefix("test_exact_sequence_after_enable_with_old_unmarked_sst").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Old data flushed while the option was off: unmarked SST with max seq 3.
+    test_util::put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: test_util::build_rows(0, 3),
+        },
+    )
+    .await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    // Enable the preserve option; later flushes carry the marker.
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Alter(RegionAlterRequest {
+                kind: AlterKind::SetRegionOptions {
+                    options: vec![SetRegionOption::PreserveRowSequence(true)],
+                },
+            }),
+        )
+        .await
+        .unwrap();
+
+    // New marked data: seq 4..9 in two flushed SSTs.
+    for (start, end) in [(3, 6), (6, 9)] {
+        test_util::put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: column_schemas.clone(),
+                rows: test_util::build_rows(start, end),
+            },
+        )
+        .await;
+        test_util::flush_region(&engine, region_id, None).await;
+    }
+
+    let mut markers = engine
+        .get_region(region_id)
+        .unwrap()
+        .version()
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .map(|file| file.meta_ref().preserve_row_sequence)
+        .collect::<Vec<_>>();
+    markers.sort_unstable();
+    assert_eq!(vec![false, true, true], markers);
+
+    // Exact (6, 9]: C=6 is at/after the unmarked file's max (3), so the old
+    // unmarked file is pruned and only the new marked rows are returned.
+    let stream = engine
+        .scan_to_stream(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(6),
+                memtable_max_sequence: Some(9),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let pretty = batches.pretty_print().unwrap();
+    for tag in ["6", "7", "8"] {
+        assert!(
+            pretty.contains(&format!("| {tag} ")),
+            "new row {tag} missing from exact scan:\n{pretty}"
+        );
+    }
+    for tag in ["0", "1", "2", "3", "4", "5"] {
+        assert!(
+            !pretty.contains(&format!("| {tag} ")),
+            "old row {tag} leaked into exact scan:\n{pretty}"
+        );
+    }
+    assert_eq!(
+        3,
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        "exact (6, 9] rows:\n{pretty}"
+    );
+
+    // Normal scans still return everything.
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(9, batches.iter().map(|b| b.num_rows()).sum::<usize>());
+}
+
+// Exact sequence-range mode must read every time-matching SST, so the legacy
+// `sst_min_sequence` file-pruning hint is incompatible: it could silently skip
+// a preserved file that still contains rows inside `(min, max]`. The request
+// must be rejected with the structured unsupported error, not approximated.
+#[tokio::test]
+async fn test_exact_sequence_range_rejects_sst_min_sequence_hint() {
+    let mut env =
+        TestEnv::with_prefix("test_exact_sequence_range_rejects_sst_min_sequence_hint").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    // Non-trivial `sst_min_sequence` hint combined with an exact range: the
+    // pruning hint could drop the preserved file (whose max sequence is 3)
+    // for lower thresholds, losing in-range rows, so reject explicitly.
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(0),
+                memtable_max_sequence: Some(1),
+                sst_min_sequence: Some(2),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected sequence-range unsupported error");
+    assert!(
+        matches!(err, Error::SequenceRangeUnsupported { .. }),
+        "unexpected err: {err}"
+    );
+    assert_eq!(err.status_code(), StatusCode::Unsupported);
+
+    // Without the hint the exact scan must still read the SST (no data loss).
+    let stream = engine
+        .scan_to_stream(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(0),
+                memtable_max_sequence: Some(1),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let row_count: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(1, row_count, "expected seq 1 only");
+}
+
+// Exact `(0, 1]` scans must not let the row-group-level `LastRow` shortcut drop
+// in-range rows: a series with seq 1 at t1 and seq 2 at t2 must return seq 1
+// (t1) instead of being reduced to seq 2 (t2) and then filtered out. Non-exact
+// `LastRow` scans keep their existing behavior (only the last row per series).
+#[tokio::test]
+async fn test_exact_sequence_read_with_last_row_selector_keeps_in_range_rows() {
+    let mut env = TestEnv::with_prefix("test_exact_sequence_read_with_last_row_selector").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Same series/tag: seq 1 at t1 (field 1.0), seq 2 at t2 (field 2.0).
+    let rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows_for_key("series", 1, 3, 1),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let scan = async |request: ScanRequest| -> String {
+        let stream = engine.scan_to_stream(region_id, request).await.unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        batches.pretty_print().unwrap()
+    };
+
+    // Exact (0, 1] with the LastRow selector: seq 1 (t1) must survive the
+    // row-level sequence filter and be selected as the last row.
+    assert_eq!(
+        "\
++--------+---------+---------------------+
+| tag_0  | field_0 | ts                  |
++--------+---------+---------------------+
+| series | 1.0     | 1970-01-01T00:00:01 |
++--------+---------+---------------------+",
+        scan(ScanRequest {
+            memtable_min_sequence: Some(0),
+            memtable_max_sequence: Some(1),
+            exact_sequence_range: true,
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+            ..Default::default()
+        })
+        .await
+    );
+
+    // Non-exact LastRow scan (no regression): still returns only the last row
+    // of the series, seq 2 (t2).
+    assert_eq!(
+        "\
++--------+---------+---------------------+
+| tag_0  | field_0 | ts                  |
++--------+---------+---------------------+
+| series | 2.0     | 1970-01-01T00:00:02 |
++--------+---------+---------------------+",
+        scan(ScanRequest {
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+            ..Default::default()
+        })
+        .await
+    );
+}
+
+// Exact delta spanning both SSTs and the memtable: rows after C that are partly
+// flushed and partly still in the memtable must all be returned, with the H
+// watermark respected.
+#[tokio::test]
+async fn test_exact_sequence_read_partial_sst_partial_memtable() {
+    let mut env =
+        TestEnv::with_prefix("test_exact_sequence_read_partial_sst_partial_memtable").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // seq 1..3 flushed into an SST.
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    // seq 4..6 stay in the memtable.
+    let rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(3, 6),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+
+    let scan_exact = async |min: Option<u64>, max: Option<u64>| -> String {
+        let stream = engine
+            .scan_to_stream(
+                region_id,
+                ScanRequest {
+                    memtable_min_sequence: min,
+                    memtable_max_sequence: max,
+                    exact_sequence_range: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        batches.pretty_print().unwrap()
+    };
+
+    // The merged output order across SST + memtable sources is not guaranteed,
+    // and each source batch repeats the pretty-printed header row, so compare
+    // only the data rows (excluding header/separator lines).
+    let result = scan_exact(Some(2), Some(6)).await;
+    let mut rows = result
+        .lines()
+        .filter(|l| l.starts_with("| ") && !l.starts_with("| tag_0 "))
+        .collect::<Vec<_>>();
+    rows.sort_unstable();
+    assert_eq!(
+        vec![
+            "| 2     | 2.0     | 1970-01-01T00:00:02 |",
+            "| 3     | 3.0     | 1970-01-01T00:00:03 |",
+            "| 4     | 4.0     | 1970-01-01T00:00:04 |",
+            "| 5     | 5.0     | 1970-01-01T00:00:05 |",
+        ],
+        rows,
+        "unexpected set for (2, 6]:\n{result}"
+    );
+}
+
+/// Builds a bulk insert request with rows `[start, end)` in the flat schema.
+fn build_bulk_insert_request(
+    region_id: RegionId,
+    start: usize,
+    end: usize,
+) -> RegionBulkInsertsRequest {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("tag_0", DataType::Utf8, true),
+        Field::new("field_0", DataType::Float64, true),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
+    ]));
+    let tag = Arc::new(StringArray::from_iter_values(
+        (start..end).map(|value| value.to_string()),
+    )) as ArrayRef;
+    let field = Arc::new(Float64Array::from_iter_values(
+        (start..end).map(|value| value as f64),
+    )) as ArrayRef;
+    let ts = Arc::new(TimestampMillisecondArray::from_iter_values(
+        (start..end).map(|value| value as i64 * 1000),
+    )) as ArrayRef;
+    let payload = DfRecordBatch::try_new(schema, vec![tag, field, ts]).unwrap();
+    let (schema, record_batch) = encode_to_flight_data(payload.clone());
+
+    RegionBulkInsertsRequest {
+        region_id,
+        payload,
+        raw_data: ArrowIpc {
+            schema: schema.data_header,
+            data_header: record_batch.data_header,
+            payload: record_batch.data_body,
+        },
+        partition_expr_version: None,
+        aligned_schema_version: None,
+    }
+}
+
+// Bulk parts fold per-part sequences (commit-unit granularity): an exact range
+// keeps or drops each whole part. The same set must hold before flush, after
+// flush, and after compaction.
+#[tokio::test]
+async fn test_exact_sequence_read_bulk_parts() {
+    let mut env = TestEnv::with_prefix("test_exact_sequence_read_bulk_parts").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .insert_option("memtable.type", "bulk")
+        .build();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Two bulk parts: [0,3) and [3,6). Each part carries one folded sequence.
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::BulkInserts(build_bulk_insert_request(region_id, 0, 3)),
+        )
+        .await
+        .unwrap();
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::BulkInserts(build_bulk_insert_request(region_id, 3, 6)),
+        )
+        .await
+        .unwrap();
+
+    let scan_exact = async |min: Option<u64>, max: Option<u64>| -> String {
+        let stream = engine
+            .scan_to_stream(
+                region_id,
+                ScanRequest {
+                    memtable_min_sequence: min,
+                    memtable_max_sequence: max,
+                    exact_sequence_range: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        batches.pretty_print().unwrap()
+    };
+
+    let expected_all = "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 0     | 0.0     | 1970-01-01T00:00:00 |
+| 1     | 1.0     | 1970-01-01T00:00:01 |
+| 2     | 2.0     | 1970-01-01T00:00:02 |
+| 3     | 3.0     | 1970-01-01T00:00:03 |
+| 4     | 4.0     | 1970-01-01T00:00:04 |
+| 5     | 5.0     | 1970-01-01T00:00:05 |
++-------+---------+---------------------+";
+
+    // A wide range covering every folded part sequence returns all rows.
+    assert_eq!(expected_all, scan_exact(Some(0), Some(100)).await);
+
+    // Commit-unit granularity: a lower bound that excludes the first part's
+    // folded sequence drops the whole first part, keeps the second.
+    let scan = scan_exact(Some(2), Some(100)).await;
+    assert!(
+        !scan.contains("| 0 ") && !scan.contains("| 1 ") && !scan.contains("| 2 "),
+        "first bulk part should be fully excluded, got:\n{scan}"
+    );
+    assert!(scan.contains("| 3 "), "second bulk part missing:\n{scan}");
+
+    test_util::flush_region(&engine, region_id, None).await;
+    assert_eq!(scan_exact(Some(2), Some(100)).await, scan);
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest::default()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(scan_exact(Some(2), Some(100)).await, scan);
+}
+
+// Bulk commit publication ordering: the committed sequence must never cover a
+// bulk part before its rows are physically installed in the memtable. A scan
+// opening in the window between ordinary-memtable handling and bulk
+// installation binds H to the pre-bulk committed sequence, sees no bulk rows,
+// and a follow-up exact scan over the fresh range returns the bulk rows once.
+#[tokio::test]
+async fn test_bulk_write_sequence_not_committed_before_install() {
+    let mut env =
+        TestEnv::with_prefix("test_bulk_write_sequence_not_committed_before_install").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .insert_option("memtable.type", "bulk")
+        .build();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let committed_sequence = || {
+        engine
+            .find_region(region_id)
+            .unwrap()
+            .find_committed_sequence()
+    };
+    assert_eq!(0, committed_sequence());
+
+    let mut barrier = crate::region_write_ctx::test_hooks::arm_bulk_install_barrier(
+        region_id,
+        engine
+            .get_region(region_id)
+            .unwrap()
+            .version_control
+            .clone(),
+    );
+
+    // Start a bulk write in the background; it pauses before installation.
+    let engine_clone = engine.clone();
+    let write_handle = tokio::spawn(async move {
+        engine_clone
+            .handle_request(
+                region_id,
+                RegionRequest::BulkInserts(build_bulk_insert_request(region_id, 0, 3)),
+            )
+            .await
+            .unwrap();
+    });
+
+    // Wait until the write paused between memtable handling and bulk install.
+    tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        barrier.wait_until_reached(),
+    )
+    .await
+    .expect("bulk write never reached the install barrier");
+
+    // Open the snapshot-bound scanner while the write is still paused at the
+    // barrier: it must bind H to the pre-bulk committed sequence (0) because
+    // the bulk part is not installed yet.
+    let scanner = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(0),
+                snapshot_on_scan: true,
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        Some(0),
+        scanner.snapshot_sequence(),
+        "snapshot-bound scan must bind H to the pre-bulk committed sequence"
+    );
+
+    // The committed sequence must still be the pre-bulk value: publication
+    // happens strictly after the bulk part is in the memtable.
+    assert_eq!(
+        0,
+        committed_sequence(),
+        "committed sequence leaked before the bulk part was installed"
+    );
+
+    // Release the barrier: the bulk part installs and the committed sequence
+    // advances to cover it.
+    barrier.release();
+    write_handle.await.expect("bulk write should complete");
+    assert_eq!(3, committed_sequence());
+
+    // The scanner opened while paused stays bound at the pre-bulk H and so
+    // sees no bulk rows.
+    let stream = scanner.scan().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        0,
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        "bulk rows visible to a snapshot bound before installation:\n{}",
+        batches.pretty_print().unwrap()
+    );
+
+    // The follow-up exact scan over (pre_H, post_H] returns the bulk rows once.
+    let stream = engine
+        .scan_to_stream(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(0),
+                memtable_max_sequence: Some(3),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        3,
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        "bulk rows must be returned exactly once:\n{}",
+        batches.pretty_print().unwrap()
+    );
+    let pretty = batches.pretty_print().unwrap();
+    for tag in ["0", "1", "2"] {
+        assert!(
+            pretty.contains(&format!("| {tag} ")),
+            "bulk row {tag} missing from (0, 3]:\n{pretty}"
+        );
+    }
+}
+
+// Compaction must not launder a legacy (unmarked) input SST into a trusted
+// output: with the region option ON but an input lacking the preserved-sequence
+// marker, the rewritten output must stay unmarked and exact scans must keep
+// returning the structured unsupported error (never silent data).
+#[tokio::test]
+async fn test_compaction_output_not_laundered_from_legacy_input() {
+    let mut env =
+        TestEnv::with_prefix("test_compaction_output_not_laundered_from_legacy_input").await;
+    // Suppress automatic compactions (flush- and edit-triggered) so the
+    // explicit Compact below is the only compaction in flight (deterministic).
+    let engine = env
+        .create_engine(MitoConfig {
+            min_compaction_interval: std::time::Duration::from_secs(60 * 60),
+            schedule_compaction_after_edit: false,
+            ..Default::default()
+        })
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Two real marked SSTs on disk so the twcs compaction rewrites them.
+    for (start, end) in [(0, 3), (3, 6)] {
+        let rows = Rows {
+            schema: column_schemas.clone(),
+            rows: test_util::build_rows(start, end),
+        };
+        test_util::put_rows(&engine, region_id, rows).await;
+        test_util::flush_region(&engine, region_id, None).await;
+    }
+
+    let region = engine.get_region(region_id).unwrap();
+    let version = region.version();
+    let level0 = &version.ssts.levels()[0].files;
+    assert_eq!(2, level0.len());
+    let first_file = level0
+        .values()
+        .next()
+        .expect("flushed SST")
+        .meta_ref()
+        .clone();
+    assert!(first_file.preserve_row_sequence);
+
+    // Seed the first physical file as a legacy (unmarked) file: replace the
+    // version's FileMeta so the marker is false while the file stays on disk.
+    let mut unmarked = first_file.clone();
+    unmarked.preserve_row_sequence = false;
+    engine
+        .edit_region(
+            region_id,
+            RegionEdit {
+                files_to_add: vec![unmarked],
+                files_to_remove: vec![],
+                timestamp_ms: None,
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    let version = region.version();
+    let level0 = &version.ssts.levels()[0].files;
+    assert_eq!(2, level0.len());
+    assert!(
+        level0
+            .values()
+            .any(|file| !file.meta_ref().preserve_row_sequence),
+        "seeded file should be unmarked"
+    );
+
+    // Compact: the rewritten output must NOT be laundered back to marked.
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest::default()),
+        )
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    let version = region.version();
+    let outputs = version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        1,
+        outputs.len(),
+        "two inputs should rewrite into one output file"
+    );
+    assert!(
+        !outputs[0].meta_ref().preserve_row_sequence,
+        "legacy input must not be laundered into a marked output"
+    );
+
+    // The compacted output is unmarked. The region-edit handler filled its max
+    // sequence with `committed + 1` (7). Exact scans with a lower bound C
+    // at/after 7 are disjoint from it and served (the (7, 8] range is empty),
+    // while C below 7 is unsupported because the unmarked file may still
+    // contain in-range rows.
+    let stream = engine
+        .scan_to_stream(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(7),
+                memtable_max_sequence: Some(8),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        0,
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        "exact (7, 8] must be empty:\n{}",
+        batches.pretty_print().unwrap()
+    );
+
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(6),
+                memtable_max_sequence: Some(7),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected sequence-range unsupported error for C below unmarked max");
+    assert!(
+        matches!(err, Error::SequenceRangeUnsupported { .. }),
+        "unexpected err: {err}"
+    );
+}
+
+// Multi-input primary-key-format compaction: two preserved pk-format files
+// rewrite into one output that still carries the marker, and an exact scan
+// over the compacted output returns every row in range.
+#[tokio::test]
+async fn test_exact_sequence_read_pk_format_compaction_multiple_inputs() {
+    let mut env =
+        TestEnv::with_prefix("test_exact_sequence_read_pk_format_compaction_multiple_inputs").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .insert_option("sst_format", "primary_key")
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Two preserved pk-format input files: seq 1..3 and seq 4..6.
+    for (start, end) in [(0, 3), (3, 6)] {
+        let rows = Rows {
+            schema: column_schemas.clone(),
+            rows: test_util::build_rows(start, end),
+        };
+        test_util::put_rows(&engine, region_id, rows).await;
+        test_util::flush_region(&engine, region_id, None).await;
+    }
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest::default()),
+        )
+        .await
+        .unwrap();
+
+    // The rewritten output still carries the preserved-sequence marker.
+    let region = engine.get_region(region_id).unwrap();
+    let version = region.version();
+    let outputs = version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        1,
+        outputs.len(),
+        "two pk inputs should rewrite into one output file"
+    );
+    assert!(outputs[0].meta_ref().preserve_row_sequence);
+
+    // Exact scan over the compacted pk-format output returns all rows in range.
+    let stream = engine
+        .scan_to_stream(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(1),
+                memtable_max_sequence: Some(5),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let pretty = batches.pretty_print().unwrap();
+    for tag in ["1", "2", "3", "4"] {
+        assert!(
+            pretty.contains(&format!("| {tag} ")),
+            "row {tag} missing from compacted pk output:\n{pretty}"
+        );
+    }
+    assert_eq!(
+        4,
+        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+        "exact range rows:\n{pretty}"
+    );
+    assert!(
+        !pretty.contains("| 0 ") && !pretty.contains("| 5 "),
+        "rows outside (1, 5] leaked:\n{pretty}"
+    );
+}
+
+// Exact sequence-range reads through the active production `PerSeries` series
+// scan path: row-level filtering must hold across the flushed SST and the
+// memtable regardless of the requested time-series distribution.
+#[tokio::test]
+async fn test_exact_sequence_read_series_scan_per_series() {
+    let mut env = TestEnv::with_prefix("test_exact_sequence_read_series_scan_per_series").await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: true,
+            ..Default::default()
+        })
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // seq 1..3 flushed into an SST, seq 4..6 stay in the memtable.
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: test_util::build_rows(0, 3),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+    test_util::flush_region(&engine, region_id, None).await;
+    let rows = Rows {
+        schema: column_schemas,
+        rows: test_util::build_rows(3, 6),
+    };
+    test_util::put_rows(&engine, region_id, rows).await;
+
+    let scan_exact_series = async |min: Option<u64>, max: Option<u64>| -> String {
+        let stream = engine
+            .scan_to_stream(
+                region_id,
+                ScanRequest {
+                    memtable_min_sequence: min,
+                    memtable_max_sequence: max,
+                    exact_sequence_range: true,
+                    distribution: Some(TimeSeriesDistribution::PerSeries),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        batches.pretty_print().unwrap()
+    };
+
+    let result = scan_exact_series(Some(2), Some(6)).await;
+    let mut rows = result
+        .lines()
+        .filter(|l| l.starts_with("| ") && !l.starts_with("| tag_0 "))
+        .collect::<Vec<_>>();
+    rows.sort_unstable();
+    assert_eq!(
+        vec![
+            "| 2     | 2.0     | 1970-01-01T00:00:02 |",
+            "| 3     | 3.0     | 1970-01-01T00:00:03 |",
+            "| 4     | 4.0     | 1970-01-01T00:00:04 |",
+            "| 5     | 5.0     | 1970-01-01T00:00:05 |",
+        ],
+        rows,
+        "unexpected set for (2, 6] on PerSeries path:\n{result}"
+    );
+}
+
+// Range-cache fingerprint: identical files and filters with different (C, H]
+// sequence ranges must never share a cache entry, otherwise the second scan
+// would replay the first scan's filtered rows.
+#[tokio::test]
+async fn test_range_cache_key_separates_sequence_ranges() {
+    let mut env = TestEnv::new().await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: true,
+            // Explicitly enable the range result cache: the sharing bug only
+            // reproduces when the second scan can replay the first scan's
+            // cached batches.
+            range_result_cache_size: ReadableSize::mb(64),
+            ..Default::default()
+        })
+        .await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Single flushed flat SST with rows seq 1..6.
+    test_util::put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas,
+            rows: test_util::build_rows(0, 6),
+        },
+    )
+    .await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let tag_filter = || col("tag_0").gt_eq(lit(ScalarValue::Utf8(Some("0".to_string()))));
+    let scan_exact = async |min: Option<u64>, max: Option<u64>| -> Vec<String> {
+        let stream = engine
+            .scan_to_stream(
+                region_id,
+                ScanRequest {
+                    filters: vec![tag_filter()],
+                    memtable_min_sequence: min,
+                    memtable_max_sequence: max,
+                    exact_sequence_range: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        let mut rows = batches
+            .pretty_print()
+            .unwrap()
+            .lines()
+            .filter(|l| l.starts_with("| ") && !l.starts_with("| tag_0 "))
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>();
+        rows.sort_unstable();
+        rows
+    };
+
+    // (1, 3] -> rows with sequences 2..3: tags "1" and "2".
+    let first = scan_exact(Some(1), Some(3)).await;
+    assert_eq!(
+        vec![
+            "| 1     | 1.0     | 1970-01-01T00:00:01 |",
+            "| 2     | 2.0     | 1970-01-01T00:00:02 |",
+        ],
+        first
+    );
+
+    // (3, 4] -> row with sequence 4: tag "3" only. If the cache key ignored
+    // the sequence range, this would replay the (1, 3] cached rows instead.
+    let second = scan_exact(Some(3), Some(4)).await;
+    assert_eq!(
+        vec!["| 3     | 3.0     | 1970-01-01T00:00:03 |"],
+        second,
+        "different (C, H] shared a range-cache entry"
     );
 }

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use api::helper::encode_json_value;
 use api::v1::helper::row;
+use api::v1::region::{StrictWindow, compact_request};
 use api::v1::value::ValueData;
 use api::v1::{ArrowIpc, ColumnDataType, Rows, SemanticType, WriteHint};
 use arrow_schema::extension::ExtensionType;
@@ -2731,7 +2732,8 @@ async fn test_non_preserve_compaction_sequence_collision_with_format(flat_format
 async fn test_compaction_output_non_preserve_not_laundered_from_legacy_input() {
     let mut env =
         TestEnv::with_prefix("test_compaction_output_not_laundered_from_legacy_input").await;
-    // Suppress automatic compactions (flush- and edit-triggered) so the
+    // Suppress automatic edit-triggered compactions. The high TWCS trigger below
+    // also prevents flush-triggered compaction from consuming the inputs, so the
     // explicit Compact below is the only compaction in flight (deterministic).
     let engine = env
         .create_engine(MitoConfig {
@@ -2746,7 +2748,7 @@ async fn test_compaction_output_non_preserve_not_laundered_from_legacy_input() {
         .insert_option("append_mode", "true")
         .insert_option("preserve_row_sequence", "true")
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .insert_option("compaction.twcs.trigger_file_num", "100")
         .build();
     let column_schemas = test_util::rows_schema(&request);
 
@@ -2755,7 +2757,7 @@ async fn test_compaction_output_non_preserve_not_laundered_from_legacy_input() {
         .await
         .unwrap();
 
-    // Two real marked SSTs on disk so the twcs compaction rewrites them.
+    // Two real marked SSTs on disk so the strict-window compaction rewrites them.
     for (start, end) in [(0, 3), (3, 6)] {
         let rows = Rows {
             schema: column_schemas.clone(),
@@ -2812,7 +2814,13 @@ async fn test_compaction_output_non_preserve_not_laundered_from_legacy_input() {
     engine
         .handle_request(
             region_id,
-            RegionRequest::Compact(RegionCompactRequest::default()),
+            RegionRequest::Compact(RegionCompactRequest {
+                options: compact_request::Options::StrictWindow(StrictWindow {
+                    window_seconds: 60,
+                }),
+                parallelism: None,
+                time_range: None,
+            }),
         )
         .await
         .unwrap();

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -1872,6 +1872,83 @@ async fn test_exact_sequence_range_rejects_foreign_region_file() {
     assert_eq!(err.status_code(), StatusCode::Internal);
 }
 
+/// Exact sequence-range reads only require preserved row sequences in the
+/// SSTs selected by their time range. A legacy SST outside that range cannot
+/// contain a row in `(C, H]` for this request.
+#[tokio::test]
+async fn test_exact_sequence_range_ignores_time_pruned_unmarked_sst() {
+    let mut env =
+        TestEnv::with_prefix("test_exact_sequence_range_ignores_time_pruned_unmarked_sst").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // The old, unmarked SST covers timestamps 0s..2s.
+    test_util::put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: test_util::build_rows(0, 3),
+        },
+    )
+    .await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Alter(RegionAlterRequest {
+                kind: AlterKind::SetRegionOptions {
+                    options: vec![SetRegionOption::PreserveRowSequence(true)],
+                },
+            }),
+        )
+        .await
+        .unwrap();
+
+    // The selected SST covers timestamps 10s..12s and carries the marker.
+    test_util::put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas,
+            rows: test_util::build_rows(10, 13),
+        },
+    )
+    .await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let stream = engine
+        .scan_to_stream(
+            region_id,
+            ScanRequest {
+                filters: vec![
+                    col("ts").gt_eq(lit(ScalarValue::TimestampMillisecond(Some(10_000), None))),
+                ],
+                memtable_min_sequence: Some(3),
+                memtable_max_sequence: Some(6),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("time-pruned unmarked SST must not disable exact reads");
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        3,
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>()
+    );
+}
+
 /// Regression for #8865: a legacy (unmarked) SST written before the preserve
 /// option was enabled permanently disables exact scans. Its file sequence may
 /// be synthesized by an edit path and is never trusted for disjoint skipping;

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -1788,6 +1788,90 @@ async fn test_exact_sequence_range_unsupported_when_legacy_file() {
     assert_eq!(err.status_code(), StatusCode::Unsupported);
 }
 
+/// Exact sequence-range reads reject an SST from another region as a broken
+/// sequence domain instead of falling back to an unsupported scan.
+#[tokio::test]
+async fn test_exact_sequence_range_rejects_foreign_region_file() {
+    let mut env =
+        TestEnv::with_prefix("test_exact_sequence_range_rejects_foreign_region_file").await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("append_mode", "true")
+        .insert_option("preserve_row_sequence", "true")
+        .build();
+    let column_schemas = test_util::rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    test_util::put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas,
+            rows: test_util::build_rows(0, 3),
+        },
+    )
+    .await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    engine
+        .edit_region(
+            region_id,
+            RegionEdit {
+                files_to_add: vec![FileMeta {
+                    region_id: RegionId::new(1, 2),
+                    file_id: FileId::random(),
+                    time_range: (
+                        Timestamp::new_millisecond(0),
+                        Timestamp::new_millisecond(1000),
+                    ),
+                    level: 0,
+                    file_size: 0,
+                    max_row_group_uncompressed_size: 0,
+                    available_indexes: Default::default(),
+                    indexes: vec![],
+                    index_file_size: 0,
+                    index_version: 0,
+                    num_rows: 0,
+                    num_row_groups: 0,
+                    sequence: None,
+                    partition_expr: None,
+                    num_series: 0,
+                    preserve_row_sequence: true,
+                    ..Default::default()
+                }],
+                files_to_remove: vec![],
+                timestamp_ms: None,
+                compaction_time_window: None,
+                flushed_entry_id: None,
+                flushed_sequence: None,
+                committed_sequence: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                memtable_min_sequence: Some(3),
+                memtable_max_sequence: Some(4),
+                exact_sequence_range: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .err()
+        .expect("expected broken sequence domain error");
+    assert!(matches!(err, Error::RegionSequenceDomainBroken { .. }));
+    assert_eq!(err.status_code(), StatusCode::Internal);
+}
+
 /// Regression for #8865: a legacy (unmarked) SST written before the preserve
 /// option was enabled must not permanently block exact scans. Once the option
 /// is enabled, an exact `(C, H]` scan whose lower bound C is at/after the

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -1807,12 +1807,14 @@ async fn test_exact_sequence_range_unsupported_when_legacy_file() {
     assert_eq!(err.status_code(), StatusCode::Unsupported);
 }
 
-/// Exact sequence-range reads reject an SST from another region as a broken
-/// sequence domain instead of falling back to an unsupported scan.
+/// Region edit assigns a target-local barrier to an imported foreign SST, so
+/// exact sequence-range capability can admit it without trusting its source
+/// region marker.
 #[tokio::test]
-async fn test_exact_sequence_range_rejects_foreign_region_file() {
+async fn test_exact_sequence_range_accepts_foreign_file_with_target_barrier() {
     let mut env =
-        TestEnv::with_prefix("test_exact_sequence_range_rejects_foreign_region_file").await;
+        TestEnv::with_prefix("test_exact_sequence_range_accepts_foreign_file_with_target_barrier")
+            .await;
     let engine = env.create_engine(MitoConfig::default()).await;
 
     let region_id = RegionId::new(1, 1);
@@ -1874,7 +1876,20 @@ async fn test_exact_sequence_range_rejects_foreign_region_file() {
         .await
         .unwrap();
 
-    let err = engine
+    let version = engine.get_region(region_id).unwrap().version();
+    let foreign_file = version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .find(|file| file.region_id() != region_id)
+        .expect("foreign file should remain source-owned");
+    assert!(
+        foreign_file.meta_ref().sequence.is_some(),
+        "region edit must assign a target-local barrier"
+    );
+
+    engine
         .scanner(
             region_id,
             ScanRequest {
@@ -1885,10 +1900,7 @@ async fn test_exact_sequence_range_rejects_foreign_region_file() {
             },
         )
         .await
-        .err()
-        .expect("expected broken sequence domain error");
-    assert!(matches!(err, Error::RegionSequenceDomainBroken { .. }));
-    assert_eq!(err.status_code(), StatusCode::Internal);
+        .expect("foreign file with target barrier should be exact-capable");
 }
 
 /// Exact sequence-range reads only require preserved row sequences in the
@@ -2534,11 +2546,189 @@ async fn test_bulk_write_sequence_not_committed_before_install() {
     }
 }
 
-/// Compaction rewrites a legacy (unmarked) input as a sequence-less output
-/// with the region-local admission barrier. Exact scans skip it once C reaches
-/// that barrier and fail closed while C is below it.
+/// Non-preserving compaction must keep the physical input sequence below the
+/// admission barrier. Otherwise a later row at the barrier can collide with
+/// the compacted row when ordinary reads deduplicate overlapping SSTs.
 #[tokio::test]
-async fn test_compaction_output_not_laundered_from_legacy_input() {
+async fn test_non_preserve_compaction_sequence_collision() {
+    for flat_format in [false, true] {
+        test_non_preserve_compaction_sequence_collision_with_format(flat_format).await;
+    }
+}
+
+async fn test_non_preserve_compaction_sequence_collision_with_format(flat_format: bool) {
+    let mut env = TestEnv::with_prefix("test_non_preserve_compaction_sequence_collision").await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: flat_format,
+            min_compaction_interval: std::time::Duration::from_secs(60 * 60),
+            schedule_compaction_after_edit: false,
+            ..Default::default()
+        })
+        .await;
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.trigger_file_num", "2")
+        .build();
+    let schema = test_util::rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    async fn last_row(engine: &crate::engine::MitoEngine, region_id: RegionId) -> String {
+        let stream = engine
+            .scan_to_stream(
+                region_id,
+                ScanRequest {
+                    series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        RecordBatches::try_collect(stream)
+            .await
+            .unwrap()
+            .pretty_print()
+            .unwrap()
+    }
+
+    // SST1 and SST2 contain the same key and timestamp. Their physical/file
+    // sequences are 1 and 2, so ordinary LastRow selects value 2.
+    for value in [1, 2] {
+        test_util::put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: schema.clone(),
+                rows: test_util::build_rows_for_key("a", 0, 1, value),
+            },
+        )
+        .await;
+        test_util::flush_region(&engine, region_id, None).await;
+    }
+    let before = last_row(&engine, region_id).await;
+    assert!(
+        before.contains("| a     | 2.0"),
+        "before compaction: {before}"
+    );
+
+    // Both current SSTs are compacted through the real picker, merger, writer,
+    // and manifest update. With committed/flushed sequence 2, the untrusted
+    // output's admission barrier is exactly 3.
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest::default()),
+        )
+        .await
+        .unwrap();
+
+    let region = engine.get_region(region_id).unwrap();
+    let version = region.version();
+    let files = version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .collect::<Vec<_>>();
+    assert_eq!(1, files.len(), "both input SSTs must be replaced");
+    let compacted = files[0];
+    assert_eq!(1, compacted.meta_ref().level);
+    assert!(!compacted.meta_ref().preserve_row_sequence);
+    assert_eq!(1, compacted.num_rows());
+    assert_eq!(
+        Some(std::num::NonZeroU64::new(3).unwrap()),
+        compacted.meta_ref().sequence,
+        "admission barrier is input max 2 plus one"
+    );
+
+    // Hide FileMeta.sequence so this is a direct physical read, not a reader
+    // admission-barrier override. The output must contain physical sequence 2,
+    // not zero and not the output barrier 3.
+    let mut physical_meta = compacted.meta_ref().clone();
+    physical_meta.sequence = None;
+    let mut reader = region
+        .access_layer
+        .read_sst(FileHandle::new(
+            physical_meta,
+            Arc::new(crate::sst::file_purger::NoopFilePurger),
+        ))
+        .build()
+        .await
+        .unwrap()
+        .expect("compaction output reader");
+    let batch = reader.next_record_batch().await.unwrap().unwrap();
+    let sequences = batch
+        .column(batch.num_columns() - 2)
+        .as_any()
+        .downcast_ref::<datatypes::arrow::array::UInt64Array>()
+        .unwrap();
+    assert_eq!(&[2], sequences.values());
+
+    let after_compaction = last_row(&engine, region_id).await;
+    assert!(
+        after_compaction.contains("| a     | 2.0"),
+        "after compaction: {after_compaction}"
+    );
+
+    // The next write receives physical sequence 3, equal to the compacted
+    // output's admission barrier. It must still win because the compacted row
+    // remains physically at sequence 2; an old zero/barrier encoding would
+    // collide here and incorrectly retain value 2.
+    test_util::put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema,
+            rows: test_util::build_rows_for_key("a", 0, 1, 3),
+        },
+    )
+    .await;
+    test_util::flush_region(&engine, region_id, None).await;
+
+    let region = engine.get_region(region_id).unwrap();
+    let version = region.version();
+    let files = version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .collect::<Vec<_>>();
+    assert_eq!(2, files.len(), "compacted L1 plus newest L0 SST");
+    let newest = files
+        .iter()
+        .find(|file| file.meta_ref().level == 0)
+        .expect("newest L0 SST");
+    assert_eq!(1, newest.num_rows());
+    assert_eq!(
+        Some(std::num::NonZeroU64::new(3).unwrap()),
+        newest.meta_ref().sequence
+    );
+    let compacted = files
+        .iter()
+        .find(|file| file.meta_ref().level == 1)
+        .expect("compacted L1 SST");
+    assert_eq!(
+        Some(std::num::NonZeroU64::new(3).unwrap()),
+        compacted.meta_ref().sequence
+    );
+
+    let after_newer_write = last_row(&engine, region_id).await;
+    assert!(
+        after_newer_write.contains("| a     | 3.0"),
+        "after newer sequence-3 write: {after_newer_write}"
+    );
+}
+
+/// Compaction rewrites a legacy (unmarked) input as an untrusted output with
+/// the region-local admission barrier. Its physical rows retain the known
+/// input maximum, while exact scans skip it once C reaches that barrier and
+/// fail closed while C is below it.
+#[tokio::test]
+async fn test_compaction_output_non_preserve_not_laundered_from_legacy_input() {
     let mut env =
         TestEnv::with_prefix("test_compaction_output_not_laundered_from_legacy_input").await;
     // Suppress automatic compactions (flush- and edit-triggered) so the
@@ -2654,18 +2844,18 @@ async fn test_compaction_output_not_laundered_from_legacy_input() {
         .get();
     assert_eq!(8, barrier);
 
-    // The sequence-less parquet is encoded as all zeroes. Its physical column
-    // therefore must not retain a source-domain sequence; legacy reads use the
-    // reader's existing all-zero compatibility override from FileMeta.
-    let mut sequence_less_meta = outputs[0].meta_ref().clone();
-    sequence_less_meta.sequence = None;
-    let sequence_less_handle = FileHandle::new(
-        sequence_less_meta,
+    // Reinstalling the legacy input assigns it sequence 7, so the physical
+    // parquet retains that known input maximum rather than encoding either
+    // zero or the output admission barrier 8. The manifest marker stays false.
+    let mut sequence_meta = outputs[0].meta_ref().clone();
+    sequence_meta.sequence = None;
+    let sequence_handle = FileHandle::new(
+        sequence_meta,
         Arc::new(crate::sst::file_purger::NoopFilePurger),
     );
     let mut reader = region
         .access_layer
-        .read_sst(sequence_less_handle)
+        .read_sst(sequence_handle)
         .build()
         .await
         .unwrap()
@@ -2680,7 +2870,12 @@ async fn test_compaction_output_not_laundered_from_legacy_input() {
         .as_any()
         .downcast_ref::<datatypes::arrow::array::UInt64Array>()
         .expect("sequence column");
-    assert!(sequence.values().iter().all(|sequence| *sequence == 0));
+    assert!(
+        sequence
+            .values()
+            .iter()
+            .all(|sequence| *sequence == barrier - 1)
+    );
 
     // A cursor before the barrier must fail closed.
     let err = engine

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -1873,12 +1873,9 @@ async fn test_exact_sequence_range_rejects_foreign_region_file() {
 }
 
 /// Regression for #8865: a legacy (unmarked) SST written before the preserve
-/// option was enabled must not permanently block exact scans. Once the option
-/// is enabled, an exact `(C, H]` scan whose lower bound C is at/after the
-/// unmarked file's max sequence is disjoint from it: the unmarked file is
-/// pruned at file selection (its rows must never pass through unfiltered) and
-/// only the new marked rows are returned, while normal scans still return
-/// everything.
+/// option was enabled permanently disables exact scans. Its file sequence may
+/// be synthesized by an edit path and is never trusted for disjoint skipping;
+/// normal scans still return everything.
 #[tokio::test]
 async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
     let mut env =
@@ -1948,38 +1945,24 @@ async fn test_exact_sequence_after_enable_with_old_unmarked_sst() {
     markers.sort_unstable();
     assert_eq!(vec![false, true, true], markers);
 
-    // Exact (6, 9]: C=6 is at/after the unmarked file's max (3), so the old
-    // unmarked file is pruned and only the new marked rows are returned.
-    let stream = engine
-        .scan_to_stream(
+    // Exact scans fail closed even though C=9 is after the unmarked file's
+    // apparent sequence (3).
+    let err = engine
+        .scanner(
             region_id,
             ScanRequest {
-                memtable_min_sequence: Some(6),
-                memtable_max_sequence: Some(9),
+                memtable_min_sequence: Some(9),
+                memtable_max_sequence: Some(10),
                 exact_sequence_range: true,
                 ..Default::default()
             },
         )
         .await
-        .unwrap();
-    let batches = RecordBatches::try_collect(stream).await.unwrap();
-    let pretty = batches.pretty_print().unwrap();
-    for tag in ["6", "7", "8"] {
-        assert!(
-            pretty.contains(&format!("| {tag} ")),
-            "new row {tag} missing from exact scan:\n{pretty}"
-        );
-    }
-    for tag in ["0", "1", "2", "3", "4", "5"] {
-        assert!(
-            !pretty.contains(&format!("| {tag} ")),
-            "old row {tag} leaked into exact scan:\n{pretty}"
-        );
-    }
-    assert_eq!(
-        3,
-        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
-        "exact (6, 9] rows:\n{pretty}"
+        .err()
+        .expect("expected sequence-range unsupported error");
+    assert!(
+        matches!(err, Error::SequenceRangeUnsupported { .. }),
+        "unexpected err: {err}"
     );
 
     // Normal scans still return everything.
@@ -2581,48 +2564,28 @@ async fn test_compaction_output_not_laundered_from_legacy_input() {
         "legacy input must not be laundered into a marked output"
     );
 
-    // The compacted output is unmarked. The region-edit handler filled its max
-    // sequence with `committed + 1` (7). Exact scans with a lower bound C
-    // at/after 7 are disjoint from it and served (the (7, 8] range is empty),
-    // while C below 7 is unsupported because the unmarked file may still
-    // contain in-range rows.
-    let stream = engine
-        .scan_to_stream(
-            region_id,
-            ScanRequest {
-                memtable_min_sequence: Some(7),
-                memtable_max_sequence: Some(8),
-                exact_sequence_range: true,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-    let batches = RecordBatches::try_collect(stream).await.unwrap();
-    assert_eq!(
-        0,
-        batches.iter().map(|b| b.num_rows()).sum::<usize>(),
-        "exact (7, 8] must be empty:\n{}",
-        batches.pretty_print().unwrap()
-    );
-
-    let err = engine
-        .scanner(
-            region_id,
-            ScanRequest {
-                memtable_min_sequence: Some(6),
-                memtable_max_sequence: Some(7),
-                exact_sequence_range: true,
-                ..Default::default()
-            },
-        )
-        .await
-        .err()
-        .expect("expected sequence-range unsupported error for C below unmarked max");
-    assert!(
-        matches!(err, Error::SequenceRangeUnsupported { .. }),
-        "unexpected err: {err}"
-    );
+    // The compacted output remains unmarked. Its sequence may have been
+    // synthesized by the region-edit handler, so exact scans fail closed for
+    // any lower bound.
+    for (min, max) in [(7, 8), (6, 7)] {
+        let err = engine
+            .scanner(
+                region_id,
+                ScanRequest {
+                    memtable_min_sequence: Some(min),
+                    memtable_max_sequence: Some(max),
+                    exact_sequence_range: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .err()
+            .expect("expected sequence-range unsupported error for unmarked file");
+        assert!(
+            matches!(err, Error::SequenceRangeUnsupported { .. }),
+            "unexpected err: {err}"
+        );
+    }
 }
 
 /// Multi-input primary-key-format compaction: two preserved pk-format files

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -1511,7 +1511,16 @@ async fn test_range_cache_separates_or_equality_time_filters() {
 #[tokio::test]
 async fn test_exact_sequence_read_compacted_sst_with_preserve_row_sequence() {
     let mut env = TestEnv::new().await;
-    let engine = env.create_engine(MitoConfig::default()).await;
+    // Keep the explicit compaction below as the only compaction, so this test
+    // proves that the files are rewritten rather than observing an earlier
+    // background compaction.
+    let engine = env
+        .create_engine(MitoConfig {
+            min_compaction_interval: std::time::Duration::from_secs(60 * 60),
+            schedule_compaction_after_edit: false,
+            ..Default::default()
+        })
+        .await;
     let region_id = RegionId::new(1, 1);
 
     env.get_schema_metadata_manager()
@@ -1548,14 +1557,24 @@ async fn test_exact_sequence_read_compacted_sst_with_preserve_row_sequence() {
         test_util::flush_region(&engine, region_id, None).await;
     }
 
-    let output = engine
+    engine
         .handle_request(
             region_id,
             RegionRequest::Compact(RegionCompactRequest::default()),
         )
         .await
         .unwrap();
-    assert_eq!(output.affected_rows, 0);
+
+    let region = engine.get_region(region_id).unwrap();
+    let version = region.version();
+    let output_files = version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .collect::<Vec<_>>();
+    assert_eq!(1, output_files.len(), "three input SSTs must be rewritten");
+    assert!(output_files[0].meta_ref().preserve_row_sequence);
 
     // The compacted SST still preserves per-row sequences: the exact (2, 7] range
     // returns rows with sequence 3..=7 even though C and H are older than the

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -2322,8 +2322,7 @@ fn build_bulk_insert_request(
 }
 
 /// Bulk parts fold per-part sequences (commit-unit granularity): an exact range
-/// keeps or drops each whole part. The same set must hold before flush, after
-/// flush, and after compaction.
+/// keeps or drops each whole part. The same set must hold before and after flush.
 #[tokio::test]
 async fn test_exact_sequence_read_bulk_parts() {
     let mut env = TestEnv::with_prefix("test_exact_sequence_read_bulk_parts").await;
@@ -2398,15 +2397,6 @@ async fn test_exact_sequence_read_bulk_parts() {
     assert!(scan.contains("| 3 "), "second bulk part missing:\n{scan}");
 
     test_util::flush_region(&engine, region_id, None).await;
-    assert_eq!(scan_exact(Some(2), Some(100)).await, scan);
-
-    engine
-        .handle_request(
-            region_id,
-            RegionRequest::Compact(RegionCompactRequest::default()),
-        )
-        .await
-        .unwrap();
     assert_eq!(scan_exact(Some(2), Some(100)).await, scan);
 }
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -302,6 +302,20 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "region {} is unusable for sequence reads: file {} declares region {}",
+        region_id,
+        file_id,
+        file_region_id
+    ))]
+    RegionSequenceDomainBroken {
+        region_id: RegionId,
+        file_region_id: RegionId,
+        file_id: FileId,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Old manifest missing for region {}", region_id))]
     MissingOldManifest {
         region_id: RegionId,
@@ -1484,7 +1498,8 @@ impl ErrorExt for Error {
 
             SequenceRangeUnsupported { .. } => StatusCode::Unsupported,
 
-            RegionMetadataNotFound { .. }
+            RegionSequenceDomainBroken { .. }
+            | RegionMetadataNotFound { .. }
             | Join { .. }
             | WorkerStopped { .. }
             | Recv { .. }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -286,6 +286,22 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "SEQUENCE_RANGE_UNSUPPORTED: exact sequence-range read unsupported, region: {}, min_seq: {}, max_seq: {}, reason: {}, retry_hint: FALLBACK_MEMTABLE_ONLY_OR_FULL_RECOMPUTE",
+        region_id,
+        min_seq,
+        max_seq,
+        reason
+    ))]
+    SequenceRangeUnsupported {
+        region_id: RegionId,
+        min_seq: u64,
+        max_seq: u64,
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Old manifest missing for region {}", region_id))]
     MissingOldManifest {
         region_id: RegionId,
@@ -1465,6 +1481,8 @@ impl ErrorExt for Error {
             | InvalidSourceAndTargetRegion { .. } => StatusCode::InvalidArguments,
 
             IncrementalQueryStale { .. } | SnapshotFenceStale { .. } => StatusCode::RequestOutdated,
+
+            SequenceRangeUnsupported { .. } => StatusCode::Unsupported,
 
             RegionMetadataNotFound { .. }
             | Join { .. }

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -661,6 +661,7 @@ impl RegionFlushTask {
                         sst_info,
                         partition_expr.clone(),
                         pk_range,
+                        version.options.preserve_row_sequence,
                     ));
                 }
                 if hook.is_some() {
@@ -784,6 +785,7 @@ impl RegionFlushTask {
         sst_info: &SstInfo,
         partition_expr: Option<PartitionExpr>,
         primary_key_range: Option<(Bytes, Bytes)>,
+        preserve_row_sequence: bool,
     ) -> FileMeta {
         let (primary_key_min, primary_key_max) = match primary_key_range {
             Some((min, max)) => (Some(min), Some(max)),
@@ -807,6 +809,7 @@ impl RegionFlushTask {
             num_series: sst_info.num_series,
             primary_key_min,
             primary_key_max,
+            preserve_row_sequence,
         }
     }
 
@@ -833,6 +836,7 @@ impl RegionFlushTask {
             } else {
                 FormatType::PrimaryKey
             },
+            preserve_row_sequence: version.options.preserve_row_sequence,
             index_options: self.index_options.clone(),
             index_config: self.engine_config.index.clone(),
             inverted_index_config: self.engine_config.inverted_index.clone(),

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -31,7 +31,7 @@ use datatypes::value::scalar_value_to_timestamp;
 use futures::TryStreamExt;
 use snafu::ResultExt;
 use store_api::region_engine::PartitionRange;
-use store_api::storage::{FileId, RegionId, TimeSeriesRowSelector};
+use store_api::storage::{FileId, RegionId, SequenceRange, TimeSeriesRowSelector};
 use table::predicate::is_string_timestamp_literal;
 use tokio::sync::{mpsc, oneshot};
 
@@ -63,6 +63,10 @@ pub(crate) struct ScanRequestFingerprint {
     append_mode: bool,
     filter_deleted: bool,
     merge_mode: MergeMode,
+    /// Exact sequence range applied row-level on SST reads, or `None` for scans
+    /// without row-level sequence filtering. Kept in the cache key so filtered
+    /// range results are never reused for scans with a different (or no) range.
+    sequence_range: Option<SequenceRange>,
     stage: RangeScanStage,
     /// We keep the partition expr version to ensure we won't reuse the fingerprint after we change the partition expr.
     /// We store the version instead of the whole partition expr or partition expr filters.
@@ -86,6 +90,7 @@ pub(crate) struct ScanRequestFingerprintBuilder {
     pub(crate) append_mode: bool,
     pub(crate) filter_deleted: bool,
     pub(crate) merge_mode: MergeMode,
+    pub(crate) sequence_range: Option<SequenceRange>,
     pub(crate) partition_expr_version: u64,
 }
 
@@ -100,6 +105,7 @@ impl ScanRequestFingerprintBuilder {
             append_mode,
             filter_deleted,
             merge_mode,
+            sequence_range,
             partition_expr_version,
         } = self;
 
@@ -114,6 +120,7 @@ impl ScanRequestFingerprintBuilder {
             append_mode,
             filter_deleted,
             merge_mode,
+            sequence_range,
             stage: RangeScanStage::Data,
             partition_expr_version,
         }
@@ -164,6 +171,7 @@ impl ScanRequestFingerprint {
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
+            sequence_range: self.sequence_range,
             stage: self.stage,
             partition_expr_version: self.partition_expr_version,
         }
@@ -177,6 +185,7 @@ impl ScanRequestFingerprint {
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
+            sequence_range: self.sequence_range,
             stage: RangeScanStage::CandidateSeries,
             partition_expr_version: self.partition_expr_version,
         }
@@ -190,6 +199,7 @@ impl ScanRequestFingerprint {
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
+            sequence_range: self.sequence_range,
             stage: RangeScanStage::SeriesData(range),
             partition_expr_version: self.partition_expr_version,
         }
@@ -855,6 +865,7 @@ pub fn bench_cache_flat_range_stream(
         append_mode: false,
         filter_deleted: false,
         merge_mode: MergeMode::LastRow,
+        sequence_range: None,
         partition_expr_version: 0,
     }
     .build();
@@ -921,6 +932,7 @@ mod tests {
             append_mode: false,
             filter_deleted,
             merge_mode: MergeMode::LastRow,
+            sequence_range: None,
             partition_expr_version,
         }
         .build()

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -56,7 +56,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheStrategy;
 use crate::config::DEFAULT_MAX_CONCURRENT_SCAN_FILES;
-use crate::error::{InvalidPartitionExprSnafu, InvalidRequestSnafu, Result};
+use crate::error::{
+    InvalidPartitionExprSnafu, InvalidRequestSnafu, Result, SequenceRangeUnsupportedSnafu,
+};
 #[cfg(feature = "enterprise")]
 use crate::extension::{BoxedExtensionRange, BoxedExtensionRangeProvider};
 use crate::memtable::{MemtableRange, RangesOptions};
@@ -86,6 +88,7 @@ use crate::sst::index::vector_index::applier::{VectorIndexApplier, VectorIndexAp
 use crate::sst::parquet::Json2RewriteTargets;
 use crate::sst::parquet::file_range::PreFilterMode;
 use crate::sst::parquet::reader::ReaderMetrics;
+use crate::sst::version::SstVersion;
 
 #[cfg(feature = "vector_index")]
 const VECTOR_INDEX_OVERFETCH_MULTIPLIER: usize = 2;
@@ -438,6 +441,23 @@ impl ScanRegion {
     async fn scan_input(self) -> Result<ScanInput> {
         let metadata = &self.version.metadata;
         let sst_min_sequence = self.request.sst_min_sequence.and_then(NonZeroU64::new);
+        // Exact `sequence_range` mode filters rows row-level on every
+        // time-matching SST. The legacy `sst_min_sequence` file-pruning hint
+        // would silently skip preserved files whose max sequence does not
+        // exceed it (e.g. `(5, 10]` with `sst_min_sequence = 8` drops a file
+        // with max = 8, losing sequences 6..8), so the conflicting combination
+        // is rejected explicitly instead of being silently approximated.
+        if sst_min_sequence.is_some() && self.exact_sequence_range().is_some() {
+            return SequenceRangeUnsupportedSnafu {
+                region_id: self.region_id(),
+                min_seq: self.request.memtable_min_sequence.unwrap_or_default(),
+                max_seq: self.request.memtable_max_sequence.unwrap_or_default(),
+                reason:
+                    "sst_min_sequence pruning hint is incompatible with exact sequence-range reads"
+                        .to_string(),
+            }
+            .fail();
+        }
         let time_range = self.build_time_range_predicate();
         let predicate = PredicateGroup::new(metadata, &self.request.filters)?;
 
@@ -459,10 +479,27 @@ impl ScanRegion {
         };
 
         let ssts = &self.version.ssts;
+        // Exact `(C, H]` scans skip files whose max sequence cannot reach the
+        // lower bound C: the whole file predates the range. This applies to
+        // marked files (no in-range rows) and to unmarked files already proven
+        // disjoint by `files_allow_exact_sequence_range` (their rows must not
+        // pass through unfiltered).
+        let sequence_range = self.exact_sequence_range();
+        let exact_min_sequence = match &sequence_range {
+            Some(SequenceRange::GtLtEq { min, .. }) => Some(*min),
+            _ => None,
+        };
         let mut files = Vec::new();
         if !self.request.skip_sst_files {
             for level in ssts.levels() {
                 for file in level.files.values() {
+                    if let Some(min) = exact_min_sequence
+                        && let Some(file_sequence) = file.meta_ref().sequence
+                        && file_sequence.get() <= min
+                    {
+                        continue;
+                    }
+
                     let exceed_min_sequence = match (sst_min_sequence, file.meta_ref().sequence) {
                         (Some(min_sequence), Some(file_sequence)) => file_sequence > min_sequence,
                         // If the file's sequence is None (or actually is zero), it could mean the file
@@ -580,6 +617,7 @@ impl ScanRegion {
                     .then_some(self.request.memtable_max_sequence)
                     .flatten(),
             )
+            .with_sequence_range(sequence_range)
             .with_query_stat_counters(self.query_stat_counters);
         #[cfg(feature = "vector_index")]
         let input = input
@@ -729,6 +767,14 @@ impl ScanRegion {
 
     fn region_id(&self) -> RegionId {
         self.version.metadata.region_id
+    }
+
+    /// Returns the exact sequence range for row-level sequence filtering, or
+    /// `None` when the scan is not an exact `sequence_range` request or the
+    /// region cannot guarantee exactness (no per-row sequences preserved, or a
+    /// file in the version lacks the preserved-sequence marker).
+    fn exact_sequence_range(&self) -> Option<SequenceRange> {
+        exact_sequence_range(&self.request, &self.version)
     }
 
     /// Build time range predicate from filters.
@@ -951,6 +997,13 @@ pub struct ScanInput {
     explain_flat_format: bool,
     /// Snapshot upper bound bound at scan open and propagated back to the caller.
     pub(crate) snapshot_sequence: Option<SequenceNumber>,
+    /// Exact sequence range to filter rows row-level on SST reads.
+    ///
+    /// Set only when the region preserves per-row sequences
+    /// (`preserve_row_sequence` on an append-only table) and the scan
+    /// carries an explicit exact range. When set, SST readers apply the same
+    /// `(checkpoint, upper_bound]` row-level filter as memtables.
+    pub(crate) sequence_range: Option<SequenceRange>,
     /// Whether this scan is for compaction.
     pub(crate) compaction: bool,
     /// Compaction-only JSON2 physical rewrite targets.
@@ -994,6 +1047,7 @@ impl ScanInput {
             distribution: None,
             explain_flat_format: false,
             snapshot_sequence: None,
+            sequence_range: None,
             compaction: false,
             json2_rewrite_targets: Arc::default(),
             query_stat_counters: None,
@@ -1191,6 +1245,12 @@ impl ScanInput {
         snapshot_sequence: Option<SequenceNumber>,
     ) -> Self {
         self.snapshot_sequence = snapshot_sequence;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_sequence_range(mut self, sequence_range: Option<SequenceRange>) -> Self {
+        self.sequence_range = sequence_range;
         self
     }
 
@@ -1620,6 +1680,51 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
     }
 }
 
+/// Returns true if every unmarked SST in `ssts` can be excluded from an exact
+/// `(min_seq, max]` scan: it must carry a known max sequence not exceeding the
+/// lower bound `min_seq`, so none of its rows can fall inside the range.
+/// Marked files always qualify (the reader filters their rows row-level);
+/// unmarked files with an unknown max sequence fail closed.
+pub(crate) fn files_allow_exact_sequence_range(ssts: &SstVersion, min_seq: SequenceNumber) -> bool {
+    ssts.levels().iter().all(|level| {
+        level.files.values().all(|file| {
+            let meta = file.meta_ref();
+            meta.preserve_row_sequence || meta.sequence.is_some_and(|seq| seq.get() <= min_seq)
+        })
+    })
+}
+
+/// Single source of truth for the exact row-level sequence-range capability.
+///
+/// Returns the exact `GtLtEq { min, max }` range when **all** of the following
+/// hold — and only then — so the engine and the reader can never drift:
+/// - the scan explicitly requests `exact_sequence_range` (Flow's
+///   `sequence_range` mode; historical `memtable_only` scans never set it), and
+/// - the scan does not skip SST files (exactness requires reading them), and
+/// - the region preserves per-row sequences (`preserve_row_sequence`),
+///   and
+/// - every unmarked SST carries a known max sequence not exceeding the lower
+///   bound `min`, so it cannot contribute rows to `(min, max]`.
+///
+/// Returns `None` otherwise. Callers must keep main's fences/fallback semantics
+/// and never silently approximate.
+pub(crate) fn exact_sequence_range(
+    request: &ScanRequest,
+    version: &crate::region::version::Version,
+) -> Option<SequenceRange> {
+    if !request.exact_sequence_range
+        || request.skip_sst_files
+        || !version.options.preserve_row_sequence
+    {
+        return None;
+    }
+    let min = request.memtable_min_sequence?;
+    let max = request.memtable_max_sequence?;
+    if !files_allow_exact_sequence_range(&version.ssts, min) {
+        return None;
+    }
+    Some(SequenceRange::GtLtEq { min, max })
+}
 /// Output of [build_scan_fingerprint]: the cache fingerprint plus the derived
 /// implied time range used to decide whether the cache key can drop the time
 /// predicates for a given partition (see `build_range_cache_key`).
@@ -1734,6 +1839,7 @@ pub(crate) fn build_scan_fingerprint(input: &ScanInput) -> Option<ScanFingerprin
         append_mode: input.append_mode,
         filter_deleted: input.filter_deleted,
         merge_mode: input.merge_mode,
+        sequence_range: input.sequence_range,
         partition_expr_version: metadata.partition_expr_version,
     }
     .build();
@@ -2286,6 +2392,7 @@ mod tests {
             append_mode: false,
             filter_deleted: false,
             merge_mode: MergeMode::LastNonNull,
+            sequence_range: None,
             partition_expr_version: 0,
         }
         .build();
@@ -2359,6 +2466,7 @@ mod tests {
             append_mode: false,
             filter_deleted: true,
             merge_mode: MergeMode::LastRow,
+            sequence_range: None,
             partition_expr_version: metadata.partition_expr_version,
         }
         .build();
@@ -2726,5 +2834,40 @@ mod tests {
 
             assert_eq!(expected_mode, input.range_pre_filter_mode(source_count));
         }
+    }
+
+    #[test]
+    fn test_files_allow_exact_sequence_range() {
+        use std::num::NonZeroU64;
+
+        use crate::test_util::new_noop_file_purger;
+
+        let purger = new_noop_file_purger();
+        let file = |sequence: Option<NonZeroU64>, marked: bool| FileMeta {
+            sequence,
+            preserve_row_sequence: marked,
+            ..Default::default()
+        };
+
+        // Marked file (always OK) + unmarked files with known max sequences.
+        let mut ssts = SstVersion::new();
+        ssts.add_files(
+            purger.clone(),
+            [
+                file(NonZeroU64::new(5), true),
+                file(NonZeroU64::new(5), false),
+                file(NonZeroU64::new(9), false),
+            ]
+            .into_iter(),
+        );
+        // C=5: the unmarked file with max 9 overlaps (5, H] -> not allowed.
+        assert!(!files_allow_exact_sequence_range(&ssts, 5));
+        // C=9: every unmarked file's max <= C -> allowed.
+        assert!(files_allow_exact_sequence_range(&ssts, 9));
+
+        // Unknown max sequence fails closed even when C is large.
+        let mut ssts = SstVersion::new();
+        ssts.add_files(purger, [file(None, false)].into_iter());
+        assert!(!files_allow_exact_sequence_range(&ssts, 100));
     }
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -628,6 +628,22 @@ impl ScanRegion {
         let input = if !self.request.skip_sst_files
             && let Some(provider) = self.extension_range_provider
         {
+            if sequence_range.is_some() {
+                // Defense in depth: the engine already rejects exact
+                // sequence-range reads on follower regions with an extension
+                // provider, but if one ever reaches the reader, fail closed
+                // here rather than letting unfiltered extension streams bypass
+                // the row-level sequence filter and emit out-of-range rows.
+                return SequenceRangeUnsupportedSnafu {
+                    region_id,
+                    min_seq: self.request.memtable_min_sequence.unwrap_or_default(),
+                    max_seq: self.request.memtable_max_sequence.unwrap_or_default(),
+                    reason:
+                        "exact sequence-range reads are unsupported when an extension range provider is present"
+                            .to_string(),
+                }
+                .fail();
+            }
             let ranges = provider
                 .find_extension_ranges(self.version.flushed_sequence, time_range, &self.request)
                 .await?;

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -769,10 +769,6 @@ impl ScanRegion {
         self.version.metadata.region_id
     }
 
-    /// Returns the exact sequence range for row-level sequence filtering, or
-    /// `None` when the scan is not an exact `sequence_range` request or the
-    /// region cannot guarantee exactness (no per-row sequences preserved, or a
-    /// file in the version lacks the preserved-sequence marker).
     fn exact_sequence_range(&self) -> Option<SequenceRange> {
         exact_sequence_range(&self.request, &self.version)
     }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -480,11 +480,9 @@ impl ScanRegion {
         };
 
         let ssts = &self.version.ssts;
-        // Exact `(C, H]` scans skip files whose max sequence cannot reach the
-        // lower bound C: the whole file predates the range. This applies to
-        // marked files (no in-range rows) and to unmarked files already proven
-        // disjoint by `files_allow_exact_sequence_range` (their rows must not
-        // pass through unfiltered).
+        // Exact `(C, H]` scans skip only marked files whose max sequence cannot
+        // reach the lower bound C. Unmarked files never participate in this
+        // disjoint skip because their file sequence is not trusted.
         let sequence_range = self.exact_sequence_range()?;
         let exact_min_sequence = match &sequence_range {
             Some(SequenceRange::GtLtEq { min, .. }) => Some(*min),
@@ -494,7 +492,8 @@ impl ScanRegion {
         if !self.request.skip_sst_files {
             for level in ssts.levels() {
                 for file in level.files.values() {
-                    if let Some(min) = exact_min_sequence
+                    if file.meta_ref().preserve_row_sequence
+                        && let Some(min) = exact_min_sequence
                         && let Some(file_sequence) = file.meta_ref().sequence
                         && file_sequence.get() <= min
                     {
@@ -1688,16 +1687,14 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
     }
 }
 
-/// Returns true if every unmarked SST in `ssts` can be excluded from an exact
-/// `(min_seq, max]` scan: it must carry a known max sequence not exceeding the
-/// lower bound `min_seq`, so none of its rows can fall inside the range.
-/// Marked files always qualify (the reader filters their rows row-level);
-/// unmarked files with an unknown max sequence fail closed. Files belonging to
-/// another region are a broken sequence domain and return an error.
+/// Returns true if every SST in `ssts` preserves row sequences, as required
+/// for an exact sequence-range scan. Unmarked files, including files whose
+/// sequence was synthesized by edit or repartition paths, never participate in
+/// disjoint skipping because their file sequence is not trusted. Files belonging
+/// to another region are a broken sequence domain and return an error.
 pub(crate) fn files_allow_exact_sequence_range(
     ssts: &SstVersion,
     region_id: RegionId,
-    min_seq: SequenceNumber,
 ) -> Result<bool> {
     for level in ssts.levels() {
         for file in level.files.values() {
@@ -1710,7 +1707,7 @@ pub(crate) fn files_allow_exact_sequence_range(
                 }
                 .fail();
             }
-            if !meta.preserve_row_sequence && meta.sequence.is_none_or(|seq| seq.get() > min_seq) {
+            if !meta.preserve_row_sequence {
                 return Ok(false);
             }
         }
@@ -1727,8 +1724,8 @@ pub(crate) fn files_allow_exact_sequence_range(
 /// - the scan does not skip SST files (exactness requires reading them), and
 /// - the region preserves per-row sequences (`preserve_row_sequence`),
 ///   and
-/// - every unmarked SST carries a known max sequence not exceeding the lower
-///   bound `min`, so it cannot contribute rows to `(min, max]`.
+/// - every SST preserves row sequences. Unmarked SSTs, including those with
+///   edit/repartition-synthesized sequences, fail closed and disable exactness.
 ///
 /// Returns `None` otherwise. Callers must keep main's fences/fallback semantics
 /// and never silently approximate. An SST belonging to another region is not a
@@ -1746,7 +1743,7 @@ pub(crate) fn exact_sequence_range(
     // Check the domain before capability conditions that would otherwise return
     // `None`, so a corrupt manifest can never be treated as fallback-safe.
     let files_allow_exact_range =
-        files_allow_exact_sequence_range(&version.ssts, version.metadata.region_id, min)?;
+        files_allow_exact_sequence_range(&version.ssts, version.metadata.region_id)?;
     if !version.options.preserve_row_sequence {
         return Ok(None);
     }
@@ -2884,26 +2881,29 @@ mod tests {
             ..Default::default()
         };
 
-        // Marked file (always OK) + unmarked files with known max sequences.
+        // All marked files allow exact row-level filtering.
         let mut ssts = SstVersion::new();
         ssts.add_files(
             purger.clone(),
-            [
-                file(NonZeroU64::new(5), true),
-                file(NonZeroU64::new(5), false),
-                file(NonZeroU64::new(9), false),
-            ]
-            .into_iter(),
+            [file(NonZeroU64::new(5), true), file(None, true)].into_iter(),
         );
-        // C=5: the unmarked file with max 9 overlaps (5, H] -> not allowed.
-        assert!(!files_allow_exact_sequence_range(&ssts, region_id, 5).unwrap());
-        // C=9: every unmarked file's max <= C -> allowed.
-        assert!(files_allow_exact_sequence_range(&ssts, region_id, 9).unwrap());
+        assert!(files_allow_exact_sequence_range(&ssts, region_id).unwrap());
 
-        // Unknown max sequence fails closed even when C is large.
+        // An unmarked file fails closed even if its sequence is at or below C.
         let mut ssts = SstVersion::new();
-        ssts.add_files(purger.clone(), [file(None, false)].into_iter());
-        assert!(!files_allow_exact_sequence_range(&ssts, region_id, 100).unwrap());
+        ssts.add_files(
+            purger.clone(),
+            [file(NonZeroU64::new(5), false)].into_iter(),
+        );
+        assert!(!files_allow_exact_sequence_range(&ssts, region_id).unwrap());
+
+        // An unmarked file's sequence is never trusted, whatever its value.
+        let mut ssts = SstVersion::new();
+        ssts.add_files(
+            purger.clone(),
+            [file(NonZeroU64::new(100), false)].into_iter(),
+        );
+        assert!(!files_allow_exact_sequence_range(&ssts, region_id).unwrap());
 
         // A file from another region breaks the sequence domain even if marked.
         let mut ssts = SstVersion::new();
@@ -2916,6 +2916,6 @@ mod tests {
             }]
             .into_iter(),
         );
-        assert!(files_allow_exact_sequence_range(&ssts, region_id, 100).is_err());
+        assert!(files_allow_exact_sequence_range(&ssts, region_id).is_err());
     }
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -259,6 +259,8 @@ pub(crate) struct ScanRegion {
     /// Whether to filter out the deleted rows.
     /// Usually true for normal read, and false for scan for compaction.
     filter_deleted: bool,
+    /// Files selected by the engine's capability check, when available.
+    selected_files: Option<Vec<FileHandle>>,
     /// Counters that should receive query-load metrics.
     query_stat_counters: Option<RegionQueryStatCounters>,
     #[cfg(feature = "enterprise")]
@@ -286,6 +288,7 @@ impl ScanRegion {
             ignore_bloom_filter: false,
             start_time: None,
             filter_deleted: true,
+            selected_files: None,
             query_stat_counters: None,
             #[cfg(feature = "enterprise")]
             extension_range_provider: None,
@@ -352,6 +355,11 @@ impl ScanRegion {
 
     pub(crate) fn set_filter_deleted(&mut self, filter_deleted: bool) {
         self.filter_deleted = filter_deleted;
+    }
+
+    pub(crate) fn with_selected_files(mut self, files: Vec<FileHandle>) -> Self {
+        self.selected_files = Some(files);
+        self
     }
 
     #[cfg(feature = "enterprise")]
@@ -439,15 +447,9 @@ impl ScanRegion {
 
     /// Creates a scan input.
     #[tracing::instrument(skip_all, fields(region_id = %self.region_id()))]
-    async fn scan_input(self) -> Result<ScanInput> {
+    async fn scan_input(mut self) -> Result<ScanInput> {
         let metadata = &self.version.metadata;
         let sst_min_sequence = self.request.sst_min_sequence.and_then(NonZeroU64::new);
-        // Exact `sequence_range` mode filters rows row-level on every
-        // time-matching SST. The legacy `sst_min_sequence` file-pruning hint
-        // would silently skip preserved files whose max sequence does not
-        // exceed it (e.g. `(5, 10]` with `sst_min_sequence = 8` drops a file
-        // with max = 8, losing sequences 6..8), so the conflicting combination
-        // is rejected explicitly instead of being silently approximated.
         let time_range = self.build_time_range_predicate();
         let predicate = PredicateGroup::new(metadata, &self.request.filters)?;
 
@@ -468,12 +470,10 @@ impl ScanRegion {
             mapper
         };
 
-        // `exact_sequence_range_files` applies time pruning and, for exact
-        // requests, removes only marked files that cannot contain `(C, H]`
-        // rows. This is the same selected set used by the engine's capability
-        // fence before its remaining scan-specific pruning.
         let files = if self.request.skip_sst_files {
             Vec::new()
+        } else if let Some(files) = self.selected_files.take() {
+            files
         } else {
             exact_sequence_range_files(&self.request, &self.version)
         };

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -1657,18 +1657,21 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
     }
 }
 
-/// Returns true if every selected SST preserves row sequences, as required
-/// for an exact sequence-range scan. Files excluded by the request time range
-/// are not passed here: `(C, H]` rows are a subset of the query's time-range
-/// rows, so a time-pruned file cannot contribute a row to `(C, H]`.
+/// Returns true if every selected SST can participate in an exact
+/// sequence-range scan. Files excluded by the request time range are not
+/// passed here: `(C, H]` rows are a subset of the query's time-range rows, so a
+/// time-pruned file cannot contribute a row to `(C, H]`.
 ///
-/// Unmarked files, including files whose sequence was synthesized by edit or
-/// repartition paths, never participate in disjoint skipping because their file
-/// sequence is not trusted. Files belonging to another region are a broken
-/// sequence domain and return an error.
+/// Unmarked files use `FileMeta.sequence` as an admission barrier rather than
+/// a row maximum. Compaction and edit assign it as `committed_sequence + 1`;
+/// `C >= barrier` proves Flow has already consumed the entire file, so such a
+/// file is excluded before this check. An unmarked selected file has a missing
+/// barrier or `barrier > C` and fails closed. Files belonging to another region
+/// are a broken sequence domain and return an error.
 pub(crate) fn files_allow_exact_sequence_range(
     files: &[FileHandle],
     region_id: RegionId,
+    min_seq: SequenceNumber,
 ) -> Result<bool> {
     for file in files {
         let meta = file.meta_ref();
@@ -1680,7 +1683,9 @@ pub(crate) fn files_allow_exact_sequence_range(
             }
             .fail();
         }
-        if !meta.preserve_row_sequence {
+        if !meta.preserve_row_sequence
+            && meta.sequence.is_none_or(|barrier| barrier.get() > min_seq)
+        {
             return Ok(false);
         }
     }
@@ -1717,7 +1722,10 @@ pub(crate) fn exact_sequence_range_files(
     files_in_time_range(&version.ssts, &time_range)
         .filter(|file| {
             (!request.exact_sequence_range
-                || !file.meta_ref().preserve_row_sequence
+                // Keep a foreign-domain file in the selected read set so the
+                // exact capability fence reports RegionSequenceDomainBroken
+                // instead of silently treating its barrier as local.
+                || file.meta_ref().region_id != version.metadata.region_id
                 || request.memtable_min_sequence.is_none_or(|min| {
                     file.meta_ref()
                         .sequence
@@ -1745,9 +1753,9 @@ pub(crate) fn exact_sequence_range_files(
 ///   `sequence_range` mode; historical `memtable_only` scans never set it), and
 /// - the scan does not skip SST files (exactness requires reading them), and
 /// - the region preserves per-row sequences (`preserve_row_sequence`), and
-/// - every selected SST preserves row sequences. Unmarked SSTs, including
-///   those with edit/repartition-synthesized sequences, fail closed and disable
-///   exactness.
+/// - every selected unmarked SST has an admission barrier not exceeding the
+///   lower bound, so it is excluded before row-level filtering. Selected
+///   unmarked SSTs with a missing or newer barrier fail closed.
 ///
 /// Returns `None` otherwise. Callers must keep main's fences/fallback semantics
 /// and never silently approximate. An SST belonging to another region is not a
@@ -1766,7 +1774,7 @@ pub(crate) fn exact_sequence_range(
     // Check the domain before capability conditions that would otherwise return
     // `None`, so a corrupt manifest can never be treated as fallback-safe.
     let files_allow_exact_range =
-        files_allow_exact_sequence_range(files, version.metadata.region_id)?;
+        files_allow_exact_sequence_range(files, version.metadata.region_id, min)?;
     if !version.options.preserve_row_sequence {
         return Ok(None);
     }
@@ -2918,48 +2926,51 @@ mod tests {
                     .flat_map(|level| level.files.values())
                     .cloned()
                     .collect::<Vec<_>>(),
-                region_id
+                region_id,
+                0
             )
             .unwrap()
         );
 
-        // An unmarked file fails closed even if its sequence is at or below C.
+        // An unmarked file is safe once its admission barrier is not newer
+        // than C: it is excluded before row-level filtering.
         let mut ssts = SstVersion::new();
         ssts.add_files(
             purger.clone(),
             [file(NonZeroU64::new(5), false)].into_iter(),
         );
-        assert!(
-            !files_allow_exact_sequence_range(
-                &ssts
-                    .levels()
-                    .iter()
-                    .flat_map(|level| level.files.values())
-                    .cloned()
-                    .collect::<Vec<_>>(),
-                region_id
-            )
-            .unwrap()
-        );
+        let files = ssts
+            .levels()
+            .iter()
+            .flat_map(|level| level.files.values())
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(files_allow_exact_sequence_range(&files, region_id, 5).unwrap());
 
-        // An unmarked file's sequence is never trusted, whatever its value.
+        // A newer admission barrier may still contain rows after C.
         let mut ssts = SstVersion::new();
         ssts.add_files(
             purger.clone(),
             [file(NonZeroU64::new(100), false)].into_iter(),
         );
-        assert!(
-            !files_allow_exact_sequence_range(
-                &ssts
-                    .levels()
-                    .iter()
-                    .flat_map(|level| level.files.values())
-                    .cloned()
-                    .collect::<Vec<_>>(),
-                region_id
-            )
-            .unwrap()
-        );
+        let files = ssts
+            .levels()
+            .iter()
+            .flat_map(|level| level.files.values())
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(!files_allow_exact_sequence_range(&files, region_id, 99).unwrap());
+
+        // A missing admission barrier fails closed.
+        let mut ssts = SstVersion::new();
+        ssts.add_files(purger.clone(), [file(None, false)].into_iter());
+        let files = ssts
+            .levels()
+            .iter()
+            .flat_map(|level| level.files.values())
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(!files_allow_exact_sequence_range(&files, region_id, 100).unwrap());
 
         // A file from another region breaks the sequence domain even if marked.
         let mut ssts = SstVersion::new();
@@ -2980,7 +2991,8 @@ mod tests {
                     .flat_map(|level| level.files.values())
                     .cloned()
                     .collect::<Vec<_>>(),
-                region_id
+                region_id,
+                100
             )
             .is_err()
         );
@@ -3007,6 +3019,6 @@ mod tests {
             .filter(|file| file.meta_ref().sequence == NonZeroU64::new(5))
             .cloned()
             .collect::<Vec<_>>();
-        assert!(files_allow_exact_sequence_range(&selected_files, region_id).unwrap());
+        assert!(files_allow_exact_sequence_range(&selected_files, region_id, 5).unwrap());
     }
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -89,7 +89,6 @@ use crate::sst::index::vector_index::applier::{VectorIndexApplier, VectorIndexAp
 use crate::sst::parquet::Json2RewriteTargets;
 use crate::sst::parquet::file_range::PreFilterMode;
 use crate::sst::parquet::reader::ReaderMetrics;
-use crate::sst::version::SstVersion;
 
 #[cfg(feature = "vector_index")]
 const VECTOR_INDEX_OVERFETCH_MULTIPLIER: usize = 2;
@@ -476,14 +475,8 @@ impl ScanRegion {
         let (files, sequence_range) =
             if let Some((files, sequence_range)) = self.exact_selection.take() {
                 (files, sequence_range)
-            } else if self.request.skip_sst_files {
-                let files = Vec::new();
-                let sequence_range = exact_sequence_range(&self.request, &self.version, &files)?;
-                (files, sequence_range)
             } else {
-                let files = exact_sequence_range_files(&self.request, &self.version);
-                let sequence_range = exact_sequence_range(&self.request, &self.version, &files)?;
-                (files, sequence_range)
+                exact_sequence_range(&self.request, &self.version)?
             };
         if sst_min_sequence.is_some() && sequence_range.is_some() {
             return SequenceRangeUnsupportedSnafu {
@@ -1660,63 +1653,32 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
     }
 }
 
-/// Returns true if every selected SST can participate in an exact
-/// sequence-range scan. Files excluded by the request time range are not
-/// passed here: `(C, H]` rows are a subset of the query's time-range rows, so a
-/// time-pruned file cannot contribute a row to `(C, H]`.
+/// Selects the SST files for a scan and, when requested, determines whether
+/// the selected files support an exact sequence-range scan.
+///
+/// Files excluded by the request time range are not selected: `(C, H]` rows are
+/// a subset of the query's time-range rows, so a time-pruned file cannot
+/// contribute a row to `(C, H]`.
 ///
 /// Unmarked local files use `FileMeta.sequence` as an admission barrier rather
 /// than a row maximum. Compaction and edit assign it as `committed_sequence + 1`;
 /// `C >= barrier` proves Flow has already consumed the entire file, so such a
-/// file is excluded before this check.
+/// file is excluded before the capability check.
 ///
 /// A foreign file is different: the parquet reader virtualizes every row to its
 /// target-local `FileMeta.sequence`. Consequently, a present sequence is the
 /// only trust requirement for a foreign file; its source marker is irrelevant.
 /// A foreign file without that barrier is retained as a failed-closed error so
-/// it cannot be mistaken for a local sequence domain.
-pub(crate) fn files_allow_exact_sequence_range(
-    files: &[FileHandle],
-    region_id: RegionId,
-    min_seq: SequenceNumber,
-) -> Result<bool> {
-    for file in files {
-        let meta = file.meta_ref();
-        if meta.region_id != region_id && meta.sequence.is_none() {
-            return RegionSequenceDomainBrokenSnafu {
-                region_id,
-                file_region_id: meta.region_id,
-                file_id: meta.file_id,
-            }
-            .fail();
-        }
-        if meta.region_id == region_id
-            && !file.is_effective_target_sequence_trusted(region_id)
-            && meta.sequence.is_none_or(|barrier| barrier.get() > min_seq)
-        {
-            return Ok(false);
-        }
-    }
-    Ok(true)
-}
-
-fn files_in_time_range<'a>(
-    ssts: &'a SstVersion,
-    time_range: &'a TimestampRange,
-) -> impl Iterator<Item = &'a FileHandle> {
-    ssts.levels()
-        .iter()
-        .flat_map(|level| level.files.values())
-        .filter(move |file| file_in_range(file, time_range))
-}
-
-/// Returns time-matching SST files for use by the engine's exact capability
-/// fence. The scan builder applies the same time pruning before its remaining
-/// file-selection filters.
-pub(crate) fn exact_sequence_range_files(
+/// it cannot be mistaken for a local sequence domain. This check is performed
+/// even when another exact-range capability condition would return `None`.
+pub(crate) fn exact_sequence_range(
     request: &ScanRequest,
     version: &crate::region::version::Version,
-) -> Vec<FileHandle> {
+) -> Result<(Vec<FileHandle>, Option<SequenceRange>)> {
+    if request.skip_sst_files {
+        return Ok((Vec::new(), None));
+    }
+
     let time_index = version.metadata.time_index_column();
     let unit = time_index
         .column_schema
@@ -1726,68 +1688,70 @@ pub(crate) fn exact_sequence_range_files(
         .unit();
     let time_range =
         build_time_range_predicate(&time_index.column_schema.name, unit, &request.filters);
-    files_in_time_range(&version.ssts, &time_range)
-        .filter(|file| {
-            (!request.exact_sequence_range
-                || request.memtable_min_sequence.is_none_or(|min| {
-                    file.meta_ref()
-                        .sequence
-                        .is_none_or(|sequence| sequence.get() > min)
-                }))
-                && match (
-                    request.sst_min_sequence.and_then(NonZeroU64::new),
-                    file.meta_ref().sequence,
-                ) {
-                    (Some(min_sequence), Some(file_sequence)) => file_sequence > min_sequence,
-                    // A missing file sequence is treated as newer than the SST
-                    // pruning hint, matching scan input construction.
-                    (Some(_), None) | (None, _) => true,
+    let min = request.memtable_min_sequence;
+    let mut check_capability = request.exact_sequence_range && min.is_some();
+    let sst_min_sequence = request.sst_min_sequence.and_then(NonZeroU64::new);
+    let mut files = Vec::new();
+    let mut files_allow_exact_range = true;
+
+    for file in version
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .filter(|file| file_in_range(file, &time_range))
+    {
+        let meta = file.meta_ref();
+        let selected = (!request.exact_sequence_range
+            || min.is_none_or(|min| meta.sequence.is_none_or(|sequence| sequence.get() > min)))
+            && match (sst_min_sequence, meta.sequence) {
+                (Some(min_sequence), Some(file_sequence)) => file_sequence > min_sequence,
+                // A missing file sequence is treated as newer than the SST
+                // pruning hint, matching scan input construction.
+                (Some(_), None) | (None, _) => true,
+            };
+        if !selected {
+            continue;
+        }
+
+        if let Some(min) = min
+            && check_capability
+        {
+            if meta.region_id != version.metadata.region_id && meta.sequence.is_none() {
+                return RegionSequenceDomainBrokenSnafu {
+                    region_id: version.metadata.region_id,
+                    file_region_id: meta.region_id,
+                    file_id: meta.file_id,
                 }
-        })
-        .cloned()
-        .collect()
+                .fail();
+            }
+            if meta.region_id == version.metadata.region_id
+                && !file.is_effective_target_sequence_trusted(version.metadata.region_id)
+                && meta.sequence.is_none_or(|barrier| barrier.get() > min)
+            {
+                // Match the capability helper's short-circuit behavior: once
+                // an unadmitted local file is found, later files cannot change
+                // the result or expose a foreign-domain error.
+                files_allow_exact_range = false;
+                check_capability = false;
+            }
+        }
+        files.push(file.clone());
+    }
+
+    let sequence_range = match (
+        request.exact_sequence_range,
+        min,
+        version.options.preserve_row_sequence,
+        request.memtable_max_sequence,
+        files_allow_exact_range,
+    ) {
+        (true, Some(min), true, Some(max), true) => Some(SequenceRange::GtLtEq { min, max }),
+        _ => None,
+    };
+    Ok((files, sequence_range))
 }
 
-/// Single source of truth for the exact row-level sequence-range capability.
-///
-/// Returns the exact `GtLtEq { min, max }` range when **all** of the following
-/// hold — and only then — so the engine and the reader can never drift:
-/// - the scan explicitly requests `exact_sequence_range` (Flow's
-///   `sequence_range` mode; historical `memtable_only` scans never set it), and
-/// - the scan does not skip SST files (exactness requires reading them), and
-/// - every selected local unmarked SST has an admission barrier not exceeding
-///   the lower bound, so it is excluded before row-level filtering, and
-/// - every selected foreign SST has a target-local barrier.
-///
-/// Returns `None` otherwise. Callers must keep main's fences/fallback semantics
-/// and never silently approximate. A foreign SST without a barrier returns the
-/// existing sequence-domain error.
-pub(crate) fn exact_sequence_range(
-    request: &ScanRequest,
-    version: &crate::region::version::Version,
-    files: &[FileHandle],
-) -> Result<Option<SequenceRange>> {
-    if !request.exact_sequence_range || request.skip_sst_files {
-        return Ok(None);
-    }
-    let Some(min) = request.memtable_min_sequence else {
-        return Ok(None);
-    };
-    // Check the domain before capability conditions that would otherwise return
-    // `None`, so a corrupt manifest can never be treated as fallback-safe.
-    let files_allow_exact_range =
-        files_allow_exact_sequence_range(files, version.metadata.region_id, min)?;
-    if !version.options.preserve_row_sequence {
-        return Ok(None);
-    }
-    let Some(max) = request.memtable_max_sequence else {
-        return Ok(None);
-    };
-    if !files_allow_exact_range {
-        return Ok(None);
-    }
-    Ok(Some(SequenceRange::GtLtEq { min, max }))
-}
 /// Output of [build_scan_fingerprint]: the cache fingerprint plus the derived
 /// implied time range used to decide whether the cache key can drop the time
 /// predicates for a given partition (see `build_range_cache_key`).
@@ -2922,26 +2886,21 @@ mod tests {
                 })
                 .build(),
         );
-        let files = exact_sequence_range_files(&request, &version);
-        let range = exact_sequence_range(&request, &version, &files).unwrap();
+        let (files, range) = exact_sequence_range(&request, &version).unwrap();
+        assert!(files.is_empty());
         assert_eq!(Some(SequenceRange::GtLtEq { min: 1, max: 2 }), range);
-        assert_eq!(
-            range,
-            exact_sequence_range(&request, &version, &files).unwrap()
-        );
 
         let skip_sst_request = ScanRequest {
             skip_sst_files: true,
             ..request
         };
-        assert_eq!(
-            None,
-            exact_sequence_range(&skip_sst_request, &version, &[]).unwrap()
-        );
+        let (files, range) = exact_sequence_range(&skip_sst_request, &version).unwrap();
+        assert!(files.is_empty());
+        assert_eq!(None, range);
     }
 
     #[test]
-    fn test_exact_sequence_foreign_selection_and_capability_matrix() {
+    fn test_exact_sequence_selection_checks_selected_files() {
         use std::num::NonZeroU64;
 
         use crate::test_util::new_noop_file_purger;
@@ -2959,195 +2918,96 @@ mod tests {
             0,
             None,
         ));
-        // Foreign selection is governed by the target-local barrier, not by
-        // the source marker. A barrier at/below C is pruned; all later known
-        // barriers remain selected so the row filter can make the final call.
-        for preserve_row_sequence in [false, true] {
-            for (barrier, expected_count, expected_error) in [
-                (NonZeroU64::new(5), 0, false),
-                (NonZeroU64::new(6), 1, false),
-                (NonZeroU64::new(11), 1, false),
-                (None, 1, true),
-            ] {
-                let file_id = store_api::storage::FileId::random();
-                let version =
-                    crate::region::version::VersionBuilder::new(metadata.clone(), mutable.clone())
-                        .options(crate::region::options::RegionOptions {
-                            preserve_row_sequence: true,
+        let target_region_id = metadata.region_id;
+
+        // Files at or below the cursor are excluded. Among the remaining files,
+        // marked locals are exact-capable while unmarked locals deny exactness.
+        for (sequence, marked, expected_files, expected_range) in [
+            (NonZeroU64::new(5), false, false, true),
+            (NonZeroU64::new(5), true, false, true),
+            (NonZeroU64::new(100), false, true, false),
+            (None, false, true, false),
+            (None, true, true, true),
+        ] {
+            let version =
+                crate::region::version::VersionBuilder::new(metadata.clone(), mutable.clone())
+                    .options(crate::region::options::RegionOptions {
+                        preserve_row_sequence: true,
+                        ..Default::default()
+                    })
+                    .add_files(
+                        new_noop_file_purger(),
+                        [FileMeta {
+                            region_id: target_region_id,
+                            sequence,
+                            preserve_row_sequence: marked,
                             ..Default::default()
-                        })
-                        .add_files(
-                            new_noop_file_purger(),
-                            [FileMeta {
-                                region_id: RegionId::new(1, 2),
-                                file_id,
-                                sequence: barrier,
-                                preserve_row_sequence,
-                                ..Default::default()
-                            }]
-                            .into_iter(),
-                        )
-                        .build();
-                let version = Arc::new(version);
-                let selected = exact_sequence_range_files(&request, &version);
-                assert_eq!(expected_count, selected.len());
-                assert_eq!(
-                    expected_count,
-                    selected
-                        .iter()
-                        .filter(|file| file.meta_ref().file_id == file_id)
-                        .count()
-                );
-                let capability = exact_sequence_range(&request, &version, &selected);
-                if expected_error {
-                    assert!(capability.is_err());
-                } else {
-                    assert_eq!(
-                        Some(SequenceRange::GtLtEq { min: 5, max: 10 }),
-                        capability.unwrap()
-                    );
-                }
+                        }]
+                        .into_iter(),
+                    )
+                    .build();
+            let (files, range) = exact_sequence_range(&request, &version).unwrap();
+            assert_eq!(expected_files, !files.is_empty());
+            assert_eq!(expected_range, range.is_some());
+        }
+
+        // Foreign files use the target-local barrier, regardless of their
+        // source marker. A missing barrier fails closed.
+        for (sequence, marked, expected_count, expected_error) in [
+            (NonZeroU64::new(5), false, 0, false),
+            (NonZeroU64::new(6), false, 1, false),
+            (NonZeroU64::new(11), true, 1, false),
+            (None, true, 1, true),
+        ] {
+            let file_id = store_api::storage::FileId::random();
+            let version =
+                crate::region::version::VersionBuilder::new(metadata.clone(), mutable.clone())
+                    .options(crate::region::options::RegionOptions {
+                        preserve_row_sequence: true,
+                        ..Default::default()
+                    })
+                    .add_files(
+                        new_noop_file_purger(),
+                        [FileMeta {
+                            region_id: RegionId::new(1, 2),
+                            file_id,
+                            sequence,
+                            preserve_row_sequence: marked,
+                            ..Default::default()
+                        }]
+                        .into_iter(),
+                    )
+                    .build();
+            let result = exact_sequence_range(&request, &version);
+            if expected_error {
+                assert!(result.is_err());
+            } else {
+                let (files, range) = result.unwrap();
+                assert_eq!(expected_count, files.len());
+                assert!(range.is_some());
             }
         }
-    }
 
-    #[test]
-    fn test_files_allow_exact_sequence_range() {
-        use std::num::NonZeroU64;
-
-        use crate::test_util::new_noop_file_purger;
-
-        let purger = new_noop_file_purger();
-        let region_id = RegionId::new(1, 1);
-        let file = |sequence: Option<NonZeroU64>, marked: bool| FileMeta {
-            region_id,
-            sequence,
-            preserve_row_sequence: marked,
-            ..Default::default()
+        // Foreign-domain validation still takes precedence over preserve mode
+        // and a missing upper bound once the file is selected.
+        let request = ScanRequest {
+            memtable_max_sequence: None,
+            ..request
         };
-
-        // All marked files allow exact row-level filtering.
-        let mut ssts = SstVersion::new();
-        ssts.add_files(
-            purger.clone(),
-            [file(NonZeroU64::new(5), true), file(None, true)].into_iter(),
-        );
-        assert!(
-            files_allow_exact_sequence_range(
-                &ssts
-                    .levels()
-                    .iter()
-                    .flat_map(|level| level.files.values())
-                    .cloned()
-                    .collect::<Vec<_>>(),
-                region_id,
-                0
-            )
-            .unwrap()
-        );
-
-        // An unmarked file is safe once its admission barrier is not newer
-        // than C: it is excluded before row-level filtering.
-        let mut ssts = SstVersion::new();
-        ssts.add_files(
-            purger.clone(),
-            [file(NonZeroU64::new(5), false)].into_iter(),
-        );
-        let files = ssts
-            .levels()
-            .iter()
-            .flat_map(|level| level.files.values())
-            .cloned()
-            .collect::<Vec<_>>();
-        assert!(files_allow_exact_sequence_range(&files, region_id, 5).unwrap());
-
-        // A newer admission barrier may still contain rows after C.
-        let mut ssts = SstVersion::new();
-        ssts.add_files(
-            purger.clone(),
-            [file(NonZeroU64::new(100), false)].into_iter(),
-        );
-        let files = ssts
-            .levels()
-            .iter()
-            .flat_map(|level| level.files.values())
-            .cloned()
-            .collect::<Vec<_>>();
-        assert!(!files_allow_exact_sequence_range(&files, region_id, 99).unwrap());
-
-        // A missing admission barrier fails closed.
-        let mut ssts = SstVersion::new();
-        ssts.add_files(purger.clone(), [file(None, false)].into_iter());
-        let files = ssts
-            .levels()
-            .iter()
-            .flat_map(|level| level.files.values())
-            .cloned()
-            .collect::<Vec<_>>();
-        assert!(!files_allow_exact_sequence_range(&files, region_id, 100).unwrap());
-
-        // A foreign file is trusted by its target-local barrier regardless of
-        // the source marker; without a barrier it fails closed.
-        for marked in [true, false] {
-            let mut ssts = SstVersion::new();
-            ssts.add_files(
-                purger.clone(),
+        let version = crate::region::version::VersionBuilder::new(metadata, mutable)
+            .options(crate::region::options::RegionOptions {
+                preserve_row_sequence: false,
+                ..Default::default()
+            })
+            .add_files(
+                new_noop_file_purger(),
                 [FileMeta {
                     region_id: RegionId::new(1, 2),
-                    sequence: NonZeroU64::new(5),
-                    preserve_row_sequence: marked,
                     ..Default::default()
                 }]
                 .into_iter(),
-            );
-            let files = ssts
-                .levels()
-                .iter()
-                .flat_map(|level| level.files.values())
-                .cloned()
-                .collect::<Vec<_>>();
-            assert!(files_allow_exact_sequence_range(&files, region_id, 0).unwrap());
-        }
-        let mut ssts = SstVersion::new();
-        ssts.add_files(
-            purger.clone(),
-            [FileMeta {
-                region_id: RegionId::new(1, 2),
-                preserve_row_sequence: true,
-                ..Default::default()
-            }]
-            .into_iter(),
-        );
-        let files = ssts
-            .levels()
-            .iter()
-            .flat_map(|level| level.files.values())
-            .cloned()
-            .collect::<Vec<_>>();
-        assert!(files_allow_exact_sequence_range(&files, region_id, 100).is_err());
-
-        // Files outside the scan's selected read set cannot affect exactness.
-        let mut ssts = SstVersion::new();
-        ssts.add_files(
-            purger.clone(),
-            [
-                file(NonZeroU64::new(5), true),
-                file(NonZeroU64::new(100), false),
-                FileMeta {
-                    region_id: RegionId::new(1, 2),
-                    preserve_row_sequence: true,
-                    ..Default::default()
-                },
-            ]
-            .into_iter(),
-        );
-        let selected_files = ssts
-            .levels()
-            .iter()
-            .flat_map(|level| level.files.values())
-            .filter(|file| file.meta_ref().sequence == NonZeroU64::new(5))
-            .cloned()
-            .collect::<Vec<_>>();
-        assert!(files_allow_exact_sequence_range(&selected_files, region_id, 5).unwrap());
+            )
+            .build();
+        assert!(exact_sequence_range(&request, &version).is_err());
     }
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -1700,7 +1700,6 @@ pub(crate) fn files_allow_exact_sequence_range(
     Ok(true)
 }
 
-/// Returns SST files matching the request's time predicate.
 fn files_in_time_range<'a>(
     ssts: &'a SstVersion,
     time_range: &'a TimestampRange,

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -448,17 +448,6 @@ impl ScanRegion {
         // exceed it (e.g. `(5, 10]` with `sst_min_sequence = 8` drops a file
         // with max = 8, losing sequences 6..8), so the conflicting combination
         // is rejected explicitly instead of being silently approximated.
-        if sst_min_sequence.is_some() && self.exact_sequence_range()?.is_some() {
-            return SequenceRangeUnsupportedSnafu {
-                region_id: self.region_id(),
-                min_seq: self.request.memtable_min_sequence.unwrap_or_default(),
-                max_seq: self.request.memtable_max_sequence.unwrap_or_default(),
-                reason:
-                    "sst_min_sequence pruning hint is incompatible with exact sequence-range reads"
-                        .to_string(),
-            }
-            .fail();
-        }
         let time_range = self.build_time_range_predicate();
         let predicate = PredicateGroup::new(metadata, &self.request.filters)?;
 
@@ -479,46 +468,27 @@ impl ScanRegion {
             mapper
         };
 
-        let ssts = &self.version.ssts;
-        // Exact `(C, H]` scans skip only marked files whose max sequence cannot
-        // reach the lower bound C. Unmarked files never participate in this
-        // disjoint skip because their file sequence is not trusted.
-        let sequence_range = self.exact_sequence_range()?;
-        let exact_min_sequence = match &sequence_range {
-            Some(SequenceRange::GtLtEq { min, .. }) => Some(*min),
-            _ => None,
+        // `exact_sequence_range_files` applies time pruning and, for exact
+        // requests, removes only marked files that cannot contain `(C, H]`
+        // rows. This is the same selected set used by the engine's capability
+        // fence before its remaining scan-specific pruning.
+        let files = if self.request.skip_sst_files {
+            Vec::new()
+        } else {
+            exact_sequence_range_files(&self.request, &self.version)
         };
-        let mut files = Vec::new();
-        if !self.request.skip_sst_files {
-            for level in ssts.levels() {
-                for file in level.files.values() {
-                    if file.meta_ref().preserve_row_sequence
-                        && let Some(min) = exact_min_sequence
-                        && let Some(file_sequence) = file.meta_ref().sequence
-                        && file_sequence.get() <= min
-                    {
-                        continue;
-                    }
-
-                    let exceed_min_sequence = match (sst_min_sequence, file.meta_ref().sequence) {
-                        (Some(min_sequence), Some(file_sequence)) => file_sequence > min_sequence,
-                        // If the file's sequence is None (or actually is zero), it could mean the file
-                        // is generated and added to the region "directly". In this case, its data should
-                        // be considered as fresh as the memtable. So its sequence is treated greater than
-                        // the min_sequence, whatever the value of min_sequence is. Hence the default
-                        // "true" in this arm.
-                        (Some(_), None) => true,
-                        (None, _) => true,
-                    };
-
-                    // Finds SST files in range.
-                    if exceed_min_sequence && file_in_range(file, &time_range) {
-                        files.push(file.clone());
-                    }
-                }
+        let sequence_range = self.exact_sequence_range(&files)?;
+        if sst_min_sequence.is_some() && sequence_range.is_some() {
+            return SequenceRangeUnsupportedSnafu {
+                region_id: self.region_id(),
+                min_seq: self.request.memtable_min_sequence.unwrap_or_default(),
+                max_seq: self.request.memtable_max_sequence.unwrap_or_default(),
+                reason:
+                    "sst_min_sequence pruning hint is incompatible with exact sequence-range reads"
+                        .to_string(),
             }
+            .fail();
         }
-
         let memtables = self.version.memtables.list_memtables();
         // Skip empty memtables and memtables out of time range.
         let mut mem_range_builders = Vec::new();
@@ -782,8 +752,8 @@ impl ScanRegion {
         self.version.metadata.region_id
     }
 
-    fn exact_sequence_range(&self) -> Result<Option<SequenceRange>> {
-        exact_sequence_range(&self.request, &self.version)
+    fn exact_sequence_range(&self, files: &[FileHandle]) -> Result<Option<SequenceRange>> {
+        exact_sequence_range(&self.request, &self.version, files)
     }
 
     /// Build time range predicate from filters.
@@ -1687,32 +1657,84 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
     }
 }
 
-/// Returns true if every SST in `ssts` preserves row sequences, as required
-/// for an exact sequence-range scan. Unmarked files, including files whose
-/// sequence was synthesized by edit or repartition paths, never participate in
-/// disjoint skipping because their file sequence is not trusted. Files belonging
-/// to another region are a broken sequence domain and return an error.
+/// Returns true if every selected SST preserves row sequences, as required
+/// for an exact sequence-range scan. Files excluded by the request time range
+/// are not passed here: `(C, H]` rows are a subset of the query's time-range
+/// rows, so a time-pruned file cannot contribute a row to `(C, H]`.
+///
+/// Unmarked files, including files whose sequence was synthesized by edit or
+/// repartition paths, never participate in disjoint skipping because their file
+/// sequence is not trusted. Files belonging to another region are a broken
+/// sequence domain and return an error.
 pub(crate) fn files_allow_exact_sequence_range(
-    ssts: &SstVersion,
+    files: &[FileHandle],
     region_id: RegionId,
 ) -> Result<bool> {
-    for level in ssts.levels() {
-        for file in level.files.values() {
-            let meta = file.meta_ref();
-            if meta.region_id != region_id {
-                return RegionSequenceDomainBrokenSnafu {
-                    region_id,
-                    file_region_id: meta.region_id,
-                    file_id: meta.file_id,
-                }
-                .fail();
+    for file in files {
+        let meta = file.meta_ref();
+        if meta.region_id != region_id {
+            return RegionSequenceDomainBrokenSnafu {
+                region_id,
+                file_region_id: meta.region_id,
+                file_id: meta.file_id,
             }
-            if !meta.preserve_row_sequence {
-                return Ok(false);
-            }
+            .fail();
+        }
+        if !meta.preserve_row_sequence {
+            return Ok(false);
         }
     }
     Ok(true)
+}
+
+/// Returns SST files matching the request's time predicate.
+fn files_in_time_range<'a>(
+    ssts: &'a SstVersion,
+    time_range: &'a TimestampRange,
+) -> impl Iterator<Item = &'a FileHandle> {
+    ssts.levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .filter(move |file| file_in_range(file, time_range))
+}
+
+/// Returns time-matching SST files for use by the engine's exact capability
+/// fence. The scan builder applies the same time pruning before its remaining
+/// file-selection filters.
+pub(crate) fn exact_sequence_range_files(
+    request: &ScanRequest,
+    version: &crate::region::version::Version,
+) -> Vec<FileHandle> {
+    let time_index = version.metadata.time_index_column();
+    let unit = time_index
+        .column_schema
+        .data_type
+        .as_timestamp()
+        .expect("Time index must have timestamp-compatible type")
+        .unit();
+    let time_range =
+        build_time_range_predicate(&time_index.column_schema.name, unit, &request.filters);
+    files_in_time_range(&version.ssts, &time_range)
+        .filter(|file| {
+            (!request.exact_sequence_range
+                || !file.meta_ref().preserve_row_sequence
+                || request.memtable_min_sequence.is_none_or(|min| {
+                    file.meta_ref()
+                        .sequence
+                        .is_none_or(|sequence| sequence.get() > min)
+                }))
+                && match (
+                    request.sst_min_sequence.and_then(NonZeroU64::new),
+                    file.meta_ref().sequence,
+                ) {
+                    (Some(min_sequence), Some(file_sequence)) => file_sequence > min_sequence,
+                    // A missing file sequence is treated as newer than the SST
+                    // pruning hint, matching scan input construction.
+                    (Some(_), None) | (None, _) => true,
+                }
+        })
+        .cloned()
+        .collect()
 }
 
 /// Single source of truth for the exact row-level sequence-range capability.
@@ -1722,10 +1744,10 @@ pub(crate) fn files_allow_exact_sequence_range(
 /// - the scan explicitly requests `exact_sequence_range` (Flow's
 ///   `sequence_range` mode; historical `memtable_only` scans never set it), and
 /// - the scan does not skip SST files (exactness requires reading them), and
-/// - the region preserves per-row sequences (`preserve_row_sequence`),
-///   and
-/// - every SST preserves row sequences. Unmarked SSTs, including those with
-///   edit/repartition-synthesized sequences, fail closed and disable exactness.
+/// - the region preserves per-row sequences (`preserve_row_sequence`), and
+/// - every selected SST preserves row sequences. Unmarked SSTs, including
+///   those with edit/repartition-synthesized sequences, fail closed and disable
+///   exactness.
 ///
 /// Returns `None` otherwise. Callers must keep main's fences/fallback semantics
 /// and never silently approximate. An SST belonging to another region is not a
@@ -1733,6 +1755,7 @@ pub(crate) fn files_allow_exact_sequence_range(
 pub(crate) fn exact_sequence_range(
     request: &ScanRequest,
     version: &crate::region::version::Version,
+    files: &[FileHandle],
 ) -> Result<Option<SequenceRange>> {
     if !request.exact_sequence_range || request.skip_sst_files {
         return Ok(None);
@@ -1743,7 +1766,7 @@ pub(crate) fn exact_sequence_range(
     // Check the domain before capability conditions that would otherwise return
     // `None`, so a corrupt manifest can never be treated as fallback-safe.
     let files_allow_exact_range =
-        files_allow_exact_sequence_range(&version.ssts, version.metadata.region_id)?;
+        files_allow_exact_sequence_range(files, version.metadata.region_id)?;
     if !version.options.preserve_row_sequence {
         return Ok(None);
     }
@@ -2887,7 +2910,18 @@ mod tests {
             purger.clone(),
             [file(NonZeroU64::new(5), true), file(None, true)].into_iter(),
         );
-        assert!(files_allow_exact_sequence_range(&ssts, region_id).unwrap());
+        assert!(
+            files_allow_exact_sequence_range(
+                &ssts
+                    .levels()
+                    .iter()
+                    .flat_map(|level| level.files.values())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                region_id
+            )
+            .unwrap()
+        );
 
         // An unmarked file fails closed even if its sequence is at or below C.
         let mut ssts = SstVersion::new();
@@ -2895,7 +2929,18 @@ mod tests {
             purger.clone(),
             [file(NonZeroU64::new(5), false)].into_iter(),
         );
-        assert!(!files_allow_exact_sequence_range(&ssts, region_id).unwrap());
+        assert!(
+            !files_allow_exact_sequence_range(
+                &ssts
+                    .levels()
+                    .iter()
+                    .flat_map(|level| level.files.values())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                region_id
+            )
+            .unwrap()
+        );
 
         // An unmarked file's sequence is never trusted, whatever its value.
         let mut ssts = SstVersion::new();
@@ -2903,12 +2948,23 @@ mod tests {
             purger.clone(),
             [file(NonZeroU64::new(100), false)].into_iter(),
         );
-        assert!(!files_allow_exact_sequence_range(&ssts, region_id).unwrap());
+        assert!(
+            !files_allow_exact_sequence_range(
+                &ssts
+                    .levels()
+                    .iter()
+                    .flat_map(|level| level.files.values())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                region_id
+            )
+            .unwrap()
+        );
 
         // A file from another region breaks the sequence domain even if marked.
         let mut ssts = SstVersion::new();
         ssts.add_files(
-            purger,
+            purger.clone(),
             [FileMeta {
                 region_id: RegionId::new(1, 2),
                 preserve_row_sequence: true,
@@ -2916,6 +2972,41 @@ mod tests {
             }]
             .into_iter(),
         );
-        assert!(files_allow_exact_sequence_range(&ssts, region_id).is_err());
+        assert!(
+            files_allow_exact_sequence_range(
+                &ssts
+                    .levels()
+                    .iter()
+                    .flat_map(|level| level.files.values())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                region_id
+            )
+            .is_err()
+        );
+
+        // Files outside the scan's selected read set cannot affect exactness.
+        let mut ssts = SstVersion::new();
+        ssts.add_files(
+            purger.clone(),
+            [
+                file(NonZeroU64::new(5), true),
+                file(NonZeroU64::new(100), false),
+                FileMeta {
+                    region_id: RegionId::new(1, 2),
+                    preserve_row_sequence: true,
+                    ..Default::default()
+                },
+            ]
+            .into_iter(),
+        );
+        let selected_files = ssts
+            .levels()
+            .iter()
+            .flat_map(|level| level.files.values())
+            .filter(|file| file.meta_ref().sequence == NonZeroU64::new(5))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(files_allow_exact_sequence_range(&selected_files, region_id).unwrap());
     }
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -57,7 +57,8 @@ use crate::access_layer::AccessLayerRef;
 use crate::cache::CacheStrategy;
 use crate::config::DEFAULT_MAX_CONCURRENT_SCAN_FILES;
 use crate::error::{
-    InvalidPartitionExprSnafu, InvalidRequestSnafu, Result, SequenceRangeUnsupportedSnafu,
+    InvalidPartitionExprSnafu, InvalidRequestSnafu, RegionSequenceDomainBrokenSnafu, Result,
+    SequenceRangeUnsupportedSnafu,
 };
 #[cfg(feature = "enterprise")]
 use crate::extension::{BoxedExtensionRange, BoxedExtensionRangeProvider};
@@ -447,7 +448,7 @@ impl ScanRegion {
         // exceed it (e.g. `(5, 10]` with `sst_min_sequence = 8` drops a file
         // with max = 8, losing sequences 6..8), so the conflicting combination
         // is rejected explicitly instead of being silently approximated.
-        if sst_min_sequence.is_some() && self.exact_sequence_range().is_some() {
+        if sst_min_sequence.is_some() && self.exact_sequence_range()?.is_some() {
             return SequenceRangeUnsupportedSnafu {
                 region_id: self.region_id(),
                 min_seq: self.request.memtable_min_sequence.unwrap_or_default(),
@@ -484,7 +485,7 @@ impl ScanRegion {
         // marked files (no in-range rows) and to unmarked files already proven
         // disjoint by `files_allow_exact_sequence_range` (their rows must not
         // pass through unfiltered).
-        let sequence_range = self.exact_sequence_range();
+        let sequence_range = self.exact_sequence_range()?;
         let exact_min_sequence = match &sequence_range {
             Some(SequenceRange::GtLtEq { min, .. }) => Some(*min),
             _ => None,
@@ -782,7 +783,7 @@ impl ScanRegion {
         self.version.metadata.region_id
     }
 
-    fn exact_sequence_range(&self) -> Option<SequenceRange> {
+    fn exact_sequence_range(&self) -> Result<Option<SequenceRange>> {
         exact_sequence_range(&self.request, &self.version)
     }
 
@@ -1691,14 +1692,30 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
 /// `(min_seq, max]` scan: it must carry a known max sequence not exceeding the
 /// lower bound `min_seq`, so none of its rows can fall inside the range.
 /// Marked files always qualify (the reader filters their rows row-level);
-/// unmarked files with an unknown max sequence fail closed.
-pub(crate) fn files_allow_exact_sequence_range(ssts: &SstVersion, min_seq: SequenceNumber) -> bool {
-    ssts.levels().iter().all(|level| {
-        level.files.values().all(|file| {
+/// unmarked files with an unknown max sequence fail closed. Files belonging to
+/// another region are a broken sequence domain and return an error.
+pub(crate) fn files_allow_exact_sequence_range(
+    ssts: &SstVersion,
+    region_id: RegionId,
+    min_seq: SequenceNumber,
+) -> Result<bool> {
+    for level in ssts.levels() {
+        for file in level.files.values() {
             let meta = file.meta_ref();
-            meta.preserve_row_sequence || meta.sequence.is_some_and(|seq| seq.get() <= min_seq)
-        })
-    })
+            if meta.region_id != region_id {
+                return RegionSequenceDomainBrokenSnafu {
+                    region_id,
+                    file_region_id: meta.region_id,
+                    file_id: meta.file_id,
+                }
+                .fail();
+            }
+            if !meta.preserve_row_sequence && meta.sequence.is_none_or(|seq| seq.get() > min_seq) {
+                return Ok(false);
+            }
+        }
+    }
+    Ok(true)
 }
 
 /// Single source of truth for the exact row-level sequence-range capability.
@@ -1714,23 +1731,32 @@ pub(crate) fn files_allow_exact_sequence_range(ssts: &SstVersion, min_seq: Seque
 ///   bound `min`, so it cannot contribute rows to `(min, max]`.
 ///
 /// Returns `None` otherwise. Callers must keep main's fences/fallback semantics
-/// and never silently approximate.
+/// and never silently approximate. An SST belonging to another region is not a
+/// fail-closed `None` condition; it returns a sequence-domain error.
 pub(crate) fn exact_sequence_range(
     request: &ScanRequest,
     version: &crate::region::version::Version,
-) -> Option<SequenceRange> {
-    if !request.exact_sequence_range
-        || request.skip_sst_files
-        || !version.options.preserve_row_sequence
-    {
-        return None;
+) -> Result<Option<SequenceRange>> {
+    if !request.exact_sequence_range || request.skip_sst_files {
+        return Ok(None);
     }
-    let min = request.memtable_min_sequence?;
-    let max = request.memtable_max_sequence?;
-    if !files_allow_exact_sequence_range(&version.ssts, min) {
-        return None;
+    let Some(min) = request.memtable_min_sequence else {
+        return Ok(None);
+    };
+    // Check the domain before capability conditions that would otherwise return
+    // `None`, so a corrupt manifest can never be treated as fallback-safe.
+    let files_allow_exact_range =
+        files_allow_exact_sequence_range(&version.ssts, version.metadata.region_id, min)?;
+    if !version.options.preserve_row_sequence {
+        return Ok(None);
     }
-    Some(SequenceRange::GtLtEq { min, max })
+    let Some(max) = request.memtable_max_sequence else {
+        return Ok(None);
+    };
+    if !files_allow_exact_range {
+        return Ok(None);
+    }
+    Ok(Some(SequenceRange::GtLtEq { min, max }))
 }
 /// Output of [build_scan_fingerprint]: the cache fingerprint plus the derived
 /// implied time range used to decide whether the cache key can drop the time
@@ -2850,7 +2876,9 @@ mod tests {
         use crate::test_util::new_noop_file_purger;
 
         let purger = new_noop_file_purger();
+        let region_id = RegionId::new(1, 1);
         let file = |sequence: Option<NonZeroU64>, marked: bool| FileMeta {
+            region_id,
             sequence,
             preserve_row_sequence: marked,
             ..Default::default()
@@ -2868,13 +2896,26 @@ mod tests {
             .into_iter(),
         );
         // C=5: the unmarked file with max 9 overlaps (5, H] -> not allowed.
-        assert!(!files_allow_exact_sequence_range(&ssts, 5));
+        assert!(!files_allow_exact_sequence_range(&ssts, region_id, 5).unwrap());
         // C=9: every unmarked file's max <= C -> allowed.
-        assert!(files_allow_exact_sequence_range(&ssts, 9));
+        assert!(files_allow_exact_sequence_range(&ssts, region_id, 9).unwrap());
 
         // Unknown max sequence fails closed even when C is large.
         let mut ssts = SstVersion::new();
-        ssts.add_files(purger, [file(None, false)].into_iter());
-        assert!(!files_allow_exact_sequence_range(&ssts, 100));
+        ssts.add_files(purger.clone(), [file(None, false)].into_iter());
+        assert!(!files_allow_exact_sequence_range(&ssts, region_id, 100).unwrap());
+
+        // A file from another region breaks the sequence domain even if marked.
+        let mut ssts = SstVersion::new();
+        ssts.add_files(
+            purger,
+            [FileMeta {
+                region_id: RegionId::new(1, 2),
+                preserve_row_sequence: true,
+                ..Default::default()
+            }]
+            .into_iter(),
+        );
+        assert!(files_allow_exact_sequence_range(&ssts, region_id, 100).is_err());
     }
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -259,8 +259,8 @@ pub(crate) struct ScanRegion {
     /// Whether to filter out the deleted rows.
     /// Usually true for normal read, and false for scan for compaction.
     filter_deleted: bool,
-    /// Files selected by the engine's capability check, when available.
-    selected_files: Option<Vec<FileHandle>>,
+    /// Files and exact sequence capability selected together by the engine.
+    exact_selection: Option<(Vec<FileHandle>, Option<SequenceRange>)>,
     /// Counters that should receive query-load metrics.
     query_stat_counters: Option<RegionQueryStatCounters>,
     #[cfg(feature = "enterprise")]
@@ -288,7 +288,7 @@ impl ScanRegion {
             ignore_bloom_filter: false,
             start_time: None,
             filter_deleted: true,
-            selected_files: None,
+            exact_selection: None,
             query_stat_counters: None,
             #[cfg(feature = "enterprise")]
             extension_range_provider: None,
@@ -357,8 +357,11 @@ impl ScanRegion {
         self.filter_deleted = filter_deleted;
     }
 
-    pub(crate) fn with_selected_files(mut self, files: Vec<FileHandle>) -> Self {
-        self.selected_files = Some(files);
+    pub(crate) fn with_exact_selection(
+        mut self,
+        exact_selection: (Vec<FileHandle>, Option<SequenceRange>),
+    ) -> Self {
+        self.exact_selection = Some(exact_selection);
         self
     }
 
@@ -470,14 +473,18 @@ impl ScanRegion {
             mapper
         };
 
-        let files = if self.request.skip_sst_files {
-            Vec::new()
-        } else if let Some(files) = self.selected_files.take() {
-            files
-        } else {
-            exact_sequence_range_files(&self.request, &self.version)
-        };
-        let sequence_range = self.exact_sequence_range(&files)?;
+        let (files, sequence_range) =
+            if let Some((files, sequence_range)) = self.exact_selection.take() {
+                (files, sequence_range)
+            } else if self.request.skip_sst_files {
+                let files = Vec::new();
+                let sequence_range = exact_sequence_range(&self.request, &self.version, &files)?;
+                (files, sequence_range)
+            } else {
+                let files = exact_sequence_range_files(&self.request, &self.version);
+                let sequence_range = exact_sequence_range(&self.request, &self.version, &files)?;
+                (files, sequence_range)
+            };
         if sst_min_sequence.is_some() && sequence_range.is_some() {
             return SequenceRangeUnsupportedSnafu {
                 region_id: self.region_id(),
@@ -750,10 +757,6 @@ impl ScanRegion {
 
     fn region_id(&self) -> RegionId {
         self.version.metadata.region_id
-    }
-
-    fn exact_sequence_range(&self, files: &[FileHandle]) -> Result<Option<SequenceRange>> {
-        exact_sequence_range(&self.request, &self.version, files)
     }
 
     /// Build time range predicate from filters.
@@ -1662,12 +1665,16 @@ fn pre_filter_mode(append_mode: bool, merge_mode: MergeMode) -> PreFilterMode {
 /// passed here: `(C, H]` rows are a subset of the query's time-range rows, so a
 /// time-pruned file cannot contribute a row to `(C, H]`.
 ///
-/// Unmarked files use `FileMeta.sequence` as an admission barrier rather than
-/// a row maximum. Compaction and edit assign it as `committed_sequence + 1`;
+/// Unmarked local files use `FileMeta.sequence` as an admission barrier rather
+/// than a row maximum. Compaction and edit assign it as `committed_sequence + 1`;
 /// `C >= barrier` proves Flow has already consumed the entire file, so such a
-/// file is excluded before this check. An unmarked selected file has a missing
-/// barrier or `barrier > C` and fails closed. Files belonging to another region
-/// are a broken sequence domain and return an error.
+/// file is excluded before this check.
+///
+/// A foreign file is different: the parquet reader virtualizes every row to its
+/// target-local `FileMeta.sequence`. Consequently, a present sequence is the
+/// only trust requirement for a foreign file; its source marker is irrelevant.
+/// A foreign file without that barrier is retained as a failed-closed error so
+/// it cannot be mistaken for a local sequence domain.
 pub(crate) fn files_allow_exact_sequence_range(
     files: &[FileHandle],
     region_id: RegionId,
@@ -1675,7 +1682,7 @@ pub(crate) fn files_allow_exact_sequence_range(
 ) -> Result<bool> {
     for file in files {
         let meta = file.meta_ref();
-        if meta.region_id != region_id {
+        if meta.region_id != region_id && meta.sequence.is_none() {
             return RegionSequenceDomainBrokenSnafu {
                 region_id,
                 file_region_id: meta.region_id,
@@ -1683,7 +1690,8 @@ pub(crate) fn files_allow_exact_sequence_range(
             }
             .fail();
         }
-        if !meta.preserve_row_sequence
+        if meta.region_id == region_id
+            && !file.is_effective_target_sequence_trusted(region_id)
             && meta.sequence.is_none_or(|barrier| barrier.get() > min_seq)
         {
             return Ok(false);
@@ -1722,10 +1730,6 @@ pub(crate) fn exact_sequence_range_files(
     files_in_time_range(&version.ssts, &time_range)
         .filter(|file| {
             (!request.exact_sequence_range
-                // Keep a foreign-domain file in the selected read set so the
-                // exact capability fence reports RegionSequenceDomainBroken
-                // instead of silently treating its barrier as local.
-                || file.meta_ref().region_id != version.metadata.region_id
                 || request.memtable_min_sequence.is_none_or(|min| {
                     file.meta_ref()
                         .sequence
@@ -1752,14 +1756,13 @@ pub(crate) fn exact_sequence_range_files(
 /// - the scan explicitly requests `exact_sequence_range` (Flow's
 ///   `sequence_range` mode; historical `memtable_only` scans never set it), and
 /// - the scan does not skip SST files (exactness requires reading them), and
-/// - the region preserves per-row sequences (`preserve_row_sequence`), and
-/// - every selected unmarked SST has an admission barrier not exceeding the
-///   lower bound, so it is excluded before row-level filtering. Selected
-///   unmarked SSTs with a missing or newer barrier fail closed.
+/// - every selected local unmarked SST has an admission barrier not exceeding
+///   the lower bound, so it is excluded before row-level filtering, and
+/// - every selected foreign SST has a target-local barrier.
 ///
 /// Returns `None` otherwise. Callers must keep main's fences/fallback semantics
-/// and never silently approximate. An SST belonging to another region is not a
-/// fail-closed `None` condition; it returns a sequence-domain error.
+/// and never silently approximate. A foreign SST without a barrier returns the
+/// existing sequence-domain error.
 pub(crate) fn exact_sequence_range(
     request: &ScanRequest,
     version: &crate::region::version::Version,
@@ -2898,6 +2901,118 @@ mod tests {
     }
 
     #[test]
+    fn test_exact_sequence_selection_preserves_range_and_fallback() {
+        let request = ScanRequest {
+            exact_sequence_range: true,
+            memtable_min_sequence: Some(1),
+            memtable_max_sequence: Some(2),
+            ..Default::default()
+        };
+        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
+        let mutable = Arc::new(crate::memtable::time_partition::TimePartitions::new(
+            metadata.clone(),
+            Arc::new(crate::test_util::memtable_util::EmptyMemtableBuilder::default()),
+            0,
+            None,
+        ));
+        let version = Arc::new(
+            crate::region::version::VersionBuilder::new(metadata, mutable)
+                .options(crate::region::options::RegionOptions {
+                    preserve_row_sequence: true,
+                    ..Default::default()
+                })
+                .build(),
+        );
+        let files = exact_sequence_range_files(&request, &version);
+        let range = exact_sequence_range(&request, &version, &files).unwrap();
+        assert_eq!(Some(SequenceRange::GtLtEq { min: 1, max: 2 }), range);
+        assert_eq!(
+            range,
+            exact_sequence_range(&request, &version, &files).unwrap()
+        );
+
+        let skip_sst_request = ScanRequest {
+            skip_sst_files: true,
+            ..request
+        };
+        assert_eq!(
+            None,
+            exact_sequence_range(&skip_sst_request, &version, &[]).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_exact_sequence_foreign_selection_and_capability_matrix() {
+        use std::num::NonZeroU64;
+
+        use crate::test_util::new_noop_file_purger;
+
+        let request = ScanRequest {
+            exact_sequence_range: true,
+            memtable_min_sequence: Some(5),
+            memtable_max_sequence: Some(10),
+            ..Default::default()
+        };
+        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
+        let mutable = Arc::new(crate::memtable::time_partition::TimePartitions::new(
+            metadata.clone(),
+            Arc::new(crate::test_util::memtable_util::EmptyMemtableBuilder::default()),
+            0,
+            None,
+        ));
+        // Foreign selection is governed by the target-local barrier, not by
+        // the source marker. A barrier at/below C is pruned; all later known
+        // barriers remain selected so the row filter can make the final call.
+        for preserve_row_sequence in [false, true] {
+            for (barrier, expected_count, expected_error) in [
+                (NonZeroU64::new(5), 0, false),
+                (NonZeroU64::new(6), 1, false),
+                (NonZeroU64::new(11), 1, false),
+                (None, 1, true),
+            ] {
+                let file_id = store_api::storage::FileId::random();
+                let version =
+                    crate::region::version::VersionBuilder::new(metadata.clone(), mutable.clone())
+                        .options(crate::region::options::RegionOptions {
+                            preserve_row_sequence: true,
+                            ..Default::default()
+                        })
+                        .add_files(
+                            new_noop_file_purger(),
+                            [FileMeta {
+                                region_id: RegionId::new(1, 2),
+                                file_id,
+                                sequence: barrier,
+                                preserve_row_sequence,
+                                ..Default::default()
+                            }]
+                            .into_iter(),
+                        )
+                        .build();
+                let version = Arc::new(version);
+                let selected = exact_sequence_range_files(&request, &version);
+                assert_eq!(expected_count, selected.len());
+                assert_eq!(
+                    expected_count,
+                    selected
+                        .iter()
+                        .filter(|file| file.meta_ref().file_id == file_id)
+                        .count()
+                );
+                let capability = exact_sequence_range(&request, &version, &selected);
+                if expected_error {
+                    assert!(capability.is_err());
+                } else {
+                    assert_eq!(
+                        Some(SequenceRange::GtLtEq { min: 5, max: 10 }),
+                        capability.unwrap()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_files_allow_exact_sequence_range() {
         use std::num::NonZeroU64;
 
@@ -2972,7 +3087,28 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(!files_allow_exact_sequence_range(&files, region_id, 100).unwrap());
 
-        // A file from another region breaks the sequence domain even if marked.
+        // A foreign file is trusted by its target-local barrier regardless of
+        // the source marker; without a barrier it fails closed.
+        for marked in [true, false] {
+            let mut ssts = SstVersion::new();
+            ssts.add_files(
+                purger.clone(),
+                [FileMeta {
+                    region_id: RegionId::new(1, 2),
+                    sequence: NonZeroU64::new(5),
+                    preserve_row_sequence: marked,
+                    ..Default::default()
+                }]
+                .into_iter(),
+            );
+            let files = ssts
+                .levels()
+                .iter()
+                .flat_map(|level| level.files.values())
+                .cloned()
+                .collect::<Vec<_>>();
+            assert!(files_allow_exact_sequence_range(&files, region_id, 0).unwrap());
+        }
         let mut ssts = SstVersion::new();
         ssts.add_files(
             purger.clone(),
@@ -2983,19 +3119,13 @@ mod tests {
             }]
             .into_iter(),
         );
-        assert!(
-            files_allow_exact_sequence_range(
-                &ssts
-                    .levels()
-                    .iter()
-                    .flat_map(|level| level.files.values())
-                    .cloned()
-                    .collect::<Vec<_>>(),
-                region_id,
-                100
-            )
-            .is_err()
-        );
+        let files = ssts
+            .levels()
+            .iter()
+            .flat_map(|level| level.files.values())
+            .cloned()
+            .collect::<Vec<_>>();
+        assert!(files_allow_exact_sequence_range(&files, region_id, 100).is_err());
 
         // Files outside the scan's selected read set cannot affect exactness.
         let mut ssts = SstVersion::new();

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -515,9 +515,6 @@ impl ScanRegion {
                     if exceed_min_sequence && file_in_range(file, &time_range) {
                         files.push(file.clone());
                     }
-                    // There is no need to check and prune for file's sequence here as the sequence number is usually very new,
-                    // unless the timing is too good, or the sequence number wouldn't be in file.
-                    // and the batch will be filtered out by tree reader anyway.
                 }
             }
         }
@@ -1009,8 +1006,6 @@ pub struct ScanInput {
     explain_flat_format: bool,
     /// Snapshot upper bound bound at scan open and propagated back to the caller.
     pub(crate) snapshot_sequence: Option<SequenceNumber>,
-    /// Exact sequence range to filter rows row-level on SST reads.
-    ///
     /// Set only when the region preserves per-row sequences
     /// (`preserve_row_sequence` on an append-only table) and the scan
     /// carries an explicit exact range. When set, SST readers apply the same

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -32,7 +32,7 @@ use smallvec::SmallVec;
 use snafu::ResultExt;
 use store_api::storage::{RegionId, SequenceRange};
 
-use crate::error::{ComputeArrowSnafu, RegionSequenceDomainBrokenSnafu, Result};
+use crate::error::{ComputeArrowSnafu, Result};
 use crate::memtable::MemScanMetrics;
 use crate::metrics::{
     IN_PROGRESS_SCAN, PRECISE_FILTER_ROWS_TOTAL, READ_BATCHES_RETURN, READ_ROW_GROUPS_TOTAL,
@@ -1509,30 +1509,24 @@ pub(crate) async fn scan_flat_file_ranges(
 /// (`__primary_key`, `__sequence`, `__op_type`), so it must be applied before any
 /// projection/compat conversion that drops internal columns.
 ///
-/// `file_preserves_sequence` is the per-file `preserve_row_sequence` marker:
-/// only marked files may be row-level sequence filtered. Without it, rows pass
-/// through untouched to keep main's file-level semantics. An active range also
-/// rejects files from another region instead of passing them through.
+/// `file_preserves_sequence` is the local per-file marker. Foreign reader
+/// batches have already been virtualized to the target-local file barrier, so
+/// they are always filtered using the effective batch sequence. Local
+/// untrusted files pass through because exact capability excludes them before
+/// row filtering.
 fn filter_flat_batch_by_sequence(
     record_batch: RecordBatch,
     sequence_range: Option<SequenceRange>,
     file_preserves_sequence: bool,
     region_id: RegionId,
     file_region_id: RegionId,
-    file_id: store_api::storage::FileId,
+    _file_id: store_api::storage::FileId,
 ) -> Result<Option<RecordBatch>> {
     let Some(sequence) = sequence_range else {
         return Ok(Some(record_batch));
     };
-    if file_region_id != region_id {
-        return RegionSequenceDomainBrokenSnafu {
-            region_id,
-            file_region_id,
-            file_id,
-        }
-        .fail();
-    };
-    if !file_preserves_sequence {
+    let foreign = file_region_id != region_id;
+    if !foreign && !file_preserves_sequence {
         return Ok(Some(record_batch));
     }
 
@@ -2234,18 +2228,17 @@ mod sequence_filter_tests {
         .unwrap();
         assert_eq!(out.unwrap().num_rows(), 0);
 
-        let err = filter_flat_batch_by_sequence(
-            b,
-            Some(SequenceRange::GtLtEq { min: 0, max: 10 }),
-            true,
+        // Foreign batches are already virtualized by the reader. Their source
+        // marker is irrelevant, and filtering uses the effective batch values.
+        let out = filter_flat_batch_by_sequence(
+            batch(&[1, 5, 9]),
+            Some(SequenceRange::GtLtEq { min: 2, max: 8 }),
+            false,
             region_id,
             RegionId::new(1, 2),
             file_id,
         )
-        .unwrap_err();
-        assert!(matches!(
-            err,
-            crate::error::Error::RegionSequenceDomainBroken { .. }
-        ));
+        .unwrap();
+        assert_eq!(remaining_tags(&out.unwrap()), vec!["1"]);
     }
 }

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -29,9 +29,10 @@ use datatypes::timestamp::timestamp_array_to_primitive;
 use futures::Stream;
 use prometheus::IntGauge;
 use smallvec::SmallVec;
-use store_api::storage::RegionId;
+use snafu::ResultExt;
+use store_api::storage::{RegionId, SequenceRange};
 
-use crate::error::Result;
+use crate::error::{ComputeArrowSnafu, Result};
 use crate::memtable::MemScanMetrics;
 use crate::metrics::{
     IN_PROGRESS_SCAN, PRECISE_FILTER_ROWS_TOTAL, READ_BATCHES_RETURN, READ_ROW_GROUPS_TOTAL,
@@ -48,7 +49,7 @@ use crate::sst::index::bloom_filter::applier::BloomFilterIndexApplyMetrics;
 use crate::sst::index::fulltext_index::applier::FulltextIndexApplyMetrics;
 use crate::sst::index::inverted_index::applier::InvertedIndexApplyMetrics;
 use crate::sst::parquet::file_range::{FileRange, PreFilterMode};
-use crate::sst::parquet::flat_format::time_index_column_index;
+use crate::sst::parquet::flat_format::{sequence_column_index, time_index_column_index};
 use crate::sst::parquet::reader::{MetadataCacheMetrics, ReaderFilterMetrics, ReaderMetrics};
 use crate::sst::parquet::row_group::ParquetFetchMetrics;
 use crate::sst::parquet::{DEFAULT_READ_BATCH_SIZE, DEFAULT_ROW_GROUP_SIZE};
@@ -1501,6 +1502,49 @@ pub(crate) async fn scan_flat_file_ranges(
     ))
 }
 
+/// Filters a flat-format record batch by the exact sequence range.
+///
+/// Returns `None` when the entire batch is filtered out. The sequence column is
+/// the second-to-last internal column of the flat format
+/// (`__primary_key`, `__sequence`, `__op_type`), so it must be applied before any
+/// projection/compat conversion that drops internal columns.
+///
+/// `file_preserves_sequence` gates the filter per file: only files written with
+/// preserved per-row sequences (the `preserve_row_sequence` marker) may be
+/// row-level sequence filtered. Without the marker, rows are passed through
+/// untouched to keep main's file-level semantics.
+fn filter_flat_batch_by_sequence(
+    record_batch: RecordBatch,
+    sequence_range: Option<SequenceRange>,
+    file_preserves_sequence: bool,
+) -> Result<Option<RecordBatch>> {
+    let Some(sequence) = sequence_range else {
+        return Ok(Some(record_batch));
+    };
+    if !file_preserves_sequence {
+        return Ok(Some(record_batch));
+    }
+
+    let num_rows = record_batch.num_rows();
+    if num_rows == 0 {
+        return Ok(Some(record_batch));
+    }
+    let sequence_column = record_batch.column(sequence_column_index(record_batch.num_columns()));
+    let predicate = sequence
+        .filter(sequence_column)
+        .context(ComputeArrowSnafu)?;
+    let select_count = predicate.true_count();
+    if select_count == 0 {
+        return Ok(None);
+    }
+    if select_count == num_rows {
+        return Ok(Some(record_batch));
+    }
+    let filtered_batch = datatypes::arrow::compute::filter_record_batch(&record_batch, &predicate)
+        .context(ComputeArrowSnafu)?;
+    Ok(Some(filtered_batch))
+}
+
 /// Build the stream of scanning the input [`FileRange`]s using flat reader that returns RecordBatch.
 #[tracing::instrument(
     skip_all,
@@ -1527,7 +1571,19 @@ pub fn build_flat_file_range_scan_stream(
             let build_reader_start = Instant::now();
             let Some(mut reader) = range
                 .flat_reader(
-                    stream_ctx.input.series_row_selector,
+                    // In exact `sequence_range` mode the row-group-level LastRow
+                    // shortcut would reduce each row group to its last-timestamp
+                    // row *before* the row-level sequence filter runs, silently
+                    // dropping in-range rows (a series with seq 1 at t1 and seq 2
+                    // at t2 under `(0, 1]` keeps only seq 2 and then filters it
+                    // out). Bypass the shortcut so the final per-row selector
+                    // (`FlatLastRowReader`, applied after source merging and the
+                    // sequence filter) selects on the filtered rows instead.
+                    if stream_ctx.input.sequence_range.is_some() {
+                        None
+                    } else {
+                        stream_ctx.input.series_row_selector
+                    },
                     fetch_metrics.as_deref(),
                 )
                 .await?
@@ -1546,6 +1602,14 @@ pub fn build_flat_file_range_scan_stream(
                     batch
                 } else {
                     record_batch
+                };
+
+                let Some(record_batch) = filter_flat_batch_by_sequence(
+                    record_batch,
+                    stream_ctx.input.sequence_range,
+                    range.file_handle().meta_ref().preserve_row_sequence,
+                )? else {
+                    continue;
                 };
 
                 if let Some(flat_compat) = may_compat {
@@ -2031,5 +2095,110 @@ mod tests {
         assert!(batches.is_empty());
 
         assert_eq!(split_ts(&[42]), vec![vec![42]]);
+    }
+}
+
+#[cfg(test)]
+mod sequence_filter_tests {
+    use std::sync::Arc;
+
+    use datatypes::arrow::array::{Int64Array, StringArray, UInt8Array, UInt64Array};
+    use datatypes::arrow::datatypes::{DataType, Field, Schema};
+    use datatypes::arrow::record_batch::RecordBatch;
+    use store_api::storage::SequenceRange;
+
+    use super::filter_flat_batch_by_sequence;
+
+    /// Builds a flat-format record batch: `(tag, field, ts, __primary_key, __sequence, __op_type)`.
+    fn batch(sequences: &[u64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("tag_0", DataType::Utf8, false),
+            Field::new("field_0", DataType::Int64, false),
+            Field::new(
+                "ts",
+                DataType::Timestamp(datatypes::arrow::datatypes::TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("__primary_key", DataType::UInt8, false),
+            Field::new("__sequence", DataType::UInt64, false),
+            Field::new("__op_type", DataType::UInt8, false),
+        ]));
+        let tags = StringArray::from_iter_values((0..sequences.len()).map(|i| i.to_string()));
+        let fields = Int64Array::from_iter_values(0..sequences.len() as i64);
+        let ts = datatypes::arrow::array::TimestampMillisecondArray::from_iter_values(
+            (0..sequences.len()).map(|i| i as i64 * 1000),
+        );
+        let pk = UInt8Array::from(vec![0u8; sequences.len()]);
+        let seq = UInt64Array::from_iter_values(sequences.iter().copied());
+        let op = UInt8Array::from(vec![0u8; sequences.len()]);
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(tags),
+                Arc::new(fields),
+                Arc::new(ts),
+                Arc::new(pk),
+                Arc::new(seq),
+                Arc::new(op),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn remaining_tags(batch: &RecordBatch) -> Vec<String> {
+        batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .iter()
+            .map(|v| v.unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_filter_flat_batch_by_sequence_no_range_or_legacy_file() {
+        let b = batch(&[1, 2, 3, 4]);
+
+        let out = filter_flat_batch_by_sequence(b.clone(), None, true).unwrap();
+        assert_eq!(remaining_tags(&out.unwrap()), vec!["0", "1", "2", "3"]);
+
+        let out = filter_flat_batch_by_sequence(
+            b.clone(),
+            Some(SequenceRange::GtLtEq { min: 2, max: 3 }),
+            false,
+        )
+        .unwrap();
+        assert_eq!(remaining_tags(&out.unwrap()), vec!["0", "1", "2", "3"]);
+    }
+
+    #[test]
+    fn test_filter_flat_batch_by_sequence_exact_range() {
+        let b = batch(&[1, 2, 3, 4]);
+
+        let out = filter_flat_batch_by_sequence(
+            b.clone(),
+            Some(SequenceRange::GtLtEq { min: 2, max: 3 }),
+            true,
+        )
+        .unwrap();
+        assert_eq!(remaining_tags(&out.unwrap()), vec!["2"]);
+
+        let out = filter_flat_batch_by_sequence(
+            b.clone(),
+            Some(SequenceRange::GtLtEq { min: 10, max: 20 }),
+            true,
+        )
+        .unwrap();
+        assert!(out.is_none());
+
+        let empty = batch(&[]);
+        let out = filter_flat_batch_by_sequence(
+            empty,
+            Some(SequenceRange::GtLtEq { min: 0, max: 10 }),
+            true,
+        )
+        .unwrap();
+        assert_eq!(out.unwrap().num_rows(), 0);
     }
 }

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1509,10 +1509,9 @@ pub(crate) async fn scan_flat_file_ranges(
 /// (`__primary_key`, `__sequence`, `__op_type`), so it must be applied before any
 /// projection/compat conversion that drops internal columns.
 ///
-/// `file_preserves_sequence` gates the filter per file: only files written with
-/// preserved per-row sequences (the `preserve_row_sequence` marker) may be
-/// row-level sequence filtered. Without the marker, rows are passed through
-/// untouched to keep main's file-level semantics.
+/// `file_preserves_sequence` is the per-file `preserve_row_sequence` marker:
+/// only marked files may be row-level sequence filtered. Without it, rows pass
+/// through untouched to keep main's file-level semantics.
 fn filter_flat_batch_by_sequence(
     record_batch: RecordBatch,
     sequence_range: Option<SequenceRange>,

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -32,7 +32,7 @@ use smallvec::SmallVec;
 use snafu::ResultExt;
 use store_api::storage::{RegionId, SequenceRange};
 
-use crate::error::{ComputeArrowSnafu, Result};
+use crate::error::{ComputeArrowSnafu, RegionSequenceDomainBrokenSnafu, Result};
 use crate::memtable::MemScanMetrics;
 use crate::metrics::{
     IN_PROGRESS_SCAN, PRECISE_FILTER_ROWS_TOTAL, READ_BATCHES_RETURN, READ_ROW_GROUPS_TOTAL,
@@ -1511,14 +1511,26 @@ pub(crate) async fn scan_flat_file_ranges(
 ///
 /// `file_preserves_sequence` is the per-file `preserve_row_sequence` marker:
 /// only marked files may be row-level sequence filtered. Without it, rows pass
-/// through untouched to keep main's file-level semantics.
+/// through untouched to keep main's file-level semantics. An active range also
+/// rejects files from another region instead of passing them through.
 fn filter_flat_batch_by_sequence(
     record_batch: RecordBatch,
     sequence_range: Option<SequenceRange>,
     file_preserves_sequence: bool,
+    region_id: RegionId,
+    file_region_id: RegionId,
+    file_id: store_api::storage::FileId,
 ) -> Result<Option<RecordBatch>> {
     let Some(sequence) = sequence_range else {
         return Ok(Some(record_batch));
+    };
+    if file_region_id != region_id {
+        return RegionSequenceDomainBrokenSnafu {
+            region_id,
+            file_region_id,
+            file_id,
+        }
+        .fail();
     };
     if !file_preserves_sequence {
         return Ok(Some(record_batch));
@@ -1603,10 +1615,14 @@ pub fn build_flat_file_range_scan_stream(
                     record_batch
                 };
 
+                let file_meta = range.file_handle().meta_ref();
                 let Some(record_batch) = filter_flat_batch_by_sequence(
                     record_batch,
                     stream_ctx.input.sequence_range,
-                    range.file_handle().meta_ref().preserve_row_sequence,
+                    file_meta.preserve_row_sequence,
+                    stream_ctx.input.region_metadata().region_id,
+                    file_meta.region_id,
+                    file_meta.file_id,
                 )? else {
                     continue;
                 };
@@ -2104,7 +2120,7 @@ mod sequence_filter_tests {
     use datatypes::arrow::array::{Int64Array, StringArray, UInt8Array, UInt64Array};
     use datatypes::arrow::datatypes::{DataType, Field, Schema};
     use datatypes::arrow::record_batch::RecordBatch;
-    use store_api::storage::SequenceRange;
+    use store_api::storage::{FileId, RegionId, SequenceRange};
 
     use super::filter_flat_batch_by_sequence;
 
@@ -2159,13 +2175,20 @@ mod sequence_filter_tests {
     fn test_filter_flat_batch_by_sequence_no_range_or_legacy_file() {
         let b = batch(&[1, 2, 3, 4]);
 
-        let out = filter_flat_batch_by_sequence(b.clone(), None, true).unwrap();
+        let region_id = RegionId::new(1, 1);
+        let file_id = FileId::random();
+        let out =
+            filter_flat_batch_by_sequence(b.clone(), None, true, region_id, region_id, file_id)
+                .unwrap();
         assert_eq!(remaining_tags(&out.unwrap()), vec!["0", "1", "2", "3"]);
 
         let out = filter_flat_batch_by_sequence(
             b.clone(),
             Some(SequenceRange::GtLtEq { min: 2, max: 3 }),
             false,
+            region_id,
+            region_id,
+            file_id,
         )
         .unwrap();
         assert_eq!(remaining_tags(&out.unwrap()), vec!["0", "1", "2", "3"]);
@@ -2174,11 +2197,16 @@ mod sequence_filter_tests {
     #[test]
     fn test_filter_flat_batch_by_sequence_exact_range() {
         let b = batch(&[1, 2, 3, 4]);
+        let region_id = RegionId::new(1, 1);
+        let file_id = FileId::random();
 
         let out = filter_flat_batch_by_sequence(
             b.clone(),
             Some(SequenceRange::GtLtEq { min: 2, max: 3 }),
             true,
+            region_id,
+            region_id,
+            file_id,
         )
         .unwrap();
         assert_eq!(remaining_tags(&out.unwrap()), vec!["2"]);
@@ -2187,6 +2215,9 @@ mod sequence_filter_tests {
             b.clone(),
             Some(SequenceRange::GtLtEq { min: 10, max: 20 }),
             true,
+            region_id,
+            region_id,
+            file_id,
         )
         .unwrap();
         assert!(out.is_none());
@@ -2196,8 +2227,25 @@ mod sequence_filter_tests {
             empty,
             Some(SequenceRange::GtLtEq { min: 0, max: 10 }),
             true,
+            region_id,
+            region_id,
+            file_id,
         )
         .unwrap();
         assert_eq!(out.unwrap().num_rows(), 0);
+
+        let err = filter_flat_batch_by_sequence(
+            b,
+            Some(SequenceRange::GtLtEq { min: 0, max: 10 }),
+            true,
+            region_id,
+            RegionId::new(1, 2),
+            file_id,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::RegionSequenceDomainBroken { .. }
+        ));
     }
 }

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1509,24 +1509,19 @@ pub(crate) async fn scan_flat_file_ranges(
 /// (`__primary_key`, `__sequence`, `__op_type`), so it must be applied before any
 /// projection/compat conversion that drops internal columns.
 ///
-/// `file_preserves_sequence` is the local per-file marker. Foreign reader
+/// `file_sequence_trusted` is the per-file trust decision. Foreign reader
 /// batches have already been virtualized to the target-local file barrier, so
-/// they are always filtered using the effective batch sequence. Local
-/// untrusted files pass through because exact capability excludes them before
-/// row filtering.
+/// they are filtered using the effective batch sequence. Local untrusted files
+/// pass through because exact capability excludes them before row filtering.
 fn filter_flat_batch_by_sequence(
     record_batch: RecordBatch,
     sequence_range: Option<SequenceRange>,
-    file_preserves_sequence: bool,
-    region_id: RegionId,
-    file_region_id: RegionId,
-    _file_id: store_api::storage::FileId,
+    file_sequence_trusted: bool,
 ) -> Result<Option<RecordBatch>> {
     let Some(sequence) = sequence_range else {
         return Ok(Some(record_batch));
     };
-    let foreign = file_region_id != region_id;
-    if !foreign && !file_preserves_sequence {
+    if !file_sequence_trusted {
         return Ok(Some(record_batch));
     }
 
@@ -1599,6 +1594,9 @@ pub fn build_flat_file_range_scan_stream(
             part_metrics.inc_build_reader_cost(build_cost);
 
             let may_compat = range.compat_batch();
+            let file_sequence_trusted = range
+                .file_handle()
+                .is_effective_target_sequence_trusted(stream_ctx.input.region_metadata().region_id);
 
             let mapper = range.compaction_projection_mapper();
             while let Some(record_batch) = reader.next_batch().await? {
@@ -1609,14 +1607,10 @@ pub fn build_flat_file_range_scan_stream(
                     record_batch
                 };
 
-                let file_meta = range.file_handle().meta_ref();
                 let Some(record_batch) = filter_flat_batch_by_sequence(
                     record_batch,
                     stream_ctx.input.sequence_range,
-                    file_meta.preserve_row_sequence,
-                    stream_ctx.input.region_metadata().region_id,
-                    file_meta.region_id,
-                    file_meta.file_id,
+                    file_sequence_trusted,
                 )? else {
                     continue;
                 };
@@ -2114,7 +2108,7 @@ mod sequence_filter_tests {
     use datatypes::arrow::array::{Int64Array, StringArray, UInt8Array, UInt64Array};
     use datatypes::arrow::datatypes::{DataType, Field, Schema};
     use datatypes::arrow::record_batch::RecordBatch;
-    use store_api::storage::{FileId, RegionId, SequenceRange};
+    use store_api::storage::SequenceRange;
 
     use super::filter_flat_batch_by_sequence;
 
@@ -2169,20 +2163,13 @@ mod sequence_filter_tests {
     fn test_filter_flat_batch_by_sequence_no_range_or_legacy_file() {
         let b = batch(&[1, 2, 3, 4]);
 
-        let region_id = RegionId::new(1, 1);
-        let file_id = FileId::random();
-        let out =
-            filter_flat_batch_by_sequence(b.clone(), None, true, region_id, region_id, file_id)
-                .unwrap();
+        let out = filter_flat_batch_by_sequence(b.clone(), None, true).unwrap();
         assert_eq!(remaining_tags(&out.unwrap()), vec!["0", "1", "2", "3"]);
 
         let out = filter_flat_batch_by_sequence(
             b.clone(),
             Some(SequenceRange::GtLtEq { min: 2, max: 3 }),
             false,
-            region_id,
-            region_id,
-            file_id,
         )
         .unwrap();
         assert_eq!(remaining_tags(&out.unwrap()), vec!["0", "1", "2", "3"]);
@@ -2191,16 +2178,10 @@ mod sequence_filter_tests {
     #[test]
     fn test_filter_flat_batch_by_sequence_exact_range() {
         let b = batch(&[1, 2, 3, 4]);
-        let region_id = RegionId::new(1, 1);
-        let file_id = FileId::random();
-
         let out = filter_flat_batch_by_sequence(
             b.clone(),
             Some(SequenceRange::GtLtEq { min: 2, max: 3 }),
             true,
-            region_id,
-            region_id,
-            file_id,
         )
         .unwrap();
         assert_eq!(remaining_tags(&out.unwrap()), vec!["2"]);
@@ -2209,9 +2190,6 @@ mod sequence_filter_tests {
             b.clone(),
             Some(SequenceRange::GtLtEq { min: 10, max: 20 }),
             true,
-            region_id,
-            region_id,
-            file_id,
         )
         .unwrap();
         assert!(out.is_none());
@@ -2221,9 +2199,6 @@ mod sequence_filter_tests {
             empty,
             Some(SequenceRange::GtLtEq { min: 0, max: 10 }),
             true,
-            region_id,
-            region_id,
-            file_id,
         )
         .unwrap();
         assert_eq!(out.unwrap().num_rows(), 0);
@@ -2233,10 +2208,7 @@ mod sequence_filter_tests {
         let out = filter_flat_batch_by_sequence(
             batch(&[1, 5, 9]),
             Some(SequenceRange::GtLtEq { min: 2, max: 8 }),
-            false,
-            region_id,
-            RegionId::new(1, 2),
-            file_id,
+            true,
         )
         .unwrap();
         assert_eq!(remaining_tags(&out.unwrap()), vec!["1"]);

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -118,6 +118,19 @@ pub struct RegionOptions {
     /// the configured size; zero disables both limits.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_buffer_size: Option<ReadableSize>,
+    /// Whether to preserve per-row sequence numbers through flush and compaction.
+    ///
+    /// Only meaningful for append-only tables (`append_mode = true`): when enabled,
+    /// every row keeps its exact sequence number in memtables, flushed SSTs and
+    /// compacted SSTs, and scans with an exact `(checkpoint, upper_bound]` sequence
+    /// range can filter SST rows row-level instead of falling back to file-level
+    /// sequence metadata.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub preserve_row_sequence: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl RegionOptions {
@@ -147,6 +160,14 @@ impl RegionOptions {
                     reason: format!(
                         "max_row_group_row_count must be in (0, {MAX_ROW_GROUP_ROW_COUNT_LIMIT}], got {row_count}",
                     ),
+                }
+            );
+        }
+        if self.preserve_row_sequence {
+            ensure!(
+                self.append_mode,
+                InvalidRegionOptionsSnafu {
+                    reason: "preserve_row_sequence is only supported for append-only tables (append_mode must be true)",
                 }
             );
         }
@@ -286,6 +307,7 @@ impl RegionOptions {
             max_row_group_row_count: options.max_row_group_row_count,
             primary_key_encoding,
             write_buffer_size: options.write_buffer_size,
+            preserve_row_sequence: options.preserve_row_sequence,
         };
         opts.validate()?;
 
@@ -400,6 +422,8 @@ struct RegionOptionsWithoutEnum {
     sst_format: Option<FormatType>,
     #[serde_as(as = "NoneAsEmptyString")]
     max_row_group_row_count: Option<usize>,
+    #[serde_as(as = "DisplayFromStr")]
+    preserve_row_sequence: bool,
 }
 
 impl Default for RegionOptionsWithoutEnum {
@@ -415,6 +439,7 @@ impl Default for RegionOptionsWithoutEnum {
             merge_mode: options.merge_mode,
             sst_format: options.sst_format,
             max_row_group_row_count: options.max_row_group_row_count,
+            preserve_row_sequence: options.preserve_row_sequence,
         }
     }
 }
@@ -969,8 +994,32 @@ mod tests {
             max_row_group_row_count: None,
             primary_key_encoding: None,
             write_buffer_size: None,
+            preserve_row_sequence: false,
         };
         assert_eq!(expect, options);
+    }
+
+    #[test]
+    fn test_with_preserve_row_sequence() {
+        // Option requires append mode.
+        let map = make_map(&[("append_mode", "false"), ("preserve_row_sequence", "true")]);
+        let err = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap_err();
+        assert_eq!(StatusCode::InvalidArguments, err.status_code());
+        assert!(err.to_string().contains("preserve_row_sequence"));
+
+        let map = make_map(&[("append_mode", "true"), ("preserve_row_sequence", "true")]);
+        let options = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap();
+        assert!(options.append_mode);
+        assert!(options.preserve_row_sequence);
+
+        // Default is false and disabled keeps main behavior.
+        let map = make_map(&[("append_mode", "true")]);
+        let options = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap();
+        assert!(!options.preserve_row_sequence);
+
+        let map = make_map(&[]);
+        let options = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap();
+        assert_eq!(RegionOptions::default(), options);
     }
 
     #[test]
@@ -1002,6 +1051,7 @@ mod tests {
             max_row_group_row_count: None,
             primary_key_encoding: None,
             write_buffer_size: Some(ReadableSize::mb(128)),
+            preserve_row_sequence: false,
         };
         let region_options_json_str = serde_json::to_string(&options).unwrap();
         let got: RegionOptions = serde_json::from_str(&region_options_json_str).unwrap();
@@ -1069,8 +1119,27 @@ mod tests {
             max_row_group_row_count: None,
             primary_key_encoding: None,
             write_buffer_size: None,
+            preserve_row_sequence: false,
         };
         assert_eq!(options, got);
+    }
+
+    #[test]
+    fn test_region_options_serde_preserve_row_sequence_roundtrip() {
+        let options = RegionOptions {
+            append_mode: true,
+            preserve_row_sequence: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&options).unwrap();
+        assert!(json.contains("preserve_row_sequence"));
+        let got: RegionOptions = serde_json::from_str(&json).unwrap();
+        assert_eq!(options, got);
+
+        // Old manifests without the key default to false.
+        let old_json = r#"{"append_mode": true}"#;
+        let got: RegionOptions = serde_json::from_str(old_json).unwrap();
+        assert!(!got.preserve_row_sequence);
     }
 
     #[test]

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -1049,15 +1049,18 @@ mod tests {
             max_row_group_row_count: None,
             primary_key_encoding: None,
             write_buffer_size: Some(ReadableSize::mb(128)),
-            preserve_row_sequence: false,
+            preserve_row_sequence: true,
         };
         let region_options_json_str = serde_json::to_string(&options).unwrap();
+        assert!(region_options_json_str.contains("preserve_row_sequence"));
         let got: RegionOptions = serde_json::from_str(&region_options_json_str).unwrap();
         assert_eq!(options, got);
 
+        // Old manifests without the key default to false.
         let old_region_options_json_str = r#"{"ttl":null}"#;
         let got: RegionOptions = serde_json::from_str(old_region_options_json_str).unwrap();
         assert_eq!(None, got.write_buffer_size);
+        assert!(!got.preserve_row_sequence);
 
         let default_json = serde_json::to_value(RegionOptions::default()).unwrap();
         assert!(default_json.get(WRITE_BUFFER_SIZE_KEY).is_none());
@@ -1120,24 +1123,6 @@ mod tests {
             preserve_row_sequence: false,
         };
         assert_eq!(options, got);
-    }
-
-    #[test]
-    fn test_region_options_serde_preserve_row_sequence_roundtrip() {
-        let options = RegionOptions {
-            append_mode: true,
-            preserve_row_sequence: true,
-            ..Default::default()
-        };
-        let json = serde_json::to_string(&options).unwrap();
-        assert!(json.contains("preserve_row_sequence"));
-        let got: RegionOptions = serde_json::from_str(&json).unwrap();
-        assert_eq!(options, got);
-
-        // Old manifests without the key default to false.
-        let old_json = r#"{"append_mode": true}"#;
-        let got: RegionOptions = serde_json::from_str(old_json).unwrap();
-        assert!(!got.preserve_row_sequence);
     }
 
     #[test]

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -1001,7 +1001,6 @@ mod tests {
 
     #[test]
     fn test_with_preserve_row_sequence() {
-        // Option requires append mode.
         let map = make_map(&[("append_mode", "false"), ("preserve_row_sequence", "true")]);
         let err = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap_err();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
@@ -1012,7 +1011,6 @@ mod tests {
         assert!(options.append_mode);
         assert!(options.preserve_row_sequence);
 
-        // Default is false and disabled keeps main behavior.
         let map = make_map(&[("append_mode", "true")]);
         let options = RegionOptions::try_from_options(RegionId::new(0, 0), &map).unwrap();
         assert!(!options.preserve_row_sequence);

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -282,6 +282,18 @@ pub struct FileMeta {
         deserialize_with = "deserialize_bytes_option"
     )]
     pub primary_key_max: Option<Bytes>,
+    /// Whether the file preserves per-row sequence numbers usable for exact
+    /// row-level sequence filtering.
+    ///
+    /// Set when the file is written by a flush or compaction of a region with
+    /// `preserve_row_sequence` enabled (append-only tables). Absent
+    /// or `false` in legacy files, which must not be row-level sequence filtered.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub preserve_row_sequence: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl Debug for FileMeta {
@@ -1116,6 +1128,30 @@ mod tests {
             deserialized_file_meta.file_id,
             FileId::from_str("bc5896ec-e4d8-4017-a80d-f2de73188d55").unwrap()
         );
+        assert!(!deserialized_file_meta.preserve_row_sequence);
+    }
+
+    #[test]
+    fn test_file_meta_preserve_row_sequence_serde() {
+        let file_meta = FileMeta {
+            preserve_row_sequence: true,
+            ..Default::default()
+        };
+
+        let serialized = serde_json::to_string(&file_meta).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(value["preserve_row_sequence"], true);
+
+        let deserialized: FileMeta = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(file_meta, deserialized);
+
+        let file_meta_false = FileMeta {
+            preserve_row_sequence: false,
+            ..file_meta.clone()
+        };
+        let serialized_false = serde_json::to_string(&file_meta_false).unwrap();
+        let value_false: serde_json::Value = serde_json::from_str(&serialized_false).unwrap();
+        assert!(value_false.get("preserve_row_sequence").is_none());
     }
     #[test]
     fn test_is_index_consistent_with_region() {

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -284,10 +284,6 @@ pub struct FileMeta {
     pub primary_key_max: Option<Bytes>,
     /// Whether the file preserves per-row sequence numbers usable for exact
     /// row-level sequence filtering.
-    ///
-    /// Set when the file is written by a flush or compaction of a region with
-    /// `preserve_row_sequence` enabled (append-only tables). Absent
-    /// or `false` in legacy files, which must not be row-level sequence filtered.
     #[serde(default, skip_serializing_if = "is_false")]
     pub preserve_row_sequence: bool,
 }

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -515,6 +515,18 @@ impl FileHandle {
         self.inner.meta.region_id
     }
 
+    /// Returns whether this file's row sequences are trusted in the target region.
+    ///
+    /// Foreign files use their target-local sequence barrier; local files require
+    /// the preserve marker because their physical sequences belong to this region.
+    pub(crate) fn is_effective_target_sequence_trusted(&self, target_region_id: RegionId) -> bool {
+        if self.region_id() != target_region_id {
+            self.meta_ref().sequence.is_some()
+        } else {
+            self.meta_ref().preserve_row_sequence
+        }
+    }
+
     /// Returns the cross-region file id.
     pub fn file_id(&self) -> RegionFileId {
         RegionFileId::new(self.inner.meta.region_id, self.inner.meta.file_id)

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -1700,6 +1700,7 @@ mod tests {
             max_sequence: None,
             sst_write_format: Default::default(),
             cache_manager: Default::default(),
+            preserve_row_sequence: false,
             index_options: IndexOptions::default(),
             index_config,
             inverted_index_config: Default::default(),

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -1703,8 +1703,20 @@ mod tests {
             }
         }
 
-        let custom_sequence = 12345u64;
+        fn handle_with_meta(
+            handle: &FileHandle,
+            sequence: Option<u64>,
+            preserve_row_sequence: bool,
+        ) -> FileHandle {
+            let mut file_meta = handle.meta_ref().clone();
+            file_meta.sequence = sequence.and_then(std::num::NonZeroU64::new);
+            file_meta.preserve_row_sequence = preserve_row_sequence;
+            FileHandle::new(file_meta, Arc::new(NoopFilePurger))
+        }
+
+        let custom_sequence = 12345;
         let local_zero_handle = sst_file_handle(0, 1000);
+        let local_nonzero_handle = sst_file_handle(0, 1000);
         write_sst(
             object_store.clone(),
             metadata.clone(),
@@ -1713,8 +1725,15 @@ mod tests {
             0,
         )
         .await;
+        write_sst(
+            object_store.clone(),
+            metadata.clone(),
+            local_nonzero_handle.clone(),
+            flat_format,
+            7,
+        )
+        .await;
 
-        // Local all-zero SSTs retain the compatibility override.
         let local_zero_none = read_sequences(
             ParquetReaderBuilder::new(
                 FILE_DIR.to_string(),
@@ -1727,17 +1746,12 @@ mod tests {
         .await;
         assert!(local_zero_none.iter().all(|sequence| *sequence == 0));
 
-        let mut local_zero_meta = local_zero_handle.meta_ref().clone();
-        local_zero_meta.sequence = Some(std::num::NonZeroU64::new(custom_sequence).unwrap());
-        let local_zero_override_handle = FileHandle::new(
-            local_zero_meta,
-            Arc::new(crate::sst::file_purger::NoopFilePurger),
-        );
+        // Legacy local all-zero files use the FileMeta sequence compatibility override.
         let local_zero_override = read_sequences(
             ParquetReaderBuilder::new(
                 FILE_DIR.to_string(),
                 PathType::Bare,
-                local_zero_override_handle,
+                handle_with_meta(&local_zero_handle, Some(custom_sequence), false),
                 object_store.clone(),
             )
             .expected_metadata(Some(metadata.clone())),
@@ -1749,28 +1763,12 @@ mod tests {
                 .all(|sequence| *sequence == custom_sequence)
         );
 
-        let local_nonzero_handle = sst_file_handle(0, 1000);
-        write_sst(
-            object_store.clone(),
-            metadata.clone(),
-            local_nonzero_handle.clone(),
-            flat_format,
-            7,
-        )
-        .await;
-
-        // Local nonzero SSTs retain physical per-row sequences, even with FileMeta.sequence.
-        let mut local_nonzero_meta = local_nonzero_handle.meta_ref().clone();
-        local_nonzero_meta.sequence = Some(std::num::NonZeroU64::new(custom_sequence).unwrap());
-        let local_nonzero_override_handle = FileHandle::new(
-            local_nonzero_meta,
-            Arc::new(crate::sst::file_purger::NoopFilePurger),
-        );
+        // Local nonzero physical sequences must not be replaced by a legacy barrier.
         let local_nonzero_override = read_sequences(
             ParquetReaderBuilder::new(
                 FILE_DIR.to_string(),
                 PathType::Bare,
-                local_nonzero_override_handle,
+                handle_with_meta(&local_nonzero_handle, Some(custom_sequence), false),
                 object_store.clone(),
             )
             .expected_metadata(Some(metadata.clone())),
@@ -1778,7 +1776,6 @@ mod tests {
         .await;
         assert!(local_nonzero_override.iter().all(|sequence| *sequence == 7));
 
-        // None never overrides a local nonzero physical sequence.
         let local_nonzero_none = read_sequences(
             ParquetReaderBuilder::new(
                 FILE_DIR.to_string(),
@@ -1791,28 +1788,80 @@ mod tests {
         .await;
         assert!(local_nonzero_none.iter().all(|sequence| *sequence == 7));
 
-        // A source-owned handle is foreign when read against target metadata, so the
-        // target-local manifest barrier is applied even for nonzero physical sequences.
-        let mut target_metadata = (*metadata).clone();
-        target_metadata.region_id = RegionId::new(0, 1);
-        let target_metadata = Arc::new(target_metadata);
-        let mut foreign_meta = local_nonzero_handle.meta_ref().clone();
-        foreign_meta.sequence = Some(std::num::NonZeroU64::new(custom_sequence).unwrap());
-        let foreign_handle = FileHandle::new(
-            foreign_meta,
-            Arc::new(crate::sst::file_purger::NoopFilePurger),
-        );
-        let foreign = read_sequences(
+        // The trusted marker preserves physical sequences, including explicit all-zero data.
+        let local_trusted_nonzero = read_sequences(
             ParquetReaderBuilder::new(
                 FILE_DIR.to_string(),
                 PathType::Bare,
-                foreign_handle,
+                handle_with_meta(&local_nonzero_handle, Some(custom_sequence), true),
+                object_store.clone(),
+            )
+            .expected_metadata(Some(metadata.clone())),
+        )
+        .await;
+        assert!(local_trusted_nonzero.iter().all(|sequence| *sequence == 7));
+
+        let local_trusted_zero = read_sequences(
+            ParquetReaderBuilder::new(
+                FILE_DIR.to_string(),
+                PathType::Bare,
+                handle_with_meta(&local_zero_handle, Some(custom_sequence), true),
+                object_store.clone(),
+            )
+            .expected_metadata(Some(metadata.clone())),
+        )
+        .await;
+        assert!(local_trusted_zero.iter().all(|sequence| *sequence == 0));
+
+        let mut target_metadata = (*metadata).clone();
+        target_metadata.region_id = RegionId::new(0, 1);
+        let target_metadata = Arc::new(target_metadata);
+
+        // A foreign file always uses the target-local barrier, regardless of its marker.
+        let foreign_marked = read_sequences(
+            ParquetReaderBuilder::new(
+                FILE_DIR.to_string(),
+                PathType::Bare,
+                handle_with_meta(&local_nonzero_handle, Some(custom_sequence), true),
+                object_store.clone(),
+            )
+            .expected_metadata(Some(target_metadata.clone())),
+        )
+        .await;
+        assert!(
+            foreign_marked
+                .iter()
+                .all(|sequence| *sequence == custom_sequence)
+        );
+
+        let foreign_unmarked = read_sequences(
+            ParquetReaderBuilder::new(
+                FILE_DIR.to_string(),
+                PathType::Bare,
+                handle_with_meta(&local_nonzero_handle, Some(custom_sequence), false),
+                object_store.clone(),
+            )
+            .expected_metadata(Some(target_metadata.clone())),
+        )
+        .await;
+        assert!(
+            foreign_unmarked
+                .iter()
+                .all(|sequence| *sequence == custom_sequence)
+        );
+
+        // A foreign handle without a barrier leaves physical sequences untouched.
+        let foreign_none = read_sequences(
+            ParquetReaderBuilder::new(
+                FILE_DIR.to_string(),
+                PathType::Bare,
+                handle_with_meta(&local_nonzero_handle, None, false),
                 object_store,
             )
             .expected_metadata(Some(target_metadata)),
         )
         .await;
-        assert!(foreign.iter().all(|sequence| *sequence == custom_sequence));
+        assert!(foreign_none.iter().all(|sequence| *sequence == 7));
     }
 
     #[tokio::test]

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -539,9 +539,18 @@ impl ParquetReaderBuilder {
                 expected_region_id,
             );
         }
-        if is_foreign || need_override_sequence(&parquet_meta) {
-            read_format
-                .set_override_sequence(self.file_handle.meta_ref().sequence.map(|x| x.get()));
+        let file_meta = self.file_handle.meta_ref();
+        let override_sequence = if is_foreign {
+            file_meta.sequence.map(|sequence| sequence.get())
+        } else if file_meta.preserve_row_sequence {
+            None
+        } else if need_override_sequence(&parquet_meta) {
+            file_meta.sequence.map(|sequence| sequence.get())
+        } else {
+            None
+        };
+        if let Some(sequence) = override_sequence {
+            read_format.set_override_sequence(Some(sequence));
         }
 
         // Computes the projection mask.

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -343,15 +343,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             .build()
         })?;
         if all_options_altered {
-            // No option independently requires an empty memtable
-            // (preserve_row_sequence toggles apply in memory): apply the staged
-            // options directly without flushing.
+            // preserve_row_sequence toggles apply in memory and do not require
+            // an empty memtable.
             region.version_control.alter_options(candidate);
             Ok(None)
         } else {
-            // Some option independently requires an empty memtable (e.g.
-            // append_mode, sst_format or max_row_group_row_count): stage the
-            // complete final options and follow the existing flush path.
+            // Some options require an empty memtable (e.g. append_mode,
+            // sst_format, or max_row_group_row_count).
             Ok(Some(candidate))
         }
     }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -197,7 +197,11 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     /// Handles requests that changes region options, like TTL. It only affects memory state
     /// since changes are persisted in the `DatanodeTableValue` in metasrv.
     ///
-    /// If the options require empty memtable, it only does validation.
+    /// Options that can be applied without an empty memtable (e.g. TTL,
+    /// `preserve_row_sequence`) are applied directly through the fast path.
+    /// If another option in the same ALTER requires an empty memtable (e.g.
+    /// `append_mode`), only the complete final options are staged and the
+    /// existing flush path is followed.
     ///
     /// Returns the staged options if they need further alteration.
     fn handle_alter_region_options_fast(
@@ -301,6 +305,19 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         all_options_altered = false;
                     }
                 }
+                SetRegionOption::PreserveRowSequence(new_preserve) => {
+                    // Toggling preserve_row_sequence only affects in-memory
+                    // RegionOptions and how future flushes/compactions mark SST
+                    // metadata; it does not require an empty memtable, so it
+                    // never blocks the fast path.
+                    if new_preserve != current_options.preserve_row_sequence {
+                        info!(
+                            "Update region preserve_row_sequence: {}, previous: {:?} new: {:?}",
+                            region.region_id, current_options.preserve_row_sequence, new_preserve
+                        );
+                        current_options.preserve_row_sequence = new_preserve;
+                    }
+                }
                 SetRegionOption::SkipWal => {
                     if !current_options.skip_wal {
                         info!("Stop writing WAL for region: {}", region.region_id);
@@ -309,15 +326,33 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 }
             }
         }
+        let kind = AlterKind::SetRegionOptions { options };
+        // Validate the complete final options. The loop above validates
+        // per-option, but a combined ALTER may flip append_mode and toggle
+        // preserve_row_sequence in the same request, which is only valid when
+        // viewed together (order-independent). Validating the staged outcome
+        // also guarantees that a preserve-only toggle applied via the fast path
+        // below cannot create an invalid state (preserve requires append_mode).
+        let candidate = new_region_options_on_empty_memtable(&current_options, &kind)
+            .unwrap_or_else(|| current_options.clone());
+        candidate.validate().map_err(|e| {
+            store_api::metadata::InvalidRegionRequestSnafu {
+                region_id: region.region_id,
+                err: e.to_string(),
+            }
+            .build()
+        })?;
         if all_options_altered {
-            region.version_control.alter_options(current_options);
+            // No option independently requires an empty memtable
+            // (preserve_row_sequence toggles apply in memory): apply the staged
+            // options directly without flushing.
+            region.version_control.alter_options(candidate);
             Ok(None)
         } else {
-            let kind = AlterKind::SetRegionOptions { options };
-            Ok(new_region_options_on_empty_memtable(
-                &current_options,
-                &kind,
-            ))
+            // Some option independently requires an empty memtable (e.g.
+            // append_mode, sst_format or max_row_group_row_count): stage the
+            // complete final options and follow the existing flush path.
+            Ok(Some(candidate))
         }
     }
 }
@@ -368,6 +403,9 @@ fn new_region_options_on_empty_memtable(
             }
             SetRegionOption::MaxRowGroupRowCount(new_row_count) => {
                 current_options.max_row_group_row_count = *new_row_count;
+            }
+            SetRegionOption::PreserveRowSequence(new_preserve) => {
+                current_options.preserve_row_sequence = *new_preserve;
             }
         }
     }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -306,10 +306,6 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     }
                 }
                 SetRegionOption::PreserveRowSequence(new_preserve) => {
-                    // Toggling preserve_row_sequence only affects in-memory
-                    // RegionOptions and how future flushes/compactions mark SST
-                    // metadata; it does not require an empty memtable, so it
-                    // never blocks the fast path.
                     if new_preserve != current_options.preserve_row_sequence {
                         info!(
                             "Update region preserve_row_sequence: {}, previous: {:?} new: {:?}",
@@ -343,8 +339,6 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             .build()
         })?;
         if all_options_altered {
-            // preserve_row_sequence toggles apply in memory and do not require
-            // an empty memtable.
             region.version_control.alter_options(candidate);
             Ok(None)
         } else {

--- a/src/mito2/src/worker/handle_copy_region.rs
+++ b/src/mito2/src/worker/handle_copy_region.rs
@@ -177,12 +177,16 @@ impl<S> RegionWorkerLoop<S> {
                 // physical per-row sequences in the copied file belong to the
                 // source region, so they must not be trusted for exact
                 // sequence-range reads on the target. Clear the
-                // `preserve_row_sequence` marker to fail closed until the scan
-                // provably cannot intersect the copied rows (see
+                // `preserve_row_sequence` marker and the source-domain max
+                // sequence to fail closed until the scan provably cannot
+                // intersect the copied rows (see
                 // `files_allow_exact_sequence_range`); otherwise an exact
                 // request would replay source-domain rows as if they were
-                // target sequences.
+                // target sequences, and an unmarked file with a stale
+                // source-domain `sequence` hint could be silently skipped as
+                // "proven disjoint".
                 new_file_meta.preserve_row_sequence = false;
+                new_file_meta.sequence = None;
                 files_to_copy.push(new_file_meta);
             }
         }

--- a/src/mito2/src/worker/handle_copy_region.rs
+++ b/src/mito2/src/worker/handle_copy_region.rs
@@ -25,6 +25,7 @@ use crate::region::{
 use crate::request::{
     BackgroundNotify, CopyRegionFromFinished, CopyRegionFromRequest, WorkerRequest,
 };
+use crate::sst::file::FileMeta;
 use crate::sst::location::region_dir_from_table_dir;
 use crate::worker::{RegionWorkerLoop, WorkerRequestWithTime};
 
@@ -68,7 +69,7 @@ impl<S> RegionWorkerLoop<S> {
         let worker_sender = self.sender.clone();
 
         common_runtime::spawn_global(async move {
-            let (region_edit, file_ids) = match Self::copy_region_from(
+            let (region_edit, source_file_ids) = match Self::copy_region_from(
                 &region,
                 region_metadata_loader,
                 source_region_id,
@@ -104,7 +105,7 @@ impl<S> RegionWorkerLoop<S> {
                 }
                 None => {
                     let _ = sender.send(Ok(MitoCopyRegionFromResponse {
-                        copied_file_ids: file_ids,
+                        copied_file_ids: source_file_ids,
                     }));
                 }
             }
@@ -138,7 +139,7 @@ impl<S> RegionWorkerLoop<S> {
 
     /// Returns the region edit and the file ids that were copied from the source region to the target region.
     ///
-    /// If no need to copy files, returns (None, file_ids).
+    /// If no need to copy files, returns (None, source_file_ids).
     async fn copy_region_from(
         region: &MitoRegionRef,
         region_metadata_loader: RegionMetadataLoader,
@@ -158,9 +159,9 @@ impl<S> RegionWorkerLoop<S> {
             .context(MissingManifestSnafu {
                 region_id: source_region_id,
             })?;
-        let mut files_to_copy = vec![];
+        let mut new_file_metas = vec![];
         let target_region_manifest = region.manifest_ctx.manifest().await;
-        let file_ids = source_region_manifest
+        let source_file_ids = source_region_manifest
             .files
             .keys()
             .cloned()
@@ -171,57 +172,16 @@ impl<S> RegionWorkerLoop<S> {
         );
         for (file_id, file_meta) in &source_region_manifest.files {
             if !target_region_manifest.files.contains_key(file_id) {
-                let mut new_file_meta = file_meta.clone();
-                new_file_meta.region_id = target_region_id;
-                // The target region has an independent sequence domain: the
-                // physical per-row sequences in the copied file belong to the
-                // source region, so they must not be trusted for exact
-                // sequence-range reads on the target. Clear the
-                // `preserve_row_sequence` marker and the source-domain max
-                // sequence to fail closed until the scan provably cannot
-                // intersect the copied rows (see
-                // `files_allow_exact_sequence_range`); otherwise an exact
-                // request would replay source-domain rows as if they were
-                // target sequences, and an unmarked file with a stale
-                // source-domain `sequence` hint could be silently skipped as
-                // "proven disjoint".
-                new_file_meta.preserve_row_sequence = false;
-                new_file_meta.sequence = None;
-                files_to_copy.push(new_file_meta);
+                new_file_metas.push(remap_copied_file_meta(file_meta, target_region_id));
             }
         }
-        if files_to_copy.is_empty() {
-            return Ok((None, file_ids));
+        if new_file_metas.is_empty() {
+            return Ok((None, source_file_ids));
         }
 
-        let file_descriptors = files_to_copy
+        let file_descriptors = new_file_metas
             .iter()
-            .flat_map(|file_meta| {
-                if file_meta.exists_index() {
-                    let region_index_id = file_meta.index_id();
-                    let file_id = region_index_id.file_id.file_id();
-                    let version = region_index_id.version;
-                    let file_size = file_meta.file_size;
-                    let index_file_size = file_meta.index_file_size();
-                    vec![
-                        FileDescriptor::Data {
-                            file_id: file_meta.file_id,
-                            size: file_size,
-                        },
-                        FileDescriptor::Index {
-                            file_id,
-                            version,
-                            size: index_file_size,
-                        },
-                    ]
-                } else {
-                    let file_size = file_meta.file_size;
-                    vec![FileDescriptor::Data {
-                        file_id: file_meta.file_id,
-                        size: file_size,
-                    }]
-                }
-            })
+            .flat_map(file_descriptors_for_meta)
             .collect();
         debug!("File descriptors to copy: {:?}", file_descriptors);
         let copier = RegionFileCopier::new(region.access_layer());
@@ -235,7 +195,7 @@ impl<S> RegionWorkerLoop<S> {
             )
             .await?;
         let edit = RegionEdit {
-            files_to_add: files_to_copy,
+            files_to_add: new_file_metas,
             files_to_remove: vec![],
             timestamp_ms: Some(chrono::Utc::now().timestamp_millis()),
             compaction_time_window: None,
@@ -256,6 +216,43 @@ impl<S> RegionWorkerLoop<S> {
             "Successfully update manifest version to {version}, region: {target_region_id}, reason: CopyRegionFrom"
         );
 
-        Ok((Some(edit), file_ids))
+        Ok((Some(edit), source_file_ids))
+    }
+}
+
+fn remap_copied_file_meta(file_meta: &FileMeta, target_region_id: RegionId) -> FileMeta {
+    let mut new_file_meta = file_meta.clone();
+    new_file_meta.region_id = target_region_id;
+    // The target region has an independent sequence domain: the physical
+    // per-row sequences in the copied file belong to the source region, so they
+    // must not be trusted for exact sequence-range reads on the target. Clear
+    // the `preserve_row_sequence` marker and source-domain max sequence to fail
+    // closed until the scan provably cannot intersect the copied rows (see
+    // `files_allow_exact_sequence_range`); otherwise an exact request would
+    // replay source-domain rows as target sequences, and an unmarked file with
+    // a stale source-domain `sequence` hint could be silently skipped as
+    // "proven disjoint".
+    new_file_meta.preserve_row_sequence = false;
+    new_file_meta.sequence = None;
+    new_file_meta
+}
+
+fn file_descriptors_for_meta(file_meta: &FileMeta) -> Vec<FileDescriptor> {
+    let data = FileDescriptor::Data {
+        file_id: file_meta.file_id,
+        size: file_meta.file_size,
+    };
+    if file_meta.exists_index() {
+        let region_index_id = file_meta.index_id();
+        vec![
+            data,
+            FileDescriptor::Index {
+                file_id: region_index_id.file_id.file_id(),
+                version: region_index_id.version,
+                size: file_meta.index_file_size(),
+            },
+        ]
+    } else {
+        vec![data]
     }
 }

--- a/src/mito2/src/worker/handle_copy_region.rs
+++ b/src/mito2/src/worker/handle_copy_region.rs
@@ -173,6 +173,16 @@ impl<S> RegionWorkerLoop<S> {
             if !target_region_manifest.files.contains_key(file_id) {
                 let mut new_file_meta = file_meta.clone();
                 new_file_meta.region_id = target_region_id;
+                // The target region has an independent sequence domain: the
+                // physical per-row sequences in the copied file belong to the
+                // source region, so they must not be trusted for exact
+                // sequence-range reads on the target. Clear the
+                // `preserve_row_sequence` marker to fail closed until the scan
+                // provably cannot intersect the copied rows (see
+                // `files_allow_exact_sequence_range`); otherwise an exact
+                // request would replay source-domain rows as if they were
+                // target sequences.
+                new_file_meta.preserve_row_sequence = false;
                 files_to_copy.push(new_file_meta);
             }
         }

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -316,9 +316,15 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let file_sequence = region.version_control.committed_sequence() + 1;
         edit.committed_sequence = Some(file_sequence);
 
-        // For every file added through region edit, we should fill the file sequence
+        // For every file added through region edit, we should fill the file sequence.
+        // Generic region edits (direct/import/staging) assign a new destination
+        // sequence domain but cannot prove or rewrite the physical per-row sequence
+        // column. The added files are therefore atomic/untrusted: clear the
+        // `preserve_row_sequence` marker so exact sequence-range scans fail closed
+        // until the scan reaches the assigned max sequence.
         for file in &mut edit.files_to_add {
             file.sequence = NonZeroU64::new(file_sequence);
+            file.preserve_row_sequence = false;
         }
 
         // Allow retrieving `is_staging` before spawn the edit region task.

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -316,7 +316,6 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let file_sequence = region.version_control.committed_sequence() + 1;
         edit.committed_sequence = Some(file_sequence);
 
-        // For every file added through region edit, we should fill the file sequence.
         // Generic region edits (direct/import/staging) assign a new destination
         // sequence domain but cannot prove or rewrite the physical per-row sequence
         // column. The added files are therefore atomic/untrusted: clear the

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -72,6 +72,8 @@ pub const SST_FORMAT_KEY: &str = "sst_format";
 pub const MAX_ROW_GROUP_ROW_COUNT: &str = "max_row_group_row_count";
 /// Upper bound for [`MAX_ROW_GROUP_ROW_COUNT`].
 pub const MAX_ROW_GROUP_ROW_COUNT_LIMIT: usize = 10 * 1024 * 1024;
+/// Option key for preserving per-row sequence numbers through flush and compaction.
+pub const PRESERVE_ROW_SEQUENCE: &str = "preserve_row_sequence";
 // Note: Adding new options here should also check if this option should be removed in [metric_engine::engine::create::region_options_for_metadata_region].
 
 /// Returns true if the `key` is a valid option key for the mito engine.
@@ -104,6 +106,7 @@ pub fn is_mito_engine_option_key(key: &str) -> bool {
         MERGE_MODE_KEY,
         SST_FORMAT_KEY,
         MAX_ROW_GROUP_ROW_COUNT,
+        PRESERVE_ROW_SEQUENCE,
     ]
     .contains(&key)
 }
@@ -151,6 +154,7 @@ mod tests {
         ));
         assert!(is_mito_engine_option_key("append_mode"));
         assert!(is_mito_engine_option_key("max_row_group_row_count"));
+        assert!(is_mito_engine_option_key("preserve_row_sequence"));
         assert!(!is_mito_engine_option_key("foo"));
     }
 }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -1494,7 +1494,6 @@ pub enum SetRegionOption {
     AutoFlushInterval(Option<Duration>),
     // Modifying the max number of rows in a parquet row group.
     MaxRowGroupRowCount(Option<usize>),
-    /// Modifying the preserve per-row sequence numbers option.
     PreserveRowSequence(bool),
     // Stops writing new WAL entries. This operation is irreversible.
     SkipWal,
@@ -1612,7 +1611,6 @@ pub enum UnsetRegionOption {
     Ttl,
     MaxRowGroupRowCount,
     WriteBufferSize,
-    /// Unset the preserve per-row sequence numbers option.
     PreserveRowSequence,
 }
 

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -57,7 +57,7 @@ use crate::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use crate::metrics;
 use crate::mito_engine_options::{
     APPEND_MODE_KEY, AUTO_FLUSH_INTERVAL_KEY, MAX_ROW_GROUP_ROW_COUNT,
-    MAX_ROW_GROUP_ROW_COUNT_LIMIT, SKIP_WAL_KEY, SST_FORMAT_KEY, TTL_KEY,
+    MAX_ROW_GROUP_ROW_COUNT_LIMIT, PRESERVE_ROW_SEQUENCE, SKIP_WAL_KEY, SST_FORMAT_KEY, TTL_KEY,
     TWCS_MAX_OUTPUT_FILE_SIZE, TWCS_TIME_WINDOW, TWCS_TRIGGER_FILE_NUM, WRITE_BUFFER_SIZE_KEY,
 };
 use crate::path_utils::table_dir;
@@ -1494,6 +1494,8 @@ pub enum SetRegionOption {
     AutoFlushInterval(Option<Duration>),
     // Modifying the max number of rows in a parquet row group.
     MaxRowGroupRowCount(Option<usize>),
+    /// Modifying the preserve per-row sequence numbers option.
+    PreserveRowSequence(bool),
     // Stops writing new WAL entries. This operation is irreversible.
     SkipWal,
 }
@@ -1553,6 +1555,12 @@ impl TryFrom<&PbOption> for SetRegionOption {
                     .ok_or_else(|| InvalidSetRegionOptionRequestSnafu { key, value }.build())?;
                 Ok(Self::MaxRowGroupRowCount(Some(row_count)))
             }
+            PRESERVE_ROW_SEQUENCE => {
+                let preserve = value
+                    .parse::<bool>()
+                    .map_err(|_| InvalidSetRegionOptionRequestSnafu { key, value }.build())?;
+                Ok(Self::PreserveRowSequence(preserve))
+            }
             SKIP_WAL_KEY if value == "true" => Ok(Self::SkipWal),
             _ => InvalidSetRegionOptionRequestSnafu { key, value }.fail(),
         }
@@ -1574,6 +1582,7 @@ impl From<&UnsetRegionOption> for SetRegionOption {
             UnsetRegionOption::Ttl => SetRegionOption::Ttl(Default::default()),
             UnsetRegionOption::MaxRowGroupRowCount => SetRegionOption::MaxRowGroupRowCount(None),
             UnsetRegionOption::WriteBufferSize => SetRegionOption::WriteBufferSize(None),
+            UnsetRegionOption::PreserveRowSequence => SetRegionOption::PreserveRowSequence(false),
         }
     }
 }
@@ -1589,6 +1598,7 @@ impl TryFrom<&str> for UnsetRegionOption {
             TWCS_MAX_OUTPUT_FILE_SIZE => Ok(Self::TwcsMaxOutputFileSize),
             TWCS_TIME_WINDOW => Ok(Self::TwcsTimeWindow),
             MAX_ROW_GROUP_ROW_COUNT => Ok(Self::MaxRowGroupRowCount),
+            PRESERVE_ROW_SEQUENCE => Ok(Self::PreserveRowSequence),
             _ => InvalidUnsetRegionOptionRequestSnafu { key }.fail(),
         }
     }
@@ -1602,6 +1612,8 @@ pub enum UnsetRegionOption {
     Ttl,
     MaxRowGroupRowCount,
     WriteBufferSize,
+    /// Unset the preserve per-row sequence numbers option.
+    PreserveRowSequence,
 }
 
 impl UnsetRegionOption {
@@ -1613,6 +1625,7 @@ impl UnsetRegionOption {
             Self::TwcsMaxOutputFileSize => TWCS_MAX_OUTPUT_FILE_SIZE,
             Self::TwcsTimeWindow => TWCS_TIME_WINDOW,
             Self::MaxRowGroupRowCount => MAX_ROW_GROUP_ROW_COUNT,
+            Self::PreserveRowSequence => PRESERVE_ROW_SEQUENCE,
         }
     }
 }
@@ -2018,6 +2031,37 @@ mod tests {
         assert_eq!(
             UnsetRegionOption::MaxRowGroupRowCount,
             UnsetRegionOption::try_from(MAX_ROW_GROUP_ROW_COUNT).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_set_region_option_preserve_row_sequence_try_from() {
+        for (value, expected) in [("true", true), ("false", false)] {
+            let pb = PbOption {
+                key: PRESERVE_ROW_SEQUENCE.to_string(),
+                value: value.to_string(),
+            };
+            assert_eq!(
+                SetRegionOption::PreserveRowSequence(expected),
+                SetRegionOption::try_from(&pb).unwrap()
+            );
+        }
+
+        for value in ["1", "invalid"] {
+            let pb = PbOption {
+                key: PRESERVE_ROW_SEQUENCE.to_string(),
+                value: value.to_string(),
+            };
+            assert!(SetRegionOption::try_from(&pb).is_err());
+        }
+
+        assert_eq!(
+            UnsetRegionOption::PreserveRowSequence,
+            UnsetRegionOption::try_from(PRESERVE_ROW_SEQUENCE).unwrap()
+        );
+        assert_eq!(
+            SetRegionOption::PreserveRowSequence(false),
+            (&UnsetRegionOption::PreserveRowSequence).into()
         );
     }
 

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -129,6 +129,15 @@ pub struct ScanRequest {
     pub skip_sst_files: bool,
     /// Whether to bind the effective snapshot upper bound when opening the scan.
     pub snapshot_on_scan: bool,
+    /// Explicit intent to read an exact row-level sequence delta `(min, max]`
+    /// across memtables and all SST files (Flow's `sequence_range` incremental
+    /// mode). The engine performs exact row-level filtering only when the region
+    /// preserves per-row sequences and every participating SST file is trusted;
+    /// otherwise it returns a structured stale/unsupported error so the caller
+    /// falls back instead of silently approximating.
+    ///
+    /// Historical `memtable_only` reads must never set this flag.
+    pub exact_sequence_range: bool,
     /// Optional hint for the distribution of time-series data.
     pub distribution: Option<TimeSeriesDistribution>,
     /// Optional hint for KNN vector search. When set, the scan should use
@@ -223,6 +232,9 @@ impl Display for ScanRequest {
                 self.snapshot_on_scan
             )?;
         }
+        if self.exact_sequence_range {
+            write!(f, "{}exact_sequence_range: true", delimiter.as_str())?;
+        }
         if self.preserve_pk_dictionary_encoding {
             write!(
                 f,
@@ -312,11 +324,12 @@ mod tests {
 
         let request = ScanRequest {
             snapshot_on_scan: true,
+            exact_sequence_range: true,
             ..Default::default()
         };
         assert_eq!(
             request.to_string(),
-            "ScanRequest { snapshot_on_scan: true }"
+            "ScanRequest { snapshot_on_scan: true, exact_sequence_range: true }"
         );
 
         let request = ScanRequest {

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -31,7 +31,7 @@ use snafu::{OptionExt, ResultExt, ensure};
 use store_api::metric_engine_consts::PHYSICAL_TABLE_METADATA_KEY;
 use store_api::mito_engine_options::{
     APPEND_MODE_KEY, AUTO_FLUSH_INTERVAL_KEY, COMPACTION_TYPE, COMPACTION_TYPE_TWCS,
-    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, SKIP_WAL_KEY, SST_FORMAT_KEY,
+    MAX_ROW_GROUP_ROW_COUNT, MERGE_MODE_KEY, PRESERVE_ROW_SEQUENCE, SKIP_WAL_KEY, SST_FORMAT_KEY,
 };
 use store_api::region_request::{SetRegionOption, UnsetRegionOption};
 use store_api::storage::{ColumnDescriptor, ColumnDescriptorBuilder, ColumnId};
@@ -404,6 +404,15 @@ impl TableMeta {
                             .insert(MAX_ROW_GROUP_ROW_COUNT.to_string(), row_count.to_string());
                     } else {
                         new_options.extra_options.remove(MAX_ROW_GROUP_ROW_COUNT);
+                    }
+                }
+                SetRegionOption::PreserveRowSequence(preserve) => {
+                    if *preserve {
+                        new_options
+                            .extra_options
+                            .insert(PRESERVE_ROW_SEQUENCE.to_string(), preserve.to_string());
+                    } else {
+                        new_options.extra_options.remove(PRESERVE_ROW_SEQUENCE);
                     }
                 }
                 SetRegionOption::SkipWal => {
@@ -1823,6 +1832,66 @@ mod tests {
                 .extra_options
                 .get(MERGE_MODE_KEY)
                 .map(String::as_str)
+        );
+    }
+
+    #[test]
+    fn test_set_preserve_row_sequence_option() {
+        let schema = Arc::new(new_test_schema());
+        let meta = TableMetaBuilder::empty()
+            .schema(schema)
+            .primary_key_indices(vec![0])
+            .engine("engine")
+            .next_column_id(3)
+            .build()
+            .unwrap();
+
+        let apply = |meta: &TableMeta, kind: &AlterKind| {
+            meta.builder_with_alter_kind("my_table", kind)
+                .unwrap()
+                .build()
+                .unwrap()
+        };
+
+        let with_true = apply(
+            &meta,
+            &AlterKind::SetTableOptions {
+                options: vec![SetRegionOption::PreserveRowSequence(true)],
+            },
+        );
+        assert_eq!(
+            Some("true"),
+            with_true
+                .options
+                .extra_options
+                .get(PRESERVE_ROW_SEQUENCE)
+                .map(String::as_str)
+        );
+
+        let set_false = apply(
+            &with_true,
+            &AlterKind::SetTableOptions {
+                options: vec![SetRegionOption::PreserveRowSequence(false)],
+            },
+        );
+        assert!(
+            !set_false
+                .options
+                .extra_options
+                .contains_key(PRESERVE_ROW_SEQUENCE)
+        );
+
+        let unset = apply(
+            &with_true,
+            &AlterKind::UnsetTableOptions {
+                keys: vec![UnsetRegionOption::PreserveRowSequence],
+            },
+        );
+        assert!(
+            !unset
+                .options
+                .extra_options
+                .contains_key(PRESERVE_ROW_SEQUENCE)
         );
     }
 

--- a/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
+++ b/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
@@ -1,0 +1,126 @@
+-- Test altering preserve_row_sequence on an append-only table, including
+-- persistence across a restart.
+-- Create an append-only table
+CREATE TABLE test_alter_preserve_row_sequence(
+    host STRING,
+    ts TIMESTAMP TIME INDEX,
+    cpu DOUBLE,
+    PRIMARY KEY(host)
+) ENGINE=mito WITH('append_mode'='true');
+
+Affected Rows: 0
+
+-- Insert some data
+INSERT INTO test_alter_preserve_row_sequence VALUES ('host1', 0, 1.0), ('host2', 1, 2.0);
+
+Affected Rows: 2
+
+-- SET preserve_row_sequence on the append-only table should succeed
+ALTER TABLE test_alter_preserve_row_sequence SET 'preserve_row_sequence' = 'true';
+
+Affected Rows: 0
+
+-- SHOW CREATE TABLE should show both append_mode and preserve_row_sequence
+SHOW CREATE TABLE test_alter_preserve_row_sequence;
+
++----------------------------------+-----------------------------------------------------------------+
+| Table                            | Create Table                                                    |
++----------------------------------+-----------------------------------------------------------------+
+| test_alter_preserve_row_sequence | CREATE TABLE IF NOT EXISTS "test_alter_preserve_row_sequence" ( |
+|                                  |   "host" STRING NULL,                                           |
+|                                  |   "ts" TIMESTAMP(3) NOT NULL,                                   |
+|                                  |   "cpu" DOUBLE NULL,                                            |
+|                                  |   TIME INDEX ("ts"),                                            |
+|                                  |   PRIMARY KEY ("host")                                          |
+|                                  | )                                                               |
+|                                  |                                                                 |
+|                                  | ENGINE=mito                                                     |
+|                                  | WITH(                                                           |
+|                                  |   append_mode = 'true',                                         |
+|                                  |   preserve_row_sequence = 'true'                                |
+|                                  | )                                                               |
++----------------------------------+-----------------------------------------------------------------+
+
+-- Restart the server: the option and the inserted data must survive
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE test_alter_preserve_row_sequence;
+
++----------------------------------+-----------------------------------------------------------------+
+| Table                            | Create Table                                                    |
++----------------------------------+-----------------------------------------------------------------+
+| test_alter_preserve_row_sequence | CREATE TABLE IF NOT EXISTS "test_alter_preserve_row_sequence" ( |
+|                                  |   "host" STRING NULL,                                           |
+|                                  |   "ts" TIMESTAMP(3) NOT NULL,                                   |
+|                                  |   "cpu" DOUBLE NULL,                                            |
+|                                  |   TIME INDEX ("ts"),                                            |
+|                                  |   PRIMARY KEY ("host")                                          |
+|                                  | )                                                               |
+|                                  |                                                                 |
+|                                  | ENGINE=mito                                                     |
+|                                  | WITH(                                                           |
+|                                  |   append_mode = 'true',                                         |
+|                                  |   preserve_row_sequence = 'true'                                |
+|                                  | )                                                               |
++----------------------------------+-----------------------------------------------------------------+
+
+-- Ordinary query should still see the inserted rows after restart
+SELECT * FROM test_alter_preserve_row_sequence ORDER BY host, ts;
+
++-------+-------------------------+-----+
+| host  | ts                      | cpu |
++-------+-------------------------+-----+
+| host1 | 1970-01-01T00:00:00     | 1.0 |
+| host2 | 1970-01-01T00:00:00.001 | 2.0 |
++-------+-------------------------+-----+
+
+-- UNSET preserve_row_sequence should succeed
+ALTER TABLE test_alter_preserve_row_sequence UNSET 'preserve_row_sequence';
+
+Affected Rows: 0
+
+-- SHOW CREATE TABLE should keep append_mode but drop preserve_row_sequence
+SHOW CREATE TABLE test_alter_preserve_row_sequence;
+
++----------------------------------+-----------------------------------------------------------------+
+| Table                            | Create Table                                                    |
++----------------------------------+-----------------------------------------------------------------+
+| test_alter_preserve_row_sequence | CREATE TABLE IF NOT EXISTS "test_alter_preserve_row_sequence" ( |
+|                                  |   "host" STRING NULL,                                           |
+|                                  |   "ts" TIMESTAMP(3) NOT NULL,                                   |
+|                                  |   "cpu" DOUBLE NULL,                                            |
+|                                  |   TIME INDEX ("ts"),                                            |
+|                                  |   PRIMARY KEY ("host")                                          |
+|                                  | )                                                               |
+|                                  |                                                                 |
+|                                  | ENGINE=mito                                                     |
+|                                  | WITH(                                                           |
+|                                  |   append_mode = 'true'                                          |
+|                                  | )                                                               |
++----------------------------------+-----------------------------------------------------------------+
+
+-- Clean up
+DROP TABLE test_alter_preserve_row_sequence;
+
+Affected Rows: 0
+
+-- Test that preserve_row_sequence requires append_mode=true
+CREATE TABLE test_alter_preserve_no_append(
+    host STRING,
+    ts TIMESTAMP TIME INDEX,
+    cpu DOUBLE,
+    PRIMARY KEY(host)
+) ENGINE=mito;
+
+Affected Rows: 0
+
+-- Setting preserve_row_sequence on a non-append-only table should fail
+-- SQLNESS REPLACE \d+\(\d+,\s+\d+\) REDACTED
+ALTER TABLE test_alter_preserve_no_append SET 'preserve_row_sequence' = 'true';
+
+Error: 1004(InvalidArguments), Invalid region request, region_id: REDACTED, err: Invalid region options, preserve_row_sequence is only supported for append-only tables (append_mode must be true)
+
+-- Clean up
+DROP TABLE test_alter_preserve_no_append;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
+++ b/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
@@ -1,6 +1,5 @@
 -- Test altering preserve_row_sequence on an append-only table, including
 -- persistence across a restart.
--- Create an append-only table
 CREATE TABLE test_alter_preserve_row_sequence(
     host STRING,
     ts TIMESTAMP TIME INDEX,
@@ -10,7 +9,6 @@ CREATE TABLE test_alter_preserve_row_sequence(
 
 Affected Rows: 0
 
--- Insert some data
 INSERT INTO test_alter_preserve_row_sequence VALUES ('host1', 0, 1.0), ('host2', 1, 2.0);
 
 Affected Rows: 2
@@ -98,7 +96,6 @@ SHOW CREATE TABLE test_alter_preserve_row_sequence;
 |                                  | )                                                               |
 +----------------------------------+-----------------------------------------------------------------+
 
--- Clean up
 DROP TABLE test_alter_preserve_row_sequence;
 
 Affected Rows: 0
@@ -119,7 +116,6 @@ ALTER TABLE test_alter_preserve_no_append SET 'preserve_row_sequence' = 'true';
 
 Error: 1004(InvalidArguments), Invalid region request, region_id: REDACTED, err: Invalid region options, preserve_row_sequence is only supported for append-only tables (append_mode must be true)
 
--- Clean up
 DROP TABLE test_alter_preserve_no_append;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
+++ b/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
@@ -119,4 +119,3 @@ Error: 1004(InvalidArguments), Invalid region request, region_id: REDACTED, err:
 DROP TABLE test_alter_preserve_no_append;
 
 Affected Rows: 0
-

--- a/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
+++ b/tests/cases/standalone/common/alter/alter_preserve_row_sequence.result
@@ -119,3 +119,4 @@ Error: 1004(InvalidArguments), Invalid region request, region_id: REDACTED, err:
 DROP TABLE test_alter_preserve_no_append;
 
 Affected Rows: 0
+

--- a/tests/cases/standalone/common/alter/alter_preserve_row_sequence.sql
+++ b/tests/cases/standalone/common/alter/alter_preserve_row_sequence.sql
@@ -1,7 +1,6 @@
 -- Test altering preserve_row_sequence on an append-only table, including
 -- persistence across a restart.
 
--- Create an append-only table
 CREATE TABLE test_alter_preserve_row_sequence(
     host STRING,
     ts TIMESTAMP TIME INDEX,
@@ -9,7 +8,6 @@ CREATE TABLE test_alter_preserve_row_sequence(
     PRIMARY KEY(host)
 ) ENGINE=mito WITH('append_mode'='true');
 
--- Insert some data
 INSERT INTO test_alter_preserve_row_sequence VALUES ('host1', 0, 1.0), ('host2', 1, 2.0);
 
 -- SET preserve_row_sequence on the append-only table should succeed
@@ -31,7 +29,6 @@ ALTER TABLE test_alter_preserve_row_sequence UNSET 'preserve_row_sequence';
 -- SHOW CREATE TABLE should keep append_mode but drop preserve_row_sequence
 SHOW CREATE TABLE test_alter_preserve_row_sequence;
 
--- Clean up
 DROP TABLE test_alter_preserve_row_sequence;
 
 -- Test that preserve_row_sequence requires append_mode=true
@@ -46,5 +43,4 @@ CREATE TABLE test_alter_preserve_no_append(
 -- SQLNESS REPLACE \d+\(\d+,\s+\d+\) REDACTED
 ALTER TABLE test_alter_preserve_no_append SET 'preserve_row_sequence' = 'true';
 
--- Clean up
 DROP TABLE test_alter_preserve_no_append;

--- a/tests/cases/standalone/common/alter/alter_preserve_row_sequence.sql
+++ b/tests/cases/standalone/common/alter/alter_preserve_row_sequence.sql
@@ -1,0 +1,50 @@
+-- Test altering preserve_row_sequence on an append-only table, including
+-- persistence across a restart.
+
+-- Create an append-only table
+CREATE TABLE test_alter_preserve_row_sequence(
+    host STRING,
+    ts TIMESTAMP TIME INDEX,
+    cpu DOUBLE,
+    PRIMARY KEY(host)
+) ENGINE=mito WITH('append_mode'='true');
+
+-- Insert some data
+INSERT INTO test_alter_preserve_row_sequence VALUES ('host1', 0, 1.0), ('host2', 1, 2.0);
+
+-- SET preserve_row_sequence on the append-only table should succeed
+ALTER TABLE test_alter_preserve_row_sequence SET 'preserve_row_sequence' = 'true';
+
+-- SHOW CREATE TABLE should show both append_mode and preserve_row_sequence
+SHOW CREATE TABLE test_alter_preserve_row_sequence;
+
+-- Restart the server: the option and the inserted data must survive
+-- SQLNESS ARG restart=true
+SHOW CREATE TABLE test_alter_preserve_row_sequence;
+
+-- Ordinary query should still see the inserted rows after restart
+SELECT * FROM test_alter_preserve_row_sequence ORDER BY host, ts;
+
+-- UNSET preserve_row_sequence should succeed
+ALTER TABLE test_alter_preserve_row_sequence UNSET 'preserve_row_sequence';
+
+-- SHOW CREATE TABLE should keep append_mode but drop preserve_row_sequence
+SHOW CREATE TABLE test_alter_preserve_row_sequence;
+
+-- Clean up
+DROP TABLE test_alter_preserve_row_sequence;
+
+-- Test that preserve_row_sequence requires append_mode=true
+CREATE TABLE test_alter_preserve_no_append(
+    host STRING,
+    ts TIMESTAMP TIME INDEX,
+    cpu DOUBLE,
+    PRIMARY KEY(host)
+) ENGINE=mito;
+
+-- Setting preserve_row_sequence on a non-append-only table should fail
+-- SQLNESS REPLACE \d+\(\d+,\s+\d+\) REDACTED
+ALTER TABLE test_alter_preserve_no_append SET 'preserve_row_sequence' = 'true';
+
+-- Clean up
+DROP TABLE test_alter_preserve_no_append;

--- a/tests/compatibility/cases/downgrade_compatibility/case.toml
+++ b/tests/compatibility/cases/downgrade_compatibility/case.toml
@@ -1,8 +1,8 @@
 name = "downgrade_compatibility"
-reason = "Verify v1.1.4 can reopen a table whose region WAL options were written by the current binary."
-introduced_by = "fix: preserve legacy region WAL options format"
+reason = "Verify v1.1.4 can reopen a table whose region WAL options were written by the current binary, and can read all rows of an append-only table flushed and compacted with preserve_row_sequence enabled."
+introduced_by = "fix: preserve legacy region WAL options format; preserve_row_sequence"
 topologies = ["distributed", "standalone"]
 from_range = [">=v1.2.0"]
 to_range = ["=v1.1.4"]
-features = ["table", "wal", "downgrade"]
+features = ["table", "wal", "downgrade", "append", "preserve_row_sequence"]
 owner = "metasrv"

--- a/tests/compatibility/cases/downgrade_compatibility/setup.sql
+++ b/tests/compatibility/cases/downgrade_compatibility/setup.sql
@@ -9,3 +9,26 @@ INSERT INTO t_downgrade_compatibility VALUES
 ('2024-02-09 00:01:00+0000', 'host_b', 2);
 
 ADMIN FLUSH_TABLE('t_downgrade_compatibility');
+
+CREATE TABLE t_preserve_sequence_downgrade(
+    ts TIMESTAMP TIME INDEX,
+    host STRING,
+    val INT,
+    PRIMARY KEY(host)
+)
+ENGINE=mito
+WITH(append_mode='true', preserve_row_sequence='true');
+
+INSERT INTO t_preserve_sequence_downgrade VALUES
+('2024-02-09 00:00:00+0000', 'host_a', 1),
+('2024-02-09 00:01:00+0000', 'host_b', 2);
+
+ADMIN FLUSH_TABLE('t_preserve_sequence_downgrade');
+
+INSERT INTO t_preserve_sequence_downgrade VALUES
+('2024-02-09 00:02:00+0000', 'host_a', 3),
+('2024-02-09 00:03:00+0000', 'host_c', 4);
+
+ADMIN FLUSH_TABLE('t_preserve_sequence_downgrade');
+
+ADMIN COMPACT_TABLE('t_preserve_sequence_downgrade');

--- a/tests/compatibility/cases/downgrade_compatibility/verify.result
+++ b/tests/compatibility/cases/downgrade_compatibility/verify.result
@@ -6,3 +6,14 @@ SELECT ts, host, val FROM t_downgrade_compatibility ORDER BY ts, host;
 | 2024-02-09T00:00:00 | host_a | 1   |
 | 2024-02-09T00:01:00 | host_b | 2   |
 +---------------------+--------+-----+
+
+SELECT ts, host, val FROM t_preserve_sequence_downgrade ORDER BY ts, host;
+
++---------------------+--------+-----+
+| ts                  | host   | val |
++---------------------+--------+-----+
+| 2024-02-09T00:00:00 | host_a | 1   |
+| 2024-02-09T00:01:00 | host_b | 2   |
+| 2024-02-09T00:02:00 | host_a | 3   |
+| 2024-02-09T00:03:00 | host_c | 4   |
++---------------------+--------+-----+

--- a/tests/compatibility/cases/downgrade_compatibility/verify.sql
+++ b/tests/compatibility/cases/downgrade_compatibility/verify.sql
@@ -1,1 +1,3 @@
 SELECT ts, host, val FROM t_downgrade_compatibility ORDER BY ts, host;
+
+SELECT ts, host, val FROM t_preserve_sequence_downgrade ORDER BY ts, host;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Depends on #8862; the Flow caller that enables `exact_sequence_range=true` is intentionally delivered in a later stacked PR.

## What's changed and what's your intention?

This PR adds the OSS storage support needed for Flow sequence-range reads. It introduces the append-only `preserve_row_sequence` option, which keeps each row's physical `__sequence` through flush and compaction, and persists a per-SST capability marker so the storage layer can safely answer an exact `(C, H]` sequence-range request.

The exact-read path derives the time-selected SST set once and uses that same set for capability validation and scanning. It applies row-level sequence filtering only when the region and every selected file can prove that their sequence domains are compatible; legacy, unmarked, mixed, copied, foreign-region, or otherwise untrusted files fail closed with `SEQUENCE_RANGE_UNSUPPORTED` rather than returning an approximation. Existing non-exact scans retain their normal behavior, and incompatible pruning hints are rejected.

The change also:

- Supports `ALTER TABLE ... SET/UNSET 'preserve_row_sequence'`, including metadata persistence, `SHOW CREATE TABLE`, restart behavior, and rejection when `append_mode` is not enabled.
- Preserves the option through both normal and write-cache SST creation and through compaction only when all inputs are trusted. Compaction rewrites untrusted inputs without laundering their sequence capability; copied files likewise clear the marker.
- Adds the required request, region-option, file-metadata, scan, cache-key, and compatibility serialization coverage.
- Adds Mito tests for flat and primary-key formats, flush/compaction rewrites, legacy and mixed-file fail-closed behavior, copy-region handling, `LastRow`, bulk publication ordering, and exact-range filtering, plus the `alter_preserve_row_sequence` SQLness case.
- Includes final diff cleanup: a single exact-read SST selection derivation, hardened compaction rewrite coverage, consolidated serde coverage, removal of obsolete no-op bulk-compaction claims, ALTER comment cleanup, and the SQLness result trailing-newline fix.

The persisted option and file metadata remain backward compatible. This PR provides the storage/data-plane capability; it does not yet make Flow issue `exact_sequence_range=true`, which is handled by the later stacked caller change.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
