### PR TITLE
perf: optimize Prometheus remote write v2 decoding

### DIFF
--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -178,6 +178,7 @@ common-version.workspace = true
 [[bench]]
 name = "bench_prom"
 harness = false
+required-features = ["testing"]
 
 [[bench]]
 name = "to_http_output"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -178,6 +178,10 @@ common-version.workspace = true
 [[bench]]
 name = "bench_prom"
 harness = false
+
+[[bench]]
+name = "prom_decode"
+harness = false
 required-features = ["testing"]
 
 [[bench]]

--- a/src/servers/benches/prom_decode.rs
+++ b/src/servers/benches/prom_decode.rs
@@ -17,7 +17,9 @@ use std::time::Duration;
 
 use api::greptime_proto::io::prometheus::write::v2 as write_v2;
 use api::prom_store::remote::{self as write_v1, WriteRequest};
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
+};
 use prost::Message;
 use servers::prom_remote_write::decode::{PromSeriesProcessor, PromWriteRequest};
 use servers::prom_remote_write::v2::test_util as remote_write_v2;
@@ -187,6 +189,7 @@ fn bench_decode_prom_request(c: &mut Criterion) {
 /// Workloads:
 /// - `fixture`: existing `write_request.pb.data` converted v1 -> v2
 /// - `synthetic_*`: generated series with shared labels (symbol-table friendly)
+#[allow(clippy::print_stderr)]
 fn bench_prom_v1_vs_v2_decode(c: &mut Criterion) {
     let fixture_v1_bytes = load_fixture_v1_bytes();
     let fixture_v1 = WriteRequest::decode(fixture_v1_bytes.as_slice()).unwrap();
@@ -251,23 +254,25 @@ fn bench_prom_v1_vs_v2_decode(c: &mut Criterion) {
     // --- full path: protobuf -> Greptime row inserts ---
     {
         let mut group = c.benchmark_group("prom_rw_decode_to_rows");
-        group.measurement_time(Duration::from_secs(3));
+        group.sample_size(50);
+        group.measurement_time(Duration::from_secs(5));
 
         for (name, v1_bytes, v2_bytes) in &workloads {
             group.throughput(Throughput::Bytes(v1_bytes.len() as u64));
             group.bench_with_input(BenchmarkId::new("v1_custom", name), v1_bytes, |b, bytes| {
                 let mut prom_request = PromWriteRequest::default();
                 let mut processor = PromSeriesProcessor::default_processor();
-                b.iter(|| {
-                    prom_request
-                        .decode(
-                            black_box(bytes.clone()),
-                            PromValidationMode::Strict,
-                            &mut processor,
-                        )
-                        .unwrap();
-                    black_box(prom_request.as_row_insert_requests());
-                });
+                b.iter_batched(
+                    || bytes.clone(),
+                    |bytes| {
+                        prom_request
+                            .decode(black_box(bytes), PromValidationMode::Strict, &mut processor)
+                            .unwrap();
+                        let rows = prom_request.as_row_insert_requests();
+                        black_box(&rows);
+                    },
+                    BatchSize::LargeInput,
+                );
             });
 
             // Baseline: stock prost WriteRequest + existing converter.

--- a/src/servers/benches/prom_decode.rs
+++ b/src/servers/benches/prom_decode.rs
@@ -280,10 +280,15 @@ fn bench_prom_v1_vs_v2_decode(c: &mut Criterion) {
             });
 
             group.throughput(Throughput::Bytes(v2_bytes.len() as u64));
-            group.bench_with_input(BenchmarkId::new("v2", name), v2_bytes, |b, bytes| {
+            group.bench_with_input(BenchmarkId::new("v2_manual", name), v2_bytes, |b, bytes| {
                 b.iter(|| {
-                    let request = write_v2::Request::decode(black_box(bytes.as_slice())).unwrap();
-                    black_box(remote_write_v2::write_requests(request).unwrap());
+                    black_box(
+                        remote_write_v2::decode_uncompressed_write_requests(
+                            black_box(bytes.as_slice()),
+                            true,
+                        )
+                        .unwrap(),
+                    );
                 });
             });
         }

--- a/src/servers/benches/prom_decode.rs
+++ b/src/servers/benches/prom_decode.rs
@@ -12,21 +12,135 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
-use api::prom_store::remote::WriteRequest;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use api::greptime_proto::io::prometheus::write::v2 as write_v2;
+use api::prom_store::remote::{self as write_v1, WriteRequest};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use prost::Message;
 use servers::prom_remote_write::decode::{PromSeriesProcessor, PromWriteRequest};
+use servers::prom_remote_write::v2::test_util as remote_write_v2;
 use servers::prom_remote_write::validation::{PromValidationMode, validate_label_name};
 use servers::prom_store::to_grpc_row_insert_requests;
 
-fn bench_decode_prom_request(c: &mut Criterion) {
+fn load_fixture_v1_bytes() -> Vec<u8> {
     let mut d = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("benches");
     d.push("write_request.pb.data");
+    std::fs::read(d).expect("read write_request.pb.data fixture")
+}
 
-    let data = std::fs::read(d).unwrap();
+/// Convert a PRW v1 `WriteRequest` into an equivalent PRW v2 `Request`.
+///
+/// Labels are interned into the v2 symbol table so payloads with repeated label
+/// names/values exercise the main on-wire advantage of v2.
+fn write_request_v1_to_v2(v1: &WriteRequest) -> write_v2::Request {
+    let mut symbols = vec![String::new()];
+    let mut symbol_index: HashMap<String, u32> = HashMap::new();
+    symbol_index.insert(String::new(), 0);
+
+    let mut intern = |value: &str| -> u32 {
+        if let Some(&idx) = symbol_index.get(value) {
+            return idx;
+        }
+        let idx = symbols.len() as u32;
+        symbols.push(value.to_string());
+        symbol_index.insert(value.to_string(), idx);
+        idx
+    };
+
+    let timeseries = v1
+        .timeseries
+        .iter()
+        .map(|series| {
+            let mut labels: Vec<&write_v1::Label> = series.labels.iter().collect();
+            // PRW v2 requires lexicographically sorted label pairs.
+            labels.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.value.cmp(&b.value)));
+
+            let mut labels_refs = Vec::with_capacity(labels.len() * 2);
+            for label in labels {
+                labels_refs.push(intern(&label.name));
+                labels_refs.push(intern(&label.value));
+            }
+
+            write_v2::TimeSeries {
+                labels_refs,
+                samples: series
+                    .samples
+                    .iter()
+                    .map(|sample| write_v2::Sample {
+                        value: sample.value,
+                        timestamp: sample.timestamp,
+                        start_timestamp: 0,
+                    })
+                    .collect(),
+                histograms: Vec::new(),
+                exemplars: Vec::new(),
+                metadata: None,
+            }
+        })
+        .collect();
+
+    write_v2::Request {
+        symbols,
+        timeseries,
+    }
+}
+
+/// Synthetic sample workload with controllable label reuse.
+///
+/// `shared_labels` keeps common label names/values across series (v2-friendly).
+/// Each series also gets a unique `series_id` label so cardinality stays high.
+fn generate_sample_workload(
+    series_count: usize,
+    samples_per_series: usize,
+    shared_label_count: usize,
+) -> (WriteRequest, write_v2::Request) {
+    let shared_labels: Vec<write_v1::Label> = (0..shared_label_count)
+        .map(|i| write_v1::Label {
+            name: format!("label_{i}"),
+            value: format!("value_{}", i % 16),
+        })
+        .collect();
+
+    let timeseries = (0..series_count)
+        .map(|series_idx| {
+            let mut labels = Vec::with_capacity(shared_label_count + 2);
+            labels.push(write_v1::Label {
+                name: "__name__".to_string(),
+                value: format!("metric_{}", series_idx % 32),
+            });
+            labels.extend(shared_labels.iter().cloned());
+            labels.push(write_v1::Label {
+                name: "series_id".to_string(),
+                value: series_idx.to_string(),
+            });
+
+            write_v1::TimeSeries {
+                labels,
+                samples: (0..samples_per_series)
+                    .map(|sample_idx| write_v1::Sample {
+                        value: (series_idx * 1000 + sample_idx) as f64,
+                        timestamp: 1_700_000_000_000 + sample_idx as i64 * 1_000,
+                    })
+                    .collect(),
+                exemplars: Vec::new(),
+                histograms: Vec::new(),
+            }
+        })
+        .collect();
+
+    let v1 = WriteRequest {
+        timeseries,
+        metadata: Vec::new(),
+    };
+    let v2 = write_request_v1_to_v2(&v1);
+    (v1, v2)
+}
+
+fn bench_decode_prom_request(c: &mut Criterion) {
+    let data = load_fixture_v1_bytes();
 
     let mut group = c.benchmark_group("decode_prom_request");
     group.measurement_time(Duration::from_secs(3));
@@ -62,6 +176,120 @@ fn bench_decode_prom_request(c: &mut Criterion) {
     }
 
     group.finish();
+}
+
+/// Compare Prometheus remote-write v1 vs v2 decoding efficiency.
+///
+/// Two layers are measured on equivalent logical payloads:
+/// 1. protobuf decode only (`WriteRequest` / v2 `Request`)
+/// 2. full Greptime path to row-insert requests
+///
+/// Workloads:
+/// - `fixture`: existing `write_request.pb.data` converted v1 -> v2
+/// - `synthetic_*`: generated series with shared labels (symbol-table friendly)
+fn bench_prom_v1_vs_v2_decode(c: &mut Criterion) {
+    let fixture_v1_bytes = load_fixture_v1_bytes();
+    let fixture_v1 = WriteRequest::decode(fixture_v1_bytes.as_slice()).unwrap();
+    let fixture_v2 = write_request_v1_to_v2(&fixture_v1);
+    let fixture_v2_bytes = fixture_v2.encode_to_vec();
+
+    let synthetic = [
+        (
+            "synthetic_1k_series_1_sample",
+            generate_sample_workload(1_000, 1, 8),
+        ),
+        (
+            "synthetic_1k_series_10_samples",
+            generate_sample_workload(1_000, 10, 8),
+        ),
+        (
+            "synthetic_5k_series_1_sample",
+            generate_sample_workload(5_000, 1, 8),
+        ),
+    ];
+
+    let mut workloads: Vec<(&str, Vec<u8>, Vec<u8>)> =
+        vec![("fixture", fixture_v1_bytes, fixture_v2_bytes)];
+    for (name, (v1, v2)) in &synthetic {
+        workloads.push((*name, v1.encode_to_vec(), v2.encode_to_vec()));
+    }
+
+    eprintln!("\nprom remote-write v1 vs v2 payload sizes:");
+    for (name, v1_bytes, v2_bytes) in &workloads {
+        let ratio = v2_bytes.len() as f64 / v1_bytes.len() as f64;
+        eprintln!(
+            "  {name}: v1={} B, v2={} B, v2/v1={ratio:.3}",
+            v1_bytes.len(),
+            v2_bytes.len()
+        );
+    }
+
+    // --- protobuf decode only ---
+    {
+        let mut group = c.benchmark_group("prom_rw_protobuf_decode");
+        group.measurement_time(Duration::from_secs(3));
+
+        for (name, v1_bytes, v2_bytes) in &workloads {
+            group.throughput(Throughput::Bytes(v1_bytes.len() as u64));
+            group.bench_with_input(BenchmarkId::new("v1", name), v1_bytes, |b, bytes| {
+                b.iter(|| {
+                    black_box(WriteRequest::decode(black_box(bytes.as_slice())).unwrap());
+                });
+            });
+
+            group.throughput(Throughput::Bytes(v2_bytes.len() as u64));
+            group.bench_with_input(BenchmarkId::new("v2", name), v2_bytes, |b, bytes| {
+                b.iter(|| {
+                    black_box(write_v2::Request::decode(black_box(bytes.as_slice())).unwrap());
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    // --- full path: protobuf -> Greptime row inserts ---
+    {
+        let mut group = c.benchmark_group("prom_rw_decode_to_rows");
+        group.measurement_time(Duration::from_secs(3));
+
+        for (name, v1_bytes, v2_bytes) in &workloads {
+            group.throughput(Throughput::Bytes(v1_bytes.len() as u64));
+            group.bench_with_input(BenchmarkId::new("v1_custom", name), v1_bytes, |b, bytes| {
+                let mut prom_request = PromWriteRequest::default();
+                let mut processor = PromSeriesProcessor::default_processor();
+                b.iter(|| {
+                    prom_request
+                        .decode(
+                            black_box(bytes.clone()),
+                            PromValidationMode::Strict,
+                            &mut processor,
+                        )
+                        .unwrap();
+                    black_box(prom_request.as_row_insert_requests());
+                });
+            });
+
+            // Baseline: stock prost WriteRequest + existing converter.
+            group.throughput(Throughput::Bytes(v1_bytes.len() as u64));
+            group.bench_with_input(BenchmarkId::new("v1_prost", name), v1_bytes, |b, bytes| {
+                b.iter(|| {
+                    let request = WriteRequest::decode(black_box(bytes.as_slice())).unwrap();
+                    black_box(to_grpc_row_insert_requests(&request).unwrap());
+                });
+            });
+
+            group.throughput(Throughput::Bytes(v2_bytes.len() as u64));
+            group.bench_with_input(BenchmarkId::new("v2", name), v2_bytes, |b, bytes| {
+                b.iter(|| {
+                    let request = write_v2::Request::decode(black_box(bytes.as_slice())).unwrap();
+                    black_box(remote_write_v2::write_requests(request).unwrap());
+                });
+            });
+        }
+
+        group.finish();
+    }
 }
 
 /// Benchmark comparing UTF-8 string validation (`decode_string`) vs
@@ -155,6 +383,7 @@ fn bench_utf8_validation(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_decode_prom_request,
+    bench_prom_v1_vs_v2_decode,
     bench_label_name_validation,
     bench_utf8_validation
 );

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -48,7 +48,7 @@ use crate::http::header::{
 use crate::pending_rows_batcher::PendingRowsBatcher;
 use crate::prom_remote_write::decode::PromSeriesProcessor;
 use crate::prom_remote_write::decode_remote_write_request;
-use crate::prom_remote_write::v2::{decode_remote_write_v2_request, into_write_requests};
+use crate::prom_remote_write::v2::decode_remote_write_v2;
 use crate::prom_remote_write::validation::PromValidationMode;
 use crate::prom_store::snappy_decompress;
 use crate::query_handler::{PipelineHandlerRef, PromStoreProtocolHandlerRef, PromStoreResponse};
@@ -235,23 +235,11 @@ async fn remote_write_v2(
     let (db, mut query_ctx, _timer) =
         prepare_remote_write_context(&params, query_ctx, REMOTE_WRITE_V2_VERSION);
 
-    let request = match decode_remote_write_v2_request(is_zstd, body) {
-        Ok(request) => request,
-        Err(error) => return Ok(remote_write_v2_error_response(error, 0, 0, 0)),
-    };
-    if !experimental_enable_prometheus_native_histogram && request_has_native_histograms(&request) {
-        return Ok(remote_write_v2_error_response(
-            error::InvalidPromRemoteRequestSnafu {
-                msg: "prometheus remote write v2 native histogram ingestion is experimental; set prom_store.experimental_enable_prometheus_native_histogram = true to enable it"
-                    .to_string(),
-            }
-            .build(),
-            0,
-            0,
-            0,
-        ));
-    }
-    let req = match into_write_requests(request) {
+    let req = match decode_remote_write_v2(
+        is_zstd,
+        body,
+        experimental_enable_prometheus_native_histogram,
+    ) {
         Ok(req) => req,
         Err(error) => return Ok(remote_write_v2_error_response(error, 0, 0, 0)),
     };
@@ -300,15 +288,6 @@ async fn remote_write_v2(
     );
 
     Ok((StatusCode::NO_CONTENT, headers).into_response())
-}
-
-fn request_has_native_histograms(
-    request: &api::greptime_proto::io::prometheus::write::v2::Request,
-) -> bool {
-    request
-        .timeseries
-        .iter()
-        .any(|series| !series.histograms.is_empty())
 }
 
 fn vm_proto_version_response(params: &RemoteWriteQuery) -> Option<axum::response::Response> {

--- a/src/servers/src/prom_remote_write/README.md
+++ b/src/servers/src/prom_remote_write/README.md
@@ -11,27 +11,32 @@ Remote write v2 enters through `remote_write_v2` in
 ```mermaid
 flowchart TD
     A["HTTP /v1/prometheus/write"] --> B["remote_write_v2"]
-    B --> C["decode_remote_write_v2_request"]
-    C --> D["into_write_requests"]
+    B --> C["decode_remote_write_v2"]
+    C --> D["borrow symbols and time-series bytes"]
+    D --> E["decode leaf messages and build rows"]
 
-    D --> E["samples ContextReq"]
-    D --> F["histograms ContextReq"]
+    E --> F["samples ContextReq"]
+    E --> G["histograms ContextReq"]
 
-    E --> G["write_prometheus_rows_with_progress"]
-    G --> H["metric engine / pending batcher when enabled"]
+    F --> H["write_prometheus_rows_with_progress"]
+    H --> I["metric engine / pending batcher when enabled"]
 
-    F --> I["histogram ContextOpt"]
-    I --> J["write_prometheus_rows_with_progress"]
-    J --> K["same metric-engine flag as samples, no batcher"]
-    K --> L["table: <metric>"]
+    G --> J["histogram ContextOpt"]
+    J --> K["write_prometheus_rows_with_progress"]
+    K --> L["same metric-engine flag as samples, no batcher"]
+    L --> M["table: <metric>"]
 
-    L --> M["field: configured native-histogram Struct"]
-    M --> N["struct children: counts, spans, buckets, sum, schema"]
-    H --> P["written headers and counters"]
-    K --> P
+    M --> N["field: configured native-histogram Struct"]
+    N --> O["struct children: counts, spans, buckets, sum, schema"]
+    I --> P["written headers and counters"]
+    L --> P
 ```
 
 The conversion step splits one v2 request into two `ContextReq`s:
+
+The `decode` codec metric covers decompression and the borrowed request
+envelope. The `convert` metric covers per-series scans, leaf prost decoding,
+validation, and row construction.
 
 - samples keep the existing sample table name and can use the metric-engine
   physical table path and pending rows batcher;

--- a/src/servers/src/prom_remote_write/v2.rs
+++ b/src/servers/src/prom_remote_write/v2.rs
@@ -22,8 +22,11 @@ use api::greptime_proto::io::prometheus::write::v2::{
 #[cfg(test)]
 use api::greptime_proto::io::prometheus::write::v2::{Request, TimeSeries};
 use api::helper::ColumnDataTypeWrapper;
+use api::v1::helper::{field_column_schema, time_index_column_schema};
 use api::v1::value::ValueData;
-use api::v1::{ColumnSchema, ListValue, RowInsertRequest, Rows, SemanticType, Value};
+use api::v1::{
+    ColumnDataType, ColumnSchema, ListValue, RowInsertRequest, Rows, SemanticType, Value,
+};
 use bytes::{Buf, Bytes};
 use common_grpc::precision::Precision;
 use common_query::native_histogram::*;
@@ -390,6 +393,8 @@ fn decode_series_leaves(
     mut rows_remaining: usize,
     scratch: &mut LeafScratch,
 ) -> Result<()> {
+    let mut sample_row_template = None;
+
     while buf.has_remaining() {
         let (tag, wire_type) = decode_key(&mut buf).context(error::DecodePromRemoteRequestSnafu)?;
         match tag {
@@ -414,14 +419,38 @@ fn decode_series_leaves(
                     }
                 })?;
                 if let Some(SeriesWriter::Samples(table_data)) = &mut writer {
-                    if rows_remaining == 0 {
-                        write_sample(
+                    if sample_row_template.is_none() {
+                        let timestamp_index =
+                            table_data.ensure_column(time_index_column_schema(
+                                greptime_timestamp(),
+                                ColumnDataType::TimestampMillisecond,
+                            ))?;
+                        let value_index = table_data.ensure_column(field_column_schema(
+                            greptime_value(),
+                            ColumnDataType::Float64,
+                        ))?;
+                        let mut row = table_data.alloc_one_row();
+                        row_writer::write_tags(
                             table_data,
-                            &scratch.sample,
                             std::mem::take(&mut tags).into_iter(),
+                            &mut row,
                         )?;
-                    } else {
-                        write_sample(table_data, &scratch.sample, tags.iter().cloned())?;
+                        sample_row_template = Some((row, timestamp_index, value_index));
+                    }
+
+                    if let Some((row, timestamp_index, value_index)) = sample_row_template.as_mut()
+                    {
+                        row[*timestamp_index].value_data = Some(
+                            ValueData::TimestampMillisecondValue(scratch.sample.timestamp),
+                        );
+                        row[*value_index].value_data =
+                            Some(ValueData::F64Value(scratch.sample.value));
+                        let row = if rows_remaining == 0 {
+                            std::mem::take(row)
+                        } else {
+                            row.clone()
+                        };
+                        table_data.add_row(row);
                     }
                 }
             }
@@ -546,26 +575,6 @@ fn get_or_create_table_data(
         }
         Entry::Vacant(entry) => entry.insert(TableData::new(column_count, row_count)),
     }
-}
-
-fn write_sample(
-    table_data: &mut TableData,
-    sample: &Sample,
-    tags: impl Iterator<Item = (String, String)>,
-) -> Result<()> {
-    let mut row = table_data.alloc_one_row();
-    row_writer::write_ts_to_millis(
-        table_data,
-        greptime_timestamp(),
-        Some(sample.timestamp),
-        Precision::Millisecond,
-        &mut row,
-    )?;
-    row_writer::write_f64(table_data, greptime_value(), sample.value, &mut row)?;
-    row_writer::write_tags(table_data, tags, &mut row)?;
-    table_data.add_row(row);
-
-    Ok(())
 }
 
 fn write_native_histogram(
@@ -1758,6 +1767,14 @@ mod tests {
         assert_eq!(
             rows.rows[1].values[1].value_data,
             Some(ValueData::F64Value(43.0))
+        );
+        assert_eq!(
+            rows.rows[1].values[2].value_data,
+            Some(ValueData::StringValue("api".to_string()))
+        );
+        assert_eq!(
+            rows.rows[1].values[3].value_data,
+            Some(ValueData::StringValue("localhost:9090".to_string()))
         );
     }
 

--- a/src/servers/src/prom_remote_write/v2.rs
+++ b/src/servers/src/prom_remote_write/v2.rs
@@ -61,6 +61,11 @@ type PromTags<'a> = Vec<(&'a str, String)>;
 type ResolvedSeriesLabels<'a> = (PromCtx, String, PromTags<'a>);
 const MAX_REMOTE_WRITE_V2_SCHEMA: i32 = 8;
 const MAX_REDUCIBLE_REMOTE_WRITE_V2_SCHEMA: i32 = 52;
+const TIME_SERIES_LABELS_REFS_TAG: u32 = 1;
+const TIME_SERIES_SAMPLES_TAG: u32 = 2;
+const TIME_SERIES_HISTOGRAMS_TAG: u32 = 3;
+const TIME_SERIES_EXEMPLARS_TAG: u32 = 4;
+const TIME_SERIES_METADATA_TAG: u32 = 5;
 
 struct BorrowedRequest<'a> {
     symbols: Vec<&'a str>,
@@ -334,12 +339,14 @@ fn scan_series(
     while buf.has_remaining() {
         let (tag, wire_type) = decode_key(&mut buf)?;
         match tag {
-            1 => uint32::merge_repeated(wire_type, labels_refs, &mut buf, DecodeContext::default())
-                .map_err(|mut error| {
+            TIME_SERIES_LABELS_REFS_TAG => {
+                uint32::merge_repeated(wire_type, labels_refs, &mut buf, DecodeContext::default())
+                    .map_err(|mut error| {
                     error.push("TimeSeries", "labels_refs");
                     error
-                })?,
-            2 => {
+                })?
+            }
+            TIME_SERIES_SAMPLES_TAG => {
                 take_length_delimited(wire_type, &mut buf).map_err(|mut error| {
                     error.push("TimeSeries", "samples");
                     error
@@ -348,7 +355,7 @@ fn scan_series(
                     DecodeError::new("remote write v2 sample count overflows usize")
                 })?;
             }
-            3 => {
+            TIME_SERIES_HISTOGRAMS_TAG => {
                 take_length_delimited(wire_type, &mut buf).map_err(|mut error| {
                     error.push("TimeSeries", "histograms");
                     error
@@ -357,15 +364,17 @@ fn scan_series(
                     DecodeError::new("remote write v2 histogram count overflows usize")
                 })?;
             }
-            4 => {
+            TIME_SERIES_EXEMPLARS_TAG => {
                 take_length_delimited(wire_type, &mut buf)?;
             }
-            5 => message::merge(wire_type, metadata, &mut buf, DecodeContext::default()).map_err(
-                |mut error| {
-                    error.push("TimeSeries", "metadata");
-                    error
-                },
-            )?,
+            TIME_SERIES_METADATA_TAG => {
+                message::merge(wire_type, metadata, &mut buf, DecodeContext::default()).map_err(
+                    |mut error| {
+                        error.push("TimeSeries", "metadata");
+                        error
+                    },
+                )?
+            }
             _ => skip_field(wire_type, tag, &mut buf, DecodeContext::default())?,
         }
     }
@@ -397,9 +406,11 @@ fn decode_series_leaves(
     while buf.has_remaining() {
         let (tag, wire_type) = decode_key(&mut buf).context(error::DecodePromRemoteRequestSnafu)?;
         match tag {
-            1 => skip_field(wire_type, tag, &mut buf, DecodeContext::default())
-                .context(error::DecodePromRemoteRequestSnafu)?,
-            2 => {
+            TIME_SERIES_LABELS_REFS_TAG => {
+                skip_field(wire_type, tag, &mut buf, DecodeContext::default())
+                    .context(error::DecodePromRemoteRequestSnafu)?
+            }
+            TIME_SERIES_SAMPLES_TAG => {
                 scratch.sample.clear();
                 message::merge(
                     wire_type,
@@ -454,7 +465,7 @@ fn decode_series_leaves(
                     }
                 }
             }
-            3 => {
+            TIME_SERIES_HISTOGRAMS_TAG => {
                 scratch.histogram.clear();
                 message::merge(
                     wire_type,
@@ -488,7 +499,7 @@ fn decode_series_leaves(
                     }
                 }
             }
-            4 => {
+            TIME_SERIES_EXEMPLARS_TAG => {
                 scratch.exemplar.clear();
                 message::merge(
                     wire_type,
@@ -502,7 +513,7 @@ fn decode_series_leaves(
                 })
                 .context(error::DecodePromRemoteRequestSnafu)?;
             }
-            5 => {
+            TIME_SERIES_METADATA_TAG => {
                 take_length_delimited(wire_type, &mut buf)
                     .map_err(|mut error| {
                         error.push("TimeSeries", "metadata");

--- a/src/servers/src/prom_remote_write/v2.rs
+++ b/src/servers/src/prom_remote_write/v2.rs
@@ -17,19 +17,22 @@ use std::collections::hash_map::Entry;
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use api::greptime_proto::io::prometheus::write::v2::histogram::{Count, ZeroCount};
 use api::greptime_proto::io::prometheus::write::v2::{
-    BucketSpan, Histogram, Request, Sample, TimeSeries, metadata,
+    BucketSpan, Exemplar, Histogram, Metadata, Sample, metadata,
 };
 #[cfg(test)]
-use api::greptime_proto::io::prometheus::write::v2::{Exemplar, Metadata};
+use api::greptime_proto::io::prometheus::write::v2::{Request, TimeSeries};
 use api::helper::ColumnDataTypeWrapper;
 use api::v1::value::ValueData;
 use api::v1::{ColumnSchema, ListValue, RowInsertRequest, Rows, SemanticType, Value};
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use common_grpc::precision::Precision;
 use common_query::native_histogram::*;
 use common_query::prelude::{greptime_native_histogram, greptime_timestamp, greptime_value};
 use pipeline::{ContextOpt, ContextReq};
-use prost::Message;
+use prost::encoding::{
+    DecodeContext, WireType, decode_key, decode_varint, message, skip_field, uint32,
+};
+use prost::{DecodeError, Message};
 use snafu::{OptionExt, ResultExt, ensure};
 use table::requests::{
     METADATA_QUALITY_DECLARED, SEMANTIC_METRIC_METADATA_QUALITY, SEMANTIC_METRIC_TYPE,
@@ -57,18 +60,50 @@ type ResolvedSeriesLabels = (PromCtx, String, PromTags);
 const MAX_REMOTE_WRITE_V2_SCHEMA: i32 = 8;
 const MAX_REDUCIBLE_REMOTE_WRITE_V2_SCHEMA: i32 = 52;
 
-pub(crate) fn decode_remote_write_v2_request(is_zstd: bool, body: Bytes) -> Result<Request> {
-    let _timer = crate::metrics::METRIC_HTTP_PROM_STORE_DECODE_ELAPSED.start_timer();
+struct BorrowedRequest<'a> {
+    symbols: Vec<&'a str>,
+    timeseries: Vec<&'a [u8]>,
+}
 
-    // Match the v1 decoder's VictoriaMetrics fallback: some clients may send a
-    // mismatched content-encoding header, so try the other compression on failure.
-    let buf = if let Ok(buf) = try_decompress(is_zstd, &body[..]) {
-        buf
-    } else {
-        try_decompress(!is_zstd, &body[..])?
-    };
+impl<'a> BorrowedRequest<'a> {
+    fn decode(mut buf: &'a [u8]) -> std::result::Result<Self, DecodeError> {
+        let mut symbols = Vec::new();
+        let mut timeseries = Vec::new();
 
-    Request::decode(&buf[..]).context(error::DecodePromRemoteRequestSnafu)
+        while buf.has_remaining() {
+            let (tag, wire_type) = decode_key(&mut buf)?;
+            match tag {
+                4 => {
+                    let value =
+                        take_length_delimited(wire_type, &mut buf).map_err(|mut error| {
+                            error.push("Request", "symbols");
+                            error
+                        })?;
+                    let symbol = std::str::from_utf8(value).map_err(|_| {
+                        let mut error =
+                            DecodeError::new("invalid string value: data is not UTF-8 encoded");
+                        error.push("Request", "symbols");
+                        error
+                    })?;
+                    symbols.push(symbol);
+                }
+                5 => {
+                    let series =
+                        take_length_delimited(wire_type, &mut buf).map_err(|mut error| {
+                            error.push("Request", "timeseries");
+                            error
+                        })?;
+                    timeseries.push(series);
+                }
+                _ => skip_field(wire_type, tag, &mut buf, DecodeContext::default())?,
+            }
+        }
+
+        Ok(Self {
+            symbols,
+            timeseries,
+        })
+    }
 }
 
 pub(crate) struct RemoteWriteV2WriteRequests {
@@ -81,19 +116,33 @@ pub(crate) struct RemoteWriteV2WriteRequests {
     pub semantic_index: SemanticIndexes,
 }
 
-/// Converts a PRW v2 request into normal sample writes and native histogram writes.
-///
-/// A metric name may appear in only one payload kind per request because the
-/// metric-engine logical table is either a float metric or a native histogram.
-pub(crate) fn into_write_requests(request: Request) -> Result<RemoteWriteV2WriteRequests> {
-    let _timer = crate::metrics::METRIC_HTTP_PROM_STORE_CONVERT_ELAPSED.start_timer();
-    let Request {
-        symbols,
-        timeseries,
-    } = request;
+pub(crate) fn decode_remote_write_v2(
+    is_zstd: bool,
+    body: Bytes,
+    native_histograms_enabled: bool,
+) -> Result<RemoteWriteV2WriteRequests> {
+    let decode_timer = crate::metrics::METRIC_HTTP_PROM_STORE_DECODE_ELAPSED.start_timer();
 
+    // Match the v1 decoder's VictoriaMetrics fallback: some clients may send a
+    // mismatched content-encoding header, so try the other compression on failure.
+    let buf = if let Ok(buf) = try_decompress(is_zstd, &body[..]) {
+        buf
+    } else {
+        try_decompress(!is_zstd, &body[..])?
+    };
+    let request = BorrowedRequest::decode(&buf).context(error::DecodePromRemoteRequestSnafu)?;
+    drop(decode_timer);
+
+    let _convert_timer = crate::metrics::METRIC_HTTP_PROM_STORE_CONVERT_ELAPSED.start_timer();
+    convert_remote_write_v2(request, native_histograms_enabled)
+}
+
+fn convert_remote_write_v2(
+    request: BorrowedRequest<'_>,
+    native_histograms_enabled: bool,
+) -> Result<RemoteWriteV2WriteRequests> {
     ensure!(
-        symbols.first().map(|s| s.as_str()) == Some(""),
+        request.symbols.first().copied() == Some(""),
         error::InvalidPromRemoteRequestSnafu {
             msg: "remote write v2 symbols must start with an empty string".to_string(),
         }
@@ -104,28 +153,40 @@ pub(crate) fn into_write_requests(request: Request) -> Result<RemoteWriteV2Write
     let mut label_names = HashSet::new();
     let mut sample_count_total = 0;
     let mut histogram_count_total = 0;
+    let mut labels_refs = Vec::new();
+    let mut metadata = Metadata::default();
+    let mut scratch = LeafScratch::default();
     let mut semantic_index = SemanticIndexes::default();
 
-    for series in timeseries {
-        // Exemplars are intentionally ignored for now.
-        let sample_count = series.samples.len();
-        let histogram_count = series.histograms.len();
-        if sample_count == 0 && histogram_count == 0 {
+    for series in request.timeseries {
+        let counts = scan_series(series, &mut labels_refs, &mut metadata)
+            .context(error::DecodePromRemoteRequestSnafu)?;
+
+        ensure!(
+            native_histograms_enabled || counts.histograms == 0,
+            error::InvalidPromRemoteRequestSnafu {
+                msg: "prometheus remote write v2 native histogram ingestion is experimental; set prom_store.experimental_enable_prometheus_native_histogram = true to enable it"
+                    .to_string(),
+            }
+        );
+
+        if counts.samples == 0 && counts.histograms == 0 {
+            decode_series_leaves(series, None, Vec::new(), 0, &mut scratch)?;
             continue;
         }
 
         let (prom_ctx, table_name, tags) =
-            resolve_series_labels(&symbols, &series, &mut label_names)?;
+            resolve_series_labels(&request.symbols, &labels_refs, &mut label_names)?;
         ensure_no_internal_histogram_labels(&tags)?;
         record_series_metadata(
             &mut semantic_index,
-            &symbols,
-            &series,
+            &request.symbols,
+            &metadata,
             &prom_ctx,
             &table_name,
         )?;
-        let has_other_value_type = if sample_count > 0 {
-            histogram_count > 0
+        let has_other_value_type = if counts.samples > 0 {
+            counts.histograms > 0
                 || histogram_tables
                     .get(&prom_ctx)
                     .is_some_and(|tables| tables.contains_key(&table_name))
@@ -143,42 +204,40 @@ pub(crate) fn into_write_requests(request: Request) -> Result<RemoteWriteV2Write
             }
         );
 
-        if sample_count > 0 && histogram_count == 0 {
-            // Fast path for regular sample-only series. Move the resolved labels into
-            // the sample writer instead of cloning them for a histogram path we won't use.
-            let table_data = get_or_create_table_data(
-                &mut sample_tables,
-                prom_ctx,
-                table_name,
-                tags.len() + 2,
-                sample_count,
-            );
+        let column_count =
+            tags.len()
+                .checked_add(2)
+                .with_context(|| error::InvalidPromRemoteRequestSnafu {
+                    msg: "remote write v2 series has too many labels".to_string(),
+                })?;
+        let (writer, row_count) = if counts.samples > 0 {
+            (
+                SeriesWriter::Samples(get_or_create_table_data(
+                    &mut sample_tables,
+                    prom_ctx,
+                    table_name,
+                    column_count,
+                    counts.samples,
+                )),
+                counts.samples,
+            )
+        } else {
+            (
+                SeriesWriter::Histograms(get_or_create_table_data(
+                    &mut histogram_tables,
+                    prom_ctx,
+                    table_name,
+                    column_count,
+                    counts.histograms,
+                )),
+                counts.histograms,
+            )
+        };
 
-            write_samples(table_data, series.samples, tags)?;
-            sample_count_total += sample_count as u64;
-            // The owned labels were moved above, so skip the mixed-series path below.
-            continue;
-        }
-
-        if histogram_count > 0 {
-            let table_data = get_or_create_table_data(
-                &mut histogram_tables,
-                prom_ctx,
-                table_name,
-                tags.len() + 2,
-                histogram_count,
-            );
-
-            let mut histograms = series.histograms;
-            let Some(last_histogram) = histograms.pop() else {
-                continue;
-            };
-            for histogram in &histograms {
-                write_native_histogram(table_data, histogram, tags.iter().cloned())?;
-            }
-            write_native_histogram(table_data, &last_histogram, tags.into_iter())?;
-            histogram_count_total += histogram_count as u64;
-        }
+        decode_series_leaves(series, Some(writer), tags, row_count, &mut scratch)?;
+        sample_count_total = checked_total(sample_count_total, counts.samples, "sample")?;
+        histogram_count_total =
+            checked_total(histogram_count_total, counts.histograms, "histogram")?;
     }
 
     Ok(RemoteWriteV2WriteRequests {
@@ -201,14 +260,11 @@ pub(crate) fn into_write_requests(request: Request) -> Result<RemoteWriteV2Write
 /// symbol table.
 fn record_series_metadata(
     index: &mut SemanticIndexes,
-    symbols: &[String],
-    series: &TimeSeries,
+    symbols: &[&str],
+    series_metadata: &Metadata,
     prom_ctx: &PromCtx,
     table_name: &str,
 ) -> Result<()> {
-    let Some(series_metadata) = &series.metadata else {
-        return Ok(());
-    };
     // Symbol 0 is the mandatory empty string: no help / no unit.
     if series_metadata.help_ref != 0 {
         symbol_ref(symbols, series_metadata.help_ref, "metadata help")?;
@@ -258,6 +314,223 @@ fn metric_type_value(wire_type: i32) -> Option<&'static str> {
     }
 }
 
+#[derive(Default)]
+struct SeriesCounts {
+    samples: usize,
+    histograms: usize,
+}
+
+fn scan_series(
+    mut buf: &[u8],
+    labels_refs: &mut Vec<u32>,
+    metadata: &mut Metadata,
+) -> std::result::Result<SeriesCounts, DecodeError> {
+    labels_refs.clear();
+    metadata.clear();
+    let mut counts = SeriesCounts::default();
+
+    while buf.has_remaining() {
+        let (tag, wire_type) = decode_key(&mut buf)?;
+        match tag {
+            1 => uint32::merge_repeated(wire_type, labels_refs, &mut buf, DecodeContext::default())
+                .map_err(|mut error| {
+                    error.push("TimeSeries", "labels_refs");
+                    error
+                })?,
+            2 => {
+                take_length_delimited(wire_type, &mut buf).map_err(|mut error| {
+                    error.push("TimeSeries", "samples");
+                    error
+                })?;
+                counts.samples = counts.samples.checked_add(1).ok_or_else(|| {
+                    DecodeError::new("remote write v2 sample count overflows usize")
+                })?;
+            }
+            3 => {
+                take_length_delimited(wire_type, &mut buf).map_err(|mut error| {
+                    error.push("TimeSeries", "histograms");
+                    error
+                })?;
+                counts.histograms = counts.histograms.checked_add(1).ok_or_else(|| {
+                    DecodeError::new("remote write v2 histogram count overflows usize")
+                })?;
+            }
+            4 => {
+                take_length_delimited(wire_type, &mut buf)?;
+            }
+            5 => message::merge(wire_type, metadata, &mut buf, DecodeContext::default()).map_err(
+                |mut error| {
+                    error.push("TimeSeries", "metadata");
+                    error
+                },
+            )?,
+            _ => skip_field(wire_type, tag, &mut buf, DecodeContext::default())?,
+        }
+    }
+
+    Ok(counts)
+}
+
+#[derive(Default)]
+struct LeafScratch {
+    sample: Sample,
+    histogram: Histogram,
+    exemplar: Exemplar,
+}
+
+enum SeriesWriter<'a> {
+    Samples(&'a mut TableData),
+    Histograms(&'a mut TableData),
+}
+
+fn decode_series_leaves(
+    mut buf: &[u8],
+    mut writer: Option<SeriesWriter<'_>>,
+    mut tags: PromTags,
+    mut rows_remaining: usize,
+    scratch: &mut LeafScratch,
+) -> Result<()> {
+    while buf.has_remaining() {
+        let (tag, wire_type) = decode_key(&mut buf).context(error::DecodePromRemoteRequestSnafu)?;
+        match tag {
+            1 => skip_field(wire_type, tag, &mut buf, DecodeContext::default())
+                .context(error::DecodePromRemoteRequestSnafu)?,
+            2 => {
+                scratch.sample.clear();
+                message::merge(
+                    wire_type,
+                    &mut scratch.sample,
+                    &mut buf,
+                    DecodeContext::default(),
+                )
+                .map_err(|mut error| {
+                    error.push("TimeSeries", "samples");
+                    error
+                })
+                .context(error::DecodePromRemoteRequestSnafu)?;
+                rows_remaining = rows_remaining.checked_sub(1).with_context(|| {
+                    error::InvalidPromRemoteRequestSnafu {
+                        msg: "remote write v2 sample count changed between scans".to_string(),
+                    }
+                })?;
+                if let Some(SeriesWriter::Samples(table_data)) = &mut writer {
+                    if rows_remaining == 0 {
+                        write_sample(
+                            table_data,
+                            &scratch.sample,
+                            std::mem::take(&mut tags).into_iter(),
+                        )?;
+                    } else {
+                        write_sample(table_data, &scratch.sample, tags.iter().cloned())?;
+                    }
+                }
+            }
+            3 => {
+                scratch.histogram.clear();
+                message::merge(
+                    wire_type,
+                    &mut scratch.histogram,
+                    &mut buf,
+                    DecodeContext::default(),
+                )
+                .map_err(|mut error| {
+                    error.push("TimeSeries", "histograms");
+                    error
+                })
+                .context(error::DecodePromRemoteRequestSnafu)?;
+                rows_remaining = rows_remaining.checked_sub(1).with_context(|| {
+                    error::InvalidPromRemoteRequestSnafu {
+                        msg: "remote write v2 histogram count changed between scans".to_string(),
+                    }
+                })?;
+                if let Some(SeriesWriter::Histograms(table_data)) = &mut writer {
+                    if rows_remaining == 0 {
+                        write_native_histogram(
+                            table_data,
+                            &scratch.histogram,
+                            std::mem::take(&mut tags).into_iter(),
+                        )?;
+                    } else {
+                        write_native_histogram(
+                            table_data,
+                            &scratch.histogram,
+                            tags.iter().cloned(),
+                        )?;
+                    }
+                }
+            }
+            4 => {
+                scratch.exemplar.clear();
+                message::merge(
+                    wire_type,
+                    &mut scratch.exemplar,
+                    &mut buf,
+                    DecodeContext::default(),
+                )
+                .map_err(|mut error| {
+                    error.push("TimeSeries", "exemplars");
+                    error
+                })
+                .context(error::DecodePromRemoteRequestSnafu)?;
+            }
+            5 => {
+                take_length_delimited(wire_type, &mut buf)
+                    .map_err(|mut error| {
+                        error.push("TimeSeries", "metadata");
+                        error
+                    })
+                    .context(error::DecodePromRemoteRequestSnafu)?;
+            }
+            _ => skip_field(wire_type, tag, &mut buf, DecodeContext::default())
+                .context(error::DecodePromRemoteRequestSnafu)?,
+        }
+    }
+
+    ensure!(
+        rows_remaining == 0,
+        error::InvalidPromRemoteRequestSnafu {
+            msg: "remote write v2 row count changed between scans".to_string(),
+        }
+    );
+
+    Ok(())
+}
+
+fn take_length_delimited<'a>(
+    wire_type: WireType,
+    buf: &mut &'a [u8],
+) -> std::result::Result<&'a [u8], DecodeError> {
+    if wire_type != WireType::LengthDelimited {
+        return Err(DecodeError::new(format!(
+            "invalid wire type: {wire_type:?} (expected LengthDelimited)"
+        )));
+    }
+
+    let len = decode_varint(buf)?;
+    let len =
+        usize::try_from(len).map_err(|_| DecodeError::new("length delimiter exceeds usize"))?;
+    if len > buf.len() {
+        return Err(DecodeError::new("buffer underflow"));
+    }
+    let (value, remaining) = buf.split_at(len);
+    *buf = remaining;
+    Ok(value)
+}
+
+fn checked_total(total: u64, count: usize, name: &str) -> Result<u64> {
+    let count =
+        u64::try_from(count)
+            .ok()
+            .with_context(|| error::InvalidPromRemoteRequestSnafu {
+                msg: format!("remote write v2 {name} count exceeds u64"),
+            })?;
+    total
+        .checked_add(count)
+        .with_context(|| error::InvalidPromRemoteRequestSnafu {
+            msg: format!("remote write v2 {name} count overflows u64"),
+        })
+}
+
 fn get_or_create_table_data(
     tables: &mut HashMap<PromCtx, HashMap<String, TableData>>,
     prom_ctx: PromCtx,
@@ -273,22 +546,6 @@ fn get_or_create_table_data(
         }
         Entry::Vacant(entry) => entry.insert(TableData::new(column_count, row_count)),
     }
-}
-
-fn write_samples(
-    table_data: &mut TableData,
-    mut samples: Vec<Sample>,
-    tags: PromTags,
-) -> Result<()> {
-    let Some(last_sample) = samples.pop() else {
-        return Ok(());
-    };
-
-    for sample in &samples {
-        write_sample(table_data, sample, tags.iter().cloned())?;
-    }
-
-    write_sample(table_data, &last_sample, tags.into_iter())
 }
 
 fn write_sample(
@@ -579,7 +836,7 @@ fn validate_native_histogram_spans(
     let span_len = spans
         .iter()
         .try_fold(0usize, |sum, span| sum.checked_add(span.length as usize))
-        .context(error::InvalidPromRemoteRequestSnafu {
+        .with_context(|| error::InvalidPromRemoteRequestSnafu {
             msg: format!("remote write v2 native histogram {name} spans overflow"),
         })?;
     ensure!(
@@ -606,13 +863,13 @@ fn validate_native_histogram_spans(
         current_index = if span_index == 0 {
             span.offset
         } else {
-            current_index.checked_add(span.offset).context(
+            current_index.checked_add(span.offset).with_context(|| {
                 error::InvalidPromRemoteRequestSnafu {
                     msg: format!(
                         "remote write v2 native histogram {name} span index overflows i32"
                     ),
-                },
-            )?
+                }
+            })?
         };
 
         for _ in 0..span.length {
@@ -701,7 +958,7 @@ fn validate_integer_native_histogram_counts(
         .try_fold(zero_count, |total, bucket| {
             total.checked_add(*bucket as u64)
         })
-        .context(error::InvalidPromRemoteRequestSnafu {
+        .with_context(|| error::InvalidPromRemoteRequestSnafu {
             msg: "remote write v2 native histogram bucket total overflows u64".to_string(),
         })?;
     ensure!(
@@ -824,11 +1081,12 @@ fn bucket_counts_from_deltas(deltas: &[i64]) -> Result<Vec<i64>> {
     let mut buckets = Vec::with_capacity(deltas.len());
 
     for delta in deltas {
-        count = count
-            .checked_add(*delta)
-            .context(error::InvalidPromRemoteRequestSnafu {
-                msg: "remote write v2 native histogram bucket count overflows i64".to_string(),
-            })?;
+        count =
+            count
+                .checked_add(*delta)
+                .with_context(|| error::InvalidPromRemoteRequestSnafu {
+                    msg: "remote write v2 native histogram bucket count overflows i64".to_string(),
+                })?;
         ensure!(
             count >= 0,
             error::InvalidPromRemoteRequestSnafu {
@@ -858,12 +1116,12 @@ fn ensure_no_internal_histogram_labels(tags: &PromTags) -> Result<()> {
 }
 
 fn resolve_series_labels<'a>(
-    symbols: &'a [String],
-    series: &TimeSeries,
+    symbols: &'a [&str],
+    labels_refs: &[u32],
     label_names: &mut HashSet<&'a str>,
 ) -> Result<ResolvedSeriesLabels> {
     ensure!(
-        series.labels_refs.len().is_multiple_of(2),
+        labels_refs.len().is_multiple_of(2),
         error::InvalidPromRemoteRequestSnafu {
             msg: "remote write v2 labels_refs must contain name/value pairs".to_string(),
         }
@@ -871,10 +1129,10 @@ fn resolve_series_labels<'a>(
 
     let mut prom_ctx = PromCtx::default();
     let mut table_name = None;
-    let mut tags = Vec::with_capacity(series.labels_refs.len() / 2);
+    let mut tags = Vec::with_capacity(labels_refs.len() / 2);
     label_names.clear();
 
-    for pair in series.labels_refs.chunks_exact(2) {
+    for pair in labels_refs.chunks_exact(2) {
         let name = symbol_ref(symbols, pair[0], "label name")?;
         let value = symbol_ref(symbols, pair[1], "label value")?;
         validate_label(name)?;
@@ -896,7 +1154,7 @@ fn resolve_series_labels<'a>(
         tags.push((name.to_string(), value.to_string()));
     }
 
-    let table_name = table_name.context(error::InvalidPromRemoteRequestSnafu {
+    let table_name = table_name.with_context(|| error::InvalidPromRemoteRequestSnafu {
         msg: "missing '__name__' label in time-series".to_string(),
     })?;
     ensure!(
@@ -920,10 +1178,15 @@ fn validate_label(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn symbol_ref<'a>(symbols: &'a [String], idx: u32, field: &str) -> Result<&'a str> {
+fn symbol_ref<'a>(symbols: &'a [&str], idx: u32, field: &str) -> Result<&'a str> {
+    let idx = usize::try_from(idx)
+        .ok()
+        .with_context(|| error::InvalidPromRemoteRequestSnafu {
+            msg: format!("remote write v2 {field} symbol reference exceeds usize"),
+        })?;
     symbols
-        .get(idx as usize)
-        .map(String::as_str)
+        .get(idx)
+        .copied()
         .with_context(|| error::InvalidPromRemoteRequestSnafu {
             msg: format!(
                 "remote write v2 {field} symbol reference {idx} is out of range, symbols len: {}",
@@ -994,8 +1257,12 @@ pub mod test_util {
     use api::greptime_proto::io::prometheus::write::v2::{Histogram, Request, Sample, TimeSeries};
     use api::v1::RowInsertRequest;
     use bytes::Bytes;
+    use prost::Message;
+    use snafu::ResultExt;
 
-    use crate::error::Result;
+    use crate::error::{self, Result};
+    use crate::prom_remote_write::try_decompress;
+    use crate::prom_store::snappy_compress;
 
     pub fn request_with_labels_and_samples(
         labels: Vec<(&str, &str)>,
@@ -1012,13 +1279,42 @@ pub mod test_util {
     }
 
     pub fn decode_request(is_zstd: bool, body: Bytes) -> Result<Request> {
-        super::decode_remote_write_v2_request(is_zstd, body)
+        let buf = if let Ok(buf) = try_decompress(is_zstd, &body[..]) {
+            buf
+        } else {
+            try_decompress(!is_zstd, &body[..])?
+        };
+        Request::decode(&buf[..]).context(error::DecodePromRemoteRequestSnafu)
     }
 
     pub fn write_requests(
         request: Request,
     ) -> Result<(Vec<RowInsertRequest>, Vec<RowInsertRequest>, u64, u64)> {
-        let requests = super::into_write_requests(request)?;
+        let body = Bytes::from(snappy_compress(&request.encode_to_vec())?);
+        decode_write_requests(false, body, true)
+    }
+
+    pub fn decode_write_requests(
+        is_zstd: bool,
+        body: Bytes,
+        native_histograms_enabled: bool,
+    ) -> Result<(Vec<RowInsertRequest>, Vec<RowInsertRequest>, u64, u64)> {
+        let requests = super::decode_remote_write_v2(is_zstd, body, native_histograms_enabled)?;
+        Ok((
+            requests.samples.all_req().collect(),
+            requests.histograms.all_req().collect(),
+            requests.sample_count,
+            requests.histogram_count,
+        ))
+    }
+
+    pub fn decode_uncompressed_write_requests(
+        body: &[u8],
+        native_histograms_enabled: bool,
+    ) -> Result<(Vec<RowInsertRequest>, Vec<RowInsertRequest>, u64, u64)> {
+        let request =
+            super::BorrowedRequest::decode(body).context(error::DecodePromRemoteRequestSnafu)?;
+        let requests = super::convert_remote_write_v2(request, native_histograms_enabled)?;
         Ok((
             requests.samples.all_req().collect(),
             requests.histograms.all_req().collect(),
@@ -1109,7 +1405,7 @@ mod tests {
         let body =
             Bytes::from(crate::prom_store::snappy_compress(&request.encode_to_vec()).unwrap());
 
-        let decoded = decode_remote_write_v2_request(false, body).unwrap();
+        let decoded = test_util::decode_request(false, body.clone()).unwrap();
 
         assert_eq!(decoded.symbols, request.symbols);
         assert_eq!(decoded.timeseries.len(), 1);
@@ -1117,11 +1413,291 @@ mod tests {
         assert_eq!(decoded.timeseries[0].samples.len(), 1);
         assert_eq!(decoded.timeseries[0].samples[0].value, 42.0);
         assert_eq!(decoded.timeseries[0].metadata.as_ref().unwrap().r#type, 1);
+        assert_eq!(
+            decode_remote_write_v2(true, body, true)
+                .unwrap()
+                .sample_count,
+            1
+        );
+    }
+
+    #[test]
+    fn test_fused_decoder_accepts_arbitrary_field_order_and_split_labels() {
+        let mut first_sample = Sample {
+            value: 42.0,
+            timestamp: 1000,
+            start_timestamp: 500,
+        }
+        .encode_to_vec();
+        first_sample.extend(varint_field(90, 1));
+        let second_sample = Sample {
+            value: 43.0,
+            timestamp: 2000,
+            start_timestamp: 1000,
+        }
+        .encode_to_vec();
+
+        let mut series = encoded_message_field(2, &first_sample);
+        series.extend(packed_u32_field(1, &[1]));
+        series.extend(varint_field(90, 1));
+        series.extend(encoded_message_field(2, &second_sample));
+        series.extend(varint_field(1, 2));
+
+        let mut wire = encoded_message_field(5, &series);
+        wire.extend(string_field(4, b""));
+        wire.extend(varint_field(90, 1));
+        wire.extend(string_field(4, METRIC_NAME_LABEL.as_bytes()));
+        wire.extend(encoded_message_field(5, &packed_u32_field(1, &[99])));
+        wire.extend(string_field(4, b"http_requests_total"));
+
+        let requests = decode_wire(&wire, true).unwrap();
+        assert_eq!(requests.sample_count, 2);
+        assert_eq!(requests.histogram_count, 0);
+        let rows = requests.samples.all_req().next().unwrap().rows.unwrap();
+        assert_eq!(rows.rows.len(), 2);
+        assert_eq!(
+            rows.schema
+                .iter()
+                .map(|column| column.column_name.as_str())
+                .collect::<Vec<_>>(),
+            vec![greptime_timestamp(), greptime_value()]
+        );
+        assert_eq!(
+            rows.rows[0].values[1].value_data,
+            Some(ValueData::F64Value(42.0))
+        );
+        assert_eq!(
+            rows.rows[1].values[1].value_data,
+            Some(ValueData::F64Value(43.0))
+        );
+    }
+
+    #[test]
+    fn test_fused_decoder_accepts_histogram_before_labels_and_unknown_fields() {
+        let mut histogram = Histogram {
+            count: Some(Count::CountInt(0)),
+            zero_count: Some(ZeroCount::ZeroCountInt(0)),
+            timestamp: 2000,
+            start_timestamp: 1000,
+            ..Default::default()
+        }
+        .encode_to_vec();
+        histogram.extend(varint_field(90, 1));
+
+        let mut series = encoded_message_field(3, &histogram);
+        series.extend(packed_u32_field(1, &[1, 2]));
+        let wire = request_wire(&["", METRIC_NAME_LABEL, "metric"], &[series]);
+
+        let requests = decode_wire(&wire, true).unwrap();
+        assert_eq!(requests.histogram_count, 1);
+        let rows = requests.histograms.all_req().next().unwrap().rows.unwrap();
+        assert_eq!(
+            histogram_field_value(&rows, 0, START_TIMESTAMP_FIELD),
+            Some(ValueData::TimestampMillisecondValue(1000))
+        );
+    }
+
+    #[test]
+    fn test_fused_decoder_rejects_malformed_wire() {
+        let mut wrong_request_wire = varint_field(4, 0);
+        let invalid_utf8 = string_field(4, &[0xff]);
+
+        let mut truncated_request = Vec::new();
+        prost::encoding::encode_key(5, WireType::LengthDelimited, &mut truncated_request);
+        prost::encoding::encode_varint(2, &mut truncated_request);
+        truncated_request.push(0);
+
+        let mut oversized_request = Vec::new();
+        prost::encoding::encode_key(4, WireType::LengthDelimited, &mut oversized_request);
+        prost::encoding::encode_varint(u64::MAX, &mut oversized_request);
+
+        let malformed_varint = vec![0x80; 10];
+
+        let mut wrong_labels_wire = Vec::new();
+        prost::encoding::encode_key(1, WireType::SixtyFourBit, &mut wrong_labels_wire);
+        wrong_labels_wire.extend([0; 8]);
+        wrong_labels_wire = request_wire(&[""], &[std::mem::take(&mut wrong_labels_wire)]);
+
+        let wrong_series_wire = request_wire(&[""], &[varint_field(2, 0)]);
+
+        let mut truncated_series = Vec::new();
+        prost::encoding::encode_key(2, WireType::LengthDelimited, &mut truncated_series);
+        prost::encoding::encode_varint(2, &mut truncated_series);
+        truncated_series.push(0x08);
+        let truncated_series = request_wire(&[""], &[truncated_series]);
+
+        let mut oversized_series = Vec::new();
+        prost::encoding::encode_key(3, WireType::LengthDelimited, &mut oversized_series);
+        prost::encoding::encode_varint(u64::MAX, &mut oversized_series);
+        let oversized_series = request_wire(&[""], &[oversized_series]);
+
+        let invalid_sample = series_wire(&[1, 2], 2, &varint_field(1, 1));
+        let invalid_sample = request_wire(&["", METRIC_NAME_LABEL, "metric"], &[invalid_sample]);
+        let invalid_histogram = series_wire(&[1, 2], 3, &varint_field(3, 1));
+        let invalid_histogram =
+            request_wire(&["", METRIC_NAME_LABEL, "metric"], &[invalid_histogram]);
+
+        for (name, wire) in [
+            (
+                "wrong request wire type",
+                std::mem::take(&mut wrong_request_wire),
+            ),
+            ("invalid utf8", invalid_utf8),
+            ("truncated request", truncated_request),
+            ("oversized request length", oversized_request),
+            ("malformed varint", malformed_varint),
+            ("wrong labels wire type", wrong_labels_wire),
+            ("wrong series wire type", wrong_series_wire),
+            ("truncated series", truncated_series),
+            ("oversized series length", oversized_series),
+            ("invalid sample", invalid_sample),
+            ("invalid histogram", invalid_histogram),
+        ] {
+            let error = decode_wire_error(&wire, true, name);
+            assert!(
+                matches!(error, error::Error::DecodePromRemoteRequest { .. }),
+                "{name}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_fused_decoder_rejects_malformed_ignored_messages() {
+        for tag in [4, 5] {
+            let mut series = series_wire(&[1, 2], 2, &Sample::default().encode_to_vec());
+            series.extend(encoded_message_field(tag, &[0x08]));
+            let wire = request_wire(&["", METRIC_NAME_LABEL, "metric"], &[series]);
+
+            let error = decode_wire_error(&wire, true, "malformed ignored message");
+            assert!(matches!(
+                error,
+                error::Error::DecodePromRemoteRequest { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn test_fused_decoder_ignores_exemplar_symbol_refs() {
+        let request = Request {
+            symbols: vec![
+                String::new(),
+                METRIC_NAME_LABEL.to_string(),
+                "metric".to_string(),
+            ],
+            timeseries: vec![TimeSeries {
+                labels_refs: vec![1, 2],
+                samples: vec![Sample::default()],
+                exemplars: vec![Exemplar {
+                    labels_refs: vec![99],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        assert_eq!(decode_test_request(request).unwrap().sample_count, 1);
+    }
+
+    #[test]
+    fn test_fused_decoder_preserves_empty_request_and_series_behavior() {
+        let request = Request {
+            symbols: vec![
+                String::new(),
+                METRIC_NAME_LABEL.to_string(),
+                "metric".to_string(),
+                "job".to_string(),
+            ],
+            timeseries: vec![
+                TimeSeries {
+                    labels_refs: vec![99, 99],
+                    ..Default::default()
+                },
+                TimeSeries {
+                    labels_refs: vec![1],
+                    ..Default::default()
+                },
+                TimeSeries {
+                    labels_refs: vec![3, 2, 3, 2],
+                    ..Default::default()
+                },
+                TimeSeries::default(),
+            ],
+        };
+
+        let requests = decode_test_request(request).unwrap();
+        assert_eq!(requests.sample_count, 0);
+        assert_eq!(requests.histogram_count, 0);
+
+        let requests = decode_test_request(Request {
+            symbols: vec![String::new()],
+            timeseries: Vec::new(),
+        })
+        .unwrap();
+        assert_eq!(requests.sample_count, 0);
+        assert!(decode_wire(&[], true).is_err());
+        assert!(decode_wire(&[0x0a, 0x00], true).is_err());
+    }
+
+    #[test]
+    fn test_fused_decoder_rejects_duplicate_resolved_label_names() {
+        let request = Request {
+            symbols: vec![
+                String::new(),
+                METRIC_NAME_LABEL.to_string(),
+                "metric".to_string(),
+                "job".to_string(),
+                "job".to_string(),
+                "api".to_string(),
+                "worker".to_string(),
+            ],
+            timeseries: vec![TimeSeries {
+                labels_refs: vec![1, 2, 3, 5, 4, 6],
+                samples: vec![Sample::default()],
+                ..Default::default()
+            }],
+        };
+
+        assert_invalid(
+            "duplicate resolved labels",
+            request,
+            "label name `job` is repeated",
+        );
+    }
+
+    #[test]
+    fn test_fused_decoder_pins_experimental_error_precedence() {
+        let histogram = series_wire(&[1, 2], 3, &Histogram::default().encode_to_vec());
+        let malformed_sample = series_wire(&[1, 2], 2, &[0x08]);
+
+        let wire = request_wire(
+            &["", METRIC_NAME_LABEL, "metric"],
+            &[histogram.clone(), malformed_sample.clone()],
+        );
+        let error = decode_wire_error(&wire, false, "histogram before malformed series");
+        assert!(error.to_string().contains("ingestion is experimental"));
+
+        let wire = request_wire(
+            &["", METRIC_NAME_LABEL, "metric"],
+            &[malformed_sample, histogram.clone()],
+        );
+        let error = decode_wire_error(&wire, false, "malformed series before histogram");
+        assert!(matches!(
+            error,
+            error::Error::DecodePromRemoteRequest { .. }
+        ));
+
+        let missing_name = series_wire(&[3, 4], 2, &Sample::default().encode_to_vec());
+        let wire = request_wire(
+            &["", METRIC_NAME_LABEL, "metric", "job", "api"],
+            &[missing_name, histogram],
+        );
+        let error = decode_wire_error(&wire, false, "conversion error before histogram");
+        assert!(error.to_string().contains("missing '__name__'"));
     }
 
     #[test]
     fn test_into_context_req_samples() {
-        let ctx_req = into_write_requests(test_util::request_with_labels_and_samples(
+        let ctx_req = decode_test_request(test_util::request_with_labels_and_samples(
             vec![
                 (METRIC_NAME_LABEL, "http_requests_total"),
                 ("job", "api"),
@@ -1187,7 +1763,7 @@ mod tests {
 
     #[test]
     fn test_into_context_req_special_labels() {
-        let ctx_req = into_write_requests(test_util::request_with_labels_and_samples(
+        let ctx_req = decode_test_request(test_util::request_with_labels_and_samples(
             vec![
                 (METRIC_NAME_LABEL, "cpu_usage"),
                 (DATABASE_LABEL, "tenant_a"),
@@ -1518,7 +2094,7 @@ mod tests {
 
     #[test]
     fn test_into_context_req_allows_nan_observations_outside_buckets() {
-        into_write_requests(request_with_histogram(Histogram {
+        decode_test_request(request_with_histogram(Histogram {
             count: Some(Count::CountInt(2)),
             sum: f64::NAN,
             positive_spans: vec![BucketSpan {
@@ -1533,7 +2109,7 @@ mod tests {
 
     #[test]
     fn test_into_context_req_allows_empty_label_values() {
-        let ctx_req = into_write_requests(test_util::request_with_labels_and_samples(
+        let ctx_req = decode_test_request(test_util::request_with_labels_and_samples(
             vec![(METRIC_NAME_LABEL, "metric"), ("job", "")],
             vec![Sample {
                 value: 1.0,
@@ -1649,7 +2225,7 @@ mod tests {
                     }];
                     histogram.negative_deltas = vec![1];
                 }
-                into_write_requests(request_with_histogram(histogram.clone())).unwrap();
+                decode_test_request(request_with_histogram(histogram.clone())).unwrap();
 
                 let beyond = max_index + 1;
                 if positive {
@@ -1694,7 +2270,7 @@ mod tests {
             ],
         };
 
-        let ctx_req = into_write_requests(request).unwrap();
+        let ctx_req = decode_test_request(request).unwrap();
 
         assert_eq!(ctx_req.sample_count, 1);
         assert_eq!(ctx_req.histogram_count, 1);
@@ -1708,7 +2284,7 @@ mod tests {
             test_util::request_with_labels_and_samples(vec![(METRIC_NAME_LABEL, "metric")], vec![]);
         request.timeseries[0].histograms.push(Histogram::default());
 
-        let ctx_req = into_write_requests(request).unwrap();
+        let ctx_req = decode_test_request(request).unwrap();
 
         assert_eq!(ctx_req.sample_count, 0);
         assert_eq!(ctx_req.histogram_count, 1);
@@ -1744,7 +2320,7 @@ mod tests {
 
     #[test]
     fn test_into_context_req_preserves_histogram_start_timestamp() {
-        let ctx_req = into_write_requests(test_util::request_with_labels_and_histograms(
+        let ctx_req = decode_test_request(test_util::request_with_labels_and_histograms(
             vec![(METRIC_NAME_LABEL, "metric")],
             vec![Histogram {
                 timestamp: 2000,
@@ -1774,7 +2350,7 @@ mod tests {
         );
         request.timeseries[0].histograms.push(Histogram::default());
 
-        let err = match into_write_requests(request) {
+        let err = match decode_test_request(request) {
             Ok(_) => panic!("expected invalid request error"),
             Err(err) => err,
         };
@@ -1837,7 +2413,7 @@ mod tests {
             ],
         };
 
-        let ctx_req = into_write_requests(request).unwrap();
+        let ctx_req = decode_test_request(request).unwrap();
 
         assert_eq!(ctx_req.histogram_count, 2);
         let mut inserts = ctx_req.histograms.all_req().collect::<Vec<_>>();
@@ -1883,6 +2459,65 @@ mod tests {
         ));
     }
 
+    fn decode_wire(
+        wire: &[u8],
+        native_histograms_enabled: bool,
+    ) -> Result<RemoteWriteV2WriteRequests> {
+        let body = Bytes::from(crate::prom_store::snappy_compress(wire).unwrap());
+        decode_remote_write_v2(false, body, native_histograms_enabled)
+    }
+
+    fn decode_wire_error(wire: &[u8], native_histograms_enabled: bool, name: &str) -> error::Error {
+        match decode_wire(wire, native_histograms_enabled) {
+            Ok(_) => panic!("{name}: expected decoder error"),
+            Err(error) => error,
+        }
+    }
+
+    fn request_wire(symbols: &[&str], series: &[Vec<u8>]) -> Vec<u8> {
+        let mut wire = Vec::new();
+        for symbol in symbols {
+            wire.extend(string_field(4, symbol.as_bytes()));
+        }
+        for series in series {
+            wire.extend(encoded_message_field(5, series));
+        }
+        wire
+    }
+
+    fn series_wire(labels_refs: &[u32], leaf_tag: u32, leaf: &[u8]) -> Vec<u8> {
+        let mut series = packed_u32_field(1, labels_refs);
+        series.extend(encoded_message_field(leaf_tag, leaf));
+        series
+    }
+
+    fn string_field(tag: u32, value: &[u8]) -> Vec<u8> {
+        encoded_message_field(tag, value)
+    }
+
+    fn encoded_message_field(tag: u32, value: &[u8]) -> Vec<u8> {
+        let mut field = Vec::new();
+        prost::encoding::encode_key(tag, WireType::LengthDelimited, &mut field);
+        prost::encoding::encode_varint(u64::try_from(value.len()).unwrap(), &mut field);
+        field.extend_from_slice(value);
+        field
+    }
+
+    fn varint_field(tag: u32, value: u64) -> Vec<u8> {
+        let mut field = Vec::new();
+        prost::encoding::encode_key(tag, WireType::Varint, &mut field);
+        prost::encoding::encode_varint(value, &mut field);
+        field
+    }
+
+    fn packed_u32_field(tag: u32, values: &[u32]) -> Vec<u8> {
+        let mut packed = Vec::new();
+        for value in values {
+            prost::encoding::encode_varint(u64::from(*value), &mut packed);
+        }
+        encoded_message_field(tag, &packed)
+    }
+
     fn request_with_sample(labels: Vec<(&str, &str)>) -> Request {
         test_util::request_with_labels_and_samples(
             labels,
@@ -1901,8 +2536,21 @@ mod tests {
         )
     }
 
+    fn decode_test_request(request: Request) -> Result<RemoteWriteV2WriteRequests> {
+        decode_test_request_with_histograms(request, true)
+    }
+
+    fn decode_test_request_with_histograms(
+        request: Request,
+        native_histograms_enabled: bool,
+    ) -> Result<RemoteWriteV2WriteRequests> {
+        let body =
+            Bytes::from(crate::prom_store::snappy_compress(&request.encode_to_vec()).unwrap());
+        decode_remote_write_v2(false, body, native_histograms_enabled)
+    }
+
     fn assert_invalid(name: &str, request: Request, expected: &str) {
-        let err = match into_write_requests(request) {
+        let err = match decode_test_request(request) {
             Ok(_) => panic!("{name}: expected invalid request error"),
             Err(err) => err,
         };
@@ -1993,7 +2641,7 @@ mod tests {
     >;
 
     fn decoded_index(request: Request) -> DecodedIndex {
-        let encoded = into_write_requests(request)
+        let encoded = decode_test_request(request)
             .unwrap()
             .semantic_index
             .encode("public")
@@ -2045,7 +2693,7 @@ mod tests {
         assert!(!untyped.contains_key(SEMANTIC_METRIC_TYPE));
         assert!(!untyped.contains_key(SEMANTIC_METRIC_METADATA_QUALITY));
 
-        let requests = into_write_requests(metadata_request(vec![(
+        let requests = decode_test_request(metadata_request(vec![(
             vec![(METRIC_NAME_LABEL, "untyped_unitless_total")],
             metadata::MetricType::Unspecified as i32,
             None,
@@ -2054,7 +2702,7 @@ mod tests {
         assert!(requests.semantic_index.is_empty());
 
         // No metadata at all behaves the same.
-        let requests = into_write_requests(test_util::request_with_labels_and_samples(
+        let requests = decode_test_request(test_util::request_with_labels_and_samples(
             vec![(METRIC_NAME_LABEL, "bare_total")],
             vec![Sample {
                 value: 1.0,
@@ -2123,7 +2771,7 @@ mod tests {
             None,
         )]);
         request.timeseries[0].metadata.as_mut().unwrap().unit_ref = 999;
-        let err = into_write_requests(request).err().unwrap();
+        let err = decode_test_request(request).err().unwrap();
         assert!(err.to_string().contains("out of range"), "{err}");
 
         // unit_ref must be validated even when the type is UNSPECIFIED
@@ -2134,7 +2782,7 @@ mod tests {
             None,
         )]);
         request.timeseries[0].metadata.as_mut().unwrap().unit_ref = 999;
-        let err = into_write_requests(request).err().unwrap();
+        let err = decode_test_request(request).err().unwrap();
         assert!(err.to_string().contains("out of range"), "{err}");
 
         // help_ref is validated although help is never persisted.
@@ -2144,7 +2792,7 @@ mod tests {
             None,
         )]);
         request.timeseries[0].metadata.as_mut().unwrap().help_ref = 999;
-        let err = into_write_requests(request).err().unwrap();
+        let err = decode_test_request(request).err().unwrap();
         assert!(err.to_string().contains("out of range"), "{err}");
     }
 }

--- a/src/servers/src/prom_remote_write/v2.rs
+++ b/src/servers/src/prom_remote_write/v2.rs
@@ -22,7 +22,6 @@ use api::greptime_proto::io::prometheus::write::v2::{
 #[cfg(test)]
 use api::greptime_proto::io::prometheus::write::v2::{Request, TimeSeries};
 use api::helper::ColumnDataTypeWrapper;
-use api::v1::helper::{field_column_schema, time_index_column_schema};
 use api::v1::value::ValueData;
 use api::v1::{
     ColumnDataType, ColumnSchema, ListValue, RowInsertRequest, Rows, SemanticType, Value,
@@ -58,8 +57,8 @@ use crate::semantic::{
     openmetrics_unit_to_ucum,
 };
 
-type PromTags = Vec<(String, String)>;
-type ResolvedSeriesLabels = (PromCtx, String, PromTags);
+type PromTags<'a> = Vec<(&'a str, String)>;
+type ResolvedSeriesLabels<'a> = (PromCtx, String, PromTags<'a>);
 const MAX_REMOTE_WRITE_V2_SCHEMA: i32 = 8;
 const MAX_REDUCIBLE_REMOTE_WRITE_V2_SCHEMA: i32 = 52;
 
@@ -389,7 +388,7 @@ enum SeriesWriter<'a> {
 fn decode_series_leaves(
     mut buf: &[u8],
     mut writer: Option<SeriesWriter<'_>>,
-    mut tags: PromTags,
+    mut tags: PromTags<'_>,
     mut rows_remaining: usize,
     scratch: &mut LeafScratch,
 ) -> Result<()> {
@@ -420,15 +419,16 @@ fn decode_series_leaves(
                 })?;
                 if let Some(SeriesWriter::Samples(table_data)) = &mut writer {
                     if sample_row_template.is_none() {
-                        let timestamp_index =
-                            table_data.ensure_column(time_index_column_schema(
-                                greptime_timestamp(),
-                                ColumnDataType::TimestampMillisecond,
-                            ))?;
-                        let value_index = table_data.ensure_column(field_column_schema(
+                        let timestamp_index = table_data.ensure_column_by_name(
+                            greptime_timestamp(),
+                            ColumnDataType::TimestampMillisecond,
+                            SemanticType::Timestamp,
+                        )?;
+                        let value_index = table_data.ensure_column_by_name(
                             greptime_value(),
                             ColumnDataType::Float64,
-                        ))?;
+                            SemanticType::Field,
+                        )?;
                         let mut row = table_data.alloc_one_row();
                         row_writer::write_tags(
                             table_data,
@@ -577,10 +577,10 @@ fn get_or_create_table_data(
     }
 }
 
-fn write_native_histogram(
+fn write_native_histogram<'a>(
     table_data: &mut TableData,
     histogram: &Histogram,
-    tags: impl Iterator<Item = (String, String)>,
+    tags: impl Iterator<Item = (&'a str, String)>,
 ) -> Result<()> {
     // Persist both int and float families into the logical table schema. Only one
     // family is populated per row; the other is written as NULL so PromQL can
@@ -1108,11 +1108,11 @@ fn bucket_counts_from_deltas(deltas: &[i64]) -> Result<Vec<i64>> {
     Ok(buckets)
 }
 
-fn ensure_no_internal_histogram_labels(tags: &PromTags) -> Result<()> {
+fn ensure_no_internal_histogram_labels(tags: &PromTags<'_>) -> Result<()> {
     // The histogram field column is generated from the protobuf payload.
     for (name, _) in tags {
         ensure!(
-            name != greptime_native_histogram() && name != NATIVE_HISTOGRAM_FIELD,
+            *name != greptime_native_histogram() && *name != NATIVE_HISTOGRAM_FIELD,
             error::InvalidPromRemoteRequestSnafu {
                 msg: format!(
                     "remote write v2 label `{name}` conflicts with an internal native histogram label"
@@ -1128,7 +1128,7 @@ fn resolve_series_labels<'a>(
     symbols: &'a [&str],
     labels_refs: &[u32],
     label_names: &mut HashSet<&'a str>,
-) -> Result<ResolvedSeriesLabels> {
+) -> Result<ResolvedSeriesLabels<'a>> {
     ensure!(
         labels_refs.len().is_multiple_of(2),
         error::InvalidPromRemoteRequestSnafu {
@@ -1160,7 +1160,7 @@ fn resolve_series_labels<'a>(
             continue;
         }
 
-        tags.push((name.to_string(), value.to_string()));
+        tags.push((name, value.to_string()));
     }
 
     let table_name = table_name.with_context(|| error::InvalidPromRemoteRequestSnafu {
@@ -2383,7 +2383,7 @@ mod tests {
         assert_eq!(greptime_native_histogram(), "custom_native_histogram");
 
         let err = ensure_no_internal_histogram_labels(&vec![(
-            NATIVE_HISTOGRAM_FIELD.to_string(),
+            NATIVE_HISTOGRAM_FIELD,
             "user_value".to_string(),
         )])
         .unwrap_err();

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -92,6 +92,26 @@ impl TableData {
         Ok(index)
     }
 
+    /// Ensures a default column schema without allocating its name when it already exists.
+    pub(crate) fn ensure_column_by_name(
+        &mut self,
+        name: &str,
+        datatype: ColumnDataType,
+        semantic_type: SemanticType,
+    ) -> Result<usize> {
+        if let Some(index) = self.column_indexes.get(name).copied() {
+            check_schema(datatype, semantic_type, &self.schema[index])?;
+            return Ok(index);
+        }
+
+        self.ensure_column(ColumnSchema {
+            column_name: name.to_string(),
+            datatype: datatype as i32,
+            semantic_type: semantic_type as i32,
+            ..Default::default()
+        })
+    }
+
     #[allow(dead_code)]
     pub fn columns(&self) -> &Vec<ColumnSchema> {
         &self.schema
@@ -211,11 +231,14 @@ impl MultiTableData {
 }
 
 /// Write data as tags into the table data.
-pub fn write_tags(
+pub fn write_tags<K>(
     table_data: &mut TableData,
-    tags: impl Iterator<Item = (String, String)>,
+    tags: impl Iterator<Item = (K, String)>,
     one_row: &mut Vec<Value>,
-) -> Result<()> {
+) -> Result<()>
+where
+    K: AsRef<str> + Into<String>,
+{
     let ktv_iter = tags.map(|(k, v)| (k, ColumnDataType::String, Some(ValueData::StringValue(v))));
     write_by_semantic_type(table_data, SemanticType::Tag, ktv_iter, one_row)
 }
@@ -326,12 +349,15 @@ pub(crate) fn write_by_schema(
     Ok(())
 }
 
-fn write_by_semantic_type(
+fn write_by_semantic_type<K>(
     table_data: &mut TableData,
     semantic_type: SemanticType,
-    ktv_iter: impl Iterator<Item = (String, ColumnDataType, Option<ValueData>)>,
+    ktv_iter: impl Iterator<Item = (K, ColumnDataType, Option<ValueData>)>,
     one_row: &mut Vec<Value>,
-) -> Result<()> {
+) -> Result<()>
+where
+    K: AsRef<str> + Into<String>,
+{
     let TableData {
         schema,
         column_indexes,
@@ -339,12 +365,13 @@ fn write_by_semantic_type(
     } = table_data;
 
     for (name, datatype, value) in ktv_iter {
-        let index = column_indexes.get(&name);
+        let index = column_indexes.get(name.as_ref()).copied();
         if let Some(index) = index {
-            check_schema(datatype, semantic_type, &schema[*index])?;
-            one_row[*index].value_data = value;
+            check_schema(datatype, semantic_type, &schema[index])?;
+            one_row[index].value_data = value;
         } else {
             let index = schema.len();
+            let name = name.into();
             schema.push(ColumnSchema {
                 column_name: name.clone(),
                 datatype: datatype as i32,

--- a/src/servers/tests/prom_remote_write_v2_test.rs
+++ b/src/servers/tests/prom_remote_write_v2_test.rs
@@ -77,7 +77,7 @@ fn test_decode_remote_write_v2_native_histogram_dump() {
     assert_eq!(histogram.timestamp, 1782358160412);
 
     let (sample_inserts, histogram_inserts, sample_count, histogram_count) =
-        remote_write_v2::write_requests(decoded).unwrap();
+        remote_write_v2::decode_write_requests(false, Bytes::from_static(BODY), true).unwrap();
     assert!(sample_inserts.is_empty());
     assert_eq!(sample_count, 0);
     assert_eq!(histogram_count, 1);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request improves Prometheus Remote Write v2 ingestion by replacing full-request Prost materialization with a borrowed envelope and fused per-series decoder that builds sample and native-histogram rows directly. It reuses sample row templates, borrows symbol-table label names, and avoids repeated fixed-column allocations, allowing v2 to match or outperform the tuned v1 path in the included workloads.

It also adds an equivalent v1/v2 Criterion benchmark matrix and documents the updated decoder and codec-timing boundaries. The PRW v2 wire contract and output schema remain unchanged; compression fallback, malformed-wire validation, metadata handling, and experimental native-histogram gating are preserved.

### Benchmark results

`cargo bench -p servers --bench bench_prom --features testing -- prom_rw_`

Criterion point estimates from the same local run; lower is better. Full-path cases compare equivalent protobuf-to-row boundaries.

#### Payload size

| Workload | v1 | v2 | Bytes saved |
|---|---:|---:|---:|
| fixture | 189,265 B | 50,569 B | 138,696 B (73.3%) |
| 1k series × 1 sample | 221,563 B | 48,313 B | 173,250 B (78.2%) |
| 1k series × 10 samples | 383,563 B | 211,313 B | 172,250 B (44.9%) |
| 5k series × 1 sample | 1,112,313 B | 244,313 B | 868,000 B (78.0%) |

#### Raw Prost decode

| Workload | v1 | v2 | Time saved |
|---|---:|---:|---:|
| fixture | 506.64 µs | 154.43 µs | 352.21 µs (69.5%) |
| 1k × 1 | 735.07 µs | 172.90 µs | 562.17 µs (76.5%) |
| 1k × 10 | 927.13 µs | 356.57 µs | 570.56 µs (61.5%) |
| 5k × 1 | 3,739.10 µs | 855.50 µs | 2,883.60 µs (77.1%) |

#### Full decode-to-rows path

| Workload | v1 custom | v1 Prost | v2 manual | v2 vs v1 custom |
|---|---:|---:|---:|---:|
| fixture | 550.31 µs | 955.32 µs | 504.68 µs | 45.63 µs faster (8.3%) |
| 1k × 1 | 622.81 µs | 1,230.90 µs | 511.65 µs | 111.16 µs faster (17.8%) |
| 1k × 10 | 2,474.40 µs | 5,142.80 µs | 2,297.70 µs | 176.70 µs faster (7.1%) |
| 5k × 1 | 3,064.70 µs | 6,292.20 µs | 2,439.10 µs | 625.60 µs faster (20.4%) |

The optimized v2 path is smaller and faster to decode while also outperforming the tuned v1 custom full path across all four workloads.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
