### PR TITLE
feat(flow): drain short ranges serially per tick

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -671,6 +671,7 @@
 | `flow.batching_mode.experimental_frontend_scan_timeout` | String | `30s` | Flow wait for available frontend timeout,<br/>if failed to find available frontend after frontend_scan_timeout elapsed, return error<br/>which prevent flownode from starting |
 | `flow.batching_mode.experimental_max_filter_num_per_query` | Integer | `20` | Maximum number of filters allowed in a single query |
 | `flow.batching_mode.experimental_time_window_merge_threshold` | Integer | `3` | Time window merge distance |
+| `flow.batching_mode.experimental_max_queries_per_tick` | Integer | `1` | Maximum number of independent short-range child queries executed serially<br/>within one flow tick. 1 (default) keeps the current single-query behavior;<br/>N > 1 splits one tick into up to N child queries, each scoped to at most one<br/>time-window-sized dirty window. Subsequent child queries continue only for<br/>scoped dirty-window work; unfiltered full-snapshot and incremental-delta<br/>queries execute at most once per tick. 0 is treated as 1. |
 | `flow.batching_mode.experimental_enable_incremental_read` | Bool | `false` | Whether to enable experimental flow incremental source reads.<br/>When disabled, batching flows always execute full-snapshot queries.<br/>Can be overridden per flow with WITH (experimental_enable_incremental_read = 'true'). |
 | `flow.batching_mode.read_preference` | String | `Leader` | Read preference of the Frontend client. |
 | `flow.batching_mode.frontend_tls` | -- | -- | -- |

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -27,12 +27,13 @@ node_id = 14
 ## Time window merge distance
 #+experimental_time_window_merge_threshold=3
 ## Maximum number of independent short-range child queries executed serially
-## within one flow tick. 1 (default) keeps the current single-query behavior;
-## N > 1 splits one tick into up to N child queries, each scoped to at most one
-## time-window-sized dirty window. Subsequent child queries continue only for
-## scoped dirty-window work; unfiltered full-snapshot and incremental-delta
-## queries execute at most once per tick. 0 is treated as 1.
-#+experimental_max_queries_per_tick=1
+## within one flow tick (Phase 0 batching scheduling). 3 (default) enables the
+## strategy: child queries consume the newest dirty windows first, and while a
+## backlog remains the next tick starts immediately. Set to 1 to opt out and
+## restore the legacy single-query-per-tick behavior; 0 is treated as 1.
+## Unfiltered full-snapshot and incremental-delta queries execute at most once
+## per tick.
+#+experimental_max_queries_per_tick=3
 ## Whether to enable experimental flow incremental source reads.
 ## When disabled, batching flows always execute full-snapshot queries.
 ## Can be overridden per flow with WITH (experimental_enable_incremental_read = 'true').

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -26,6 +26,13 @@ node_id = 14
 #+experimental_max_filter_num_per_query=20
 ## Time window merge distance
 #+experimental_time_window_merge_threshold=3
+## Maximum number of independent short-range child queries executed serially
+## within one flow tick. 1 (default) keeps the current single-query behavior;
+## N > 1 splits one tick into up to N child queries, each scoped to at most one
+## time-window-sized dirty window. Subsequent child queries continue only for
+## scoped dirty-window work; unfiltered full-snapshot and incremental-delta
+## queries execute at most once per tick. 0 is treated as 1.
+#+experimental_max_queries_per_tick=1
 ## Whether to enable experimental flow incremental source reads.
 ## When disabled, batching flows always execute full-snapshot queries.
 ## Can be overridden per flow with WITH (experimental_enable_incremental_read = 'true').

--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -55,6 +55,19 @@ pub struct BatchingModeOptions {
     pub experimental_max_filter_num_per_query: usize,
     /// Time window merge distance
     pub experimental_time_window_merge_threshold: usize,
+    /// Maximum number of independent short-range child queries executed
+    /// serially within one flow tick (Phase 0 batching scheduling).
+    ///
+    /// `1` (the default) keeps the current single-query behavior exactly: one
+    /// query per tick using the existing max_filter/merge behavior. `N > 1`
+    /// splits one tick into up to `N` child queries, each scoped by
+    /// `max_window_cnt = Some(1)` so its generated filter covers at most one
+    /// `window_size`-sized dirty window, executed serially under one
+    /// `execution_lock`. Subsequent child queries continue only for scoped
+    /// dirty-window work (`ScopedBaseRepair`/`FencedRepairChunk`); unfiltered
+    /// full-snapshot and incremental-delta queries execute at most once per
+    /// tick. `0` is treated as `1` defensively.
+    pub experimental_max_queries_per_tick: usize,
     /// Whether to enable experimental flow incremental source reads.
     ///
     /// When disabled, batching flows always execute full-snapshot queries.
@@ -76,6 +89,7 @@ impl Default for BatchingModeOptions {
             experimental_frontend_scan_timeout: Duration::from_secs(30),
             experimental_max_filter_num_per_query: 20,
             experimental_time_window_merge_threshold: 3,
+            experimental_max_queries_per_tick: 1,
             experimental_enable_incremental_read: false,
             read_preference: Default::default(),
             frontend_tls: None,

--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -58,15 +58,21 @@ pub struct BatchingModeOptions {
     /// Maximum number of independent short-range child queries executed
     /// serially within one flow tick (Phase 0 batching scheduling).
     ///
-    /// `1` (the default) keeps the current single-query behavior exactly: one
-    /// query per tick using the existing max_filter/merge behavior. `N > 1`
-    /// splits one tick into up to `N` child queries, each scoped by
+    /// `3` (the default) enables the Phase 0 short-range strategy: one tick
+    /// splits into up to `N` child queries, each scoped by
     /// `max_window_cnt = Some(1)` so its generated filter covers at most one
     /// `window_size`-sized dirty window, executed serially under one
-    /// `execution_lock`. Subsequent child queries continue only for scoped
-    /// dirty-window work (`ScopedBaseRepair`/`FencedRepairChunk`); unfiltered
-    /// full-snapshot and incremental-delta queries execute at most once per
-    /// tick. `0` is treated as `1` defensively.
+    /// `execution_lock`. Child queries take the newest dirty windows first,
+    /// and when a backlog still remains after a successful tick the next tick
+    /// starts immediately (no sleep). Subsequent child queries continue only
+    /// for scoped dirty-window work (`ScopedBaseRepair`/`FencedRepairChunk`);
+    /// unfiltered full-snapshot and incremental-delta queries execute at most
+    /// once per tick.
+    ///
+    /// `1` is the official opt-out: it restores the legacy single-query-per-
+    /// tick behavior exactly (one query per tick using the existing
+    /// max_filter/merge behavior, oldest windows first). `0` is treated as `1`
+    /// defensively (a `1`-compatible alias).
     pub experimental_max_queries_per_tick: usize,
     /// Whether to enable experimental flow incremental source reads.
     ///
@@ -89,7 +95,7 @@ impl Default for BatchingModeOptions {
             experimental_frontend_scan_timeout: Duration::from_secs(30),
             experimental_max_filter_num_per_query: 20,
             experimental_time_window_merge_threshold: 3,
-            experimental_max_queries_per_tick: 1,
+            experimental_max_queries_per_tick: 3,
             experimental_enable_incremental_read: false,
             read_preference: Default::default(),
             frontend_tls: None,

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -639,7 +639,7 @@ impl DirtyTimeWindows {
 
             if let Some(task_ctx) = task_ctx {
                 debug!(
-                    "Flow id = {:?}, too many time windows: {}, only the first {} are taken for this query, the group by expression might be wrong. Time window expr={:?}, expire_after={:?}, first_time_window={:?}, last_time_window={:?}, the original query: {:?}",
+                    "Flow id = {:?}, too many time windows: {}, only {} are taken for this query, the group by expression might be wrong. Time window expr={:?}, expire_after={:?}, first_time_window={:?}, last_time_window={:?}, the original query: {:?}",
                     task_ctx.config.flow_id,
                     merged_windows.len(),
                     window_cnt,
@@ -651,7 +651,7 @@ impl DirtyTimeWindows {
                 );
             } else {
                 debug!(
-                    "Flow id = {:?}, too many time windows: {}, only the first {} are taken for this query, the group by expression might be wrong. first_time_window={:?}, last_time_window={:?}",
+                    "Flow id = {:?}, too many time windows: {}, only {} are taken for this query, the group by expression might be wrong. first_time_window={:?}, last_time_window={:?}",
                     flow_id,
                     merged_windows.len(),
                     window_cnt,
@@ -661,7 +661,10 @@ impl DirtyTimeWindows {
             }
         }
 
-        // get the first `window_cnt` time windows
+        // Select the windows to query. Phase 0 child queries
+        // (`window_cnt == 1`) take the NEWEST dirty window first so short-range
+        // children drain recent data ahead of the backlog; the general
+        // `window_cnt > 1` path keeps the legacy oldest-first order.
         let max_time_range = window_size * window_cnt as i32;
 
         let mut to_be_query = BTreeMap::new();
@@ -669,54 +672,91 @@ impl DirtyTimeWindows {
         // are removed/inserted here and only committed on success.
         let mut new_windows = merged_windows.clone();
         let mut cur_time_range = chrono::Duration::zero();
-        for (idx, (start, end)) in merged_windows.iter().enumerate() {
-            let first_end = start
-                .add_duration(window_size.to_std().unwrap())
-                .context(TimeSnafu)?;
-            let end = end.unwrap_or(first_end);
 
-            // if time range is too long, stop
-            if cur_time_range >= max_time_range {
-                break;
+        if window_cnt == 1 {
+            // Newest-first Phase 0 selection: take the last merged window.
+            if let Some((start, end)) = merged_windows.last_key_value() {
+                let first_end = start
+                    .add_duration(window_size.to_std().unwrap())
+                    .context(TimeSnafu)?;
+                // `None` end keeps the existing `[start, start+window_size)`
+                // behavior.
+                let end = end.unwrap_or(first_end);
+
+                let Some(x) = end.sub(start) else {
+                    // Unrepresentable range; nothing to select this round.
+                    // Mirrors the legacy `continue` on `end.sub(start)`.
+                    return Ok(None);
+                };
+                if x <= window_size {
+                    // Whole window fits: take `[start, end)` entirely.
+                    to_be_query.insert(*start, Some(end));
+                    new_windows.remove(start);
+                    cur_time_range += x;
+                } else {
+                    // Window larger than one chunk: take the newest chunk
+                    // `[end - window_size, end)` and keep the remainder
+                    // `[start, end - window_size)` dirty.
+                    let split_at = end
+                        .sub_duration(window_size.to_std().unwrap())
+                        .context(TimeSnafu)?;
+                    to_be_query.insert(split_at, Some(end));
+                    new_windows.remove(start);
+                    new_windows.insert(*start, Some(split_at));
+                    cur_time_range += window_size;
+                }
             }
+        } else {
+            // Legacy oldest-first: get the first `window_cnt` time windows.
+            for (idx, (start, end)) in merged_windows.iter().enumerate() {
+                let first_end = start
+                    .add_duration(window_size.to_std().unwrap())
+                    .context(TimeSnafu)?;
+                let end = end.unwrap_or(first_end);
 
-            // if we have enough time windows, stop
-            if idx >= window_cnt {
-                break;
-            }
-
-            let Some(x) = end.sub(start) else {
-                continue;
-            };
-            if cur_time_range + x <= max_time_range {
-                to_be_query.insert(*start, Some(end));
-                new_windows.remove(start);
-                cur_time_range += x;
-            } else {
-                // too large a window, split it
-                // split at window_size * times
-                let surplus = max_time_range - cur_time_range;
-                if surplus.num_seconds() < window_size.num_seconds() {
-                    // Skip splitting if surplus is smaller than window_size.
-                    // An exactly window-sized surplus (`surplus == window_size`)
-                    // must proceed so that `max_window_cnt=1` consumes exactly
-                    // one aligned window-sized chunk and leaves the remainder
-                    // dirty, instead of stalling on the merged range.
+                // if time range is too long, stop
+                if cur_time_range >= max_time_range {
                     break;
                 }
-                let times = surplus.num_seconds() / window_size.num_seconds();
 
-                let split_offset = window_size * times as i32;
-                let split_at = start
-                    .add_duration(split_offset.to_std().unwrap())
-                    .context(TimeSnafu)?;
-                to_be_query.insert(*start, Some(split_at));
+                // if we have enough time windows, stop
+                if idx >= window_cnt {
+                    break;
+                }
 
-                // remove the original window
-                new_windows.remove(start);
-                new_windows.insert(split_at, Some(end));
-                cur_time_range += split_offset;
-                break;
+                let Some(x) = end.sub(start) else {
+                    continue;
+                };
+                if cur_time_range + x <= max_time_range {
+                    to_be_query.insert(*start, Some(end));
+                    new_windows.remove(start);
+                    cur_time_range += x;
+                } else {
+                    // too large a window, split it
+                    // split at window_size * times
+                    let surplus = max_time_range - cur_time_range;
+                    if surplus.num_seconds() < window_size.num_seconds() {
+                        // Skip splitting if surplus is smaller than window_size.
+                        // An exactly window-sized surplus (`surplus == window_size`)
+                        // must proceed so that `max_window_cnt=1` consumes exactly
+                        // one aligned window-sized chunk and leaves the remainder
+                        // dirty, instead of stalling on the merged range.
+                        break;
+                    }
+                    let times = surplus.num_seconds() / window_size.num_seconds();
+
+                    let split_offset = window_size * times as i32;
+                    let split_at = start
+                        .add_duration(split_offset.to_std().unwrap())
+                        .context(TimeSnafu)?;
+                    to_be_query.insert(*start, Some(split_at));
+
+                    // remove the original window
+                    new_windows.remove(start);
+                    new_windows.insert(split_at, Some(end));
+                    cur_time_range += split_offset;
+                    break;
+                }
             }
         }
 
@@ -1314,11 +1354,12 @@ mod test {
         }
     }
 
-    /// `gen_filter_exprs` with `window_cnt = 1` must consume exactly one
-    /// window-sized chunk per call from a merged multi-window range. Regression
-    /// test for the exact-fit split stall: when the remaining surplus equals
-    /// exactly `window_size`, the split must still happen so the merged range
-    /// drains one chunk at a time instead of stalling forever.
+    /// `gen_filter_exprs` with `window_cnt = 1` (Phase 0 child) must consume
+    /// exactly one window-sized chunk per call from a merged multi-window
+    /// range, taking the NEWEST chunk first. Regression test for the
+    /// exact-fit split stall: when the remaining surplus equals exactly
+    /// `window_size`, the split must still happen so the merged range drains
+    /// one chunk at a time instead of stalling forever.
     #[test]
     fn test_gen_filter_exprs_window_cnt_one_consumes_one_window_chunk_per_call() {
         let window_size = chrono::Duration::seconds(5);
@@ -1336,36 +1377,36 @@ mod test {
         let first = dirty
             .gen_filter_exprs("ts", None, window_size, 1, 0, None)
             .unwrap()
-            .expect("first call should consume one window-sized chunk");
+            .expect("first call should consume the newest window-sized chunk");
         assert_eq!(
             first.time_ranges,
-            vec![(Timestamp::new_second(0), Timestamp::new_second(5))]
+            vec![(Timestamp::new_second(10), Timestamp::new_second(15))]
         );
         assert_eq!(
             dirty.windows,
-            BTreeMap::from([(Timestamp::new_second(5), Some(Timestamp::new_second(15)))])
+            BTreeMap::from([(Timestamp::new_second(0), Some(Timestamp::new_second(10)))])
         );
 
         let second = dirty
             .gen_filter_exprs("ts", None, window_size, 1, 0, None)
             .unwrap()
-            .expect("second call should consume the next window-sized chunk");
+            .expect("second call should consume the next-newest window-sized chunk");
         assert_eq!(
             second.time_ranges,
             vec![(Timestamp::new_second(5), Timestamp::new_second(10))]
         );
         assert_eq!(
             dirty.windows,
-            BTreeMap::from([(Timestamp::new_second(10), Some(Timestamp::new_second(15)))])
+            BTreeMap::from([(Timestamp::new_second(0), Some(Timestamp::new_second(5)))])
         );
 
         let third = dirty
             .gen_filter_exprs("ts", None, window_size, 1, 0, None)
             .unwrap()
-            .expect("third call should consume the last window-sized chunk");
+            .expect("third call should consume the oldest window-sized chunk");
         assert_eq!(
             third.time_ranges,
-            vec![(Timestamp::new_second(10), Timestamp::new_second(15))]
+            vec![(Timestamp::new_second(0), Timestamp::new_second(5))]
         );
         assert!(dirty.windows.is_empty());
 
@@ -1375,6 +1416,109 @@ mod test {
                 .unwrap()
                 .is_none(),
             "fully drained dirty windows should produce no filter"
+        );
+    }
+
+    /// `gen_filter_exprs` with `window_cnt > 1` must keep the legacy
+    /// oldest-first selection order even though Phase 0 children
+    /// (`window_cnt == 1`) are newest-first. Regression test for the
+    /// multi-window semantics that must not be flipped wholesale.
+    #[test]
+    fn test_gen_filter_exprs_window_cnt_gt_one_keeps_oldest_first() {
+        let window_size = chrono::Duration::seconds(5);
+        let mut dirty = DirtyTimeWindows::default();
+        // Three disjoint merged windows, far enough apart (gap > MERGE_DIST)
+        // to stay separate.
+        dirty.add_window(Timestamp::new_second(0), Some(Timestamp::new_second(5)));
+        dirty.add_window(Timestamp::new_second(100), Some(Timestamp::new_second(105)));
+        dirty.add_window(Timestamp::new_second(200), Some(Timestamp::new_second(205)));
+
+        // window_cnt = 2: the legacy path takes the two OLDEST windows.
+        let filter = dirty
+            .gen_filter_exprs("ts", None, window_size, 2, 0, None)
+            .unwrap()
+            .expect("two oldest windows should be selected");
+        assert_eq!(
+            filter.time_ranges,
+            vec![
+                (Timestamp::new_second(0), Timestamp::new_second(5)),
+                (Timestamp::new_second(100), Timestamp::new_second(105)),
+            ],
+            "window_cnt > 1 must keep oldest-first selection"
+        );
+        assert_eq!(
+            dirty.windows,
+            BTreeMap::from([(Timestamp::new_second(200), Some(Timestamp::new_second(205)))])
+        );
+    }
+
+    /// `gen_filter_exprs` with `window_cnt = 1` must keep selecting the
+    /// NEWEST window across multiple disjoint merged windows, take the whole
+    /// window when it fits, split the newest chunk off the right side when it
+    /// is larger than `window_size`, and fall back to the existing
+    /// `[start, start+window_size)` behavior for unbounded (`None` end)
+    /// windows.
+    #[test]
+    fn test_gen_filter_exprs_window_cnt_one_newest_first_multi_window_and_unbounded() {
+        let window_size = chrono::Duration::seconds(5);
+        let mut dirty = DirtyTimeWindows::default();
+        // Three disjoint merged windows: [0s, 5s), [100s, 130s) (larger than
+        // window_size) and an unbounded dirty marker at 200s.
+        dirty.add_window(Timestamp::new_second(0), Some(Timestamp::new_second(5)));
+        dirty.add_window(Timestamp::new_second(100), Some(Timestamp::new_second(130)));
+        dirty.add_window(Timestamp::new_second(200), None);
+
+        // Newest first: the unbounded marker is the last merged window; `None`
+        // end keeps the existing `[start, start+window_size)` behavior.
+        let first = dirty
+            .gen_filter_exprs("ts", None, window_size, 1, 0, None)
+            .unwrap()
+            .expect("unbounded newest window should be selected");
+        assert_eq!(
+            first.time_ranges,
+            vec![(Timestamp::new_second(200), Timestamp::new_second(205))]
+        );
+        assert_eq!(
+            dirty.windows,
+            BTreeMap::from([
+                (Timestamp::new_second(0), Some(Timestamp::new_second(5))),
+                (Timestamp::new_second(100), Some(Timestamp::new_second(130))),
+            ])
+        );
+
+        // Next: [100s, 130s) is larger than window_size; take the newest chunk
+        // [125s, 130s) and keep the remainder [100s, 125s) dirty.
+        let second = dirty
+            .gen_filter_exprs("ts", None, window_size, 1, 0, None)
+            .unwrap()
+            .expect("oversized newest window should be split from the right");
+        assert_eq!(
+            second.time_ranges,
+            vec![(Timestamp::new_second(125), Timestamp::new_second(130))]
+        );
+        assert_eq!(
+            dirty.windows,
+            BTreeMap::from([
+                (Timestamp::new_second(0), Some(Timestamp::new_second(5))),
+                (Timestamp::new_second(100), Some(Timestamp::new_second(125))),
+            ])
+        );
+
+        // And again: [120s, 125s), remainder [100s, 120s).
+        let third = dirty
+            .gen_filter_exprs("ts", None, window_size, 1, 0, None)
+            .unwrap()
+            .expect("oversized newest window should keep splitting from the right");
+        assert_eq!(
+            third.time_ranges,
+            vec![(Timestamp::new_second(120), Timestamp::new_second(125))]
+        );
+        assert_eq!(
+            dirty.windows,
+            BTreeMap::from([
+                (Timestamp::new_second(0), Some(Timestamp::new_second(5))),
+                (Timestamp::new_second(100), Some(Timestamp::new_second(120))),
+            ])
         );
     }
 
@@ -1438,8 +1582,10 @@ mod test {
         .unwrap();
 
         // Merge collapses the three windows into one [0s, 15s) range, which is
-        // selected (and split into a staged remainder) before construction; the
-        // missing time-window expression then fails the alignment step.
+        // selected via the Phase 0 newest-first path (`window_cnt == 1`): the
+        // newest chunk [10s, 15s) is staged and the remainder [0s, 10s) kept
+        // before construction; the missing time-window expression then fails
+        // the alignment step.
         let result = dirty.gen_filter_exprs("ts", None, window_size, 1, 0, Some(&task));
 
         assert!(

--- a/src/flow/src/batching_mode/state.rs
+++ b/src/flow/src/batching_mode/state.rs
@@ -619,17 +619,29 @@ impl DirtyTimeWindows {
             expire_lower_bound.map(|t| t.to_iso8601_string()),
             window_size
         );
-        self.merge_dirty_time_windows(window_size, expire_lower_bound)?;
 
-        if self.windows.len() > window_cnt {
-            let first_time_window = self.windows.first_key_value();
-            let last_time_window = self.windows.last_key_value();
+        // Merge/expiry, selection/splitting, alignment, and expression
+        // construction all run on a staged clone of the live windows. The live
+        // `self.windows` is committed only after the complete `FilterExprInfo`
+        // has been built successfully, so an `Err` at any point leaves the
+        // dirty-window map exactly unchanged (including its key/value
+        // representation).
+        let merged_windows = Self::merge_dirty_time_windows_staged(
+            &self.windows,
+            window_size,
+            self.time_window_merge_threshold,
+            expire_lower_bound,
+        )?;
+
+        if merged_windows.len() > window_cnt {
+            let first_time_window = merged_windows.first_key_value();
+            let last_time_window = merged_windows.last_key_value();
 
             if let Some(task_ctx) = task_ctx {
                 debug!(
                     "Flow id = {:?}, too many time windows: {}, only the first {} are taken for this query, the group by expression might be wrong. Time window expr={:?}, expire_after={:?}, first_time_window={:?}, last_time_window={:?}, the original query: {:?}",
                     task_ctx.config.flow_id,
-                    self.windows.len(),
+                    merged_windows.len(),
                     window_cnt,
                     task_ctx.config.time_window_expr,
                     task_ctx.config.expire_after,
@@ -641,7 +653,7 @@ impl DirtyTimeWindows {
                 debug!(
                     "Flow id = {:?}, too many time windows: {}, only the first {} are taken for this query, the group by expression might be wrong. first_time_window={:?}, last_time_window={:?}",
                     flow_id,
-                    self.windows.len(),
+                    merged_windows.len(),
                     window_cnt,
                     first_time_window,
                     last_time_window
@@ -653,9 +665,11 @@ impl DirtyTimeWindows {
         let max_time_range = window_size * window_cnt as i32;
 
         let mut to_be_query = BTreeMap::new();
-        let mut new_windows = self.windows.clone();
+        // Staged remainder: starts as the merged map; consumed ranges/splits
+        // are removed/inserted here and only committed on success.
+        let mut new_windows = merged_windows.clone();
         let mut cur_time_range = chrono::Duration::zero();
-        for (idx, (start, end)) in self.windows.iter().enumerate() {
+        for (idx, (start, end)) in merged_windows.iter().enumerate() {
             let first_end = start
                 .add_duration(window_size.to_std().unwrap())
                 .context(TimeSnafu)?;
@@ -682,8 +696,12 @@ impl DirtyTimeWindows {
                 // too large a window, split it
                 // split at window_size * times
                 let surplus = max_time_range - cur_time_range;
-                if surplus.num_seconds() <= window_size.num_seconds() {
-                    // Skip splitting if surplus is smaller than window_size
+                if surplus.num_seconds() < window_size.num_seconds() {
+                    // Skip splitting if surplus is smaller than window_size.
+                    // An exactly window-sized surplus (`surplus == window_size`)
+                    // must proceed so that `max_window_cnt=1` consumes exactly
+                    // one aligned window-sized chunk and leaves the remainder
+                    // dirty, instead of stalling on the merged range.
                     break;
                 }
                 let times = surplus.num_seconds() / window_size.num_seconds();
@@ -702,11 +720,15 @@ impl DirtyTimeWindows {
             }
         }
 
-        self.windows = new_windows;
-
-        METRIC_FLOW_BATCHING_ENGINE_QUERY_WINDOW_CNT
-            .with_label_values(&[flow_id.to_string().as_str()])
-            .observe(to_be_query.len() as f64);
+        // No eligible windows after merge/expiry: keep the existing successful
+        // semantics. The merge/expiry cleanup IS committed (expired windows are
+        // dropped, close windows are coalesced) even though no query is
+        // generated; this mirrors the pre-transactional behavior. An `Err` from
+        // this point onward still never mutates `self.windows`.
+        if to_be_query.is_empty() {
+            self.windows = new_windows;
+            return Ok(None);
+        }
 
         let full_time_range = to_be_query
             .iter()
@@ -718,12 +740,9 @@ impl DirtyTimeWindows {
                 }
             })
             .num_seconds() as f64;
-        METRIC_FLOW_BATCHING_ENGINE_QUERY_WINDOW_SIZE
-            .with_label_values(&[flow_id.to_string().as_str()])
-            .observe(full_time_range);
 
         let stalled_time_range =
-            self.windows
+            new_windows
                 .iter()
                 .fold(chrono::Duration::zero(), |acc, (start, end)| {
                     if let Some(end) = end {
@@ -732,10 +751,6 @@ impl DirtyTimeWindows {
                         acc + window_size
                     }
                 });
-
-        METRIC_FLOW_BATCHING_ENGINE_STALLED_WINDOW_SIZE
-            .with_label_values(&[flow_id.to_string().as_str()])
-            .observe(stalled_time_range.num_seconds() as f64);
 
         let std_window_size = window_size.to_std().map_err(|e| {
             InternalSnafu {
@@ -777,6 +792,20 @@ impl DirtyTimeWindows {
             expr_lst.push(expr);
         }
         let expr = expr_lst.into_iter().reduce(|a, b| a.or(b));
+
+        // All fallible construction succeeded: commit the staged remainder now.
+        self.windows = new_windows;
+
+        METRIC_FLOW_BATCHING_ENGINE_QUERY_WINDOW_CNT
+            .with_label_values(&[flow_id.to_string().as_str()])
+            .observe(time_ranges.len() as f64);
+        METRIC_FLOW_BATCHING_ENGINE_QUERY_WINDOW_SIZE
+            .with_label_values(&[flow_id.to_string().as_str()])
+            .observe(full_time_range);
+        METRIC_FLOW_BATCHING_ENGINE_STALLED_WINDOW_SIZE
+            .with_label_values(&[flow_id.to_string().as_str()])
+            .observe(stalled_time_range.num_seconds() as f64);
+
         let ret = expr.map(|expr| FilterExprInfo {
             expr,
             col_name: col_name.to_string(),
@@ -819,8 +848,29 @@ impl DirtyTimeWindows {
         window_size: chrono::Duration,
         expire_lower_bound: Option<Timestamp>,
     ) -> Result<(), Error> {
-        if self.windows.is_empty() {
-            return Ok(());
+        self.windows = Self::merge_dirty_time_windows_staged(
+            &self.windows,
+            window_size,
+            self.time_window_merge_threshold,
+            expire_lower_bound,
+        )?;
+        Ok(())
+    }
+
+    /// Pure merge/expiry of `windows` — does not mutate `self`. Returns the
+    /// merged/clipped map, or `Err` on timestamp arithmetic overflow with the
+    /// input unchanged.
+    ///
+    /// `gen_filter_exprs` stages its merge through this function so an `Err`
+    /// leaves the live `self.windows` exactly unchanged (transactional).
+    pub(crate) fn merge_dirty_time_windows_staged(
+        windows: &BTreeMap<Timestamp, Option<Timestamp>>,
+        window_size: chrono::Duration,
+        time_window_merge_threshold: usize,
+        expire_lower_bound: Option<Timestamp>,
+    ) -> Result<BTreeMap<Timestamp, Option<Timestamp>>, Error> {
+        if windows.is_empty() {
+            return Ok(BTreeMap::new());
         }
 
         let mut new_windows = BTreeMap::new();
@@ -834,7 +884,7 @@ impl DirtyTimeWindows {
 
         // previous time window
         let mut prev_tw = None;
-        for (mut lower_bound, upper_bound) in std::mem::take(&mut self.windows) {
+        for (mut lower_bound, upper_bound) in windows.clone() {
             // filter out expired time window
             if let Some(expire_lower_bound) = expire_lower_bound {
                 match upper_bound {
@@ -874,7 +924,7 @@ impl DirtyTimeWindows {
 
             if lower_bound
                 .sub(&prev_upper)
-                .map(|dist| dist <= window_size * self.time_window_merge_threshold as i32)
+                .map(|dist| dist <= window_size * time_window_merge_threshold as i32)
                 .unwrap_or(false)
             {
                 // Union the two windows: the current window may be contained
@@ -890,9 +940,7 @@ impl DirtyTimeWindows {
             new_windows.insert(prev_tw.0, prev_tw.1);
         }
 
-        self.windows = new_windows;
-
-        Ok(())
+        Ok(new_windows)
     }
 }
 
@@ -1264,6 +1312,195 @@ mod test {
                 .unwrap();
             assert_eq!(expected, dirty.windows);
         }
+    }
+
+    /// `gen_filter_exprs` with `window_cnt = 1` must consume exactly one
+    /// window-sized chunk per call from a merged multi-window range. Regression
+    /// test for the exact-fit split stall: when the remaining surplus equals
+    /// exactly `window_size`, the split must still happen so the merged range
+    /// drains one chunk at a time instead of stalling forever.
+    #[test]
+    fn test_gen_filter_exprs_window_cnt_one_consumes_one_window_chunk_per_call() {
+        let window_size = chrono::Duration::seconds(5);
+        let mut dirty = DirtyTimeWindows::default();
+        // Three adjacent one-window dirty ranges merge into a single
+        // 3-window range [0s, 15s) before filtering.
+        for i in 0..3 {
+            dirty.add_window(
+                Timestamp::new_second(i * 5),
+                Some(Timestamp::new_second((i + 1) * 5)),
+            );
+        }
+        assert_eq!(dirty.len(), 3);
+
+        let first = dirty
+            .gen_filter_exprs("ts", None, window_size, 1, 0, None)
+            .unwrap()
+            .expect("first call should consume one window-sized chunk");
+        assert_eq!(
+            first.time_ranges,
+            vec![(Timestamp::new_second(0), Timestamp::new_second(5))]
+        );
+        assert_eq!(
+            dirty.windows,
+            BTreeMap::from([(Timestamp::new_second(5), Some(Timestamp::new_second(15)))])
+        );
+
+        let second = dirty
+            .gen_filter_exprs("ts", None, window_size, 1, 0, None)
+            .unwrap()
+            .expect("second call should consume the next window-sized chunk");
+        assert_eq!(
+            second.time_ranges,
+            vec![(Timestamp::new_second(5), Timestamp::new_second(10))]
+        );
+        assert_eq!(
+            dirty.windows,
+            BTreeMap::from([(Timestamp::new_second(10), Some(Timestamp::new_second(15)))])
+        );
+
+        let third = dirty
+            .gen_filter_exprs("ts", None, window_size, 1, 0, None)
+            .unwrap()
+            .expect("third call should consume the last window-sized chunk");
+        assert_eq!(
+            third.time_ranges,
+            vec![(Timestamp::new_second(10), Timestamp::new_second(15))]
+        );
+        assert!(dirty.windows.is_empty());
+
+        assert!(
+            dirty
+                .gen_filter_exprs("ts", None, window_size, 1, 0, None)
+                .unwrap()
+                .is_none(),
+            "fully drained dirty windows should produce no filter"
+        );
+    }
+
+    /// `gen_filter_exprs` must not commit ANY mutation — including the
+    /// merge/expiry step — until the complete filter has been constructed.
+    /// This test starts with three separately represented, mergeable windows
+    /// (so merge would collapse them), then induces a deterministic
+    /// post-merge construction error via a `task_ctx` with no time-window
+    /// expression. The live `dirty.windows` must remain exactly equal to the
+    /// original map.
+    #[tokio::test]
+    async fn test_gen_filter_exprs_construction_failure_leaves_windows_unchanged() {
+        let window_size = chrono::Duration::seconds(5);
+        let mut dirty = DirtyTimeWindows::default();
+        // Three adjacent one-window dirty ranges are mergeable into one
+        // [0s, 15s) range; they stay separately represented until merge runs.
+        dirty.add_window(Timestamp::new_second(0), Some(Timestamp::new_second(5)));
+        dirty.add_window(Timestamp::new_second(5), Some(Timestamp::new_second(10)));
+        dirty.add_window(Timestamp::new_second(10), Some(Timestamp::new_second(15)));
+        assert_eq!(
+            dirty.windows.len(),
+            3,
+            "precondition: three separate windows"
+        );
+        let original_windows = dirty.windows.clone();
+
+        let query_engine = create_test_query_engine();
+        let ctx = QueryContext::arc();
+        let plan = sql_to_df_plan(
+            ctx.clone(),
+            query_engine.clone(),
+            "SELECT number, ts FROM numbers_with_ts",
+            true,
+        )
+        .await
+        .unwrap();
+        let (_tx, rx) = tokio::sync::oneshot::channel();
+        let task = BatchingTask::try_new(crate::batching_mode::task::TaskArgs {
+            flow_id: 1,
+            query: "SELECT number, ts FROM numbers_with_ts",
+            plan,
+            time_window_expr: None,
+            expire_after: None,
+            sink_table_name: [
+                "greptime".to_string(),
+                "public".to_string(),
+                "unused_sink".to_string(),
+            ],
+            source_table_names: vec![[
+                "greptime".to_string(),
+                "public".to_string(),
+                "numbers_with_ts".to_string(),
+            ]],
+            query_ctx: ctx,
+            catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+            shutdown_rx: rx,
+            batch_opts: std::sync::Arc::new(crate::batching_mode::BatchingModeOptions::default()),
+            flow_eval_interval: None,
+            eval_schedule: None,
+        })
+        .unwrap();
+
+        // Merge collapses the three windows into one [0s, 15s) range, which is
+        // selected (and split into a staged remainder) before construction; the
+        // missing time-window expression then fails the alignment step.
+        let result = dirty.gen_filter_exprs("ts", None, window_size, 1, 0, Some(&task));
+
+        assert!(
+            matches!(result, Err(Error::Unexpected { .. })),
+            "missing time-window expression must fail construction, got {result:?}"
+        );
+        assert_eq!(
+            dirty.windows, original_windows,
+            "failed filter construction must not mutate dirty windows (merge included)"
+        );
+        // Prove the merge step WOULD have changed the map, so the equality above
+        // is not vacuous: three separate entries vs one merged entry.
+        assert_eq!(original_windows.len(), 3);
+        let merged = DirtyTimeWindows::merge_dirty_time_windows_staged(
+            &original_windows,
+            window_size,
+            dirty.time_window_merge_threshold,
+            None,
+        )
+        .unwrap();
+        assert_eq!(merged.len(), 1);
+        assert_eq!(
+            merged,
+            BTreeMap::from([(Timestamp::new_second(0), Some(Timestamp::new_second(15)))])
+        );
+    }
+
+    /// On `Ok(None)` (no eligible windows after merge/expiry) the merge/expiry
+    /// cleanup commits, matching pre-transactional behavior: expired windows
+    /// are dropped even though no query runs. The committed map must come from
+    /// the staged merge and must not touch configuration fields.
+    #[test]
+    fn test_gen_filter_exprs_none_commits_merge_expiry_cleanup() {
+        let window_size = chrono::Duration::seconds(5);
+        let mut dirty = DirtyTimeWindows::default();
+        // A bounded range ending at or before the expire bound is fully
+        // expired: [0s, 5s) with expire bound 20s is dropped.
+        dirty.add_window(Timestamp::new_second(0), Some(Timestamp::new_second(5)));
+        let max_filter_before = dirty.max_filter_num_per_query;
+        let merge_threshold_before = dirty.time_window_merge_threshold;
+
+        let result = dirty.gen_filter_exprs(
+            "ts",
+            Some(Timestamp::new_second(20)),
+            window_size,
+            1,
+            0,
+            None,
+        );
+        assert!(
+            matches!(result, Ok(None)),
+            "fully expired windows should produce no query, got {result:?}"
+        );
+        assert!(
+            dirty.windows.is_empty(),
+            "expired windows must be cleaned up"
+        );
+
+        // Configuration fields untouched by the transactional path.
+        assert_eq!(dirty.max_filter_num_per_query, max_filter_before);
+        assert_eq!(dirty.time_window_merge_threshold, merge_threshold_before);
     }
 
     #[tokio::test]

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -442,7 +442,9 @@ impl BatchingTask {
     }
 
     /// Number of child queries allowed per tick in Phase 0 batching mode.
-    /// `0` is treated as `1` defensively (current single-query behavior).
+    /// The default `3` enables the strategy; `1` is the official opt-out that
+    /// restores the legacy single-query-per-tick behavior; `0` is treated as
+    /// `1` defensively (a `1`-compatible alias).
     fn max_queries_per_tick(&self) -> usize {
         self.config
             .batch_opts
@@ -453,10 +455,11 @@ impl BatchingTask {
     /// Executes one tick under `execution_lock` and keeps the generated query
     /// context for the background loop's error logging/backoff.
     ///
-    /// With Phase 0 batching enabled (`experimental_max_queries_per_tick > 1`)
-    /// this serially drains up to N independent short-range child queries, each
-    /// generated with `max_window_cnt = Some(1)` so its filter covers at most
-    /// one `window_size`-sized dirty window. It stops early on the first
+    /// With Phase 0 batching enabled (`experimental_max_queries_per_tick > 1`,
+    /// the default is `3`) this serially drains up to N independent short-range
+    /// child queries, each generated with `max_window_cnt = Some(1)` so its
+    /// filter covers at most one `window_size`-sized dirty window, and each
+    /// consuming the newest dirty window first. It stops early on the first
     /// no-dirty (`Ok(None)`) or error outcome, or when N children have run or a
     /// shutdown signal arrives. Subsequent child queries continue only while the
     /// previous successful child was scoped dirty-window work
@@ -468,8 +471,8 @@ impl BatchingTask {
     /// children are never restored. The tick outcome aggregates affected rows
     /// and elapsed durations across children.
     ///
-    /// With the default `N == 1` this delegates to the existing single-query
-    /// execution, so default behavior is exactly unchanged.
+    /// With `N == 1` (the official opt-out) this delegates to the existing
+    /// single-query execution, so the legacy behavior is exactly restored.
     async fn execute_tick_serialized_with_outcome(
         &self,
         engine: &QueryEngineRef,
@@ -1341,6 +1344,31 @@ impl BatchingTask {
                     max_window_cnt = max_window_cnt.map(|cnt| {
                         (cnt + 1).min(self.config.batch_opts.experimental_max_filter_num_per_query)
                     });
+
+                    // Phase 0 batching (N > 1): when scoped dirty work still
+                    // remains after a successful tick — live dirty windows or
+                    // pending fenced-repair windows — start the next tick
+                    // immediately instead of sleeping, so a backlog drains as
+                    // fast as the per-tick child budget allows. `Ok(None)` and
+                    // `Err` keep the existing sleep/backoff below. The EVAL
+                    // scheduled loop is unaffected (it never enters this
+                    // adaptive path).
+                    if self.max_queries_per_tick() > 1 {
+                        let has_backlog = {
+                            let state = self.state.read().unwrap();
+                            !state.dirty_time_windows.is_empty()
+                                || state
+                                    .pending_fenced_repair()
+                                    .is_some_and(|repair| !repair.pending_windows().is_empty())
+                        };
+                        if has_backlog {
+                            debug!(
+                                "Flow id = {:?}, Phase 0 backlog still present after tick, starting next tick immediately",
+                                self.config.flow_id
+                            );
+                            continue;
+                        }
+                    }
 
                     let sleep_until = {
                         let state = self.state.write().unwrap();

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -177,7 +177,7 @@ pub struct PlanInfo {
     pub coverage: QueryCoverage,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum QueryCoverage {
     /// Explicit full-query snapshot coverage, e.g. TQL or evaluation-interval
     /// SQL flows whose plan shape cannot be safely dirty-window pruned. This
@@ -227,12 +227,26 @@ pub enum DirtyRestore {
 
 struct ExecuteOnceOutcome {
     new_query: Option<PlanInfo>,
+    /// Coverage of the generated query, when one was generated. The Phase 0
+    /// tick uses this to decide whether another child query may follow.
+    coverage: Option<QueryCoverage>,
     /// Execution result of the generated insert plan.
     ///
     /// `Ok(Some((affected_rows, elapsed)))` means a query was executed.
     /// `Ok(None)` means no query was generated because there was no dirty signal.
     /// `Err(_)` means plan generation or execution failed.
     result: Result<Option<(usize, Duration)>, Error>,
+}
+
+/// Whether a successful child query is scoped dirty-window work that a Phase 0
+/// tick may continue with. Unfiltered full snapshots and incremental delta
+/// queries execute at most once per tick: repeating them could re-run the same
+/// source range or advance checkpoints multiple times.
+fn coverage_allows_phase0_continuation(coverage: &QueryCoverage) -> bool {
+    matches!(
+        coverage,
+        QueryCoverage::ScopedBaseRepair | QueryCoverage::FencedRepairChunk { .. }
+    )
 }
 
 impl BatchingTask {
@@ -427,6 +441,155 @@ impl BatchingTask {
             .await
     }
 
+    /// Number of child queries allowed per tick in Phase 0 batching mode.
+    /// `0` is treated as `1` defensively (current single-query behavior).
+    fn max_queries_per_tick(&self) -> usize {
+        self.config
+            .batch_opts
+            .experimental_max_queries_per_tick
+            .max(1)
+    }
+
+    /// Executes one tick under `execution_lock` and keeps the generated query
+    /// context for the background loop's error logging/backoff.
+    ///
+    /// With Phase 0 batching enabled (`experimental_max_queries_per_tick > 1`)
+    /// this serially drains up to N independent short-range child queries, each
+    /// generated with `max_window_cnt = Some(1)` so its filter covers at most
+    /// one `window_size`-sized dirty window. It stops early on the first
+    /// no-dirty (`Ok(None)`) or error outcome, or when N children have run or a
+    /// shutdown signal arrives. Subsequent child queries continue only while the
+    /// previous successful child was scoped dirty-window work
+    /// (`ScopedBaseRepair`/`FencedRepairChunk`); unfiltered full snapshots and
+    /// incremental delta queries execute at most once per tick. Each successful
+    /// child applies its own query result/checkpoint via
+    /// `execute_logical_plan_unlocked`; a failed child is restored through the
+    /// existing `handle_executed_query_failure` only, and prior successful
+    /// children are never restored. The tick outcome aggregates affected rows
+    /// and elapsed durations across children.
+    ///
+    /// With the default `N == 1` this delegates to the existing single-query
+    /// execution, so default behavior is exactly unchanged.
+    async fn execute_tick_serialized_with_outcome(
+        &self,
+        engine: &QueryEngineRef,
+        frontend_client: &Arc<FrontendClient>,
+        fallback_max_window_cnt: Option<usize>,
+    ) -> ExecuteOnceOutcome {
+        let _execution_guard = self.execution_lock.lock().await;
+        self.execute_tick_unlocked(engine, frontend_client, fallback_max_window_cnt)
+            .await
+    }
+
+    /// Serial multi-query tick execution. Caller must hold `execution_lock`.
+    async fn execute_tick_unlocked(
+        &self,
+        engine: &QueryEngineRef,
+        frontend_client: &Arc<FrontendClient>,
+        fallback_max_window_cnt: Option<usize>,
+    ) -> ExecuteOnceOutcome {
+        let max_queries = self.max_queries_per_tick();
+        if max_queries == 1 {
+            return self
+                .execute_once_unlocked(engine, frontend_client, fallback_max_window_cnt)
+                .await;
+        }
+
+        let flow_id_str = self.config.flow_id.to_string();
+        let mut total_rows = 0usize;
+        let mut total_elapsed = Duration::default();
+        let mut child_index = 0usize;
+        loop {
+            if child_index >= max_queries || self.is_shutdown_signaled() {
+                break;
+            }
+            child_index += 1;
+            debug!(
+                "Flow {}: Phase 0 tick executing child query {child_index}/{max_queries}",
+                flow_id_str
+            );
+            let outcome = self
+                .execute_once_unlocked(engine, frontend_client, Some(1))
+                .await;
+            match outcome.result {
+                Ok(Some((rows, elapsed))) => {
+                    total_rows += rows;
+                    total_elapsed += elapsed;
+                    let can_continue = outcome
+                        .coverage
+                        .as_ref()
+                        .map(coverage_allows_phase0_continuation)
+                        .unwrap_or(false);
+                    if !can_continue {
+                        debug!(
+                            "Flow {}: Phase 0 tick stopped at child {child_index}/{max_queries}: child executed non-scoped work (coverage={:?}), which runs at most once per tick",
+                            flow_id_str, outcome.coverage
+                        );
+                        return ExecuteOnceOutcome {
+                            new_query: outcome.new_query,
+                            coverage: outcome.coverage,
+                            result: Ok(Some((total_rows, total_elapsed))),
+                        };
+                    }
+                }
+                Ok(None) => {
+                    debug!(
+                        "Flow {}: Phase 0 tick stopped at child {child_index}/{max_queries}: no dirty windows remain",
+                        flow_id_str
+                    );
+                    return if child_index == 1 {
+                        // No dirty signal at all: preserve the existing
+                        // no-query outcome for the caller.
+                        ExecuteOnceOutcome {
+                            new_query: None,
+                            coverage: None,
+                            result: Ok(None),
+                        }
+                    } else {
+                        // At least one child succeeded; report the drained part.
+                        ExecuteOnceOutcome {
+                            new_query: None,
+                            coverage: None,
+                            result: Ok(Some((total_rows, total_elapsed))),
+                        }
+                    };
+                }
+                Err(err) => {
+                    debug!(
+                        "Flow {}: Phase 0 tick stopped at child {child_index}/{max_queries}: error",
+                        flow_id_str
+                    );
+                    // The failing child's windows were restored by the existing
+                    // `handle_executed_query_failure` inside
+                    // `execute_once_unlocked`; prior successful children are
+                    // intentionally not restored.
+                    return ExecuteOnceOutcome {
+                        new_query: outcome.new_query,
+                        coverage: outcome.coverage,
+                        result: Err(err),
+                    };
+                }
+            }
+        }
+        debug!(
+            "Flow {}: Phase 0 tick finished after {child_index}/{max_queries} child queries",
+            flow_id_str
+        );
+        if child_index == 0 {
+            ExecuteOnceOutcome {
+                new_query: None,
+                coverage: None,
+                result: Ok(None),
+            }
+        } else {
+            ExecuteOnceOutcome {
+                new_query: None,
+                coverage: None,
+                result: Ok(Some((total_rows, total_elapsed))),
+            }
+        }
+    }
+
     /// Executes one flow evaluation. Caller must hold `execution_lock`.
     async fn execute_once_unlocked(
         &self,
@@ -439,6 +602,7 @@ impl BatchingTask {
             Err(err) => {
                 return ExecuteOnceOutcome {
                     new_query: None,
+                    coverage: None,
                     result: Err(err),
                 };
             }
@@ -446,6 +610,7 @@ impl BatchingTask {
 
         if let Some(new_query) = new_query {
             debug!("Generate new query: {}", new_query.plan);
+            let coverage = new_query.coverage.clone();
             let res = self
                 .execute_logical_plan_unlocked(
                     frontend_client,
@@ -459,12 +624,14 @@ impl BatchingTask {
             }
             ExecuteOnceOutcome {
                 new_query: Some(new_query),
+                coverage: Some(coverage),
                 result: res,
             }
         } else {
             debug!("Generate no query");
             ExecuteOnceOutcome {
                 new_query: None,
+                coverage: None,
                 result: Ok(None),
             }
         }
@@ -1158,9 +1325,16 @@ impl BatchingTask {
 
             let min_refresh = self.config.batch_opts.experimental_min_refresh_duration;
 
-            let outcome = self
-                .execute_once_serialized_with_outcome(&engine, &frontend_client, max_window_cnt)
-                .await;
+            // Phase 0 batching (N > 1) serially drains up to N short-range
+            // child queries under one `execution_lock` without sleeping between
+            // them; otherwise keep the existing single-query adaptive behavior.
+            let outcome = if self.max_queries_per_tick() > 1 {
+                self.execute_tick_serialized_with_outcome(&engine, &frontend_client, None)
+                    .await
+            } else {
+                self.execute_once_serialized_with_outcome(&engine, &frontend_client, max_window_cnt)
+                    .await
+            };
 
             match outcome.result {
                 Ok(Some(_)) => {
@@ -1243,6 +1417,18 @@ impl BatchingTask {
     ) -> ExecuteOnceOutcome {
         let _execution_guard = self.execution_lock.lock().await;
 
+        self.execute_at_scheduled_time_unlocked(engine, frontend_client, scheduled_time_secs)
+            .await
+    }
+
+    /// Caller must hold `execution_lock`. The scheduled time extension is
+    /// installed once and retained for all child queries in this tick.
+    async fn execute_at_scheduled_time_unlocked(
+        &self,
+        engine: &QueryEngineRef,
+        frontend_client: &Arc<FrontendClient>,
+        scheduled_time_secs: i64,
+    ) -> ExecuteOnceOutcome {
         struct QueryContextRestoreGuard {
             state: Arc<RwLock<TaskState>>,
             old_ctx: Option<QueryContextRef>,
@@ -1278,7 +1464,7 @@ impl BatchingTask {
         };
 
         let outcome = self
-            .execute_once_unlocked(engine, frontend_client, None)
+            .execute_tick_unlocked(engine, frontend_client, None)
             .await;
 
         // Restore while still holding `execution_lock` so no future manual

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -527,11 +527,13 @@ fn assert_sql_uses_scheduled_time(sql: &str) {
     );
 }
 
-/// After a scheduled-time attempt fails (missing sink), the
-/// `FLOW_SCHEDULED_TIME_MILLIS` extension must not leak into
-/// `TaskState.query_ctx` or `frontend_extensions()`.
+/// Under the default Phase 0 batching (N=3), a scheduled-time attempt against a
+/// missing sink table with no dirty windows returns `Ok(None)`: the first
+/// scoped child query finds no dirty windows to repair and never reaches the
+/// sink lookup. The `FLOW_SCHEDULED_TIME_MILLIS` extension must still not leak
+/// into `TaskState.query_ctx` or `frontend_extensions()`.
 #[tokio::test]
-async fn test_scheduled_time_ctx_restored_on_error() {
+async fn test_scheduled_time_ctx_restored_on_default_missing_sink() {
     let TestTaskParts {
         task, query_engine, ..
     } = new_test_task_engine_and_plan_with_query(
@@ -567,10 +569,82 @@ async fn test_scheduled_time_ctx_restored_on_error() {
         )
         .await;
 
-    // Missing sink table → gen_insert_plan_unlocked should fail.
+    // Default N=3 batching: the scoped child finds no dirty windows, so the
+    // tick reports no-query (`Ok(None)`) without ever resolving the missing
+    // sink table.
+    assert!(
+        matches!(outcome.result, Ok(None)),
+        "Expected Ok(None) under default N=3 batching (no dirty windows; missing sink never reached), got {:?}",
+        outcome.result
+    );
+
+    // After: extension must be restored to absent.
+    assert_eq!(
+        task.state
+            .read()
+            .unwrap()
+            .query_ctx
+            .extension(FLOW_SCHEDULED_TIME_MILLIS),
+        None,
+        "FLOW_SCHEDULED_TIME_MILLIS leaked into query_ctx after Ok(None)"
+    );
+    assert!(
+        !task
+            .frontend_extensions()
+            .contains_key(FLOW_SCHEDULED_TIME_MILLIS),
+        "FLOW_SCHEDULED_TIME_MILLIS leaked into frontend_extensions after Ok(None)"
+    );
+}
+
+/// With `experimental_max_queries_per_tick = 1` (the official Phase 0 opt-out
+/// that restores the legacy single-query-per-tick behavior), a scheduled-time
+/// attempt against a missing sink table must fail: the legacy path resolves the
+/// sink table before generating the query, so `get_table_info_df_schema`
+/// returns `TableNotFound`. The `FLOW_SCHEDULED_TIME_MILLIS` extension must be
+/// restored to absent after the error.
+#[tokio::test]
+async fn test_scheduled_time_ctx_restored_on_error_with_legacy_opt_out() {
+    let TestTaskParts {
+        task, query_engine, ..
+    } = new_test_task_engine_and_plan_with_query_and_opts(
+        "SELECT number, ts FROM numbers_with_ts",
+        "missing_sink",
+        phase0_batch_opts(1),
+    )
+    .await;
+    let (frontend_client, _handler) =
+        FrontendClient::from_empty_grpc_handler(QueryOptions::default());
+    let frontend_client = Arc::new(frontend_client);
+
+    // Before: no scheduled time extension
+    assert_eq!(
+        task.state
+            .read()
+            .unwrap()
+            .query_ctx
+            .extension(FLOW_SCHEDULED_TIME_MILLIS),
+        None
+    );
+    assert!(
+        !task
+            .frontend_extensions()
+            .contains_key(FLOW_SCHEDULED_TIME_MILLIS)
+    );
+
+    let scheduled_time_secs = 1700000000i64;
+    let outcome = task
+        .execute_once_serialized_at_scheduled_time(
+            &query_engine,
+            &frontend_client,
+            scheduled_time_secs,
+        )
+        .await;
+
+    // N=1 opt-out restores the legacy single-query path: the missing sink table
+    // is resolved before query generation, so this must be an error.
     assert!(
         outcome.result.is_err(),
-        "Expected an error (missing sink), got {:?}",
+        "Expected an error (missing sink) with the N=1 legacy opt-out, got {:?}",
         outcome.result
     );
 
@@ -1051,10 +1125,12 @@ fn test_continued_fenced_repair_uses_pending_snapshot_not_later_live_dirty() {
     );
     assert_eq!(state.dirty_time_windows.len(), 1);
 
+    // Phase 0 children (window_cnt == 1) consume the NEWEST pending window
+    // first while the active fence keeps the frozen high H untouched.
     let first_filter = next_fenced_repair_filter(&mut state, 1);
     assert_eq!(
         first_filter.time_ranges,
-        vec![(Timestamp::new_second(10), Timestamp::new_second(15))]
+        vec![(Timestamp::new_second(100), Timestamp::new_second(105))]
     );
 
     let decision = BatchingTask::apply_query_result_to_state(
@@ -1074,7 +1150,7 @@ fn test_continued_fenced_repair_uses_pending_snapshot_not_later_live_dirty() {
     let second_filter = next_fenced_repair_filter(&mut state, 1);
     assert_eq!(
         second_filter.time_ranges,
-        vec![(Timestamp::new_second(100), Timestamp::new_second(105))]
+        vec![(Timestamp::new_second(10), Timestamp::new_second(15))]
     );
     assert!(state.fenced_repair_pending_is_empty());
     assert_eq!(state.dirty_time_windows.len(), 1);
@@ -1244,8 +1320,8 @@ async fn test_fenced_repair_mismatch_next_plan_is_scoped_base_repair() {
     };
     assert_eq!(
         filter.time_ranges,
-        vec![(Timestamp::new_second(100), Timestamp::new_second(105))],
-        "executed pre-H repair item should not be requeued; only remaining pending window is retried"
+        vec![(Timestamp::new_second(10), Timestamp::new_second(15))],
+        "executed pre-H repair item (the newest [100,105) under newest-first) should not be requeued; only remaining pending window [10,15) is retried"
     );
 }
 
@@ -2577,12 +2653,19 @@ fn phase0_batch_opts(max_queries_per_tick: usize) -> Arc<BatchingModeOptions> {
 }
 
 #[test]
-fn test_experimental_max_queries_per_tick_defaults_to_one() {
+fn test_experimental_max_queries_per_tick_defaults_to_three() {
+    // `3` is the default: Phase 0 short-range batching is enabled by default.
     assert_eq!(
         BatchingModeOptions::default().experimental_max_queries_per_tick,
-        1
+        3
     );
-    // `0` must be treated as `1` defensively.
+    // `1` is the official opt-out that restores legacy single-query behavior.
+    let opts = BatchingModeOptions {
+        experimental_max_queries_per_tick: 1,
+        ..Default::default()
+    };
+    assert_eq!(opts.experimental_max_queries_per_tick, 1);
+    // `0` must be treated as `1` defensively (a `1`-compatible alias).
     let opts = BatchingModeOptions {
         experimental_max_queries_per_tick: 0,
         ..Default::default()
@@ -3331,4 +3414,203 @@ async fn test_phase0_tick_holds_execution_lock_between_children() {
         competitor_frontend_rx.try_recv().is_err(),
         "competitor ran only after the tick drained all dirty windows, so no frontend query"
     );
+}
+
+/// Mock frontend handler for the adaptive-loop tests: re-marks a small dirty
+/// window on every call (simulating new ingest so a backlog always remains),
+/// counts calls, and sends the task shutdown signal after a chosen call count.
+struct BacklogReMarkPhase0Handler {
+    counters: Phase0Counters,
+    task: BatchingTask,
+    shutdown_tx: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    shutdown_after_calls: usize,
+}
+
+#[async_trait::async_trait]
+impl GrpcQueryHandlerWithBoxedError for BacklogReMarkPhase0Handler {
+    async fn do_query(
+        &self,
+        _query: api::v1::greptime_request::Request,
+        _ctx: QueryContextRef,
+    ) -> std::result::Result<Output, BoxedError> {
+        let call = self.counters.call_count.fetch_add(1, Ordering::SeqCst) + 1;
+        if call >= self.shutdown_after_calls {
+            if let Some(tx) = self.shutdown_tx.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+        }
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs() as i64;
+        self.task
+            .state
+            .write()
+            .unwrap()
+            .dirty_time_windows
+            .add_window(
+                Timestamp::new_second(now_secs),
+                Some(Timestamp::new_second(now_secs + 5)),
+            );
+        Ok(Output::new_with_affected_rows(1))
+    }
+}
+
+/// Adaptive loop with N=3 and a persistent live backlog: after a successful
+/// tick that still leaves dirty work, the loop must start the next tick
+/// immediately instead of sleeping `min_refresh` (set to 1 hour here). The
+/// handler re-marks a small dirty window on every call and shuts the task down
+/// after 6 frontend calls (= two ticks x three children).
+#[tokio::test]
+async fn test_phase0_adaptive_loop_continues_immediately_with_backlog() {
+    let sink_table = "phase0_adaptive_immediate";
+    let batch_opts = Arc::new(BatchingModeOptions {
+        experimental_max_queries_per_tick: 3,
+        experimental_min_refresh_duration: Duration::from_secs(3600),
+        ..Default::default()
+    });
+    let (task, query_engine, shutdown_tx) =
+        new_phase0_time_window_task(sink_table, batch_opts).await;
+    register_twe_sink(&query_engine, sink_table, 9501);
+    add_three_dirty_windows(&task);
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(BacklogReMarkPhase0Handler {
+        counters: counters.clone(),
+        task: task.clone(),
+        shutdown_tx: std::sync::Mutex::new(Some(shutdown_tx)),
+        shutdown_after_calls: 6,
+    });
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    // If the loop slept min_refresh (1h) after a successful tick, this would
+    // time out; with the immediate-continue behavior it finishes right after
+    // the 6th call sends shutdown.
+    let loop_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        task.start_adaptive_loop(query_engine, frontend_client),
+    )
+    .await;
+    assert!(
+        loop_result.is_ok(),
+        "adaptive loop with a persistent backlog must not sleep between ticks"
+    );
+    assert_eq!(
+        counters.call_count(),
+        6,
+        "expected two ticks x three children before shutdown"
+    );
+}
+
+/// Adaptive loop with N=3 and no dirty windows: the tick produces `Ok(None)`
+/// and the loop must keep the existing backoff (sleep min_refresh = 1h) rather
+/// than spinning or continuing immediately. Sending shutdown while the loop is
+/// sleeping must NOT stop it (shutdown is only checked at the top of the next
+/// iteration after the sleep elapses).
+#[tokio::test]
+async fn test_phase0_adaptive_loop_sleeps_on_no_dirty() {
+    let sink_table = "phase0_adaptive_sleep_none";
+    let batch_opts = Arc::new(BatchingModeOptions {
+        experimental_max_queries_per_tick: 3,
+        experimental_min_refresh_duration: Duration::from_secs(3600),
+        ..Default::default()
+    });
+    let (task, query_engine, shutdown_tx) =
+        new_phase0_time_window_task(sink_table, batch_opts).await;
+    register_twe_sink(&query_engine, sink_table, 9502);
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let loop_handle = tokio::spawn({
+        let task = task.clone();
+        let query_engine = query_engine.clone();
+        let frontend_client = frontend_client.clone();
+        async move {
+            task.start_adaptive_loop(query_engine, frontend_client)
+                .await;
+        }
+    });
+
+    // No dirty windows: no frontend call may happen and the loop must not
+    // finish — it should be blocked in the min_refresh sleep.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(counters.call_count(), 0);
+    assert!(!loop_handle.is_finished());
+
+    // A sleeping loop cannot observe shutdown until the sleep elapses, so it
+    // must NOT finish quickly (a spinning/continuing loop would).
+    let _ = shutdown_tx.send(());
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        !loop_handle.is_finished(),
+        "Ok(None) must keep the backoff sleep, not continue immediately"
+    );
+
+    loop_handle.abort();
+}
+
+/// Adaptive loop with N=3 and a failing child: the tick returns `Err` and the
+/// loop must keep the existing backoff (sleep min_refresh = 1h) instead of
+/// continuing immediately. The failing child is the only frontend call.
+#[tokio::test]
+async fn test_phase0_adaptive_loop_backs_off_on_error() {
+    let sink_table = "phase0_adaptive_backoff_err";
+    let batch_opts = Arc::new(BatchingModeOptions {
+        experimental_max_queries_per_tick: 3,
+        experimental_min_refresh_duration: Duration::from_secs(3600),
+        ..Default::default()
+    });
+    let (task, query_engine, shutdown_tx) =
+        new_phase0_time_window_task(sink_table, batch_opts).await;
+    register_twe_sink(&query_engine, sink_table, 9503);
+    task.state
+        .write()
+        .unwrap()
+        .dirty_time_windows
+        .add_window(Timestamp::new_second(0), Some(Timestamp::new_second(5)));
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()).failing_on(1));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let loop_handle = tokio::spawn({
+        let task = task.clone();
+        let query_engine = query_engine.clone();
+        let frontend_client = frontend_client.clone();
+        async move {
+            task.start_adaptive_loop(query_engine, frontend_client)
+                .await;
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        counters.call_count(),
+        1,
+        "the failing child should be the only frontend call"
+    );
+    assert!(!loop_handle.is_finished());
+
+    // A backing-off loop cannot observe shutdown until the sleep elapses.
+    let _ = shutdown_tx.send(());
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        !loop_handle.is_finished(),
+        "Err must keep the backoff sleep, not continue immediately"
+    );
+
+    loop_handle.abort();
 }

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use catalog::RegisterTableRequest;
 use catalog::memory::MemoryCatalogManager;
@@ -2561,5 +2562,773 @@ async fn test_insert_plan_matching_failure_restores_consumed_dirty_marker() {
     assert_eq!(
         state.dirty_time_windows.window_size(),
         std::time::Duration::from_secs(5)
+    );
+}
+
+// --- Phase 0 batching scheduling tests ---
+
+use crate::batching_mode::frontend_client::GrpcQueryHandlerWithBoxedError;
+
+fn phase0_batch_opts(max_queries_per_tick: usize) -> Arc<BatchingModeOptions> {
+    Arc::new(BatchingModeOptions {
+        experimental_max_queries_per_tick: max_queries_per_tick,
+        ..Default::default()
+    })
+}
+
+#[test]
+fn test_experimental_max_queries_per_tick_defaults_to_one() {
+    assert_eq!(
+        BatchingModeOptions::default().experimental_max_queries_per_tick,
+        1
+    );
+    // `0` must be treated as `1` defensively.
+    let opts = BatchingModeOptions {
+        experimental_max_queries_per_tick: 0,
+        ..Default::default()
+    };
+    assert_eq!(opts.experimental_max_queries_per_tick, 0);
+}
+
+/// Shared counters for [`Phase0CountingHandler`].
+#[derive(Clone)]
+struct Phase0Counters {
+    in_flight: Arc<AtomicUsize>,
+    max_in_flight: Arc<AtomicUsize>,
+    call_count: Arc<AtomicUsize>,
+    scheduled_time_extensions: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl Phase0Counters {
+    fn new() -> Self {
+        Self {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_in_flight: Arc::new(AtomicUsize::new(0)),
+            call_count: Arc::new(AtomicUsize::new(0)),
+            scheduled_time_extensions: Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+
+    fn max_in_flight(&self) -> usize {
+        self.max_in_flight.load(Ordering::SeqCst)
+    }
+
+    fn scheduled_time_extensions(&self) -> Vec<String> {
+        self.scheduled_time_extensions.lock().unwrap().clone()
+    }
+}
+
+/// Mock frontend handler that counts calls, tracks max in-flight concurrency,
+/// records the `FLOW_SCHEDULED_TIME_MILLIS` extension observed on each call,
+/// and can fail on a chosen call index.
+struct Phase0CountingHandler {
+    counters: Phase0Counters,
+    fail_on_call: Option<usize>,
+}
+
+impl Phase0CountingHandler {
+    fn new(counters: Phase0Counters) -> Self {
+        Self {
+            counters,
+            fail_on_call: None,
+        }
+    }
+
+    fn failing_on(mut self, call: usize) -> Self {
+        self.fail_on_call = Some(call);
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::batching_mode::frontend_client::GrpcQueryHandlerWithBoxedError
+    for Phase0CountingHandler
+{
+    async fn do_query(
+        &self,
+        _query: api::v1::greptime_request::Request,
+        ctx: QueryContextRef,
+    ) -> std::result::Result<Output, BoxedError> {
+        let call = self.counters.call_count.fetch_add(1, Ordering::SeqCst) + 1;
+        if self.fail_on_call == Some(call) {
+            return Err(BoxedError::new(MockError::new(StatusCode::Internal)));
+        }
+        let cur = self.counters.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.counters.max_in_flight.fetch_max(cur, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        let _ = self.counters.in_flight.fetch_sub(1, Ordering::SeqCst);
+        if let Some(v) = ctx.extension(FLOW_SCHEDULED_TIME_MILLIS) {
+            self.counters
+                .scheduled_time_extensions
+                .lock()
+                .unwrap()
+                .push(v.to_string());
+        }
+        Ok(Output::new_with_affected_rows(1))
+    }
+}
+
+/// Creates a `date_bin` time-window task whose sink table is registered, keeping
+/// the shutdown sender alive so `is_shutdown_signaled()` stays false during a
+/// tick.
+async fn new_phase0_time_window_task(
+    sink_table: &str,
+    batch_opts: Arc<BatchingModeOptions>,
+) -> (
+    BatchingTask,
+    QueryEngineRef,
+    tokio::sync::oneshot::Sender<()>,
+) {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let plan_query = "SELECT number, date_bin(INTERVAL '5 second', ts) AS time_window \
+                      FROM numbers_with_ts GROUP BY time_window, number";
+    let plan = sql_to_df_plan(ctx.clone(), query_engine.clone(), plan_query, true)
+        .await
+        .unwrap();
+    let (column_name, time_window_expr, _, df_schema) = find_time_window_expr(
+        &plan,
+        query_engine.engine_state().catalog_manager().clone(),
+        ctx.clone(),
+    )
+    .await
+    .unwrap();
+    let time_window_expr = time_window_expr
+        .map(|expr| {
+            TimeWindowExpr::from_expr(
+                &expr,
+                &column_name,
+                &df_schema,
+                &query_engine.engine_state().session_state(),
+            )
+        })
+        .transpose()
+        .unwrap();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+    let task = BatchingTask::try_new(TaskArgs {
+        flow_id: 1,
+        query: plan_query,
+        plan: plan.clone(),
+        time_window_expr,
+        expire_after: None,
+        sink_table_name: [
+            "greptime".to_string(),
+            "public".to_string(),
+            sink_table.to_string(),
+        ],
+        source_table_names: vec![[
+            "greptime".to_string(),
+            "public".to_string(),
+            "numbers_with_ts".to_string(),
+        ]],
+        query_ctx: ctx,
+        catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+        shutdown_rx,
+        batch_opts,
+        flow_eval_interval: None,
+        eval_schedule: None,
+    })
+    .unwrap();
+
+    (task, query_engine, shutdown_tx)
+}
+
+fn add_three_dirty_windows(task: &BatchingTask) {
+    let mut state = task.state.write().unwrap();
+    for i in 0..3 {
+        state.dirty_time_windows.add_window(
+            Timestamp::new_second(i * 5),
+            Some(Timestamp::new_second((i + 1) * 5)),
+        );
+    }
+}
+
+/// N=3: one tick executes three child queries serially (max in-flight 1) and
+/// consumes all three window-sized chunks.
+#[tokio::test]
+async fn test_phase0_tick_executes_three_child_queries_serially_and_drains_three_windows() {
+    let sink_table = "phase0_twe_sink_serial";
+    let (task, query_engine, _shutdown_tx) =
+        new_phase0_time_window_task(sink_table, phase0_batch_opts(3)).await;
+    register_twe_sink(&query_engine, sink_table, 9301);
+    add_three_dirty_windows(&task);
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let outcome = task
+        .execute_tick_serialized_with_outcome(&query_engine, &frontend_client, None)
+        .await;
+
+    assert!(
+        matches!(outcome.result, Ok(Some((3, _)))),
+        "tick should aggregate 3 rows across 3 child queries, got {:?}",
+        outcome.result
+    );
+    assert_eq!(
+        counters.call_count(),
+        3,
+        "tick should execute exactly 3 child queries"
+    );
+    assert_eq!(
+        counters.max_in_flight(),
+        1,
+        "child queries must run serially under one execution_lock"
+    );
+    assert!(
+        task.state.read().unwrap().dirty_time_windows.is_empty(),
+        "tick should drain all three dirty windows"
+    );
+}
+
+/// N=3 with only one dirty window: the tick executes one child then exits
+/// successfully instead of running empty child queries.
+#[tokio::test]
+async fn test_phase0_tick_stops_early_when_dirty_windows_exhausted() {
+    let sink_table = "phase0_twe_sink_early_stop";
+    let (task, query_engine, _shutdown_tx) =
+        new_phase0_time_window_task(sink_table, phase0_batch_opts(3)).await;
+    register_twe_sink(&query_engine, sink_table, 9302);
+    task.state
+        .write()
+        .unwrap()
+        .dirty_time_windows
+        .add_window(Timestamp::new_second(0), Some(Timestamp::new_second(5)));
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let outcome = task
+        .execute_tick_serialized_with_outcome(&query_engine, &frontend_client, None)
+        .await;
+
+    assert!(
+        matches!(outcome.result, Ok(Some((1, _)))),
+        "tick should report the single successful child, got {:?}",
+        outcome.result
+    );
+    assert_eq!(
+        counters.call_count(),
+        1,
+        "tick must stop early once no dirty windows remain"
+    );
+    assert!(task.state.read().unwrap().dirty_time_windows.is_empty());
+}
+
+/// Failure on child 2: child 1 stays consumed, child 2 is restored, child 3
+/// never starts, and the tick returns the error immediately.
+#[tokio::test]
+async fn test_phase0_tick_failure_on_second_child_restores_only_that_child() {
+    let sink_table = "phase0_twe_sink_fail_second";
+    let (task, query_engine, _shutdown_tx) =
+        new_phase0_time_window_task(sink_table, phase0_batch_opts(3)).await;
+    register_twe_sink(&query_engine, sink_table, 9303);
+    add_three_dirty_windows(&task);
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()).failing_on(2));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let outcome = task
+        .execute_tick_serialized_with_outcome(&query_engine, &frontend_client, None)
+        .await;
+
+    assert!(
+        outcome.result.is_err(),
+        "tick must return the child-2 error, got {:?}",
+        outcome.result
+    );
+    assert_eq!(counters.call_count(), 2, "child 3 must never start");
+    let state = task.state.read().unwrap();
+    // Child 1's [0s, 5s) window stays consumed; child 2's [5s, 10s) is
+    // restored; child 3's [10s, 15s) was never consumed.
+    assert_eq!(state.dirty_time_windows.len(), 2);
+    assert_eq!(
+        state.dirty_time_windows.window_size(),
+        std::time::Duration::from_secs(10),
+        "only the failed child's window (5s) plus the unstarted one (5s) should remain dirty"
+    );
+}
+
+/// One scheduled tick retains the same `FLOW_SCHEDULED_TIME_MILLIS` value for
+/// all child queries, and removes it afterwards.
+#[tokio::test]
+async fn test_phase0_scheduled_tick_retains_same_scheduled_time_for_all_children() {
+    let sink_table = "phase0_twe_sink_scheduled";
+    let (task, query_engine, _shutdown_tx) =
+        new_phase0_time_window_task(sink_table, phase0_batch_opts(3)).await;
+    register_twe_sink(&query_engine, sink_table, 9304);
+    add_three_dirty_windows(&task);
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let scheduled_time_secs = 1_700_000_000_i64;
+    let expected_extension = (scheduled_time_secs * 1000).to_string();
+    let outcome = task
+        .execute_once_serialized_at_scheduled_time(
+            &query_engine,
+            &frontend_client,
+            scheduled_time_secs,
+        )
+        .await;
+
+    assert!(
+        matches!(outcome.result, Ok(Some((3, _)))),
+        "scheduled tick should run three child queries, got {:?}",
+        outcome.result
+    );
+    assert_eq!(counters.call_count(), 3);
+    assert_eq!(
+        counters.scheduled_time_extensions(),
+        vec![
+            expected_extension.clone(),
+            expected_extension.clone(),
+            expected_extension
+        ],
+        "all child queries in one scheduled tick must observe the same scheduled time"
+    );
+    assert_eq!(
+        task.state
+            .read()
+            .unwrap()
+            .query_ctx
+            .extension(FLOW_SCHEDULED_TIME_MILLIS),
+        None,
+        "FLOW_SCHEDULED_TIME_MILLIS leaked into query_ctx after the tick"
+    );
+}
+
+/// N=1 must keep the current merged-range behavior: one query covering the
+/// whole merged 3-window range, not a forced one-window chunk.
+#[tokio::test]
+async fn test_phase0_n1_keeps_single_merged_query_behavior() {
+    let sink_table = "phase0_twe_sink_n1";
+    let (task, query_engine, _shutdown_tx) =
+        new_phase0_time_window_task(sink_table, phase0_batch_opts(1)).await;
+    register_twe_sink(&query_engine, sink_table, 9305);
+    add_three_dirty_windows(&task);
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let outcome = task
+        .execute_tick_serialized_with_outcome(&query_engine, &frontend_client, None)
+        .await;
+
+    assert!(
+        matches!(outcome.result, Ok(Some((1, _)))),
+        "N=1 tick should execute exactly one query, got {:?}",
+        outcome.result
+    );
+    assert_eq!(counters.call_count(), 1, "N=1 must run exactly one query");
+    let filter = match outcome.new_query {
+        Some(PlanInfo {
+            dirty_restore: DirtyRestore::Scoped(filter),
+            ..
+        }) => filter,
+        _ => panic!("expected scoped restore info for the N=1 query"),
+    };
+    assert_eq!(
+        filter.time_ranges,
+        vec![(Timestamp::new_second(0), Timestamp::new_second(15))],
+        "N=1 must keep the merged 3-window range behavior, not force one-window chunks"
+    );
+    assert!(
+        task.state.read().unwrap().dirty_time_windows.is_empty(),
+        "N=1 single query should drain the whole merged range"
+    );
+}
+
+/// Mock frontend handler that re-marks the flow dirty on every call,
+/// simulating concurrent ingest arriving mid-tick. This guarantees a buggy tick
+/// would have dirty work available to generate a second/third child query.
+struct ReMarkDirtyPhase0Handler {
+    counters: Phase0Counters,
+    task: BatchingTask,
+}
+
+#[async_trait::async_trait]
+impl GrpcQueryHandlerWithBoxedError for ReMarkDirtyPhase0Handler {
+    async fn do_query(
+        &self,
+        _query: api::v1::greptime_request::Request,
+        _ctx: QueryContextRef,
+    ) -> std::result::Result<Output, BoxedError> {
+        self.counters.call_count.fetch_add(1, Ordering::SeqCst);
+        self.task
+            .mark_all_windows_as_dirty()
+            .map_err(BoxedError::new)?;
+        Ok(Output::new_with_affected_rows(1))
+    }
+}
+
+/// Mock frontend handler that blocks the first `block_calls` frontend calls
+/// until the test releases them, signaling each blocked call's start through a
+/// channel. Used to prove the whole-tick `execution_lock` is held across child
+/// queries.
+struct HandshakePhase0Handler {
+    counters: Phase0Counters,
+    call_started: tokio::sync::mpsc::UnboundedSender<()>,
+    release: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<()>>,
+    block_calls: usize,
+}
+
+#[async_trait::async_trait]
+impl GrpcQueryHandlerWithBoxedError for HandshakePhase0Handler {
+    async fn do_query(
+        &self,
+        _query: api::v1::greptime_request::Request,
+        _ctx: QueryContextRef,
+    ) -> std::result::Result<Output, BoxedError> {
+        let call = self.counters.call_count.fetch_add(1, Ordering::SeqCst) + 1;
+        if call <= self.block_calls {
+            let _ = self.call_started.send(());
+            let mut release = self.release.lock().await;
+            release.recv().await;
+        }
+        Ok(Output::new_with_affected_rows(1))
+    }
+}
+
+/// Waits until the tick's next child query signals that it entered its
+/// frontend call (bounded by a timeout for safety).
+async fn wait_for_child_start(rx: &mut tokio::sync::mpsc::UnboundedReceiver<()>) {
+    tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("tick should start a child query")
+        .expect("channel should not close");
+}
+
+/// Mock frontend handler for the competitor execution. Signals on every
+/// frontend call so the test can prove the competitor never reaches the
+/// frontend while the tick holds `execution_lock`.
+struct CompetitorProbeHandler {
+    frontend_started: tokio::sync::mpsc::UnboundedSender<()>,
+}
+
+#[async_trait::async_trait]
+impl GrpcQueryHandlerWithBoxedError for CompetitorProbeHandler {
+    async fn do_query(
+        &self,
+        _query: api::v1::greptime_request::Request,
+        _ctx: QueryContextRef,
+    ) -> std::result::Result<Output, BoxedError> {
+        let _ = self.frontend_started.send(());
+        Ok(Output::new_with_affected_rows(1))
+    }
+}
+
+/// Waits until the competitor signals that it is about to attempt the
+/// serialized execution path (bounded by a timeout for safety). The signal is
+/// sent as the competitor's last action before `lock().await`, so receiving it
+/// proves the competitor attempted progress while the tick owns the lock.
+async fn wait_for_competitor_ready(rx: &mut tokio::sync::mpsc::UnboundedReceiver<()>) {
+    tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("competitor should signal readiness before attempting the serialized path")
+        .expect("channel should not close");
+}
+
+/// N=3 with an unfiltered full-snapshot child (eval-interval SQL without a
+/// usable time-window expression) must execute exactly ONE frontend query per
+/// tick and return success, instead of repeating the full-range query.
+#[tokio::test]
+async fn test_phase0_tick_unfiltered_full_executes_exactly_once() {
+    let query_engine = create_test_query_engine();
+    let ctx = QueryContext::arc();
+    let plan = sql_to_df_plan(
+        ctx.clone(),
+        query_engine.clone(),
+        "SELECT number, ts FROM numbers_with_ts",
+        true,
+    )
+    .await
+    .unwrap();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let task = BatchingTask::try_new(TaskArgs {
+        flow_id: 1,
+        query: "SELECT number, ts FROM numbers_with_ts",
+        plan,
+        time_window_expr: None,
+        expire_after: None,
+        sink_table_name: [
+            "greptime".to_string(),
+            "public".to_string(),
+            "numbers_with_ts".to_string(),
+        ],
+        source_table_names: vec![[
+            "greptime".to_string(),
+            "public".to_string(),
+            "numbers_with_ts".to_string(),
+        ]],
+        query_ctx: ctx,
+        catalog_manager: query_engine.engine_state().catalog_manager().clone(),
+        shutdown_rx,
+        batch_opts: phase0_batch_opts(3),
+        flow_eval_interval: Some(Duration::from_secs(60)),
+        eval_schedule: None,
+    })
+    .unwrap();
+    task.state.write().unwrap().dirty_time_windows.set_dirty();
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(Phase0CountingHandler::new(counters.clone()));
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let outcome = task
+        .execute_tick_serialized_with_outcome(&query_engine, &frontend_client, None)
+        .await;
+
+    assert!(
+        matches!(outcome.result, Ok(Some((1, _)))),
+        "unfiltered full tick should return success with one executed query, got {:?}",
+        outcome.result
+    );
+    assert_eq!(
+        counters.call_count(),
+        1,
+        "unfiltered full query must execute exactly once per tick"
+    );
+}
+
+/// N=3 with an incremental-delta child must execute exactly ONE frontend query
+/// per tick even when concurrent ingest re-marks dirty mid-tick; the tick must
+/// not repeat the delta query.
+#[tokio::test]
+async fn test_phase0_tick_incremental_delta_executes_exactly_once() {
+    let sink_table = "phase0_twe_sink_incr_once";
+    let batch_opts = Arc::new(BatchingModeOptions {
+        experimental_max_queries_per_tick: 3,
+        experimental_enable_incremental_read: true,
+        ..Default::default()
+    });
+    let (task, query_engine, _shutdown_tx) =
+        new_phase0_time_window_task(sink_table, batch_opts).await;
+    register_twe_sink(&query_engine, sink_table, 9401);
+    {
+        let mut state = task.state.write().unwrap();
+        state.advance_checkpoints(HashMap::from([(1, 10)]));
+        state
+            .dirty_time_windows
+            .add_window(Timestamp::new_second(0), Some(Timestamp::new_second(5)));
+    }
+
+    let counters = Phase0Counters::new();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(ReMarkDirtyPhase0Handler {
+        counters: counters.clone(),
+        task: task.clone(),
+    });
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    let outcome = task
+        .execute_tick_serialized_with_outcome(&query_engine, &frontend_client, None)
+        .await;
+
+    assert!(
+        matches!(outcome.result, Ok(Some((1, _)))),
+        "incremental delta tick should return success with one executed query, got {:?}",
+        outcome.result
+    );
+    assert_eq!(
+        counters.call_count(),
+        1,
+        "incremental delta query must execute exactly once per tick"
+    );
+}
+
+/// The Phase 0 continuation predicate must allow further children only for
+/// scoped dirty-window work, and stop after unfiltered/incremental work.
+#[test]
+fn test_phase0_coverage_continuation_classification() {
+    assert!(coverage_allows_phase0_continuation(
+        &QueryCoverage::ScopedBaseRepair
+    ));
+    assert!(coverage_allows_phase0_continuation(
+        &QueryCoverage::FencedRepairChunk {
+            high: BTreeMap::new()
+        }
+    ));
+    assert!(!coverage_allows_phase0_continuation(
+        &QueryCoverage::UnfilteredFull
+    ));
+    assert!(!coverage_allows_phase0_continuation(
+        &QueryCoverage::IncrementalDelta
+    ));
+}
+
+/// A concurrent manual/serialized execution cannot enter between child 1 and
+/// child 2 (or child 2 and child 3) while the N>1 tick holds `execution_lock`
+/// for the whole tick.
+///
+/// Determinism: the competitor signals readiness as its LAST action before
+/// calling the serialized execution (i.e. immediately before `lock().await`).
+/// The test waits for that signal, then yields the scheduler (no sleeps) so the
+/// competitor polls through to `lock().await` and queues behind the tick's
+/// hold (tokio Mutex is FIFO). While the tick owns the lock, the competitor
+/// cannot be finished and cannot start a frontend query; only after the tick
+/// releases the lock does the competitor proceed to completion.
+#[tokio::test]
+async fn test_phase0_tick_holds_execution_lock_between_children() {
+    let sink_table = "phase0_twe_sink_lock";
+    let (task, query_engine, _shutdown_tx) =
+        new_phase0_time_window_task(sink_table, phase0_batch_opts(3)).await;
+    register_twe_sink(&query_engine, sink_table, 9402);
+    add_three_dirty_windows(&task);
+
+    let counters = Phase0Counters::new();
+    let (call_started_tx, mut call_started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (release_tx, release_rx) = tokio::sync::mpsc::unbounded_channel();
+    let handler: Arc<dyn GrpcQueryHandlerWithBoxedError> = Arc::new(HandshakePhase0Handler {
+        counters: counters.clone(),
+        call_started: call_started_tx,
+        release: tokio::sync::Mutex::new(release_rx),
+        block_calls: 3,
+    });
+    let frontend_client = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&handler),
+        QueryOptions::default(),
+    ));
+
+    // Competitor uses its own frontend client whose handler signals on any
+    // frontend call, proving the competitor cannot start a query mid-tick.
+    let (competitor_frontend_tx, mut competitor_frontend_rx) =
+        tokio::sync::mpsc::unbounded_channel();
+    let competitor_handler: Arc<dyn GrpcQueryHandlerWithBoxedError> =
+        Arc::new(CompetitorProbeHandler {
+            frontend_started: competitor_frontend_tx,
+        });
+    let competitor_frontend = Arc::new(FrontendClient::from_grpc_handler(
+        Arc::downgrade(&competitor_handler),
+        QueryOptions::default(),
+    ));
+
+    let tick_task = tokio::spawn({
+        let task = task.clone();
+        let query_engine = query_engine.clone();
+        let frontend_client = frontend_client.clone();
+        async move {
+            task.execute_tick_serialized_with_outcome(&query_engine, &frontend_client, None)
+                .await
+        }
+    });
+
+    // Child 1 is now inside its frontend call while the tick holds
+    // `execution_lock` for the whole tick.
+    wait_for_child_start(&mut call_started_rx).await;
+
+    // Competitor: signal readiness immediately before the serialized call, so
+    // the test can prove it attempted progress while the tick owns the lock.
+    let (competitor_ready_tx, mut competitor_ready_rx) = tokio::sync::mpsc::unbounded_channel();
+    let competitor = tokio::spawn({
+        let task = task.clone();
+        let query_engine = query_engine.clone();
+        let competitor_frontend = competitor_frontend.clone();
+        async move {
+            let _ = competitor_ready_tx.send(());
+            task.execute_once_serialized(&query_engine, &competitor_frontend, None)
+                .await
+        }
+    });
+    wait_for_competitor_ready(&mut competitor_ready_rx).await;
+    // Let the competitor poll through to `execution_lock.lock().await` and
+    // queue behind the tick's hold (tokio Mutex is FIFO). Pure yields, no
+    // sleeps, so there is no time-based race.
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+    assert!(
+        !competitor.is_finished(),
+        "competitor must be blocked on execution_lock while the tick holds it"
+    );
+    assert!(
+        competitor_frontend_rx.try_recv().is_err(),
+        "competitor must not start a frontend query while the tick holds the lock"
+    );
+
+    // Release child 1; the tick proceeds to child 2 while still holding the
+    // lock, so the competitor is still blocked between children.
+    let _ = release_tx.send(());
+    wait_for_child_start(&mut call_started_rx).await;
+    assert!(
+        !competitor.is_finished(),
+        "competitor must still be blocked between child 1 and child 2"
+    );
+    assert!(
+        competitor_frontend_rx.try_recv().is_err(),
+        "competitor must not start a frontend query between child 1 and child 2"
+    );
+
+    // Release child 2; child 3 starts, lock still held.
+    let _ = release_tx.send(());
+    wait_for_child_start(&mut call_started_rx).await;
+    assert!(
+        !competitor.is_finished(),
+        "competitor must still be blocked between child 2 and child 3"
+    );
+    assert!(
+        competitor_frontend_rx.try_recv().is_err(),
+        "competitor must not start a frontend query between child 2 and child 3"
+    );
+
+    // Release child 3; the tick completes and releases the lock.
+    let _ = release_tx.send(());
+    let tick_outcome = tokio::time::timeout(Duration::from_secs(1), tick_task)
+        .await
+        .expect("tick should finish")
+        .expect("tick task should not panic");
+    assert!(
+        matches!(tick_outcome.result, Ok(Some((3, _)))),
+        "tick should execute three scoped children, got {:?}",
+        tick_outcome.result
+    );
+    assert_eq!(counters.call_count(), 3);
+
+    // With the lock released, the competitor proceeds: it acquires the lock,
+    // finds no dirty windows left (the tick drained them), and completes with
+    // no frontend query.
+    let competitor_result = tokio::time::timeout(Duration::from_secs(1), competitor)
+        .await
+        .expect("competitor should finish after the tick releases the lock")
+        .expect("competitor task should not panic");
+    assert!(matches!(competitor_result, Ok(None)));
+    assert!(
+        competitor_frontend_rx.try_recv().is_err(),
+        "competitor ran only after the tick drained all dirty windows, so no frontend query"
     );
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Batching flows currently execute at most one scoped query per scheduler tick. When dirty windows are fragmented into several short ranges, this can leave avoidable work queued even though each query is small.

This PR adds the experimental `experimental_max_queries_per_tick` flownode option:

- The default is `1`, preserving the existing behavior.
- Values greater than `1` let one tick drain up to that many scoped child queries **serially** while holding the same execution lock and sharing the same scheduled time.
- Every child handles at most one logical window and commits its checkpoint/restore state independently on a best-effort basis.
- A failed child stops the tick and restores only that child. Earlier successful children remain committed, while windows not yet started stay dirty.
- Non-scoped `UnfilteredFull` and `IncrementalDelta` queries still execute at most once per tick.

The change also fixes an exact-fit stall when `max_window_cnt = 1` selects a merged range, and makes dirty-range merge, expiry, selection, and filter construction transactional on errors.

This is Phase 0 only. It intentionally does **not** add concurrent query execution, tick-wide transactions, batch watermark aggregation, or global admission control; those remain possible follow-up work.

Compatibility:

- No public API, persisted metadata, or wire-format change.
- Existing deployments retain identical behavior unless the new experimental option is explicitly raised above `1`.

Verification performed:

- `cargo nextest run -p flow` — 247/247 passed
- `cargo check -p flow`
- `cargo fmt --all -- --check`
- `git diff --check`
- `test_load_flownode_example_config`
- Three Oracle review rounds, final verdict: approve
- Distributed smoke test with 1 metasrv, 3 datanodes, 1 frontend, and 1 flownode:
  - `N=1`: three adjacent 10-second windows merged into one 30-second query
  - `N=3`: three 10-second queries ran serially in one tick with sink output matching the baseline
  - non-scoped query with `N=3`: still executed once per tick
  - final sqlness suite passed

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
