### PR TITLE
refactor: remove trivial tests

### DIFF
--- a/src/auth/src/user_info.rs
+++ b/src/auth/src/user_info.rs
@@ -224,26 +224,6 @@ mod tests {
     }
 
     #[test]
-    fn test_default_user_info_with_name() {
-        let user_info = DefaultUserInfo::with_name("test_user");
-        assert_eq!(user_info.username(), "test_user");
-    }
-
-    #[test]
-    fn test_default_user_info_with_name_and_permission() {
-        let user_info =
-            DefaultUserInfo::with_name_and_permission("test_user", PermissionMode::ReadOnly);
-        assert_eq!(user_info.username(), "test_user");
-
-        // Cast to DefaultUserInfo to access permission_mode
-        let default_user = user_info
-            .as_any()
-            .downcast_ref::<DefaultUserInfo>()
-            .unwrap();
-        assert_eq!(default_user.permission_mode, PermissionMode::ReadOnly);
-    }
-
-    #[test]
     fn test_user_info_as_any() {
         let user_info = DefaultUserInfo::with_name("test_user");
         let any_ref = user_info.as_any();

--- a/src/frontend/src/instance/otlp/trace_ingest/tests.rs
+++ b/src/frontend/src/instance/otlp/trace_ingest/tests.rs
@@ -32,7 +32,6 @@ use servers::otlp::trace::SERVICE_NAME_COLUMN;
 use servers::otlp::trace::attributes::Attributes;
 use servers::otlp::trace::span::{SpanEvents, SpanLinks, TraceSpan};
 use servers::otlp::trace::v1::{TraceBinaryType, TraceRetryColumn};
-use servers::query_handler::TraceIngestOutcome;
 
 use super::{
     ChunkFailureReaction, Instance, TraceChunkRetry, TraceChunkSchemaState, TraceRequestSchema,

--- a/src/frontend/src/instance/otlp/trace_ingest/tests.rs
+++ b/src/frontend/src/instance/otlp/trace_ingest/tests.rs
@@ -102,14 +102,6 @@ fn test_classify_trace_prewrite_failure() {
 }
 
 #[test]
-fn test_add_trace_write_cost() {
-    let mut outcome = TraceIngestOutcome::default();
-    Instance::add_trace_write_cost(&mut outcome, 3);
-    Instance::add_trace_write_cost(&mut outcome, 5);
-    assert_eq!(outcome.write_cost, 8);
-}
-
-#[test]
 fn test_finish_trace_failure_message() {
     let message = Instance::finish_trace_failure_message(
         3,

--- a/src/meta-srv/src/gc/dropped.rs
+++ b/src/meta-srv/src/gc/dropped.rs
@@ -284,19 +284,3 @@ impl<'a> DroppedRegionCollector<'a> {
         Ok(assignment)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_dropped_region_info() {
-        let info = DroppedRegionInfo {
-            region_id: RegionId::new(1, 1),
-            table_id: 1,
-            dst_regions: HashSet::new(),
-        };
-        assert_eq!(info.region_id, RegionId::new(1, 1));
-        assert_eq!(info.table_id, 1);
-    }
-}

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -680,16 +680,6 @@ mod tests {
     }
 
     #[test]
-    fn test_region_manifest_builder() {
-        // TODO(ruihang): port this test case
-    }
-
-    #[test]
-    fn test_encode_decode_region_checkpoint() {
-        // TODO(ruihang): port this test case
-    }
-
-    #[test]
     fn test_region_manifest_compatibility() {
         // Test deserializing RegionManifest from old schema where FileId is a UUID string
         let region_manifest_json = r#"{

--- a/src/puffin/src/partial_reader/async.rs
+++ b/src/puffin/src/partial_reader/async.rs
@@ -110,11 +110,4 @@ mod tests {
         // seeking past the portion returns an error
         assert!(reader.read(31..32).await.is_err());
     }
-
-    #[tokio::test]
-    async fn is_eof_returns_true_at_end_of_portion() {
-        let data: Vec<u8> = (0..100).collect();
-        let reader = PartialReader::new(data, 10, 30);
-        let _ = reader.read(0..20).await.unwrap();
-    }
 }

--- a/tests-integration/src/tests/reconcile_table.rs
+++ b/tests-integration/src/tests/reconcile_table.rs
@@ -541,9 +541,6 @@ async fn test_renamed_table() {
     check_output_stream(output.data, expected).await;
 }
 
-#[tokio::test]
-async fn test_rename_table() {}
-
 async fn unwrap_err(output: OutputData) -> String {
     let error = match output {
         OutputData::Stream(stream) => collect_batches(stream).await.unwrap_err(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Remove eight tests that provide no meaningful behavioral or contract coverage:

- Delete two empty TODO-only manifest test placeholders.
- Delete one empty integration test and one assertion-free test that does not exercise the behavior named by the test.
- Delete four tests that only read back values directly assigned to private fields or verify a private single-line arithmetic helper.

Tests that protect public APIs, public types and constants, persisted formats, parsing, validation, edge cases, and regressions remain unchanged. This PR only removes test code and does not change production behavior, APIs, schemas, or persisted data formats.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test plan

- `make fmt`
- `cargo nextest run -p auth`
- `cargo nextest run -p frontend`
- `cargo nextest run -p meta-srv`
- `cargo nextest run -p mito2`
- `cargo nextest run -p puffin`
- `cargo nextest run -p tests-integration test_renamed_table`