### PR TITLE
feat(query): add experimental DataFusion spill-to-disk controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11796,6 +11796,7 @@ dependencies = [
  "table",
  "tokio",
  "tokio-stream",
+ "toml 0.8.23",
  "tracing",
  "uuid",
 ]

--- a/config/config.md
+++ b/config/config.md
@@ -125,6 +125,11 @@
 | `query` | -- | -- | The query engine options. |
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "2GB", "4GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `./greptimedb_data` | The working home directory. |
 | `storage.copy_root` | String | `./greptimedb_data/copy` | Root directory for standalone SQL access to local files.<br/>Relative SQL paths are resolved below this directory. Absolute paths are accepted only when<br/>they are inside this directory. Defaults to `<data_home>/copy`.<br/>Distributed deployments always reject SQL access to local files.<br/>Upgrade note: COPY commands and existing external tables that reference paths outside this<br/>directory will fail. Move those files below the copy root, set this option to a dedicated<br/>directory containing them, or migrate the files to object storage before upgrading. |
@@ -345,6 +350,11 @@
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.allow_query_fallback` | Bool | `false` | Whether to allow query fallback when push down optimize fails.<br/>Default to false, meaning when push down optimize failed, return error msg |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "4GB", "8GB") or percentage of system memory (e.g., "30%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans (only applies to datanodes). |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `datanode` | -- | -- | Datanode options. |
 | `datanode.client` | -- | -- | Datanode client options. |
 | `datanode.client.connect_timeout` | String | `10s` | -- |
@@ -548,6 +558,11 @@
 | `query` | -- | -- | The query engine options. |
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "2GB", "4GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `./greptimedb_data` | The working home directory. |
 | `storage.type` | String | `File` | The storage type used to store the data.<br/>- `File`: the data is stored in the local file system.<br/>- `S3`: the data is stored in the S3 object storage.<br/>- `Gcs`: the data is stored in the Google Cloud Storage.<br/>- `Azblob`: the data is stored in the Azure Blob Storage.<br/>- `Oss`: the data is stored in the Aliyun OSS. |
@@ -721,5 +736,10 @@
 | `query` | -- | -- | -- |
 | `query.parallelism` | Integer | `1` | Parallelism of the query engine for query sent by flownode.<br/>Default to 1, so it won't use too much cpu or memory |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "1GB", "2GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
+| `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `memory` | -- | -- | The memory options. |
 | `memory.enable_heap_profiling` | Bool | `true` | Whether to enable heap profiling activation during startup.<br/>When enabled, heap profiling will be activated if the `MALLOC_CONF` environment variable<br/>is set to "prof:true,prof_active:false". The official image adds this env variable.<br/>Default is true. |

--- a/config/config.md
+++ b/config/config.md
@@ -125,10 +125,10 @@
 | `query` | -- | -- | The query engine options. |
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "2GB", "4GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
-| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): first-come-first-served allocation; preserves current behavior.<br/>- "fair": divides available memory among spillable operators and may spill earlier.<br/>Only effective when `memory_pool_size` is bounded (>0). |
 | `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
 | `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
-| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `1GiB` | Maximum total size of spill directory (default: "1GiB").<br/>Ignored unless mode is "custom". |
 | `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `./greptimedb_data` | The working home directory. |
@@ -350,10 +350,10 @@
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.allow_query_fallback` | Bool | `false` | Whether to allow query fallback when push down optimize fails.<br/>Default to false, meaning when push down optimize failed, return error msg |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "4GB", "8GB") or percentage of system memory (e.g., "30%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans (only applies to datanodes). |
-| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): first-come-first-served allocation; preserves current behavior.<br/>- "fair": divides available memory among spillable operators and may spill earlier.<br/>Only effective when `memory_pool_size` is bounded (>0). |
 | `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
 | `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
-| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `1GiB` | Maximum total size of spill directory (default: "1GiB").<br/>Ignored unless mode is "custom". |
 | `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `datanode` | -- | -- | Datanode options. |
 | `datanode.client` | -- | -- | Datanode client options. |
@@ -558,10 +558,10 @@
 | `query` | -- | -- | The query engine options. |
 | `query.parallelism` | Integer | `0` | Parallelism of the query engine.<br/>Default to 0, which means the number of CPU cores. |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "2GB", "4GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
-| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): first-come-first-served allocation; preserves current behavior.<br/>- "fair": divides available memory among spillable operators and may spill earlier.<br/>Only effective when `memory_pool_size` is bounded (>0). |
 | `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
 | `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
-| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `1GiB` | Maximum total size of spill directory (default: "1GiB").<br/>Ignored unless mode is "custom". |
 | `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `storage` | -- | -- | The data storage options. |
 | `storage.data_home` | String | `./greptimedb_data` | The working home directory. |
@@ -736,10 +736,10 @@
 | `query` | -- | -- | -- |
 | `query.parallelism` | Integer | `1` | Parallelism of the query engine for query sent by flownode.<br/>Default to 1, so it won't use too much cpu or memory |
 | `query.memory_pool_size` | String | `50%` | Memory pool size for query execution operators (aggregation, sorting, join).<br/>Supports absolute size (e.g., "1GB", "2GB") or percentage of system memory (e.g., "20%").<br/>Setting it to 0 disables the limit (unbounded, default behavior).<br/>When this limit is reached, queries will fail with ResourceExhausted error.<br/>NOTE: This does NOT limit memory used by table scans. |
-| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): preserves current greedy allocation behavior.<br/>- "fair": shares memory evenly among spillable operators.<br/>Only effective when `memory_pool_size` is bounded (>0). |
+| `query.experimental_memory_pool_policy` | String | `greedy` | Experimental memory pool allocation policy:<br/>- "greedy" (default): first-come-first-served allocation; preserves current behavior.<br/>- "fair": divides available memory among spillable operators and may spill earlier.<br/>Only effective when `memory_pool_size` is bounded (>0). |
 | `query.experimental_spill_mode` | String | `default` | Spill mode:<br/>- "default": preserve DataFusion built-in OS temp directory (default).<br/>- "custom": explicitly configure spill path, quota, and compression.<br/>- "disabled": explicitly disable disk spilling.<br/>Set this to "custom" before using the path/quota/compression keys below. |
 | `query.experimental_spill_path` | String | Unset | Spill directory path. Ignored unless mode is "custom". |
-| `query.experimental_spill_max_temp_directory_size` | String | `100GiB` | Maximum total size of spill directory (default: "100GiB").<br/>Ignored unless mode is "custom". |
+| `query.experimental_spill_max_temp_directory_size` | String | `1GiB` | Maximum total size of spill directory (default: "1GiB").<br/>Ignored unless mode is "custom". |
 | `query.experimental_spill_compression` | String | `uncompressed` | Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".<br/>Ignored unless mode is "custom". |
 | `memory` | -- | -- | The memory options. |
 | `memory.enable_heap_profiling` | Bool | `true` | Whether to enable heap profiling activation during startup.<br/>When enabled, heap profiling will be activated if the `MALLOC_CONF` environment variable<br/>is set to "prof:true,prof_active:false". The official image adds this env variable.<br/>Default is true. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -279,8 +279,8 @@ parallelism = 0
 memory_pool_size = "50%"
 
 ## Experimental memory pool allocation policy:
-## - "greedy" (default): preserves current greedy allocation behavior.
-## - "fair": shares memory evenly among spillable operators.
+## - "greedy" (default): first-come-first-served allocation; preserves current behavior.
+## - "fair": divides available memory among spillable operators and may spill earlier.
 ## Only effective when `memory_pool_size` is bounded (>0).
 #+ experimental_memory_pool_policy = "greedy"
 
@@ -294,9 +294,9 @@ memory_pool_size = "50%"
 ## Spill directory path. Ignored unless mode is "custom".
 ## @toml2docs:none-default
 #+ experimental_spill_path = "/path/to/spill"
-## Maximum total size of spill directory (default: "100GiB").
+## Maximum total size of spill directory (default: "1GiB").
 ## Ignored unless mode is "custom".
-#+ experimental_spill_max_temp_directory_size = "100GiB"
+#+ experimental_spill_max_temp_directory_size = "1GiB"
 ## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
 ## Ignored unless mode is "custom".
 #+ experimental_spill_compression = "uncompressed"

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -278,6 +278,30 @@ parallelism = 0
 ## NOTE: This does NOT limit memory used by table scans.
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## The data storage options.
 [storage]
 ## The working home directory.

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -158,8 +158,8 @@ parallelism = 1
 memory_pool_size = "50%"
 
 ## Experimental memory pool allocation policy:
-## - "greedy" (default): preserves current greedy allocation behavior.
-## - "fair": shares memory evenly among spillable operators.
+## - "greedy" (default): first-come-first-served allocation; preserves current behavior.
+## - "fair": divides available memory among spillable operators and may spill earlier.
 ## Only effective when `memory_pool_size` is bounded (>0).
 #+ experimental_memory_pool_policy = "greedy"
 
@@ -173,9 +173,9 @@ memory_pool_size = "50%"
 ## Spill directory path. Ignored unless mode is "custom".
 ## @toml2docs:none-default
 #+ experimental_spill_path = "/path/to/spill"
-## Maximum total size of spill directory (default: "100GiB").
+## Maximum total size of spill directory (default: "1GiB").
 ## Ignored unless mode is "custom".
-#+ experimental_spill_max_temp_directory_size = "100GiB"
+#+ experimental_spill_max_temp_directory_size = "1GiB"
 ## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
 ## Ignored unless mode is "custom".
 #+ experimental_spill_compression = "uncompressed"

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -157,6 +157,30 @@ parallelism = 1
 ## NOTE: This does NOT limit memory used by table scans.
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## The memory options.
 [memory]
 ## Whether to enable heap profiling activation during startup.

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -315,6 +315,30 @@ allow_query_fallback = false
 ## NOTE: This does NOT limit memory used by table scans (only applies to datanodes).
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## Datanode options.
 [datanode]
 ## Datanode client options.

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -316,8 +316,8 @@ allow_query_fallback = false
 memory_pool_size = "50%"
 
 ## Experimental memory pool allocation policy:
-## - "greedy" (default): preserves current greedy allocation behavior.
-## - "fair": shares memory evenly among spillable operators.
+## - "greedy" (default): first-come-first-served allocation; preserves current behavior.
+## - "fair": divides available memory among spillable operators and may spill earlier.
 ## Only effective when `memory_pool_size` is bounded (>0).
 #+ experimental_memory_pool_policy = "greedy"
 
@@ -331,9 +331,9 @@ memory_pool_size = "50%"
 ## Spill directory path. Ignored unless mode is "custom".
 ## @toml2docs:none-default
 #+ experimental_spill_path = "/path/to/spill"
-## Maximum total size of spill directory (default: "100GiB").
+## Maximum total size of spill directory (default: "1GiB").
 ## Ignored unless mode is "custom".
-#+ experimental_spill_max_temp_directory_size = "100GiB"
+#+ experimental_spill_max_temp_directory_size = "1GiB"
 ## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
 ## Ignored unless mode is "custom".
 #+ experimental_spill_compression = "uncompressed"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -446,8 +446,8 @@ parallelism = 0
 memory_pool_size = "50%"
 
 ## Experimental memory pool allocation policy:
-## - "greedy" (default): preserves current greedy allocation behavior.
-## - "fair": shares memory evenly among spillable operators.
+## - "greedy" (default): first-come-first-served allocation; preserves current behavior.
+## - "fair": divides available memory among spillable operators and may spill earlier.
 ## Only effective when `memory_pool_size` is bounded (>0).
 #+ experimental_memory_pool_policy = "greedy"
 
@@ -461,9 +461,9 @@ memory_pool_size = "50%"
 ## Spill directory path. Ignored unless mode is "custom".
 ## @toml2docs:none-default
 #+ experimental_spill_path = "/path/to/spill"
-## Maximum total size of spill directory (default: "100GiB").
+## Maximum total size of spill directory (default: "1GiB").
 ## Ignored unless mode is "custom".
-#+ experimental_spill_max_temp_directory_size = "100GiB"
+#+ experimental_spill_max_temp_directory_size = "1GiB"
 ## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
 ## Ignored unless mode is "custom".
 #+ experimental_spill_compression = "uncompressed"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -445,6 +445,30 @@ parallelism = 0
 ## NOTE: This does NOT limit memory used by table scans.
 memory_pool_size = "50%"
 
+## Experimental memory pool allocation policy:
+## - "greedy" (default): preserves current greedy allocation behavior.
+## - "fair": shares memory evenly among spillable operators.
+## Only effective when `memory_pool_size` is bounded (>0).
+#+ experimental_memory_pool_policy = "greedy"
+
+# --- Experimental: DataFusion spill-to-disk controls ---
+## Spill mode:
+## - "default": preserve DataFusion built-in OS temp directory (default).
+## - "custom": explicitly configure spill path, quota, and compression.
+## - "disabled": explicitly disable disk spilling.
+## Set this to "custom" before using the path/quota/compression keys below.
+#+ experimental_spill_mode = "default"
+## Spill directory path. Ignored unless mode is "custom".
+## @toml2docs:none-default
+#+ experimental_spill_path = "/path/to/spill"
+## Maximum total size of spill directory (default: "100GiB").
+## Ignored unless mode is "custom".
+#+ experimental_spill_max_temp_directory_size = "100GiB"
+## Compression for spilled data files: "uncompressed" (default), "lz4_frame", "zstd".
+## Ignored unless mode is "custom".
+#+ experimental_spill_compression = "uncompressed"
+# --- End spill-to-disk ---
+
 ## The data storage options.
 [storage]
 ## The working home directory.

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -307,6 +307,7 @@ fn test_load_flownode_example_config() {
                 allow_query_fallback: false,
                 memory_pool_size: MemoryLimit::Percentage(50),
                 enable_per_region_metrics: false,
+                ..Default::default()
             },
             meta_client: Some(MetaClientOptions {
                 metasrv_addrs: vec!["127.0.0.1:3002".to_string()],

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -147,6 +147,7 @@ impl Default for FlownodeOptions {
                 allow_query_fallback: false,
                 memory_pool_size: MemoryLimit::default(),
                 enable_per_region_metrics: false,
+                ..Default::default()
             },
             memory: MemoryOptions::default(),
         }

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -98,3 +98,4 @@ session = { workspace = true, features = ["testing"] }
 store-api.workspace = true
 table = { workspace = true, features = ["testing"] }
 tokio-stream.workspace = true
+toml.workspace = true

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use common_base::memory_limit::MemoryLimit;
+use common_base::readable_size::ReadableSize;
 use datafusion::config::{ConfigEntry, ConfigExtension, ExtensionOptions};
 use serde::{Deserialize, Serialize};
 use session::context::QueryContextRef;
@@ -38,6 +40,40 @@ pub const QUERY_ENABLE_REMOTE_DYNAMIC_FILTER_PUSHDOWN: &str =
 
 pub const FLOW_INCREMENTAL_MODE_MEMTABLE_ONLY: &str = "memtable_only";
 
+/// Query spill mode controlling disk manager behavior.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QuerySpillMode {
+    /// Preserve DataFusion default disk manager behavior (OS temp directory).
+    Default,
+    /// Explicitly configure spill path, quota, and compression.
+    Custom,
+    /// Explicitly disable disk spilling; temporary file creation will error.
+    Disabled,
+}
+
+/// Compression for spilled data files.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QuerySpillCompression {
+    /// No compression (default, matches DataFusion default).
+    Uncompressed,
+    /// LZ4 frame compression.
+    Lz4Frame,
+    /// Zstandard compression.
+    Zstd,
+}
+
+/// Memory pool allocation policy.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMemoryPoolPolicy {
+    /// Greedy memory allocation (default, preserves current behavior).
+    Greedy,
+    /// Fair memory allocation: share available memory evenly among operators.
+    Fair,
+}
+
 /// Query engine config
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
@@ -53,6 +89,26 @@ pub struct QueryOptions {
     /// Whether to expose per-region query load metrics.
     #[serde(skip)]
     pub enable_per_region_metrics: bool,
+    /// Experimental: spill-to-disk mode.
+    /// - `default`: preserve DataFusion built-in OS temp directory behavior.
+    /// - `custom`: explicitly configure spill path, max directory size, and compression.
+    /// - `disabled`: explicitly disable disk spilling.
+    pub experimental_spill_mode: QuerySpillMode,
+    /// Experimental: spill directory path. Ignored unless `experimental_spill_mode` is
+    /// `"custom"`. When set, spill files are written into this directory.
+    pub experimental_spill_path: Option<PathBuf>,
+    /// Experimental: maximum total size of the spill directory (data written to spill files).
+    /// Ignored unless `experimental_spill_mode` is `"custom"`. Default: `100GiB`.
+    pub experimental_spill_max_temp_directory_size: ReadableSize,
+    /// Experimental: compression algorithm applied to spilled data.
+    /// Ignored unless `experimental_spill_mode` is `"custom"`. Default: `uncompressed`.
+    pub experimental_spill_compression: QuerySpillCompression,
+    /// Experimental: memory pool allocation policy.
+    /// - `greedy` (default): preserves current behavior.
+    /// - `fair`: share memory evenly among spillable operators.
+    ///
+    /// Only effective when `memory_pool_size` is bounded (>0).
+    pub experimental_memory_pool_policy: QueryMemoryPoolPolicy,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -63,6 +119,11 @@ impl Default for QueryOptions {
             allow_query_fallback: false,
             memory_pool_size: MemoryLimit::default(),
             enable_per_region_metrics: false,
+            experimental_spill_mode: QuerySpillMode::Default,
+            experimental_spill_path: None,
+            experimental_spill_max_temp_directory_size: ReadableSize::gb(100),
+            experimental_spill_compression: QuerySpillCompression::Uncompressed,
+            experimental_memory_pool_policy: QueryMemoryPoolPolicy::Greedy,
         }
     }
 }
@@ -698,5 +759,207 @@ mod flow_extension_tests {
         let exts = HashMap::from([(FLOW_SCHEDULED_TIME_MILLIS.to_string(), i64::MAX.to_string())]);
         let err = parse_scheduled_time_datetime(&exts).unwrap_err();
         assert!(format!("{err}").contains("Out-of-range"));
+    }
+}
+
+#[cfg(test)]
+mod query_options_tests {
+    use super::*;
+
+    #[test]
+    fn test_query_options_defaults() {
+        let opts = QueryOptions::default();
+        assert_eq!(opts.parallelism, 0);
+        assert!(!opts.allow_query_fallback);
+        assert!(opts.memory_pool_size.is_unlimited());
+        assert!(!opts.enable_per_region_metrics);
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
+        assert_eq!(opts.experimental_spill_path, None);
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(100)
+        );
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Uncompressed
+        );
+        assert_eq!(
+            opts.experimental_memory_pool_policy,
+            QueryMemoryPoolPolicy::Greedy
+        );
+    }
+
+    #[test]
+    fn test_selected_defaults_parse() {
+        let toml_str = "";
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        let def = QueryOptions::default();
+        assert_eq!(opts, def);
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_mode() {
+        let toml_str = r#"experimental_spill_mode = "custom""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Custom);
+
+        let toml_str = r#"experimental_spill_mode = "disabled""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Disabled);
+
+        let toml_str = r#"experimental_spill_mode = "default""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
+    }
+
+    #[test]
+    fn test_parse_invalid_spill_mode() {
+        let toml_str = r#"experimental_spill_mode = "invalid""#;
+        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_compression() {
+        let toml_str = r#"experimental_spill_compression = "zstd""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Zstd
+        );
+
+        let toml_str = r#"experimental_spill_compression = "lz4_frame""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Lz4Frame
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_spill_compression() {
+        let toml_str = r#"experimental_spill_compression = "gzip""#;
+        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
+    }
+
+    #[test]
+    fn test_parse_experimental_memory_pool_policy() {
+        let toml_str = r#"experimental_memory_pool_policy = "fair""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_memory_pool_policy,
+            QueryMemoryPoolPolicy::Fair
+        );
+
+        let toml_str = r#"experimental_memory_pool_policy = "greedy""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_memory_pool_policy,
+            QueryMemoryPoolPolicy::Greedy
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_memory_pool_policy() {
+        let toml_str = r#"experimental_memory_pool_policy = "none""#;
+        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_path_and_quota() {
+        let toml_str = r#"
+experimental_spill_path = "/tmp/spill"
+experimental_spill_max_temp_directory_size = "50GiB"
+"#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_path,
+            Some(PathBuf::from("/tmp/spill"))
+        );
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(50)
+        );
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_path_none_when_absent() {
+        let toml_str = r#"experimental_spill_mode = "custom""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_path, None);
+    }
+
+    /// Verify that `experimental_spill_compression` only takes effect
+    /// when paired with `experimental_spill_mode = "custom"`. This test
+    /// asserts the config can be parsed regardless, but the semantics
+    /// in `state.rs` enforce that compression is only applied in Custom mode.
+    #[test]
+    fn test_parse_experimental_spill_compression_without_custom_mode() {
+        let toml_str = r#"experimental_spill_compression = "zstd""#;
+        // Should parse fine, even though semantically compression
+        // is ignored unless mode is "custom".
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Zstd
+        );
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_max_temp_directory_size_default() {
+        let toml_str = "";
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(100)
+        );
+    }
+
+    #[test]
+    fn test_parse_experimental_spill_max_temp_directory_size_human_readable() {
+        let toml_str = r#"experimental_spill_max_temp_directory_size = "2GB""#;
+        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            opts.experimental_spill_max_temp_directory_size,
+            ReadableSize::gb(2)
+        );
+    }
+
+    #[test]
+    fn test_query_spill_mode_serde_roundtrip() {
+        let modes = [
+            QuerySpillMode::Default,
+            QuerySpillMode::Custom,
+            QuerySpillMode::Disabled,
+        ];
+        for mode in modes {
+            let json = serde_json::to_string(&mode).unwrap();
+            let roundtripped: QuerySpillMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(mode, roundtripped);
+        }
+    }
+
+    #[test]
+    fn test_query_spill_compression_serde_roundtrip() {
+        let compressions = [
+            QuerySpillCompression::Uncompressed,
+            QuerySpillCompression::Lz4Frame,
+            QuerySpillCompression::Zstd,
+        ];
+        for comp in compressions {
+            let json = serde_json::to_string(&comp).unwrap();
+            let roundtripped: QuerySpillCompression = serde_json::from_str(&json).unwrap();
+            assert_eq!(comp, roundtripped);
+        }
+    }
+
+    #[test]
+    fn test_query_memory_pool_policy_serde_roundtrip() {
+        let policies = [QueryMemoryPoolPolicy::Greedy, QueryMemoryPoolPolicy::Fair];
+        for policy in policies {
+            let json = serde_json::to_string(&policy).unwrap();
+            let roundtripped: QueryMemoryPoolPolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(policy, roundtripped);
+        }
     }
 }

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -68,9 +68,10 @@ pub enum QuerySpillCompression {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMemoryPoolPolicy {
-    /// Greedy memory allocation (default, preserves current behavior).
+    /// Greedy first-come-first-served (default).
     Greedy,
-    /// Fair memory allocation: share available memory evenly among operators.
+    /// Fair divides memory available after unspillable reservations evenly among
+    /// spillable reservations and may trigger earlier spills.
     Fair,
 }
 
@@ -98,16 +99,15 @@ pub struct QueryOptions {
     /// `"custom"`. When set, spill files are written into this directory.
     pub experimental_spill_path: Option<PathBuf>,
     /// Experimental: maximum total size of the spill directory (data written to spill files).
-    /// Ignored unless `experimental_spill_mode` is `"custom"`. Default: `100GiB`.
+    /// Ignored unless `experimental_spill_mode` is `"custom"`. Default: `1GiB`.
     pub experimental_spill_max_temp_directory_size: ReadableSize,
     /// Experimental: compression algorithm applied to spilled data.
     /// Ignored unless `experimental_spill_mode` is `"custom"`. Default: `uncompressed`.
     pub experimental_spill_compression: QuerySpillCompression,
     /// Experimental: memory pool allocation policy.
-    /// - `greedy` (default): preserves current behavior.
-    /// - `fair`: share memory evenly among spillable operators.
-    ///
-    /// Only effective when `memory_pool_size` is bounded (>0).
+    /// - `greedy`: Greedy first-come-first-served (default).
+    /// - `fair`: Fair divides memory available after unspillable reservations
+    ///   evenly among spillable reservations and may trigger earlier spills.
     pub experimental_memory_pool_policy: QueryMemoryPoolPolicy,
 }
 
@@ -121,7 +121,7 @@ impl Default for QueryOptions {
             enable_per_region_metrics: false,
             experimental_spill_mode: QuerySpillMode::Default,
             experimental_spill_path: None,
-            experimental_spill_max_temp_directory_size: ReadableSize::gb(100),
+            experimental_spill_max_temp_directory_size: ReadableSize::gb(1),
             experimental_spill_compression: QuerySpillCompression::Uncompressed,
             experimental_memory_pool_policy: QueryMemoryPoolPolicy::Greedy,
         }
@@ -777,7 +777,7 @@ mod query_options_tests {
         assert_eq!(opts.experimental_spill_path, None);
         assert_eq!(
             opts.experimental_spill_max_temp_directory_size,
-            ReadableSize::gb(100)
+            ReadableSize::gb(1)
         );
         assert_eq!(
             opts.experimental_spill_compression,
@@ -888,30 +888,13 @@ experimental_spill_max_temp_directory_size = "50GiB"
         assert_eq!(opts.experimental_spill_path, None);
     }
 
-    /// Verify that `experimental_spill_compression` only takes effect
-    /// when paired with `experimental_spill_mode = "custom"`. This test
-    /// asserts the config can be parsed regardless, but the semantics
-    /// in `state.rs` enforce that compression is only applied in Custom mode.
-    #[test]
-    fn test_parse_experimental_spill_compression_without_custom_mode() {
-        let toml_str = r#"experimental_spill_compression = "zstd""#;
-        // Should parse fine, even though semantically compression
-        // is ignored unless mode is "custom".
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            opts.experimental_spill_compression,
-            QuerySpillCompression::Zstd
-        );
-        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
-    }
-
     #[test]
     fn test_parse_experimental_spill_max_temp_directory_size_default() {
         let toml_str = "";
         let opts: QueryOptions = toml::from_str(toml_str).unwrap();
         assert_eq!(
             opts.experimental_spill_max_temp_directory_size,
-            ReadableSize::gb(100)
+            ReadableSize::gb(1)
         );
     }
 

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -767,110 +767,16 @@ mod query_options_tests {
     use super::*;
 
     #[test]
-    fn test_query_options_defaults() {
-        let opts = QueryOptions::default();
-        assert_eq!(opts.parallelism, 0);
-        assert!(!opts.allow_query_fallback);
-        assert!(opts.memory_pool_size.is_unlimited());
-        assert!(!opts.enable_per_region_metrics);
-        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
-        assert_eq!(opts.experimental_spill_path, None);
-        assert_eq!(
-            opts.experimental_spill_max_temp_directory_size,
-            ReadableSize::gb(1)
-        );
-        assert_eq!(
-            opts.experimental_spill_compression,
-            QuerySpillCompression::Uncompressed
-        );
-        assert_eq!(
-            opts.experimental_memory_pool_policy,
-            QueryMemoryPoolPolicy::Greedy
-        );
-    }
-
-    #[test]
-    fn test_selected_defaults_parse() {
-        let toml_str = "";
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        let def = QueryOptions::default();
-        assert_eq!(opts, def);
-    }
-
-    #[test]
-    fn test_parse_experimental_spill_mode() {
-        let toml_str = r#"experimental_spill_mode = "custom""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Custom);
-
-        let toml_str = r#"experimental_spill_mode = "disabled""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Disabled);
-
-        let toml_str = r#"experimental_spill_mode = "default""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Default);
-    }
-
-    #[test]
-    fn test_parse_invalid_spill_mode() {
-        let toml_str = r#"experimental_spill_mode = "invalid""#;
-        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
-    }
-
-    #[test]
-    fn test_parse_experimental_spill_compression() {
-        let toml_str = r#"experimental_spill_compression = "zstd""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            opts.experimental_spill_compression,
-            QuerySpillCompression::Zstd
-        );
-
-        let toml_str = r#"experimental_spill_compression = "lz4_frame""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            opts.experimental_spill_compression,
-            QuerySpillCompression::Lz4Frame
-        );
-    }
-
-    #[test]
-    fn test_parse_invalid_spill_compression() {
-        let toml_str = r#"experimental_spill_compression = "gzip""#;
-        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
-    }
-
-    #[test]
-    fn test_parse_experimental_memory_pool_policy() {
-        let toml_str = r#"experimental_memory_pool_policy = "fair""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            opts.experimental_memory_pool_policy,
-            QueryMemoryPoolPolicy::Fair
-        );
-
-        let toml_str = r#"experimental_memory_pool_policy = "greedy""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            opts.experimental_memory_pool_policy,
-            QueryMemoryPoolPolicy::Greedy
-        );
-    }
-
-    #[test]
-    fn test_parse_invalid_memory_pool_policy() {
-        let toml_str = r#"experimental_memory_pool_policy = "none""#;
-        assert!(toml::from_str::<QueryOptions>(toml_str).is_err());
-    }
-
-    #[test]
-    fn test_parse_experimental_spill_path_and_quota() {
+    fn test_parse_spill_options_from_toml() {
         let toml_str = r#"
+experimental_spill_mode = "custom"
 experimental_spill_path = "/tmp/spill"
 experimental_spill_max_temp_directory_size = "50GiB"
+experimental_spill_compression = "zstd"
+experimental_memory_pool_policy = "fair"
 "#;
         let opts: QueryOptions = toml::from_str(toml_str).unwrap();
+        assert_eq!(opts.experimental_spill_mode, QuerySpillMode::Custom);
         assert_eq!(
             opts.experimental_spill_path,
             Some(PathBuf::from("/tmp/spill"))
@@ -879,70 +785,27 @@ experimental_spill_max_temp_directory_size = "50GiB"
             opts.experimental_spill_max_temp_directory_size,
             ReadableSize::gb(50)
         );
-    }
-
-    #[test]
-    fn test_parse_experimental_spill_path_none_when_absent() {
-        let toml_str = r#"experimental_spill_mode = "custom""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(opts.experimental_spill_path, None);
-    }
-
-    #[test]
-    fn test_parse_experimental_spill_max_temp_directory_size_default() {
-        let toml_str = "";
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
         assert_eq!(
-            opts.experimental_spill_max_temp_directory_size,
-            ReadableSize::gb(1)
+            opts.experimental_spill_compression,
+            QuerySpillCompression::Zstd
+        );
+        assert_eq!(
+            opts.experimental_memory_pool_policy,
+            QueryMemoryPoolPolicy::Fair
         );
     }
 
     #[test]
-    fn test_parse_experimental_spill_max_temp_directory_size_human_readable() {
-        let toml_str = r#"experimental_spill_max_temp_directory_size = "2GB""#;
-        let opts: QueryOptions = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            opts.experimental_spill_max_temp_directory_size,
-            ReadableSize::gb(2)
-        );
-    }
-
-    #[test]
-    fn test_query_spill_mode_serde_roundtrip() {
-        let modes = [
-            QuerySpillMode::Default,
-            QuerySpillMode::Custom,
-            QuerySpillMode::Disabled,
-        ];
-        for mode in modes {
-            let json = serde_json::to_string(&mode).unwrap();
-            let roundtripped: QuerySpillMode = serde_json::from_str(&json).unwrap();
-            assert_eq!(mode, roundtripped);
-        }
-    }
-
-    #[test]
-    fn test_query_spill_compression_serde_roundtrip() {
-        let compressions = [
-            QuerySpillCompression::Uncompressed,
-            QuerySpillCompression::Lz4Frame,
-            QuerySpillCompression::Zstd,
-        ];
-        for comp in compressions {
-            let json = serde_json::to_string(&comp).unwrap();
-            let roundtripped: QuerySpillCompression = serde_json::from_str(&json).unwrap();
-            assert_eq!(comp, roundtripped);
-        }
-    }
-
-    #[test]
-    fn test_query_memory_pool_policy_serde_roundtrip() {
-        let policies = [QueryMemoryPoolPolicy::Greedy, QueryMemoryPoolPolicy::Fair];
-        for policy in policies {
-            let json = serde_json::to_string(&policy).unwrap();
-            let roundtripped: QueryMemoryPoolPolicy = serde_json::from_str(&json).unwrap();
-            assert_eq!(policy, roundtripped);
+    fn test_parse_invalid_spill_option_values() {
+        for toml_str in [
+            r#"experimental_spill_mode = "invalid""#,
+            r#"experimental_spill_compression = "gzip""#,
+            r#"experimental_memory_pool_policy = "none""#,
+        ] {
+            assert!(
+                toml::from_str::<QueryOptions>(toml_str).is_err(),
+                "{toml_str}"
+            );
         }
     }
 }

--- a/src/query/src/query_engine/runtime.rs
+++ b/src/query/src/query_engine/runtime.rs
@@ -91,10 +91,15 @@ impl DefaultQueryRuntimeProvider {
                     dm_builder =
                         dm_builder.with_mode(DiskManagerMode::Directories(vec![path.clone()]));
                 }
-                dm_builder = dm_builder.with_max_temp_directory_size(
-                    ctx.query_options
-                        .experimental_spill_max_temp_directory_size
-                        .as_bytes(),
+                let max_temp_directory_size =
+                    ctx.query_options.experimental_spill_max_temp_directory_size;
+                dm_builder =
+                    dm_builder.with_max_temp_directory_size(max_temp_directory_size.as_bytes());
+                common_telemetry::info!(
+                    "Configured custom query spill: path={:?}, max_temp_directory_size={}, compression={:?}",
+                    ctx.query_options.experimental_spill_path,
+                    max_temp_directory_size,
+                    ctx.query_options.experimental_spill_compression,
                 );
                 builder = builder.with_disk_manager_builder(dm_builder);
             }

--- a/src/query/src/query_engine/runtime.rs
+++ b/src/query/src/query_engine/runtime.rs
@@ -16,9 +16,11 @@ use std::sync::Arc;
 
 use datafusion::error::Result as DfResult;
 use datafusion::execution::context::SessionConfig;
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+use datafusion_common::config::SpillCompression;
 
-use crate::options::QueryOptions;
+use crate::options::{QueryOptions, QuerySpillCompression, QuerySpillMode};
 use crate::query_engine::state::MetricsMemoryPool;
 
 /// Reference-counted query runtime provider.
@@ -67,14 +69,67 @@ pub struct DefaultQueryRuntimeProvider;
 impl DefaultQueryRuntimeProvider {
     /// Creates a default DataFusion runtime environment builder.
     pub fn runtime_env_builder(ctx: QueryRuntimeContext<'_>) -> RuntimeEnvBuilder {
+        let mut builder = RuntimeEnvBuilder::new();
+
+        // Attach the bounded metrics memory pool only when a limit is set
+        // (>0). When unbounded (0), keep the DataFusion default
+        // (UnboundedMemoryPool).
         if ctx.resolved_memory_pool_size > 0 {
-            RuntimeEnvBuilder::new().with_memory_pool(Arc::new(MetricsMemoryPool::new(
+            builder = builder.with_memory_pool(Arc::new(MetricsMemoryPool::new(
                 ctx.resolved_memory_pool_size,
-            )))
-        } else {
-            RuntimeEnvBuilder::new()
+                ctx.query_options.experimental_memory_pool_policy,
+            )));
+        }
+
+        match ctx.query_options.experimental_spill_mode {
+            QuerySpillMode::Default => {
+                // No custom disk manager; preserve DataFusion default OS temp directory.
+            }
+            QuerySpillMode::Custom => {
+                let mut dm_builder = DiskManagerBuilder::default();
+                if let Some(ref path) = ctx.query_options.experimental_spill_path {
+                    dm_builder =
+                        dm_builder.with_mode(DiskManagerMode::Directories(vec![path.clone()]));
+                }
+                dm_builder = dm_builder.with_max_temp_directory_size(
+                    ctx.query_options
+                        .experimental_spill_max_temp_directory_size
+                        .as_bytes(),
+                );
+                builder = builder.with_disk_manager_builder(dm_builder);
+            }
+            QuerySpillMode::Disabled => {
+                let dm_builder = DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled);
+                builder = builder.with_disk_manager_builder(dm_builder);
+            }
+        }
+
+        builder
+    }
+}
+
+impl QueryRuntimeProvider for DefaultQueryRuntimeProvider {
+    fn configure_session_config(&self, ctx: QueryRuntimeContext<'_>, config: &mut SessionConfig) {
+        // Set spill compression on the session config only when spill mode is
+        // Custom. In Default/Disabled modes, DataFusion's own default
+        // (Uncompressed) is preserved—setting compression when spill is not
+        // explicitly configured would be misleading.
+        if ctx.query_options.experimental_spill_mode == QuerySpillMode::Custom {
+            config.options_mut().execution.spill_compression =
+                spill_compression_from_options(ctx.query_options.experimental_spill_compression);
         }
     }
 }
 
-impl QueryRuntimeProvider for DefaultQueryRuntimeProvider {}
+/// Map [`QuerySpillCompression`] to DataFusion's [`SpillCompression`].
+///
+/// This conversion is intentionally not a `From` impl because the
+/// semantics depend on the spill mode; callers should only invoke
+/// this when `experimental_spill_mode == Custom`.
+fn spill_compression_from_options(comp: QuerySpillCompression) -> SpillCompression {
+    match comp {
+        QuerySpillCompression::Uncompressed => SpillCompression::Uncompressed,
+        QuerySpillCompression::Lz4Frame => SpillCompression::Lz4Frame,
+        QuerySpillCompression::Zstd => SpillCompression::Zstd,
+    }
+}

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -883,8 +883,6 @@ mod tests {
         );
     }
 
-    // --- spill / memory pool tests ---
-
     /// Builds a runtime env through the default provider seam, mirroring what
     /// [`QueryEngineState::try_new`] does.
     fn build_runtime_env(options: &QueryOptions, memory_pool_size: usize) -> Arc<RuntimeEnv> {
@@ -895,18 +893,13 @@ mod tests {
             .expect("Failed to build RuntimeEnv")
     }
 
-    /// Default mode: unbounded memory, OS temp dir disk manager.
     #[test]
     fn test_build_runtime_env_default_mode_unbounded() {
         let opts = QueryOptions::default();
         let env = build_runtime_env(&opts, 0);
-        // Default mode + unbounded pool: no custom disk manager override,
-        // so tmp files should be enabled (DataFusion default).
         assert!(env.disk_manager.tmp_files_enabled());
     }
 
-    /// Default mode with bounded memory: pool is attached but disk manager
-    /// remains default.
     #[test]
     fn test_build_runtime_env_default_mode_bounded() {
         let opts = QueryOptions {
@@ -914,19 +907,14 @@ mod tests {
             ..Default::default()
         };
         let env = build_runtime_env(&opts, 128 * 1024 * 1024);
-        // Bounded pool is attached
         assert!(env.memory_pool.reserved() == 0);
-        // Disk manager remains default (OS temp dir)
         assert!(env.disk_manager.tmp_files_enabled());
     }
 
-    /// Custom mode with explicit path: disk manager is configured with the
-    /// custom directory and the directory actually gets created.
     #[test]
     fn test_build_runtime_env_custom_mode_with_path() {
         // Use a temp directory managed manually so we don't need the `tempfile` crate.
         let spill_dir = std::env::temp_dir().join(format!("df_spill_test_{}", std::process::id()));
-        // Clean up if exists from a previous run
         let _ = std::fs::remove_dir_all(&spill_dir);
         let opts = QueryOptions {
             experimental_spill_mode: QuerySpillMode::Custom,
@@ -937,17 +925,13 @@ mod tests {
         let env = build_runtime_env(&opts, 0);
 
         assert!(env.disk_manager.tmp_files_enabled());
-        // Creating a temp file should succeed
         let tmp_file = env.disk_manager.create_tmp_file("test spill");
         assert!(tmp_file.is_ok());
-        // The directory should have been created
         assert!(spill_dir.exists());
 
-        // Cleanup
         let _ = std::fs::remove_dir_all(&spill_dir);
     }
 
-    /// Disabled mode: tmp files are disabled; creating a temp file returns an error.
     #[test]
     fn test_build_runtime_env_disabled_mode() {
         let opts = QueryOptions {
@@ -962,12 +946,10 @@ mod tests {
         assert!(format!("{}", result.unwrap_err()).contains("DiskManager is disabled"));
     }
 
-    /// MetricsMemoryPool defaults to greedy with TrackConsumersPool wrapping.
     #[test]
     fn test_metrics_memory_pool_default_greedy() {
         let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Greedy);
         assert!(matches!(pool.memory_limit(), DfMemoryLimit::Finite(1024)));
-        // Smoke test: register a consumer and grow
         let pool: Arc<dyn MemoryPool> = Arc::new(pool);
         let consumer = MemoryConsumer::new("test");
         let reservation = consumer.register(&pool);
@@ -975,7 +957,6 @@ mod tests {
         assert!(pool.reserved() > 0);
     }
 
-    /// MetricsMemoryPool with fair policy: still wrapped in TrackConsumersPool.
     #[test]
     fn test_metrics_memory_pool_fair() {
         let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Fair);
@@ -987,7 +968,6 @@ mod tests {
         assert!(pool.reserved() > 0);
     }
 
-    /// Bounded fair pool rejects over-limit growth.
     #[test]
     fn test_metrics_memory_pool_fair_rejects_over_limit() {
         let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Fair);
@@ -998,7 +978,6 @@ mod tests {
         assert!(result.is_err(), "expected error but got Ok");
     }
 
-    /// Bounded greedy pool rejects over-limit growth.
     #[test]
     fn test_metrics_memory_pool_greedy_rejects_over_limit() {
         let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Greedy);
@@ -1009,8 +988,6 @@ mod tests {
         assert!(result.is_err(), "expected error but got Ok");
     }
 
-    // --- end-to-end spill smoke test ---
-
     /// Builds a runtime with custom spill configuration and a bounded memory
     /// pool, then runs sort queries that probe spill-to-disk behaviour:
     ///
@@ -1019,24 +996,18 @@ mod tests {
     ///   than the total data.  Executes the physical plan directly so we can
     ///   walk the plan tree afterwards and sum `spill_count` / `spilled_rows` /
     ///   `spilled_bytes` on `SortExec` nodes.  All three must be > 0.
-    ///
-    /// Also checks the custom spill-path directory was initialised, pool
-    /// reserved returns to 0, and output is correctly sorted.
     #[tokio::test]
     async fn test_sort_spill_smoke_with_custom_runtime() {
-        // ---- shared imports (in-function to avoid polluting the module) ----
         use arrow::array::Int32Array;
         use arrow::datatypes::{DataType, Field, Schema};
         use arrow::record_batch::RecordBatch;
         use datafusion::datasource::MemTable;
         use datafusion::physical_plan::collect as df_collect;
 
-        // ---- setup: spill directory ----
         let spill_dir =
             std::env::temp_dir().join(format!("greptime_spill_smoke_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&spill_dir);
 
-        // ---- shared options ----
         let opts = QueryOptions {
             experimental_spill_mode: QuerySpillMode::Custom,
             experimental_spill_path: Some(spill_dir.clone()),
@@ -1045,13 +1016,11 @@ mod tests {
             ..Default::default()
         };
 
-        // ---- shared session config ----
         let session_config = SessionConfig::new()
             .with_target_partitions(1)
             .with_sort_in_place_threshold_bytes(0)
             .with_sort_spill_reservation_bytes(64 * 1024);
 
-        // ---- data: 200 K rows Int32×2, split into 40 batches of 5 K ----
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
             Field::new("val", DataType::Int32, false),
@@ -1088,7 +1057,6 @@ mod tests {
             table_partitions.push(batches);
         }
 
-        // ---- helper: build a SessionContext from options + data ----
         fn build_ctx(
             session_config: &SessionConfig,
             runtime: &Arc<RuntimeEnv>,
@@ -1106,7 +1074,6 @@ mod tests {
             ctx
         }
 
-        // ---- Phase 1: 64 KB pool → OOM (proves pool is active) ----
         {
             let mem_limit: usize = 64 * 1024;
             let runtime = build_runtime_env(&opts, mem_limit);
@@ -1129,7 +1096,6 @@ mod tests {
             assert_eq!(runtime.memory_pool.reserved(), 0);
         }
 
-        // ---- Phase 2: 512 KB pool → spilling to disk ----
         {
             let mem_limit: usize = 512 * 1024; // 512 KB pool, 64 KB reserved for merge
 
@@ -1137,7 +1103,6 @@ mod tests {
             assert_eq!(runtime.memory_pool.reserved(), 0);
             let ctx = build_ctx(&session_config, &runtime, &schema, &table_partitions);
 
-            // Execute via direct physical-plan path so we can inspect metrics.
             let df = ctx
                 .sql("SELECT val FROM t ORDER BY val ASC")
                 .await
@@ -1152,7 +1117,6 @@ mod tests {
                 .await
                 .expect("executing ORDER BY");
 
-            // ---- spill metrics on SortExec nodes ----
             let (spill_count, spilled_rows, spilled_bytes, _sort_elapsed_ns) =
                 sum_sort_spill_metrics(&plan);
             assert!(
@@ -1171,7 +1135,6 @@ mod tests {
                  (spill_count={spill_count}, spilled_rows={spilled_rows})",
             );
 
-            // ---- correctness: row count & sorted order ----
             let vals: Vec<i32> = batches
                 .iter()
                 .flat_map(|b| {
@@ -1184,7 +1147,6 @@ mod tests {
                 assert!(w[0] <= w[1], "sort order violation: {} > {}", w[0], w[1]);
             }
 
-            // ---- spill-path directory was initialised ----
             assert!(
                 std::fs::read_dir(&spill_dir)
                     .ok()
@@ -1199,11 +1161,9 @@ mod tests {
                 spill_dir,
             );
 
-            // Memory pool fully released.
             assert_eq!(runtime.memory_pool.reserved(), 0);
         }
 
-        // ---- cleanup ----
         let _ = std::fs::remove_dir_all(&spill_dir);
     }
 

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -80,7 +80,7 @@ use crate::options::{QueryMemoryPoolPolicy, QueryOptions as QueryOptionsNew};
 use crate::query_engine::DefaultSerializer;
 use crate::query_engine::options::QueryOptions;
 use crate::query_engine::runtime::{
-    DefaultQueryRuntimeProvider, QueryRuntimeContext, QueryRuntimeProviderRef,
+    DefaultQueryRuntimeProvider, QueryRuntimeContext, QueryRuntimeProvider, QueryRuntimeProviderRef,
 };
 use crate::range_select::planner::RangeSelectPlanner;
 use crate::region_query::RegionQueryHandlerRef;
@@ -148,9 +148,7 @@ impl QueryEngineState {
     ) -> DfResult<Self> {
         let total_memory = get_total_memory_bytes().max(0) as u64;
         let memory_pool_size = options.memory_pool_size.resolve(total_memory) as usize;
-        let runtime_provider = plugins
-            .get::<QueryRuntimeProviderRef>()
-            .unwrap_or_else(|| Arc::new(DefaultQueryRuntimeProvider));
+        let runtime_provider = plugins.get::<QueryRuntimeProviderRef>();
         let mut session_config = SessionConfig::new().with_create_default_catalog_and_schema(false);
         if options.parallelism > 0 {
             session_config = session_config.with_target_partitions(options.parallelism);
@@ -172,9 +170,16 @@ impl QueryEngineState {
             .skip_physical_aggregate_schema_check = true;
 
         let runtime_context = QueryRuntimeContext::new(&options, memory_pool_size);
-        runtime_provider.configure_session_config(runtime_context, &mut session_config);
+        let default_runtime_provider = DefaultQueryRuntimeProvider;
+        default_runtime_provider.configure_session_config(runtime_context, &mut session_config);
+        if let Some(provider) = runtime_provider.as_ref() {
+            provider.configure_session_config(runtime_context, &mut session_config);
+        }
         let runtime_builder = DefaultQueryRuntimeProvider::runtime_env_builder(runtime_context);
-        let runtime_env = runtime_provider.build_runtime_env(runtime_context, runtime_builder)?;
+        let runtime_env = match runtime_provider {
+            Some(provider) => provider.build_runtime_env(runtime_context, runtime_builder)?,
+            None => default_runtime_provider.build_runtime_env(runtime_context, runtime_builder)?,
+        };
 
         // Apply extension rules
         let mut extension_rules = Vec::new();
@@ -571,9 +576,8 @@ impl DfQueryPlanner {
 /// This wrapper intercepts all memory pool operations and updates
 /// Prometheus metrics for monitoring query memory usage and rejections.
 ///
-/// The inner pool is always wrapped with `TrackConsumersPool` to preserve
-/// top-consumer error context on rejection, regardless of whether the
-/// underlying pool is greedy or fair.
+/// The inner pool is wrapped with `TrackConsumersPool` to preserve
+/// top-consumer error context on rejection.
 #[derive(Debug)]
 pub(super) struct MetricsMemoryPool {
     inner: Arc<dyn MemoryPool>,
@@ -584,8 +588,7 @@ impl MetricsMemoryPool {
     const TOP_CONSUMERS_TO_REPORT: usize = 5;
 
     /// Create a new metrics-wrapped memory pool with the given size limit and
-    /// allocation policy. Both greedy and fair pools are wrapped in
-    /// [`TrackConsumersPool`] to preserve top-consumer error context on rejection.
+    /// allocation policy.
     pub(super) fn new(limit: usize, policy: QueryMemoryPoolPolicy) -> Self {
         let top_n = NonZeroUsize::new(Self::TOP_CONSUMERS_TO_REPORT).unwrap();
         let inner: Arc<dyn MemoryPool> = match policy {
@@ -656,10 +659,11 @@ mod tests {
     use datafusion::error::DataFusionError;
     use datafusion::execution::memory_pool::{GreedyMemoryPool, MemoryLimit as DfMemoryLimit};
     use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+    use datafusion_common::config::SpillCompression;
     use session::context::QueryContext;
 
     use super::*;
-    use crate::options::{QueryOptions, QuerySpillMode};
+    use crate::options::{QueryOptions, QuerySpillCompression, QuerySpillMode};
     use crate::query_engine::runtime::{
         DefaultQueryRuntimeProvider, QueryRuntimeContext, QueryRuntimeProvider,
         QueryRuntimeProviderRef,
@@ -789,12 +793,23 @@ mod tests {
             plugins,
             QueryOptions {
                 memory_pool_size: MemoryLimit::Size(ReadableSize(1024)),
+                experimental_spill_mode: QuerySpillMode::Custom,
+                experimental_spill_compression: QuerySpillCompression::Zstd,
                 ..Default::default()
             },
         );
 
         assert!(provider.configure_called.load(Ordering::SeqCst));
         assert_eq!(7, state.session_state().config().target_partitions());
+        assert_eq!(
+            SpillCompression::Zstd,
+            state
+                .session_state()
+                .config()
+                .options()
+                .execution
+                .spill_compression
+        );
     }
 
     #[test]
@@ -894,24 +909,6 @@ mod tests {
     }
 
     #[test]
-    fn test_build_runtime_env_default_mode_unbounded() {
-        let opts = QueryOptions::default();
-        let env = build_runtime_env(&opts, 0);
-        assert!(env.disk_manager.tmp_files_enabled());
-    }
-
-    #[test]
-    fn test_build_runtime_env_default_mode_bounded() {
-        let opts = QueryOptions {
-            memory_pool_size: MemoryLimit::Size(ReadableSize::mb(128)),
-            ..Default::default()
-        };
-        let env = build_runtime_env(&opts, 128 * 1024 * 1024);
-        assert!(env.memory_pool.reserved() == 0);
-        assert!(env.disk_manager.tmp_files_enabled());
-    }
-
-    #[test]
     fn test_build_runtime_env_custom_mode_with_path() {
         // Use a temp directory managed manually so we don't need the `tempfile` crate.
         let spill_dir = std::env::temp_dir().join(format!("df_spill_test_{}", std::process::id()));
@@ -947,52 +944,34 @@ mod tests {
     }
 
     #[test]
-    fn test_metrics_memory_pool_default_greedy() {
-        let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Greedy);
-        assert!(matches!(pool.memory_limit(), DfMemoryLimit::Finite(1024)));
-        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
-        let consumer = MemoryConsumer::new("test");
-        let reservation = consumer.register(&pool);
-        pool.try_grow(&reservation, 128).unwrap();
-        assert!(pool.reserved() > 0);
-    }
+    fn test_metrics_memory_pool_policy_differs_with_multiple_spillable_consumers() {
+        for (policy, greedy) in [
+            (QueryMemoryPoolPolicy::Greedy, true),
+            (QueryMemoryPoolPolicy::Fair, false),
+        ] {
+            let pool: Arc<dyn MemoryPool> = Arc::new(MetricsMemoryPool::new(100, policy));
+            let first = MemoryConsumer::new("first")
+                .with_can_spill(true)
+                .register(&pool);
+            let second = MemoryConsumer::new("second")
+                .with_can_spill(true)
+                .register(&pool);
 
-    #[test]
-    fn test_metrics_memory_pool_fair() {
-        let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Fair);
-        assert!(matches!(pool.memory_limit(), DfMemoryLimit::Finite(1024)));
-        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
-        let consumer = MemoryConsumer::new("test fair");
-        let reservation = consumer.register(&pool);
-        pool.try_grow(&reservation, 128).unwrap();
-        assert!(pool.reserved() > 0);
-    }
-
-    #[test]
-    fn test_metrics_memory_pool_fair_rejects_over_limit() {
-        let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Fair);
-        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
-        let consumer = MemoryConsumer::new("test fair oom");
-        let reservation = consumer.register(&pool);
-        let result = pool.try_grow(&reservation, 201);
-        assert!(result.is_err(), "expected error but got Ok");
-    }
-
-    #[test]
-    fn test_metrics_memory_pool_greedy_rejects_over_limit() {
-        let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Greedy);
-        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
-        let consumer = MemoryConsumer::new("test greedy oom");
-        let reservation = consumer.register(&pool);
-        let result = pool.try_grow(&reservation, 201);
-        assert!(result.is_err(), "expected error but got Ok");
+            let first_result = first.try_grow(75);
+            assert_eq!(first_result.is_ok(), greedy);
+            if greedy {
+                assert!(second.try_grow(26).is_err());
+            } else {
+                first.try_grow(50).unwrap();
+                second.try_grow(50).unwrap();
+            }
+        }
     }
 
     /// Builds a runtime with custom spill configuration and a bounded memory
     /// pool, then runs sort queries that probe spill-to-disk behaviour:
     ///
-    /// - Phase 1: a pool too small to sort in-memory → OOM (proves pool active).
-    /// - Phase 2: a pool large enough for merge chunks but still much smaller
+    /// - A pool large enough for merge chunks but still much smaller
     ///   than the total data.  Executes the physical plan directly so we can
     ///   walk the plan tree afterwards and sum `spill_count` / `spilled_rows` /
     ///   `spilled_bytes` on `SortExec` nodes.  All three must be > 0.
@@ -1075,28 +1054,6 @@ mod tests {
         }
 
         {
-            let mem_limit: usize = 64 * 1024;
-            let runtime = build_runtime_env(&opts, mem_limit);
-            let ctx = build_ctx(&session_config, &runtime, &schema, &table_partitions);
-            let result = ctx
-                .sql("SELECT * FROM t ORDER BY val ASC")
-                .await
-                .unwrap()
-                .collect()
-                .await;
-            assert!(
-                result.is_err(),
-                "64 KB pool should be too small for 200K rows, but query succeeded"
-            );
-            let err_msg = format!("{}", result.unwrap_err());
-            assert!(
-                err_msg.contains("Resources exhausted") || err_msg.contains("Memory Exhausted"),
-                "error should mention resource exhaustion: {err_msg}"
-            );
-            assert_eq!(runtime.memory_pool.reserved(), 0);
-        }
-
-        {
             let mem_limit: usize = 512 * 1024; // 512 KB pool, 64 KB reserved for merge
 
             let runtime = build_runtime_env(&opts, mem_limit);
@@ -1117,8 +1074,7 @@ mod tests {
                 .await
                 .expect("executing ORDER BY");
 
-            let (spill_count, spilled_rows, spilled_bytes, _sort_elapsed_ns) =
-                sum_sort_spill_metrics(&plan);
+            let (spill_count, spilled_rows, spilled_bytes) = sum_sort_spill_metrics(&plan);
             assert!(
                 spill_count > 0,
                 "expected SortExec spill_count > 0 (pool={} KB, reservation=64 KB), got 0",
@@ -1167,21 +1123,14 @@ mod tests {
         let _ = std::fs::remove_dir_all(&spill_dir);
     }
 
-    /// Walk a physical plan tree, summing spill metrics and `elapsed_compute`
-    /// for every node whose name starts with `"SortExec"`.
-    fn sum_sort_spill_metrics(plan: &Arc<dyn ExecutionPlan>) -> (usize, usize, usize, usize) {
+    /// Walk a physical plan tree, summing spill metrics for every node whose
+    /// name starts with `"SortExec"`.
+    fn sum_sort_spill_metrics(plan: &Arc<dyn ExecutionPlan>) -> (usize, usize, usize) {
         let mut spill_count = 0usize;
         let mut spilled_rows = 0usize;
         let mut spilled_bytes = 0usize;
-        let mut elapsed_compute_ns = 0usize;
 
-        fn walk(
-            plan: &Arc<dyn ExecutionPlan>,
-            sc: &mut usize,
-            sr: &mut usize,
-            sb: &mut usize,
-            elapsed: &mut usize,
-        ) {
+        fn walk(plan: &Arc<dyn ExecutionPlan>, sc: &mut usize, sr: &mut usize, sb: &mut usize) {
             let name = plan.name();
             if name.starts_with("SortExec")
                 && let Some(m) = plan.metrics()
@@ -1189,10 +1138,9 @@ mod tests {
                 *sc += m.spill_count().unwrap_or(0);
                 *sr += m.spilled_rows().unwrap_or(0);
                 *sb += m.spilled_bytes().unwrap_or(0);
-                *elapsed += m.elapsed_compute().unwrap_or(0);
             }
             for child in plan.children() {
-                walk(child, sc, sr, sb, elapsed);
+                walk(child, sc, sr, sb);
             }
         }
 
@@ -1201,8 +1149,7 @@ mod tests {
             &mut spill_count,
             &mut spilled_rows,
             &mut spilled_bytes,
-            &mut elapsed_compute_ns,
         );
-        (spill_count, spilled_rows, spilled_bytes, elapsed_compute_ns)
+        (spill_count, spilled_rows, spilled_bytes)
     }
 }

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -35,7 +35,7 @@ use datafusion::error::Result as DfResult;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::{QueryPlanner, SessionConfig, SessionContext, SessionState};
 use datafusion::execution::memory_pool::{
-    GreedyMemoryPool, MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
+    FairSpillPool, GreedyMemoryPool, MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
     TrackConsumersPool,
 };
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
@@ -76,7 +76,7 @@ use crate::optimizer::string_normalization::StringNormalizationRule;
 use crate::optimizer::transcribe_atat::TranscribeAtatRule;
 use crate::optimizer::type_conversion::TypeConversionRule;
 use crate::optimizer::windowed_sort::WindowedSortPhysicalRule;
-use crate::options::QueryOptions as QueryOptionsNew;
+use crate::options::{QueryMemoryPoolPolicy, QueryOptions as QueryOptionsNew};
 use crate::query_engine::DefaultSerializer;
 use crate::query_engine::options::QueryOptions;
 use crate::query_engine::runtime::{
@@ -566,26 +566,37 @@ impl DfQueryPlanner {
     }
 }
 
-/// A wrapper around TrackConsumersPool that records metrics.
+/// A wrapper around a memory pool that records metrics.
 ///
 /// This wrapper intercepts all memory pool operations and updates
 /// Prometheus metrics for monitoring query memory usage and rejections.
+///
+/// The inner pool is always wrapped with `TrackConsumersPool` to preserve
+/// top-consumer error context on rejection, regardless of whether the
+/// underlying pool is greedy or fair.
 #[derive(Debug)]
 pub(super) struct MetricsMemoryPool {
-    inner: Arc<TrackConsumersPool<GreedyMemoryPool>>,
+    inner: Arc<dyn MemoryPool>,
 }
 
 impl MetricsMemoryPool {
     // Number of top memory consumers to report in OOM error messages
     const TOP_CONSUMERS_TO_REPORT: usize = 5;
 
-    pub(super) fn new(limit: usize) -> Self {
-        Self {
-            inner: Arc::new(TrackConsumersPool::new(
-                GreedyMemoryPool::new(limit),
-                NonZeroUsize::new(Self::TOP_CONSUMERS_TO_REPORT).unwrap(),
-            )),
-        }
+    /// Create a new metrics-wrapped memory pool with the given size limit and
+    /// allocation policy. Both greedy and fair pools are wrapped in
+    /// [`TrackConsumersPool`] to preserve top-consumer error context on rejection.
+    pub(super) fn new(limit: usize, policy: QueryMemoryPoolPolicy) -> Self {
+        let top_n = NonZeroUsize::new(Self::TOP_CONSUMERS_TO_REPORT).unwrap();
+        let inner: Arc<dyn MemoryPool> = match policy {
+            QueryMemoryPoolPolicy::Greedy => {
+                Arc::new(TrackConsumersPool::new(GreedyMemoryPool::new(limit), top_n))
+            }
+            QueryMemoryPoolPolicy::Fair => {
+                Arc::new(TrackConsumersPool::new(FairSpillPool::new(limit), top_n))
+            }
+        };
+        Self { inner }
     }
 
     #[inline]
@@ -648,8 +659,11 @@ mod tests {
     use session::context::QueryContext;
 
     use super::*;
-    use crate::options::QueryOptions;
-    use crate::query_engine::runtime::{QueryRuntimeProvider, QueryRuntimeProviderRef};
+    use crate::options::{QueryOptions, QuerySpillMode};
+    use crate::query_engine::runtime::{
+        DefaultQueryRuntimeProvider, QueryRuntimeContext, QueryRuntimeProvider,
+        QueryRuntimeProviderRef,
+    };
 
     fn new_query_engine_state() -> QueryEngineState {
         new_query_engine_state_with(Plugins::default(), QueryOptions::default())
@@ -867,5 +881,368 @@ mod tests {
             second.registry().query_id(),
             second_query_ctx.remote_query_id_value().unwrap()
         );
+    }
+
+    // --- spill / memory pool tests ---
+
+    /// Builds a runtime env through the default provider seam, mirroring what
+    /// [`QueryEngineState::try_new`] does.
+    fn build_runtime_env(options: &QueryOptions, memory_pool_size: usize) -> Arc<RuntimeEnv> {
+        let ctx = QueryRuntimeContext::new(options, memory_pool_size);
+        let builder = DefaultQueryRuntimeProvider::runtime_env_builder(ctx);
+        DefaultQueryRuntimeProvider
+            .build_runtime_env(ctx, builder)
+            .expect("Failed to build RuntimeEnv")
+    }
+
+    /// Default mode: unbounded memory, OS temp dir disk manager.
+    #[test]
+    fn test_build_runtime_env_default_mode_unbounded() {
+        let opts = QueryOptions::default();
+        let env = build_runtime_env(&opts, 0);
+        // Default mode + unbounded pool: no custom disk manager override,
+        // so tmp files should be enabled (DataFusion default).
+        assert!(env.disk_manager.tmp_files_enabled());
+    }
+
+    /// Default mode with bounded memory: pool is attached but disk manager
+    /// remains default.
+    #[test]
+    fn test_build_runtime_env_default_mode_bounded() {
+        let opts = QueryOptions {
+            memory_pool_size: MemoryLimit::Size(ReadableSize::mb(128)),
+            ..Default::default()
+        };
+        let env = build_runtime_env(&opts, 128 * 1024 * 1024);
+        // Bounded pool is attached
+        assert!(env.memory_pool.reserved() == 0);
+        // Disk manager remains default (OS temp dir)
+        assert!(env.disk_manager.tmp_files_enabled());
+    }
+
+    /// Custom mode with explicit path: disk manager is configured with the
+    /// custom directory and the directory actually gets created.
+    #[test]
+    fn test_build_runtime_env_custom_mode_with_path() {
+        // Use a temp directory managed manually so we don't need the `tempfile` crate.
+        let spill_dir = std::env::temp_dir().join(format!("df_spill_test_{}", std::process::id()));
+        // Clean up if exists from a previous run
+        let _ = std::fs::remove_dir_all(&spill_dir);
+        let opts = QueryOptions {
+            experimental_spill_mode: QuerySpillMode::Custom,
+            experimental_spill_path: Some(spill_dir.clone()),
+            experimental_spill_max_temp_directory_size: ReadableSize::gb(1),
+            ..Default::default()
+        };
+        let env = build_runtime_env(&opts, 0);
+
+        assert!(env.disk_manager.tmp_files_enabled());
+        // Creating a temp file should succeed
+        let tmp_file = env.disk_manager.create_tmp_file("test spill");
+        assert!(tmp_file.is_ok());
+        // The directory should have been created
+        assert!(spill_dir.exists());
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&spill_dir);
+    }
+
+    /// Disabled mode: tmp files are disabled; creating a temp file returns an error.
+    #[test]
+    fn test_build_runtime_env_disabled_mode() {
+        let opts = QueryOptions {
+            experimental_spill_mode: QuerySpillMode::Disabled,
+            ..Default::default()
+        };
+        let env = build_runtime_env(&opts, 0);
+
+        assert!(!env.disk_manager.tmp_files_enabled());
+        let result = env.disk_manager.create_tmp_file("test spill");
+        assert!(result.is_err());
+        assert!(format!("{}", result.unwrap_err()).contains("DiskManager is disabled"));
+    }
+
+    /// MetricsMemoryPool defaults to greedy with TrackConsumersPool wrapping.
+    #[test]
+    fn test_metrics_memory_pool_default_greedy() {
+        let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Greedy);
+        assert!(matches!(pool.memory_limit(), DfMemoryLimit::Finite(1024)));
+        // Smoke test: register a consumer and grow
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test");
+        let reservation = consumer.register(&pool);
+        pool.try_grow(&reservation, 128).unwrap();
+        assert!(pool.reserved() > 0);
+    }
+
+    /// MetricsMemoryPool with fair policy: still wrapped in TrackConsumersPool.
+    #[test]
+    fn test_metrics_memory_pool_fair() {
+        let pool = MetricsMemoryPool::new(1024, QueryMemoryPoolPolicy::Fair);
+        assert!(matches!(pool.memory_limit(), DfMemoryLimit::Finite(1024)));
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test fair");
+        let reservation = consumer.register(&pool);
+        pool.try_grow(&reservation, 128).unwrap();
+        assert!(pool.reserved() > 0);
+    }
+
+    /// Bounded fair pool rejects over-limit growth.
+    #[test]
+    fn test_metrics_memory_pool_fair_rejects_over_limit() {
+        let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Fair);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test fair oom");
+        let reservation = consumer.register(&pool);
+        let result = pool.try_grow(&reservation, 201);
+        assert!(result.is_err(), "expected error but got Ok");
+    }
+
+    /// Bounded greedy pool rejects over-limit growth.
+    #[test]
+    fn test_metrics_memory_pool_greedy_rejects_over_limit() {
+        let pool = MetricsMemoryPool::new(200, QueryMemoryPoolPolicy::Greedy);
+        let pool: Arc<dyn MemoryPool> = Arc::new(pool);
+        let consumer = MemoryConsumer::new("test greedy oom");
+        let reservation = consumer.register(&pool);
+        let result = pool.try_grow(&reservation, 201);
+        assert!(result.is_err(), "expected error but got Ok");
+    }
+
+    // --- end-to-end spill smoke test ---
+
+    /// Builds a runtime with custom spill configuration and a bounded memory
+    /// pool, then runs sort queries that probe spill-to-disk behaviour:
+    ///
+    /// - Phase 1: a pool too small to sort in-memory → OOM (proves pool active).
+    /// - Phase 2: a pool large enough for merge chunks but still much smaller
+    ///   than the total data.  Executes the physical plan directly so we can
+    ///   walk the plan tree afterwards and sum `spill_count` / `spilled_rows` /
+    ///   `spilled_bytes` on `SortExec` nodes.  All three must be > 0.
+    ///
+    /// Also checks the custom spill-path directory was initialised, pool
+    /// reserved returns to 0, and output is correctly sorted.
+    #[tokio::test]
+    async fn test_sort_spill_smoke_with_custom_runtime() {
+        // ---- shared imports (in-function to avoid polluting the module) ----
+        use arrow::array::Int32Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use datafusion::datasource::MemTable;
+        use datafusion::physical_plan::collect as df_collect;
+
+        // ---- setup: spill directory ----
+        let spill_dir =
+            std::env::temp_dir().join(format!("greptime_spill_smoke_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&spill_dir);
+
+        // ---- shared options ----
+        let opts = QueryOptions {
+            experimental_spill_mode: QuerySpillMode::Custom,
+            experimental_spill_path: Some(spill_dir.clone()),
+            experimental_spill_max_temp_directory_size: ReadableSize::gb(1),
+            experimental_memory_pool_policy: QueryMemoryPoolPolicy::Greedy,
+            ..Default::default()
+        };
+
+        // ---- shared session config ----
+        let session_config = SessionConfig::new()
+            .with_target_partitions(1)
+            .with_sort_in_place_threshold_bytes(0)
+            .with_sort_spill_reservation_bytes(64 * 1024);
+
+        // ---- data: 200 K rows Int32×2, split into 40 batches of 5 K ----
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("val", DataType::Int32, false),
+        ]));
+        let n_rows: i32 = 200_000;
+        let batch_size: i32 = 5_000;
+        let partitions = 1usize;
+
+        let mut table_partitions: Vec<Vec<RecordBatch>> = Vec::with_capacity(partitions);
+        for _ in 0..partitions {
+            let mut batches = Vec::new();
+            let mut row_offset: i32 = 0;
+            while row_offset < n_rows {
+                let chunk_end = (row_offset + batch_size).min(n_rows);
+                let chunk_len = (chunk_end - row_offset) as usize;
+                let mut id_builder = Int32Array::builder(chunk_len);
+                let mut val_builder = Int32Array::builder(chunk_len);
+                for i in row_offset..chunk_end {
+                    id_builder.append_value(i);
+                    val_builder.append_value(n_rows - 1 - i);
+                }
+                batches.push(
+                    RecordBatch::try_new(
+                        Arc::clone(&schema),
+                        vec![
+                            Arc::new(id_builder.finish()),
+                            Arc::new(val_builder.finish()),
+                        ],
+                    )
+                    .unwrap(),
+                );
+                row_offset = chunk_end;
+            }
+            table_partitions.push(batches);
+        }
+
+        // ---- helper: build a SessionContext from options + data ----
+        fn build_ctx(
+            session_config: &SessionConfig,
+            runtime: &Arc<RuntimeEnv>,
+            schema: &Arc<Schema>,
+            partitions: &[Vec<RecordBatch>],
+        ) -> SessionContext {
+            let session_state = SessionStateBuilder::new()
+                .with_config(session_config.clone())
+                .with_runtime_env(Arc::clone(runtime))
+                .with_default_features()
+                .build();
+            let ctx = SessionContext::new_with_state(session_state);
+            let table = MemTable::try_new(Arc::clone(schema), partitions.to_vec()).unwrap();
+            ctx.register_table("t", Arc::new(table)).unwrap();
+            ctx
+        }
+
+        // ---- Phase 1: 64 KB pool → OOM (proves pool is active) ----
+        {
+            let mem_limit: usize = 64 * 1024;
+            let runtime = build_runtime_env(&opts, mem_limit);
+            let ctx = build_ctx(&session_config, &runtime, &schema, &table_partitions);
+            let result = ctx
+                .sql("SELECT * FROM t ORDER BY val ASC")
+                .await
+                .unwrap()
+                .collect()
+                .await;
+            assert!(
+                result.is_err(),
+                "64 KB pool should be too small for 200K rows, but query succeeded"
+            );
+            let err_msg = format!("{}", result.unwrap_err());
+            assert!(
+                err_msg.contains("Resources exhausted") || err_msg.contains("Memory Exhausted"),
+                "error should mention resource exhaustion: {err_msg}"
+            );
+            assert_eq!(runtime.memory_pool.reserved(), 0);
+        }
+
+        // ---- Phase 2: 512 KB pool → spilling to disk ----
+        {
+            let mem_limit: usize = 512 * 1024; // 512 KB pool, 64 KB reserved for merge
+
+            let runtime = build_runtime_env(&opts, mem_limit);
+            assert_eq!(runtime.memory_pool.reserved(), 0);
+            let ctx = build_ctx(&session_config, &runtime, &schema, &table_partitions);
+
+            // Execute via direct physical-plan path so we can inspect metrics.
+            let df = ctx
+                .sql("SELECT val FROM t ORDER BY val ASC")
+                .await
+                .expect("planning ORDER BY");
+            let plan = df
+                .create_physical_plan()
+                .await
+                .expect("creating physical plan");
+            let task_ctx = ctx.task_ctx();
+
+            let batches = df_collect(Arc::clone(&plan), task_ctx)
+                .await
+                .expect("executing ORDER BY");
+
+            // ---- spill metrics on SortExec nodes ----
+            let (spill_count, spilled_rows, spilled_bytes, _sort_elapsed_ns) =
+                sum_sort_spill_metrics(&plan);
+            assert!(
+                spill_count > 0,
+                "expected SortExec spill_count > 0 (pool={} KB, reservation=64 KB), got 0",
+                mem_limit / 1024,
+            );
+            assert!(
+                spilled_rows > 0,
+                "expected SortExec spilled_rows > 0, got 0 \
+                 (spill_count={spill_count}, spilled_bytes={spilled_bytes})",
+            );
+            assert!(
+                spilled_bytes > 0,
+                "expected SortExec spilled_bytes > 0, got 0 \
+                 (spill_count={spill_count}, spilled_rows={spilled_rows})",
+            );
+
+            // ---- correctness: row count & sorted order ----
+            let vals: Vec<i32> = batches
+                .iter()
+                .flat_map(|b| {
+                    let col = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+                    (0..b.num_rows()).map(move |i| col.value(i))
+                })
+                .collect();
+            assert_eq!(vals.len(), n_rows as usize);
+            for w in vals.windows(2) {
+                assert!(w[0] <= w[1], "sort order violation: {} > {}", w[0], w[1]);
+            }
+
+            // ---- spill-path directory was initialised ----
+            assert!(
+                std::fs::read_dir(&spill_dir)
+                    .ok()
+                    .map(|mut entries| entries.any(|e| {
+                        e.as_ref()
+                            .map(|de| de.file_name().to_string_lossy().starts_with("datafusion-"))
+                            .unwrap_or(false)
+                    }))
+                    .unwrap_or(false),
+                "Expected 'datafusion-*' directory in spill path {:?} \
+                 (DiskManager should create it on build).",
+                spill_dir,
+            );
+
+            // Memory pool fully released.
+            assert_eq!(runtime.memory_pool.reserved(), 0);
+        }
+
+        // ---- cleanup ----
+        let _ = std::fs::remove_dir_all(&spill_dir);
+    }
+
+    /// Walk a physical plan tree, summing spill metrics and `elapsed_compute`
+    /// for every node whose name starts with `"SortExec"`.
+    fn sum_sort_spill_metrics(plan: &Arc<dyn ExecutionPlan>) -> (usize, usize, usize, usize) {
+        let mut spill_count = 0usize;
+        let mut spilled_rows = 0usize;
+        let mut spilled_bytes = 0usize;
+        let mut elapsed_compute_ns = 0usize;
+
+        fn walk(
+            plan: &Arc<dyn ExecutionPlan>,
+            sc: &mut usize,
+            sr: &mut usize,
+            sb: &mut usize,
+            elapsed: &mut usize,
+        ) {
+            let name = plan.name();
+            if name.starts_with("SortExec")
+                && let Some(m) = plan.metrics()
+            {
+                *sc += m.spill_count().unwrap_or(0);
+                *sr += m.spilled_rows().unwrap_or(0);
+                *sb += m.spilled_bytes().unwrap_or(0);
+                *elapsed += m.elapsed_compute().unwrap_or(0);
+            }
+            for child in plan.children() {
+                walk(child, sc, sr, sb, elapsed);
+            }
+        }
+
+        walk(
+            plan,
+            &mut spill_count,
+            &mut spilled_rows,
+            &mut spilled_bytes,
+            &mut elapsed_compute_ns,
+        );
+        (spill_count, spilled_rows, spilled_bytes, elapsed_compute_ns)
     }
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2345,6 +2345,10 @@ ttl = "2months 29days 2h 52m 48s"
 [query]
 parallelism = 0
 allow_query_fallback = false
+experimental_spill_mode = "default"
+experimental_spill_max_temp_directory_size = "100GiB"
+experimental_spill_compression = "uncompressed"
+experimental_memory_pool_policy = "greedy"
 
 [memory]
 enable_heap_profiling = true

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -2346,7 +2346,7 @@ ttl = "2months 29days 2h 52m 48s"
 parallelism = 0
 allow_query_fallback = false
 experimental_spill_mode = "default"
-experimental_spill_max_temp_directory_size = "100GiB"
+experimental_spill_max_temp_directory_size = "1GiB"
 experimental_spill_compression = "uncompressed"
 experimental_memory_pool_policy = "greedy"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Adds experimental spill-to-disk controls for DataFusion-backed queries in the open-source edition, matching the capability previously available only in the enterprise edition.

- Adds `QuerySpillMode {default, custom, disabled}`, `QuerySpillCompression {uncompressed, lz4_frame, zstd}`, and `QueryMemoryPoolPolicy {greedy, fair}` configuration enums.
- Adds five `experimental_*` keys under `[query]`: `experimental_spill_mode`, `experimental_spill_path`, `experimental_spill_max_temp_directory_size` (default 1GiB), `experimental_spill_compression`, and `experimental_memory_pool_policy`.
- Uses the existing `QueryRuntimeProvider` seam: `default` preserves DataFusion behavior; `custom` configures spill path, quota, and compression and logs the effective settings once; `disabled` installs a disabled disk manager.
- Makes `MetricsMemoryPool` policy-selectable while retaining `TrackConsumersPool` for top-consumer error context. `greedy` is first-come-first-served; `fair` divides memory remaining after unspillable reservations among spillable reservations and may spill earlier.
- Covers parsing/defaults, runtime construction, memory-pool behavior, a controlled SortExec disk-spill path with direct spill-metric assertions, and serialized defaults through the config API integration test.
- Updates all query example TOMLs and regenerates `config/config.md`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.