### PR TITLE
fix(mito2): split SSTs at primary key series boundaries

### DIFF
--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -1338,7 +1338,7 @@ mod tests {
         let mut pk_builder = BinaryDictionaryBuilder::<UInt32Type>::new();
         // Regions without a primary key encode it as empty bytes.
         for _ in 0..num_rows {
-            pk_builder.append(Vec::<u8>::new()).unwrap();
+            pk_builder.append([]).unwrap();
         }
 
         RecordBatch::try_new(

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -853,6 +853,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_multiple_files_without_primary_key() {
+        let mut env = TestEnv::new().await;
+        let object_store = env.init_object_store_manager();
+        let metadata = Arc::new(sst_region_metadata_without_primary_key());
+        let batch_rows = 1000;
+        let batches = vec![
+            new_record_batch_without_primary_key(0, batch_rows),
+            new_record_batch_without_primary_key(batch_rows, 2 * batch_rows),
+            new_record_batch_without_primary_key(2 * batch_rows, 3 * batch_rows),
+        ];
+        let total_rows = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        let source = new_flat_source_from_record_batches(batches);
+        let write_opts = WriteOptions {
+            row_group_size: 50,
+            max_file_size: Some(1),
+            ..Default::default()
+        };
+        let path_provider = RegionFilePathFactory {
+            table_dir: "test_no_primary_key".to_string(),
+            path_type: PathType::Bare,
+        };
+        let mut metrics = Metrics::new(WriteType::Compaction);
+        let mut writer = ParquetWriter::new_with_object_store(
+            object_store,
+            metadata,
+            IndexConfig::default(),
+            NoopIndexBuilder,
+            path_provider,
+            &mut metrics,
+        )
+        .await;
+
+        let files = writer
+            .write_all_flat(source, None, &write_opts)
+            .await
+            .unwrap();
+
+        // Regions without a primary key keep splitting at batch boundaries:
+        // the limit produces multiple files and no batch is sliced.
+        assert!(files.len() > 1);
+        assert!(files.iter().all(|file| file.num_rows % batch_rows == 0));
+        assert_eq!(
+            total_rows,
+            files.iter().map(|file| file.num_rows).sum::<usize>()
+        );
+    }
+
+    #[tokio::test]
     async fn test_write_read_with_index() {
         let mut env = TestEnv::new().await;
         let object_store = env.init_object_store_manager();
@@ -1250,6 +1298,62 @@ mod tests {
             pretty_format_batches(&actual).unwrap().to_string()
         );
         assert!(reader.next_record_batch().await.unwrap().is_none());
+    }
+
+    /// Creates a new region metadata without primary key for testing SSTs.
+    ///
+    /// Schema: field_0, ts
+    fn sst_region_metadata_without_primary_key() -> RegionMetadata {
+        let mut builder = RegionMetadataBuilder::new(REGION_ID);
+        builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "field_0".to_string(),
+                    ConcreteDataType::uint64_datatype(),
+                    true,
+                ),
+                semantic_type: SemanticType::Field,
+                column_id: 0,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "ts".to_string(),
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Timestamp,
+                column_id: 1,
+            })
+            .primary_key(vec![]);
+        builder.build().unwrap()
+    }
+
+    /// Creates a flat format RecordBatch for regions without a primary key.
+    fn new_record_batch_without_primary_key(start: usize, end: usize) -> RecordBatch {
+        assert!(end >= start);
+        let metadata = Arc::new(sst_region_metadata_without_primary_key());
+        let flat_schema = to_flat_sst_arrow_schema(&metadata, &FlatSchemaOptions::default());
+
+        let num_rows = end - start;
+        let mut pk_builder = BinaryDictionaryBuilder::<UInt32Type>::new();
+        // Regions without a primary key encode it as empty bytes.
+        for _ in 0..num_rows {
+            pk_builder.append(Vec::<u8>::new()).unwrap();
+        }
+
+        RecordBatch::try_new(
+            flat_schema,
+            vec![
+                Arc::new(UInt64Array::from_iter_values(start as u64..end as u64)) as ArrayRef,
+                Arc::new(TimestampMillisecondArray::from_iter_values(
+                    start as i64..end as i64,
+                )) as ArrayRef,
+                Arc::new(pk_builder.finish()) as ArrayRef,
+                Arc::new(UInt64Array::from_value(1000, num_rows)) as ArrayRef,
+                Arc::new(UInt8Array::from_value(OpType::Put as u8, num_rows)) as ArrayRef,
+            ],
+        )
+        .unwrap()
     }
 
     fn new_record_batch_from_rows(rows: &[(&str, &str, i64)]) -> RecordBatch {

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -152,6 +152,7 @@ mod tests {
     use crate::sst::index::inverted_index::applier::builder::InvertedIndexApplierBuilder;
     use crate::sst::index::{IndexBuildType, Indexer, IndexerBuilder, IndexerBuilderImpl};
     use crate::sst::parquet::flat_format::FlatWriteFormat;
+    use crate::sst::parquet::metadata::extract_primary_key_range;
     use crate::sst::parquet::reader::{ParquetReader, ParquetReaderBuilder, ReaderMetrics};
     use crate::sst::parquet::row_selection::RowGroupSelection;
     use crate::sst::parquet::writer::ParquetWriter;
@@ -687,12 +688,13 @@ mod tests {
         let object_store = env.init_object_store_manager();
         let metadata = Arc::new(sst_region_metadata());
         let batches = vec![
-            new_record_batch_by_range(&["a", "d"], 0, 1000),
-            new_record_batch_by_range(&["b", "f"], 0, 1000),
-            new_record_batch_by_range(&["c", "g"], 0, 1000),
-            new_record_batch_by_range(&["b", "h"], 100, 200),
-            new_record_batch_by_range(&["b", "h"], 200, 300),
-            new_record_batch_by_range(&["b", "h"], 300, 1000),
+            new_record_batch_by_range(&["a", "a"], 0, 1000),
+            new_record_batch_by_range(&["b", "b"], 0, 1000),
+            new_record_batch_by_range(&["c", "c"], 0, 1000),
+            new_record_batch_by_range(&["d", "d"], 100, 200),
+            new_record_batch_by_range(&["d", "d"], 200, 300),
+            new_record_batch_by_range(&["d", "d"], 300, 1000),
+            new_record_batch_by_range(&["e", "e"], 0, 100),
         ];
         let total_rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
 
@@ -743,6 +745,111 @@ mod tests {
             }
         }
         assert_eq!(total_rows, rows_read);
+    }
+
+    #[tokio::test]
+    async fn test_split_file_at_series_boundary_inside_batch() {
+        let mut env = TestEnv::new().await;
+        let object_store = env.init_object_store_manager();
+        let metadata = Arc::new(sst_region_metadata());
+        let first_batch_rows = (0..1000).map(|ts| ("a", "a", ts)).collect::<Vec<_>>();
+        let second_batch_rows = (0..1000).map(|ts| ("b", "b", ts)).collect::<Vec<_>>();
+        let mut third_batch_rows = (1000..2000).map(|ts| ("b", "b", ts)).collect::<Vec<_>>();
+        third_batch_rows.extend((0..1000).map(|ts| ("c", "c", ts)));
+        let batches = vec![
+            new_record_batch_from_rows(&first_batch_rows),
+            new_record_batch_from_rows(&second_batch_rows),
+            new_record_batch_from_rows(&third_batch_rows),
+        ];
+        let total_rows = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        let source = new_flat_source_from_record_batches(batches);
+        let write_opts = WriteOptions {
+            row_group_size: 50,
+            max_file_size: Some(1),
+            ..Default::default()
+        };
+        let path_provider = RegionFilePathFactory {
+            table_dir: "test_series_boundary".to_string(),
+            path_type: PathType::Bare,
+        };
+        let mut metrics = Metrics::new(WriteType::Compaction);
+        let mut writer = ParquetWriter::new_with_object_store(
+            object_store,
+            metadata.clone(),
+            IndexConfig::default(),
+            NoopIndexBuilder,
+            path_provider,
+            &mut metrics,
+        )
+        .await;
+
+        let files = writer
+            .write_all_flat(source, None, &write_opts)
+            .await
+            .unwrap();
+
+        assert!(files.len() > 1);
+        assert_eq!(
+            total_rows,
+            files.iter().map(|file| file.num_rows).sum::<usize>()
+        );
+        let primary_key_ranges = files
+            .iter()
+            .map(|file| {
+                extract_primary_key_range(file.file_metadata.as_ref().unwrap(), metadata.as_ref())
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            primary_key_ranges
+                .windows(2)
+                .all(|ranges| ranges[0].1 < ranges[1].0)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_oversized_single_series_stays_in_one_file() {
+        let mut env = TestEnv::new().await;
+        let object_store = env.init_object_store_manager();
+        let metadata = Arc::new(sst_region_metadata());
+        let first_batch_rows = (0..1000).map(|ts| ("a", "a", ts)).collect::<Vec<_>>();
+        let second_batch_rows = (1000..2000).map(|ts| ("a", "a", ts)).collect::<Vec<_>>();
+        let third_batch_rows = (2000..3000).map(|ts| ("a", "a", ts)).collect::<Vec<_>>();
+        let batches = vec![
+            new_record_batch_from_rows(&first_batch_rows),
+            new_record_batch_from_rows(&second_batch_rows),
+            new_record_batch_from_rows(&third_batch_rows),
+        ];
+        let total_rows = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        let source = new_flat_source_from_record_batches(batches);
+        let write_opts = WriteOptions {
+            row_group_size: 50,
+            max_file_size: Some(1),
+            ..Default::default()
+        };
+        let path_provider = RegionFilePathFactory {
+            table_dir: "test_oversized_series".to_string(),
+            path_type: PathType::Bare,
+        };
+        let mut metrics = Metrics::new(WriteType::Compaction);
+        let mut writer = ParquetWriter::new_with_object_store(
+            object_store,
+            metadata,
+            IndexConfig::default(),
+            NoopIndexBuilder,
+            path_provider,
+            &mut metrics,
+        )
+        .await;
+
+        let files = writer
+            .write_all_flat_as_primary_key(source, None, &write_opts)
+            .await
+            .unwrap();
+
+        assert_eq!(1, files.len());
+        assert_eq!(total_rows, files[0].num_rows);
+        assert!(files[0].file_size > write_opts.max_file_size.unwrap() as u64);
     }
 
     #[tokio::test]

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -536,7 +536,7 @@ where
 
     fn exceeds_max_file_size(&self, opts: &WriteOptions) -> bool {
         opts.max_file_size
-            .is_some_and(|max_size| self.bytes_written.load(Ordering::Relaxed) > max_size)
+            .is_some_and(|max_size| self.bytes_written.load(Ordering::Relaxed) >= max_size)
     }
 
     async fn abort_current_indexer(&mut self) {

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -23,11 +23,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Context, Poll};
 use std::time::Instant;
 
+use bytes::Bytes;
 use common_telemetry::debug;
 use common_time::Timestamp;
 use datatypes::arrow::array::{
-    ArrayRef, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-    TimestampSecondArray,
+    ArrayRef, BinaryArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+    TimestampNanosecondArray, TimestampSecondArray, UInt32Array,
 };
 use datatypes::arrow::compute::{max, min};
 use datatypes::arrow::datatypes::{DataType, SchemaRef, TimeUnit};
@@ -40,7 +41,7 @@ use parquet::file::metadata::KeyValue;
 use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 use parquet::schema::types::ColumnPath;
 use smallvec::smallvec;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::{OP_TYPE_COLUMN_NAME, SEQUENCE_COLUMN_NAME};
 use store_api::storage::{FileId, SequenceNumber};
@@ -50,13 +51,16 @@ use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
 use crate::access_layer::{FilePathProvider, Metrics, SstInfoArray, TempFileCleaner};
 use crate::config::{IndexBuildMode, IndexConfig};
 use crate::error::{
-    InvalidMetadataSnafu, OpenDalSnafu, Result, UnexpectedSnafu, WriteParquetSnafu,
+    InvalidMetadataSnafu, InvalidRecordBatchSnafu, OpenDalSnafu, Result, UnexpectedSnafu,
+    WriteParquetSnafu,
 };
 use crate::read::FlatSource;
 use crate::sst::file::RegionFileId;
 use crate::sst::index::{IndexOutput, Indexer, IndexerBuilder};
-use crate::sst::parquet::flat_format::{FlatWriteFormat, time_index_column_index};
-use crate::sst::parquet::format::PrimaryKeyWriteFormat;
+use crate::sst::parquet::flat_format::{
+    FlatWriteFormat, primary_key_column_index, time_index_column_index,
+};
+use crate::sst::parquet::format::{PrimaryKeyArray, PrimaryKeyWriteFormat};
 use crate::sst::parquet::{PARQUET_METADATA_KEY, SstInfo, WriteOptions};
 use crate::sst::{
     DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY, FlatSchemaOptions, SeriesEstimator,
@@ -83,6 +87,57 @@ impl FlatBatchConverter {
             }
         }
     }
+}
+
+enum SeriesBoundarySplit {
+    Continue(RecordBatch),
+    Split {
+        current_file_tail: Option<RecordBatch>,
+        next_file_head: RecordBatch,
+    },
+}
+
+fn encoded_primary_keys(batch: &RecordBatch) -> Result<(&UInt32Array, &BinaryArray)> {
+    let column = batch.column(primary_key_column_index(batch.num_columns()));
+    let primary_keys = column
+        .as_any()
+        .downcast_ref::<PrimaryKeyArray>()
+        .with_context(|| InvalidRecordBatchSnafu {
+            reason: format!(
+                "expected dictionary primary key column, got {:?}",
+                column.data_type()
+            ),
+        })?;
+    let values = primary_keys
+        .values()
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .with_context(|| InvalidRecordBatchSnafu {
+            reason: format!(
+                "expected binary primary key values, got {:?}",
+                primary_keys.values().data_type()
+            ),
+        })?;
+    Ok((primary_keys.keys(), values))
+}
+
+fn split_at_next_series(
+    batch: RecordBatch,
+    current_primary_key: &[u8],
+) -> Result<SeriesBoundarySplit> {
+    let (keys, values) = encoded_primary_keys(&batch)?;
+    let Some(offset) = (0..batch.num_rows())
+        .find(|&row| values.value(keys.value(row) as usize) != current_primary_key)
+    else {
+        return Ok(SeriesBoundarySplit::Continue(batch));
+    };
+
+    let next_file_head = batch.slice(offset, batch.num_rows() - offset);
+    let current_file_tail = (offset > 0).then(|| batch.slice(0, offset));
+    Ok(SeriesBoundarySplit::Split {
+        current_file_tail,
+        next_file_head,
+    })
 }
 
 /// Parquet SST writer.
@@ -336,36 +391,55 @@ where
         let mut results = smallvec![];
         let mut stats = SourceStats::default();
 
-        while let Some(record_batch) = self
-            .write_next_flat_batch(&mut source, converter, opts)
-            .await
-            .transpose()
-        {
-            match record_batch {
-                Ok(batch) => {
-                    stats.update_flat(&batch)?;
-                    if matches!(self.index_config.build_mode, IndexBuildMode::Sync) {
-                        let start = Instant::now();
-                        // safety: self.current_indexer must be set when first batch has been written.
-                        self.current_indexer
-                            .as_mut()
-                            .unwrap()
-                            .update_flat(&batch)
-                            .await;
-                        self.metrics.update_index += start.elapsed();
-                    }
-                    if let Some(max_file_size) = opts.max_file_size
-                        && self.bytes_written.load(Ordering::Relaxed) > max_file_size
-                    {
-                        self.finish_current_file(&mut results, &mut stats).await?;
-                    }
-                }
+        loop {
+            let start = Instant::now();
+            let batch = match source.next_batch().await {
+                Ok(Some(batch)) => batch,
+                Ok(None) => break,
                 Err(e) => {
-                    if let Some(indexer) = &mut self.current_indexer {
-                        indexer.abort().await;
-                    }
+                    self.abort_current_indexer().await;
                     return Err(e);
                 }
+            };
+            self.metrics.iter_source += start.elapsed();
+
+            if self.metadata.primary_key.is_empty() {
+                self.append_flat_batch(&batch, converter, opts, &mut stats)
+                    .await?;
+                if self.exceeds_max_file_size(opts) {
+                    self.finish_current_file(&mut results, &mut stats).await?;
+                }
+            } else if self.exceeds_max_file_size(opts)
+                && let Some(current_primary_key) = stats.last_primary_key.as_deref()
+            {
+                let series_split = match split_at_next_series(batch, current_primary_key) {
+                    Ok(series_split) => series_split,
+                    Err(e) => {
+                        self.abort_current_indexer().await;
+                        return Err(e);
+                    }
+                };
+                match series_split {
+                    SeriesBoundarySplit::Continue(batch) => {
+                        self.append_flat_batch(&batch, converter, opts, &mut stats)
+                            .await?;
+                    }
+                    SeriesBoundarySplit::Split {
+                        current_file_tail,
+                        next_file_head,
+                    } => {
+                        if let Some(tail) = current_file_tail {
+                            self.append_flat_batch(&tail, converter, opts, &mut stats)
+                                .await?;
+                        }
+                        self.finish_current_file(&mut results, &mut stats).await?;
+                        self.append_flat_batch(&next_file_head, converter, opts, &mut stats)
+                            .await?;
+                    }
+                }
+            } else {
+                self.append_flat_batch(&batch, converter, opts, &mut stats)
+                    .await?;
             }
         }
 
@@ -398,29 +472,53 @@ where
             .set_column_compression(op_type_col, Compression::UNCOMPRESSED)
     }
 
-    async fn write_next_flat_batch(
+    async fn append_flat_batch(
         &mut self,
-        source: &mut FlatSource,
+        batch: &RecordBatch,
         converter: &FlatBatchConverter,
         opts: &WriteOptions,
-    ) -> Result<Option<RecordBatch>> {
-        let start = Instant::now();
-        let Some(record_batch) = source.next_batch().await? else {
-            return Ok(None);
-        };
-        self.metrics.iter_source += start.elapsed();
+        stats: &mut SourceStats,
+    ) -> Result<()> {
+        let result = async {
+            let arrow_batch = converter.convert_batch(batch)?;
+            let start = Instant::now();
+            self.maybe_init_writer(arrow_batch.schema_ref(), opts)
+                .await?
+                .write(&arrow_batch)
+                .await
+                .context(WriteParquetSnafu)?;
+            self.metrics.write_batch += start.elapsed();
 
-        let arrow_batch = converter.convert_batch(&record_batch)?;
+            stats.update_flat(batch)?;
+            if matches!(self.index_config.build_mode, IndexBuildMode::Sync) {
+                let start = Instant::now();
+                // safety: self.current_indexer must be set when first batch has been written.
+                self.current_indexer
+                    .as_mut()
+                    .unwrap()
+                    .update_flat(batch)
+                    .await;
+                self.metrics.update_index += start.elapsed();
+            }
+            Ok(())
+        }
+        .await;
 
-        let start = Instant::now();
-        self.maybe_init_writer(arrow_batch.schema_ref(), opts)
-            .await?
-            .write(&arrow_batch)
-            .await
-            .context(WriteParquetSnafu)?;
-        self.metrics.write_batch += start.elapsed();
-        // Return original flat batch for stats/indexer which use flat layout.
-        Ok(Some(record_batch))
+        if result.is_err() {
+            self.abort_current_indexer().await;
+        }
+        result
+    }
+
+    fn exceeds_max_file_size(&self, opts: &WriteOptions) -> bool {
+        opts.max_file_size
+            .is_some_and(|max_size| self.bytes_written.load(Ordering::Relaxed) > max_size)
+    }
+
+    async fn abort_current_indexer(&mut self) {
+        if let Some(indexer) = &mut self.current_indexer {
+            indexer.abort().await;
+        }
     }
 
     async fn maybe_init_writer(
@@ -481,6 +579,8 @@ struct SourceStats {
     num_rows: usize,
     /// Time range of fetched batches.
     time_range: Option<(Timestamp, Timestamp)>,
+    /// Last primary key written to the current file.
+    last_primary_key: Option<Bytes>,
     /// Series estimator for computing num_series.
     series_estimator: SeriesEstimator,
 }
@@ -493,6 +593,9 @@ impl SourceStats {
 
         self.num_rows += record_batch.num_rows();
         self.series_estimator.update_flat(record_batch);
+        let (keys, values) = encoded_primary_keys(record_batch)?;
+        let key = keys.value(record_batch.num_rows() - 1);
+        self.last_primary_key = Some(Bytes::copy_from_slice(values.value(key as usize)));
 
         // Get the timestamp column by index
         let time_index_col_idx = time_index_column_index(record_batch.num_columns());

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -89,14 +89,20 @@ impl FlatBatchConverter {
     }
 }
 
+/// Result of splitting a batch at the next series boundary.
 enum SeriesBoundarySplit {
+    /// The whole batch belongs to the current series and stays in the current file.
     Continue(RecordBatch),
+    /// The batch crosses a series boundary.
     Split {
+        /// Remaining rows of the current series, appended to the current file.
         current_file_tail: Option<RecordBatch>,
+        /// Rows of the following series that start the next file.
         next_file_head: RecordBatch,
     },
 }
 
+/// Returns the dictionary keys and values of the encoded `__primary_key` column.
 fn encoded_primary_keys(batch: &RecordBatch) -> Result<(&UInt32Array, &BinaryArray)> {
     let column = batch.column(primary_key_column_index(batch.num_columns()));
     let primary_keys = column
@@ -121,6 +127,14 @@ fn encoded_primary_keys(batch: &RecordBatch) -> Result<(&UInt32Array, &BinaryArr
     Ok((primary_keys.keys(), values))
 }
 
+/// Splits `batch` at the first row whose encoded primary key differs from
+/// `current_primary_key`, the last primary key written to the current file.
+///
+/// The writer finishes an oversized file at such a series boundary so that the
+/// primary key ranges of output files never overlap, which allows pickers like
+/// TWCS to detect overlapping files by their time and primary key ranges. A
+/// series is never split in the middle: if no row starts a new series, the whole
+/// batch stays in the current file even if it already exceeds the size limit.
 fn split_at_next_series(
     batch: RecordBatch,
     current_primary_key: &[u8],
@@ -324,6 +338,13 @@ where
 
     /// Iterates FlatSource and writes all RecordBatch in flat format to Parquet file.
     ///
+    /// The source must yield batches globally sorted by the encoded primary key.
+    /// `opts.max_file_size` is a soft limit for regions with a primary key: the
+    /// current file is finished at the next series boundary after exceeding the
+    /// limit (see [split_at_next_series]), so a series larger than the limit
+    /// stays in one file. Regions without a primary key are split at batch
+    /// boundaries.
+    ///
     /// Returns the [SstInfo] if the SST is written.
     pub async fn write_all_flat(
         &mut self,
@@ -358,6 +379,9 @@ where
     }
 
     /// Iterates FlatSource and writes all RecordBatch in primary-key format to Parquet file.
+    ///
+    /// The source must yield batches globally sorted by the encoded primary key.
+    /// See [Self::write_all_flat] for the `opts.max_file_size` semantics.
     ///
     /// Returns the [SstInfo] if the SST is written.
     pub async fn write_all_flat_as_primary_key(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

**Summary**

When a compaction/flush output file exceeds `max_file_size`, the parquet writer finishes the file right after the current batch, which may cut a primary-key series across two output files. The two files then share the same boundary primary key, so their `(time range, primary key range)` boxes overlap and TWCS can no longer tell whether the files are truly disjoint.

This PR makes the writer split oversized output files at series boundaries:

- For regions with a primary key, once the current file exceeds `max_file_size`, the writer remembers the last encoded primary key and finishes the file at the first row with a different primary key in the next batch. `max_file_size` becomes a soft limit: a single series larger than the limit stays in one file and is never split in the middle.
- For regions without a primary key, output is globally ordered by timestamp, so the previous batch-boundary split behavior is kept.

**How it works**

- `SourceStats` tracks the last encoded primary key written to the current file.
- Before feeding the next batch to an oversized file, `split_at_next_series` scans the batch for the first row with a different encoded primary key and slices the batch in zero-copy fashion (`RecordBatch::slice`): the tail of the current series goes to the current file, and the remaining rows start the next file.
- Stats and index updates are applied per slice so each output file records correct metadata.

This PR does not change any persisted or wire format. `FileMeta` already persists primary key ranges; this PR only guarantees they are disjoint between adjacent output files, which paves the way for removing the sequence-based file grouping in compaction.

**Testing**

- A regression test for splitting at a series boundary inside a batch, verifying row conservation and strictly disjoint primary key ranges of adjacent files, for both flat and primary-key SST formats.
- A test that an oversized single series stays in one file.
- A test that regions without a primary key keep splitting at batch boundaries.
- `cargo nextest run -p mito2` passes (1113 tests).

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.