### PR TITLE
feat(auth): support bearer token authentication over SQL protocols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "opensrv-mysql"
 version = "0.8.0"
-source = "git+https://github.com/GreptimeTeam/opensrv?rev=1f2ce54edc0324871bf43b2c63c16f9107ddfc15#1f2ce54edc0324871bf43b2c63c16f9107ddfc15"
+source = "git+https://github.com/GreptimeTeam/opensrv?rev=f3135e5f00401e06075cf241c0cc26489e45b20a#f3135e5f00401e06075cf241c0cc26489e45b20a"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "opensrv-mysql"
 version = "0.8.0"
-source = "git+https://github.com/GreptimeTeam/opensrv?rev=6c5a451544194b7bb60a8318d155d4f892b49f2c#6c5a451544194b7bb60a8318d155d4f892b49f2c"
+source = "git+https://github.com/GreptimeTeam/opensrv?rev=1f2ce54edc0324871bf43b2c63c16f9107ddfc15#1f2ce54edc0324871bf43b2c63c16f9107ddfc15"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/src/auth/src/common.rs
+++ b/src/auth/src/common.rs
@@ -129,6 +129,46 @@ pub fn auth_mysql(
     auth_mysql_with_hash_stage_2(auth_data, salt, username, &hash_stage_2)
 }
 
+/// Authenticates a MySQL native password response against an encoded verifier.
+pub fn auth_mysql_with_verifier(
+    auth_data: HashedPassword,
+    salt: Salt,
+    username: &str,
+    verifier: &str,
+) -> Result<()> {
+    let hash_stage_2 = parse_mysql_native_password_verifier(verifier)?;
+    auth_mysql_with_hash_stage_2(auth_data, salt, username, &hash_stage_2)
+}
+
+pub fn validate_mysql_native_password_verifier(verifier: &str) -> Result<()> {
+    parse_mysql_native_password_verifier(verifier).map(|_| ())
+}
+
+pub(crate) fn parse_mysql_native_password_verifier(verifier: &str) -> Result<Vec<u8>> {
+    let Some(verifier) = verifier.strip_prefix("mysql_native_password:") else {
+        return InvalidConfigSnafu {
+            value: "mysql_native_password".to_string(),
+            msg: "Invalid mysql native password verifier format",
+        }
+        .fail();
+    };
+    let Ok(hash_stage_2) = hex::decode(verifier) else {
+        return InvalidConfigSnafu {
+            value: "mysql_native_password".to_string(),
+            msg: "Invalid mysql native password verifier encoding",
+        }
+        .fail();
+    };
+    ensure!(
+        hash_stage_2.len() == 20,
+        InvalidConfigSnafu {
+            value: "mysql_native_password".to_string(),
+            msg: "Illegal mysql native password verifier length",
+        }
+    );
+    Ok(hash_stage_2)
+}
+
 pub(crate) fn auth_mysql_with_hash_stage_2(
     auth_data: HashedPassword,
     salt: Salt,
@@ -363,6 +403,45 @@ pub fn format_pg_scram_sha256_password_verifier(
     ))
 }
 
+/// Parses and validates an encoded PostgreSQL SCRAM-SHA-256 verifier.
+pub fn parse_pg_scram_sha256_password_verifier(verifier: &str) -> Result<PgScramSha256Verifier> {
+    let Some(verifier) = verifier.strip_prefix("pg_scram_sha256:") else {
+        return InvalidConfigSnafu {
+            value: "pg_scram_sha256".to_string(),
+            msg: "Invalid pg scram sha256 verifier format",
+        }
+        .fail();
+    };
+    let mut parts = verifier.split(':');
+    let (Some(iterations), Some(salt), Some(stored_key), Some(server_key), None) = (
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+        parts.next(),
+    ) else {
+        return InvalidConfigSnafu {
+            value: "pg_scram_sha256".to_string(),
+            msg: "Invalid pg scram sha256 verifier format",
+        }
+        .fail();
+    };
+    let (Ok(iterations), Ok(salt), Ok(stored_key), Ok(server_key)) = (
+        iterations.parse::<u32>(),
+        hex::decode(salt),
+        hex::decode(stored_key),
+        hex::decode(server_key),
+    ) else {
+        return InvalidConfigSnafu {
+            value: "pg_scram_sha256".to_string(),
+            msg: "Invalid pg scram sha256 verifier encoding",
+        }
+        .fail();
+    };
+
+    PgScramSha256Verifier::new(iterations, salt, stored_key, server_key)
+}
+
 fn pg_scram_sha256_salted_password(
     password: &[u8],
     salt: &[u8],
@@ -437,6 +516,17 @@ fn double_sha1(data: &[u8]) -> Vec<u8> {
 mod tests {
     use super::*;
 
+    fn mysql_native_password_auth_data(password: &[u8], salt: &[u8]) -> Vec<u8> {
+        let hash_stage_1 = sha1_one(password);
+        let hash_stage_2 = mysql_native_password_hash(password);
+        let scramble = sha1_two(salt, &hash_stage_2);
+        hash_stage_1
+            .iter()
+            .zip(scramble)
+            .map(|(lhs, rhs)| lhs ^ rhs)
+            .collect()
+    }
+
     #[test]
     fn test_sha() {
         let sha_1_answer: Vec<u8> = vec![
@@ -467,6 +557,24 @@ mod tests {
         assert_eq!(
             "mysql_native_password:6bb4837eb74329105ee4568dda7dc67ed2ca2ad9",
             verifier
+        );
+        assert_eq!(
+            mysql_native_password_hash(b"123456"),
+            parse_mysql_native_password_verifier(&verifier).unwrap()
+        );
+        assert!(parse_mysql_native_password_verifier("mysql_native_password:00").is_err());
+
+        let salt = b"01234567890123456789";
+        let auth_data = mysql_native_password_auth_data(b"123456", salt);
+        auth_mysql_with_verifier(&auth_data, salt, "greptime", &verifier).unwrap();
+        assert!(
+            auth_mysql_with_verifier(
+                &auth_data,
+                salt,
+                "greptime",
+                &format_mysql_native_password_verifier(b"wrong")
+            )
+            .is_err()
         );
     }
 
@@ -499,6 +607,10 @@ mod tests {
             "pg_scram_sha256:4096:73616c74:945e1c466fc9932efadc23781edc5d1e78d5e10f005933652af1a6105154f084:b9bf0e811b1fb6793671c0cc3adedf7c75cd72291191092ad65878c5a02aad2c",
             verifier
         );
+        let parsed = parse_pg_scram_sha256_password_verifier(&verifier).unwrap();
+        assert_eq!(4096, parsed.iterations());
+        assert_eq!(b"salt", parsed.salt());
+        assert!(parse_pg_scram_sha256_password_verifier("pg_scram_sha256:bad").is_err());
     }
 
     #[test]

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -24,10 +24,11 @@ pub mod tests;
 pub use common::{
     DEFAULT_PBKDF2_SHA256_ITERATIONS, DEFAULT_PBKDF2_SHA256_SALT_LEN, HashedPassword, Identity,
     MAX_PBKDF2_SHA256_ITERATIONS, MAX_PBKDF2_SHA256_SALT_LEN, PBKDF2_SHA256_HASH_LEN,
-    PG_SCRAM_SHA256_KEY_LEN, Password, PgScramSha256Verifier, auth_mysql,
+    PG_SCRAM_SHA256_KEY_LEN, Password, PgScramSha256Verifier, auth_mysql, auth_mysql_with_verifier,
     format_mysql_native_password_verifier, format_pbkdf2_sha256_password_verifier,
     format_pg_scram_sha256_password_verifier, mysql_native_password_hash,
-    static_user_provider_from_option, user_provider_from_option, userinfo_by_name,
+    parse_pg_scram_sha256_password_verifier, static_user_provider_from_option,
+    user_provider_from_option, userinfo_by_name, validate_mysql_native_password_verifier,
 };
 pub use permission::{
     ALL_ACTIONS, AccessMode, DASHBOARD_DELETE, DASHBOARD_QUERY, DASHBOARD_SAVE,
@@ -38,7 +39,7 @@ pub use permission::{
 };
 pub use user_info::UserInfo;
 pub use user_provider::static_user_provider::StaticUserProvider;
-pub use user_provider::{PgAuthInfo, UserProvider};
+pub use user_provider::{MysqlAuthMethod, PgAuthInfo, UserProvider};
 
 /// pub type alias
 pub type UserInfoRef = std::sync::Arc<dyn UserInfo>;

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -39,7 +39,7 @@ pub use permission::{
 };
 pub use user_info::UserInfo;
 pub use user_provider::static_user_provider::StaticUserProvider;
-pub use user_provider::{MysqlAuthMethod, PgAuthInfo, UserProvider};
+pub use user_provider::{BEARER_TOKEN_USER, MysqlAuthMethod, PgAuthInfo, UserProvider};
 
 /// pub type alias
 pub type UserInfoRef = std::sync::Arc<dyn UserInfo>;

--- a/src/auth/src/user_provider.rs
+++ b/src/auth/src/user_provider.rs
@@ -30,8 +30,9 @@ use subtle::ConstantTimeEq;
 
 use crate::common::{
     DEFAULT_PBKDF2_SHA256_SALT_LEN, Identity, MAX_PBKDF2_SHA256_ITERATIONS,
-    MAX_PBKDF2_SHA256_SALT_LEN, PBKDF2_SHA256_HASH_LEN, PG_SCRAM_SHA256_KEY_LEN, Password,
-    PgScramSha256Verifier, auth_mysql_with_hash_stage_2,
+    MAX_PBKDF2_SHA256_SALT_LEN, PBKDF2_SHA256_HASH_LEN, Password, PgScramSha256Verifier,
+    auth_mysql_with_hash_stage_2, parse_mysql_native_password_verifier,
+    parse_pg_scram_sha256_password_verifier,
 };
 use crate::error::{
     IllegalParamSnafu, InvalidConfigSnafu, IoSnafu, Result, UnsupportedAuthMethodSnafu,
@@ -91,7 +92,15 @@ pub trait UserProvider: Send + Sync {
         .fail()
     }
 
-    async fn postgres_auth_info(&self, _id: Identity<'_>) -> Result<PgAuthInfo> {
+    fn mysql_auth_method(&self) -> MysqlAuthMethod {
+        if self.external() {
+            MysqlAuthMethod::ClearPassword
+        } else {
+            MysqlAuthMethod::NativePassword
+        }
+    }
+
+    async fn postgres_auth_info(&self, _id: Identity<'_>, _catalog: &str) -> Result<PgAuthInfo> {
         Ok(PgAuthInfo::Cleartext)
     }
 
@@ -99,6 +108,12 @@ pub trait UserProvider: Send + Sync {
     fn external(&self) -> bool {
         false
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MysqlAuthMethod {
+    NativePassword,
+    ClearPassword,
 }
 
 pub enum PgAuthInfo {
@@ -231,29 +246,13 @@ impl PasswordVerifier {
             });
         }
 
-        if let Some(verifier) = input.strip_prefix("mysql_native_password:") {
-            let hash_stage_2 = hex::decode(verifier).ok()?;
-            if hash_stage_2.len() != 20 {
-                return None;
-            }
-
+        if input.starts_with("mysql_native_password:") {
+            let hash_stage_2 = parse_mysql_native_password_verifier(input).ok()?;
             return Some(Self::MysqlNativePassword { hash_stage_2 });
         }
 
-        if let Some(verifier) = input.strip_prefix("pg_scram_sha256:") {
-            let mut parts = verifier.split(':');
-            let iterations = parts.next()?.parse::<u32>().ok()?;
-            let salt = hex::decode(parts.next()?).ok()?;
-            let stored_key = hex::decode(parts.next()?).ok()?;
-            let server_key = hex::decode(parts.next()?).ok()?;
-            if parts.next().is_some()
-                || stored_key.len() != PG_SCRAM_SHA256_KEY_LEN
-                || server_key.len() != PG_SCRAM_SHA256_KEY_LEN
-            {
-                return None;
-            }
-
-            return PgScramSha256Verifier::new(iterations, salt, stored_key, server_key)
+        if input.starts_with("pg_scram_sha256:") {
+            return parse_pg_scram_sha256_password_verifier(input)
                 .ok()
                 .map(Self::PgScramSha256);
         }

--- a/src/auth/src/user_provider.rs
+++ b/src/auth/src/user_provider.rs
@@ -131,6 +131,19 @@ pub enum MysqlAuthMethod {
     ClearPassword,
 }
 
+impl MysqlAuthMethod {
+    pub const NATIVE_PASSWORD_PLUGIN: &'static str = "mysql_native_password";
+    pub const CLEAR_PASSWORD_PLUGIN: &'static str = "mysql_clear_password";
+
+    /// Returns the MySQL authentication plugin name sent on the wire.
+    pub const fn plugin_name(self) -> &'static str {
+        match self {
+            Self::NativePassword => Self::NATIVE_PASSWORD_PLUGIN,
+            Self::ClearPassword => Self::CLEAR_PASSWORD_PLUGIN,
+        }
+    }
+}
+
 pub enum PgAuthInfo {
     ScramSha256 {
         verifier: PgScramSha256Verifier,

--- a/src/auth/src/user_provider.rs
+++ b/src/auth/src/user_provider.rs
@@ -41,6 +41,14 @@ use crate::error::{
 use crate::user_info::{DefaultUserInfo, PermissionMode};
 use crate::{UserInfoRef, auth_mysql};
 
+/// Reserved SQL-protocol username selecting bearer-token authentication.
+///
+/// User providers must not define this as a password-authenticated user.
+/// SQL servers carry the token through their clear-password exchange; this
+/// selector does not itself require TLS, so transport policy remains a server
+/// deployment choice.
+pub const BEARER_TOKEN_USER: &str = "*";
+
 #[async_trait::async_trait]
 pub trait UserProvider: Send + Sync {
     fn name(&self) -> &str;
@@ -67,8 +75,8 @@ pub trait UserProvider: Send + Sync {
         Ok(user_info)
     }
 
-    /// Authenticates and authorizes an opaque bearer token (e.g. a JWT or an
-    /// OAuth2 access token).
+    /// Authenticates an opaque bearer token (e.g. a JWT or an OAuth2 access
+    /// token) and derives its user identity.
     ///
     /// Unlike [auth()](Self::auth), the caller has no `Identity`/`Password` —
     /// the provider validates the token and *derives* the identity from it.
@@ -78,18 +86,25 @@ pub trait UserProvider: Send + Sync {
     /// The default rejects token auth with
     /// [`Error::UnsupportedAuthMethod`], so password-only providers keep
     /// today's behavior. Providers that support token auth override this to
-    /// validate the token, resolve it to a user, and
-    /// [`authorize`](Self::authorize) the connection.
-    async fn auth_bearer_token(
-        &self,
-        _token: &str,
-        _catalog: &str,
-        _schema: &str,
-    ) -> Result<UserInfoRef> {
+    /// validate the token and resolve it to a user.
+    async fn authenticate_bearer_token(&self, _token: &str, _catalog: &str) -> Result<UserInfoRef> {
         UnsupportedAuthMethodSnafu {
             method: "bearer token",
         }
         .fail()
+    }
+
+    /// Combination of [`authenticate_bearer_token`](Self::authenticate_bearer_token)
+    /// and [`authorize`](Self::authorize).
+    async fn auth_bearer_token(
+        &self,
+        token: &str,
+        catalog: &str,
+        schema: &str,
+    ) -> Result<UserInfoRef> {
+        let user_info = self.authenticate_bearer_token(token, catalog).await?;
+        self.authorize(catalog, schema, &user_info).await?;
+        Ok(user_info)
     }
 
     fn mysql_auth_method(&self) -> MysqlAuthMethod {

--- a/src/auth/src/user_provider/static_user_provider.rs
+++ b/src/auth/src/user_provider/static_user_provider.rs
@@ -71,7 +71,7 @@ impl UserProvider for StaticUserProvider {
         authenticate_with_credential(&self.users, id, pwd)
     }
 
-    async fn postgres_auth_info(&self, id: Identity<'_>) -> Result<PgAuthInfo> {
+    async fn postgres_auth_info(&self, id: Identity<'_>, _catalog: &str) -> Result<PgAuthInfo> {
         postgres_auth_info_with_credential(&self.users, id)
     }
 

--- a/src/auth/src/user_provider/watch_file_user_provider.rs
+++ b/src/auth/src/user_provider/watch_file_user_provider.rs
@@ -86,7 +86,7 @@ impl UserProvider for WatchFileUserProvider {
         authenticate_with_credential(&users, id, password)
     }
 
-    async fn postgres_auth_info(&self, id: Identity<'_>) -> Result<PgAuthInfo> {
+    async fn postgres_auth_info(&self, id: Identity<'_>, _catalog: &str) -> Result<PgAuthInfo> {
         let users = self.users.lock().expect("users credential must be valid");
         postgres_auth_info_with_credential(&users, id)
     }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -88,7 +88,7 @@ notify.workspace = true
 object-pool = "0.5"
 once_cell.workspace = true
 # Wait for https://github.com/databendlabs/opensrv/pull/81
-opensrv-mysql = { git = "https://github.com/GreptimeTeam/opensrv", rev = "6c5a451544194b7bb60a8318d155d4f892b49f2c" }
+opensrv-mysql = { git = "https://github.com/GreptimeTeam/opensrv", rev = "1f2ce54edc0324871bf43b2c63c16f9107ddfc15" }
 opentelemetry-proto.workspace = true
 operator.workspace = true
 otel-arrow-rust.workspace = true

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -88,7 +88,7 @@ notify.workspace = true
 object-pool = "0.5"
 once_cell.workspace = true
 # Wait for https://github.com/databendlabs/opensrv/pull/81
-opensrv-mysql = { git = "https://github.com/GreptimeTeam/opensrv", rev = "1f2ce54edc0324871bf43b2c63c16f9107ddfc15" }
+opensrv-mysql = { git = "https://github.com/GreptimeTeam/opensrv", rev = "f3135e5f00401e06075cf241c0cc26489e45b20a" }
 opentelemetry-proto.workspace = true
 operator.workspace = true
 otel-arrow-rust.workspace = true

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
-use ::auth::{Identity, Password, UserProviderRef};
+use ::auth::{Identity, MysqlAuthMethod, Password, UserProviderRef};
 use async_trait::async_trait;
 use chrono::{NaiveDate, NaiveDateTime};
 use common_catalog::parse_optional_catalog_and_schema_from_db_string;
@@ -349,15 +349,14 @@ impl MysqlInstanceShim {
     }
 
     fn auth_plugin(&self) -> &'static str {
-        if self
+        match self
             .user_provider
             .as_ref()
-            .map(|x| x.external())
-            .unwrap_or(false)
+            .map(|provider| provider.mysql_auth_method())
+            .unwrap_or(MysqlAuthMethod::NativePassword)
         {
-            MYSQL_CLEAR_PASSWORD
-        } else {
-            MYSQL_NATIVE_PASSWORD
+            MysqlAuthMethod::NativePassword => MYSQL_NATIVE_PASSWORD,
+            MysqlAuthMethod::ClearPassword => MYSQL_CLEAR_PASSWORD,
         }
     }
 }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
-use ::auth::{Identity, MysqlAuthMethod, Password, UserProviderRef};
+use ::auth::{BEARER_TOKEN_USER, Identity, MysqlAuthMethod, Password, UserProviderRef};
 use async_trait::async_trait;
 use chrono::{NaiveDate, NaiveDateTime};
 use common_catalog::parse_optional_catalog_and_schema_from_db_string;
@@ -349,12 +349,16 @@ impl MysqlInstanceShim {
     }
 
     fn auth_plugin(&self) -> &'static str {
-        match self
-            .user_provider
-            .as_ref()
-            .map(|provider| provider.mysql_auth_method())
-            .unwrap_or(MysqlAuthMethod::NativePassword)
-        {
+        self.auth_plugin_for_method(
+            self.user_provider
+                .as_ref()
+                .map(|provider| provider.mysql_auth_method())
+                .unwrap_or(MysqlAuthMethod::NativePassword),
+        )
+    }
+
+    fn auth_plugin_for_method(&self, method: MysqlAuthMethod) -> &'static str {
+        match method {
             MysqlAuthMethod::NativePassword => MYSQL_NATIVE_PASSWORD,
             MysqlAuthMethod::ClearPassword => MYSQL_CLEAR_PASSWORD,
         }
@@ -377,7 +381,10 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
         self.auth_plugin()
     }
 
-    async fn auth_plugin_for_username(&self, _user: &[u8]) -> &'static str {
+    async fn auth_plugin_for_username(&self, user: &[u8]) -> &'static str {
+        if user == BEARER_TOKEN_USER.as_bytes() {
+            return MYSQL_CLEAR_PASSWORD;
+        }
         self.auth_plugin()
     }
 
@@ -402,26 +409,38 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
             .client_addr
             .map(|addr| addr.to_string());
         if let Some(user_provider) = &self.user_provider {
-            let user_id = Identity::UserId(&username, addr.as_deref());
-
-            let password = match auth_plugin {
-                MYSQL_NATIVE_PASSWORD => Password::MysqlNativePassword(auth_data, salt),
-                MYSQL_CLEAR_PASSWORD => {
-                    // The raw bytes received could be represented in C-like string, ended in '\0'.
-                    // We must "trim" it to get the real password string.
-                    let password = if let &[password @ .., 0] = &auth_data {
-                        password
-                    } else {
-                        auth_data
-                    };
-                    Password::PlainText(String::from_utf8_lossy(password).to_string().into())
-                }
-                other => {
-                    error!("Unsupported mysql auth plugin: {}", other);
+            let result = if username.as_ref() == BEARER_TOKEN_USER {
+                if auth_plugin != MYSQL_CLEAR_PASSWORD {
+                    warn!("Bearer-token MySQL authentication requires mysql_clear_password");
                     return false;
                 }
+                let token = auth_data.strip_suffix(&[0]).unwrap_or(auth_data);
+                let Ok(token) = std::str::from_utf8(token) else {
+                    warn!("Bearer token is not valid UTF-8");
+                    return false;
+                };
+                let catalog = self.session.catalog();
+                user_provider
+                    .authenticate_bearer_token(token, &catalog)
+                    .await
+            } else {
+                let user_id = Identity::UserId(&username, addr.as_deref());
+                let password = match auth_plugin {
+                    MYSQL_NATIVE_PASSWORD => Password::MysqlNativePassword(auth_data, salt),
+                    MYSQL_CLEAR_PASSWORD => {
+                        // The raw bytes received could be represented in C-like string, ended in '\0'.
+                        // We must "trim" it to get the real password string.
+                        let password = auth_data.strip_suffix(&[0]).unwrap_or(auth_data);
+                        Password::PlainText(String::from_utf8_lossy(password).to_string().into())
+                    }
+                    other => {
+                        error!("Unsupported mysql auth plugin: {}", other);
+                        return false;
+                    }
+                };
+                user_provider.authenticate(user_id, password).await
             };
-            match user_provider.authenticate(user_id, password).await {
+            match result {
                 Ok(userinfo) => {
                     user_info = Some(userinfo);
                 }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -388,6 +388,25 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
         salt: &[u8],
         auth_data: &[u8],
     ) -> bool {
+        <Self as AsyncMysqlShim<W>>::authenticate_with_database(
+            self,
+            auth_plugin,
+            username,
+            salt,
+            auth_data,
+            None,
+        )
+        .await
+    }
+
+    async fn authenticate_with_database(
+        &self,
+        auth_plugin: &str,
+        username: &[u8],
+        salt: &[u8],
+        auth_data: &[u8],
+        database: Option<&[u8]>,
+    ) -> bool {
         // if not specified then **greptime** will be used
         let username = String::from_utf8_lossy(username);
 
@@ -408,7 +427,17 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
                     warn!("Bearer token is not valid UTF-8");
                     return false;
                 };
-                let catalog = self.session.catalog();
+                let catalog = if let Some(database) = database {
+                    let Ok(database) = std::str::from_utf8(database) else {
+                        warn!("MySQL database is not valid UTF-8");
+                        return false;
+                    };
+                    parse_optional_catalog_and_schema_from_db_string(database)
+                        .0
+                        .unwrap_or_else(|| self.session.catalog())
+                } else {
+                    self.session.catalog()
+                };
                 user_provider
                     .authenticate_bearer_token(token, &catalog)
                     .await

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -58,9 +58,6 @@ use crate::mysql::writer;
 use crate::mysql::writer::{create_mysql_column, handle_err};
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 
-const MYSQL_NATIVE_PASSWORD: &str = "mysql_native_password";
-const MYSQL_CLEAR_PASSWORD: &str = "mysql_clear_password";
-
 /// Parameters for the prepared statement
 enum Params<'a> {
     /// Parameters passed through protocol
@@ -349,19 +346,11 @@ impl MysqlInstanceShim {
     }
 
     fn auth_plugin(&self) -> &'static str {
-        self.auth_plugin_for_method(
-            self.user_provider
-                .as_ref()
-                .map(|provider| provider.mysql_auth_method())
-                .unwrap_or(MysqlAuthMethod::NativePassword),
-        )
-    }
-
-    fn auth_plugin_for_method(&self, method: MysqlAuthMethod) -> &'static str {
-        match method {
-            MysqlAuthMethod::NativePassword => MYSQL_NATIVE_PASSWORD,
-            MysqlAuthMethod::ClearPassword => MYSQL_CLEAR_PASSWORD,
-        }
+        self.user_provider
+            .as_ref()
+            .map(|provider| provider.mysql_auth_method())
+            .unwrap_or(MysqlAuthMethod::NativePassword)
+            .plugin_name()
     }
 }
 
@@ -383,7 +372,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
 
     async fn auth_plugin_for_username(&self, user: &[u8]) -> &'static str {
         if user == BEARER_TOKEN_USER.as_bytes() {
-            return MYSQL_CLEAR_PASSWORD;
+            return MysqlAuthMethod::ClearPassword.plugin_name();
         }
         self.auth_plugin()
     }
@@ -410,7 +399,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
             .map(|addr| addr.to_string());
         if let Some(user_provider) = &self.user_provider {
             let result = if username.as_ref() == BEARER_TOKEN_USER {
-                if auth_plugin != MYSQL_CLEAR_PASSWORD {
+                if auth_plugin != MysqlAuthMethod::CLEAR_PASSWORD_PLUGIN {
                     warn!("Bearer-token MySQL authentication requires mysql_clear_password");
                     return false;
                 }
@@ -426,8 +415,10 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
             } else {
                 let user_id = Identity::UserId(&username, addr.as_deref());
                 let password = match auth_plugin {
-                    MYSQL_NATIVE_PASSWORD => Password::MysqlNativePassword(auth_data, salt),
-                    MYSQL_CLEAR_PASSWORD => {
+                    MysqlAuthMethod::NATIVE_PASSWORD_PLUGIN => {
+                        Password::MysqlNativePassword(auth_data, salt)
+                    }
+                    MysqlAuthMethod::CLEAR_PASSWORD_PLUGIN => {
                         // The raw bytes received could be represented in C-like string, ended in '\0'.
                         // We must "trim" it to get the real password string.
                         let password = auth_data.strip_suffix(&[0]).unwrap_or(auth_data);

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -152,9 +152,13 @@ impl PgLoginVerifier {
             Some(name) => name,
             None => return Ok(PgAuthInfo::Cleartext),
         };
+        let catalog = match &login.catalog {
+            Some(name) => name,
+            None => return Ok(PgAuthInfo::Cleartext),
+        };
 
         match user_provider
-            .postgres_auth_info(Identity::UserId(user_name, None))
+            .postgres_auth_info(Identity::UserId(user_name, None), catalog)
             .await
         {
             Err(e) => {

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -16,8 +16,8 @@ use std::fmt::Debug;
 use std::sync::Exclusive;
 
 use ::auth::{
-    Identity, Password, PgAuthInfo, PgScramSha256Verifier, UserInfoRef, UserProviderRef,
-    userinfo_by_name,
+    BEARER_TOKEN_USER, Identity, Password, PgAuthInfo, PgScramSha256Verifier, UserInfoRef,
+    UserProviderRef, userinfo_by_name,
 };
 use async_trait::async_trait;
 use base64::Engine;
@@ -123,15 +123,21 @@ impl PgLoginVerifier {
             None => return Ok(None),
         };
 
-        match user_provider
-            .auth(
-                Identity::UserId(user_name, None),
-                Password::PlainText(password.to_string().into()),
-                catalog,
-                schema,
-            )
-            .await
-        {
+        let result = if user_name == BEARER_TOKEN_USER {
+            user_provider
+                .auth_bearer_token(password, catalog, schema)
+                .await
+        } else {
+            user_provider
+                .auth(
+                    Identity::UserId(user_name, None),
+                    Password::PlainText(password.to_string().into()),
+                    catalog,
+                    schema,
+                )
+                .await
+        };
+        match result {
             Err(e) => {
                 METRIC_AUTH_FAILURE
                     .with_label_values(&[e.status_code().as_ref()])
@@ -152,6 +158,9 @@ impl PgLoginVerifier {
             Some(name) => name,
             None => return Ok(PgAuthInfo::Cleartext),
         };
+        if user_name == BEARER_TOKEN_USER {
+            return Ok(PgAuthInfo::Cleartext);
+        }
         let catalog = match &login.catalog {
             Some(name) => name,
             None => return Ok(PgAuthInfo::Cleartext),
@@ -281,7 +290,6 @@ impl StartupHandler for PostgresServerHandlerInner {
                             return send_password_authentication_failed(client).await;
                         }
                     };
-
                     client.set_state(PgWireConnectionState::AuthenticationInProgress);
                     match auth_info {
                         PgAuthInfo::ScramSha256 { .. } => {

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -18,7 +18,6 @@ use api::v1::greptime_request::Request;
 use api::v1::query_request::Query;
 use async_trait::async_trait;
 use catalog::memory::MemoryCatalogManager;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_error::ext::BoxedError;
 use common_grpc::flight::do_put::DoPutResponse;
 use common_query::Output;
@@ -169,7 +168,13 @@ impl SqlQueryHandler for DummyInstance {
     }
 
     async fn is_valid_schema(&self, catalog: &str, schema: &str) -> Result<bool> {
-        Ok(catalog == DEFAULT_CATALOG_NAME && schema == DEFAULT_SCHEMA_NAME)
+        Ok(self
+            .query_engine
+            .engine_state()
+            .catalog_manager()
+            .schema_exists(catalog, schema, None)
+            .await
+            .unwrap())
     }
 }
 

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -14,10 +14,12 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use auth::tests::{DatabaseAuthInfo, MockUserProvider};
+use auth::{BEARER_TOKEN_USER, Identity, Password, UserInfoRef, UserProvider};
 use chrono::{Datelike, NaiveDate};
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_query::Output;
@@ -55,14 +57,60 @@ struct MysqlOpts<'a> {
     reject_no_database: bool,
 }
 
+#[derive(Default)]
+struct BearerProvider {
+    authentications: AtomicUsize,
+    authorizations: AtomicUsize,
+}
+
+#[async_trait]
+impl UserProvider for BearerProvider {
+    fn name(&self) -> &str {
+        "bearer-test"
+    }
+
+    async fn authenticate(
+        &self,
+        _: Identity<'_>,
+        _: Password<'_>,
+    ) -> auth::error::Result<UserInfoRef> {
+        unreachable!("the bearer sentinel must not use password authentication")
+    }
+
+    async fn authenticate_bearer_token(
+        &self,
+        token: &str,
+        catalog: &str,
+    ) -> auth::error::Result<UserInfoRef> {
+        assert_eq!("signed-token", token);
+        assert_eq!("greptime", catalog);
+        self.authentications.fetch_add(1, Ordering::Relaxed);
+        Ok(auth::userinfo_by_name(Some("alice".to_string())))
+    }
+
+    async fn authorize(
+        &self,
+        catalog: &str,
+        schema: &str,
+        user_info: &UserInfoRef,
+    ) -> auth::error::Result<()> {
+        assert_eq!("greptime", catalog);
+        assert_eq!(DEFAULT_SCHEMA_NAME, schema);
+        assert_eq!("alice", user_info.username());
+        self.authorizations.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
 fn create_mysql_server(table: TableRef, opts: MysqlOpts<'_>) -> Result<Box<dyn Server>> {
     let query_handler = create_testing_sql_query_handler(table);
-    create_mysql_server_with_query_handler(query_handler, opts)
+    create_mysql_server_with_query_handler(query_handler, opts, None)
 }
 
 fn create_mysql_server_with_query_handler(
     query_handler: ServerSqlQueryHandlerRef,
     opts: MysqlOpts<'_>,
+    user_provider: Option<auth::UserProviderRef>,
 ) -> Result<Box<dyn Server>> {
     let _ = install_default_crypto_provider();
     let io_runtime = RuntimeBuilder::default()
@@ -71,10 +119,13 @@ fn create_mysql_server_with_query_handler(
         .build()
         .unwrap();
 
-    let mut provider = MockUserProvider::default();
-    if let Some(auth_info) = opts.auth_info {
-        provider.set_authorization_info(auth_info);
-    }
+    let user_provider = user_provider.unwrap_or_else(|| {
+        let mut provider = MockUserProvider::default();
+        if let Some(auth_info) = opts.auth_info {
+            provider.set_authorization_info(auth_info);
+        }
+        Arc::new(provider)
+    });
 
     let tls_server_config = Arc::new(
         ReloadableTlsServerConfig::try_new(opts.tls.clone())
@@ -83,7 +134,7 @@ fn create_mysql_server_with_query_handler(
 
     Ok(MysqlServer::create_server(
         io_runtime,
-        Arc::new(MysqlSpawnRef::new(query_handler, Some(Arc::new(provider)))),
+        Arc::new(MysqlSpawnRef::new(query_handler, Some(user_provider))),
         Arc::new(MysqlSpawnConfig::new(
             opts.tls.should_force_tls(),
             tls_server_config,
@@ -328,6 +379,41 @@ async fn test_server_require_secure_client_secure_with_pkcs8_priv_key() -> Resul
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_bearer_token_auth_over_clear_password() -> Result<()> {
+    common_telemetry::init_default_ut_logging();
+    let provider = Arc::new(BearerProvider::default());
+    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let mut server = create_mysql_server_with_query_handler(
+        query_handler,
+        MysqlOpts::default(),
+        Some(provider.clone()),
+    )?;
+    server.start("127.0.0.1:0".parse().unwrap()).await?;
+    let port = server.bind_addr().unwrap().port();
+
+    let client_opts = mysql_async::OptsBuilder::default()
+        .ip_or_hostname("127.0.0.1")
+        .tcp_port(port)
+        .prefer_socket(false)
+        .user(Some(BEARER_TOKEN_USER.to_string()))
+        .pass(Some("signed-token".to_string()))
+        .db_name(Some(DEFAULT_SCHEMA_NAME.to_string()))
+        .enable_cleartext_plugin(true);
+    let mut connection = Conn::new(client_opts).await.unwrap();
+    let value: u32 = connection
+        .query_first("SELECT uint32s FROM numbers LIMIT 1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(0, value);
+    assert_eq!(1, provider.authentications.load(Ordering::Relaxed));
+    assert_eq!(1, provider.authorizations.load(Ordering::Relaxed));
+
+    server.shutdown().await?;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_server_required_secure_client_plain() -> Result<()> {
     let server_tls = TlsOption {
@@ -525,7 +611,7 @@ async fn test_mysql_text_protocol_max_timestamp_with_session_timezone_fails_clos
         inner: create_testing_sql_query_handler(table),
     });
     let mut mysql_server =
-        create_mysql_server_with_query_handler(query_handler, Default::default())?;
+        create_mysql_server_with_query_handler(query_handler, Default::default(), None)?;
     let listening = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
     mysql_server.start(listening).await.unwrap();
 

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -20,6 +20,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use auth::tests::{DatabaseAuthInfo, MockUserProvider};
 use auth::{BEARER_TOKEN_USER, Identity, Password, UserInfoRef, UserProvider};
+use catalog::RegisterSchemaRequest;
+use catalog::memory::MemoryCatalogManager;
 use chrono::{Datelike, NaiveDate};
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_query::Output;
@@ -34,6 +36,8 @@ use datatypes::value::Value;
 use datatypes::vectors::{Int32Vector, TimestampMicrosecondVector, TimestampSecondVector};
 use mysql_async::prelude::*;
 use mysql_async::{Conn, Row, SslOpts};
+use query::QueryEngineFactory;
+use query::options::QueryOptions;
 use query::parser::PromQuery;
 use query::query_engine::DescribeResult;
 use servers::error::Result;
@@ -47,8 +51,8 @@ use sql::statements::statement::Statement;
 use table::TableRef;
 use table::test_util::MemTable;
 
-use crate::create_testing_sql_query_handler;
 use crate::mysql::{MysqlTextRow, TestingData, all_datatype_testing_data};
+use crate::{DummyInstance, create_testing_sql_query_handler};
 
 #[derive(Default)]
 struct MysqlOpts<'a> {
@@ -59,6 +63,7 @@ struct MysqlOpts<'a> {
 
 #[derive(Default)]
 struct BearerProvider {
+    catalog: &'static str,
     authentications: AtomicUsize,
     authorizations: AtomicUsize,
 }
@@ -83,7 +88,7 @@ impl UserProvider for BearerProvider {
         catalog: &str,
     ) -> auth::error::Result<UserInfoRef> {
         assert_eq!("signed-token", token);
-        assert_eq!("greptime", catalog);
+        assert_eq!(self.catalog, catalog);
         self.authentications.fetch_add(1, Ordering::Relaxed);
         Ok(auth::userinfo_by_name(Some("alice".to_string())))
     }
@@ -94,7 +99,7 @@ impl UserProvider for BearerProvider {
         schema: &str,
         user_info: &UserInfoRef,
     ) -> auth::error::Result<()> {
-        assert_eq!("greptime", catalog);
+        assert_eq!(self.catalog, catalog);
         assert_eq!(DEFAULT_SCHEMA_NAME, schema);
         assert_eq!("alice", user_info.username());
         self.authorizations.fetch_add(1, Ordering::Relaxed);
@@ -382,35 +387,85 @@ async fn test_server_require_secure_client_secure_with_pkcs8_priv_key() -> Resul
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_bearer_token_auth_over_clear_password() -> Result<()> {
     common_telemetry::init_default_ut_logging();
-    let provider = Arc::new(BearerProvider::default());
-    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
-    let mut server = create_mysql_server_with_query_handler(
-        query_handler,
-        MysqlOpts::default(),
-        Some(provider.clone()),
-    )?;
-    server.start("127.0.0.1:0".parse().unwrap()).await?;
-    let port = server.bind_addr().unwrap().port();
-
-    let client_opts = mysql_async::OptsBuilder::default()
-        .ip_or_hostname("127.0.0.1")
-        .tcp_port(port)
-        .prefer_socket(false)
-        .user(Some(BEARER_TOKEN_USER.to_string()))
-        .pass(Some("signed-token".to_string()))
-        .db_name(Some(DEFAULT_SCHEMA_NAME.to_string()))
-        .enable_cleartext_plugin(true);
-    let mut connection = Conn::new(client_opts).await.unwrap();
-    let value: u32 = connection
-        .query_first("SELECT uint32s FROM numbers LIMIT 1")
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(0, value);
-    assert_eq!(1, provider.authentications.load(Ordering::Relaxed));
-    assert_eq!(1, provider.authorizations.load(Ordering::Relaxed));
-
-    server.shutdown().await?;
+    for tls in [false, true] {
+        for (database, catalog) in [
+            (None, "greptime"),
+            (Some("public"), "greptime"),
+            (Some("greptime-public"), "greptime"),
+            (Some("tenant-public"), "tenant"),
+        ] {
+            let provider = Arc::new(BearerProvider {
+                catalog,
+                ..Default::default()
+            });
+            let catalog_manager =
+                MemoryCatalogManager::new_with_table(MemTable::default_numbers_table());
+            catalog_manager.register_catalog_sync("tenant").unwrap();
+            catalog_manager
+                .register_schema_sync(RegisterSchemaRequest {
+                    catalog: "tenant".to_string(),
+                    schema: DEFAULT_SCHEMA_NAME.to_string(),
+                })
+                .unwrap();
+            let query_handler = Arc::new(DummyInstance::new(
+                QueryEngineFactory::new(
+                    catalog_manager,
+                    None,
+                    None,
+                    None,
+                    None,
+                    false,
+                    QueryOptions::default(),
+                )
+                .query_engine(),
+            ));
+            let server_tls = if tls {
+                TlsOption {
+                    mode: servers::tls::TlsMode::Require,
+                    cert_path: "tests/ssl/server.crt".to_string(),
+                    key_path: "tests/ssl/server-rsa.key".to_string(),
+                    ..Default::default()
+                }
+            } else {
+                TlsOption::default()
+            };
+            let mut server = create_mysql_server_with_query_handler(
+                query_handler,
+                MysqlOpts {
+                    tls: server_tls,
+                    ..Default::default()
+                },
+                Some(provider.clone()),
+            )?;
+            server.start("127.0.0.1:0".parse().unwrap()).await?;
+            let port = server.bind_addr().unwrap().port();
+            let mut client_opts = mysql_async::OptsBuilder::default()
+                .ip_or_hostname("127.0.0.1")
+                .tcp_port(port)
+                .prefer_socket(false)
+                .user(Some(BEARER_TOKEN_USER.to_string()))
+                .pass(Some("signed-token".to_string()))
+                .db_name(database.map(str::to_string))
+                .enable_cleartext_plugin(true);
+            if tls {
+                client_opts = client_opts.ssl_opts(
+                    SslOpts::default()
+                        .with_danger_skip_domain_validation(true)
+                        .with_danger_accept_invalid_certs(true),
+                );
+            }
+            let mut connection = Conn::new(client_opts).await.unwrap();
+            let value: u32 = connection.query_first("SELECT 1").await.unwrap().unwrap();
+            assert_eq!(1, value);
+            assert_eq!(1, provider.authentications.load(Ordering::Relaxed));
+            assert_eq!(
+                usize::from(database.is_some()),
+                provider.authorizations.load(Ordering::Relaxed)
+            );
+            connection.disconnect().await.unwrap();
+            server.shutdown().await?;
+        }
+    }
     Ok(())
 }
 

--- a/src/servers/tests/postgres/mod.rs
+++ b/src/servers/tests/postgres/mod.rs
@@ -14,10 +14,15 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use async_trait::async_trait;
 use auth::tests::{DatabaseAuthInfo, MockUserProvider};
-use auth::{UserProviderRef, format_pg_scram_sha256_password_verifier, user_provider_from_option};
+use auth::{
+    BEARER_TOKEN_USER, Identity, Password, UserInfoRef, UserProvider, UserProviderRef,
+    format_pg_scram_sha256_password_verifier, user_provider_from_option,
+};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_runtime::Builder as RuntimeBuilder;
 use common_runtime::runtime::BuilderBuild;
@@ -36,6 +41,51 @@ use table::test_util::MemTable;
 use tokio_postgres::{Client, Error as PgError, NoTls, SimpleQueryMessage};
 
 use crate::create_testing_instance;
+
+#[derive(Default)]
+struct BearerProvider {
+    authentications: AtomicUsize,
+    authorizations: AtomicUsize,
+}
+
+#[async_trait]
+impl UserProvider for BearerProvider {
+    fn name(&self) -> &str {
+        "bearer-test"
+    }
+
+    async fn authenticate(
+        &self,
+        _: Identity<'_>,
+        _: Password<'_>,
+    ) -> auth::error::Result<UserInfoRef> {
+        unreachable!("the bearer sentinel must not use password authentication")
+    }
+
+    async fn authenticate_bearer_token(
+        &self,
+        token: &str,
+        catalog: &str,
+    ) -> auth::error::Result<UserInfoRef> {
+        assert_eq!("signed-token", token);
+        assert_eq!(DEFAULT_CATALOG_NAME, catalog);
+        self.authentications.fetch_add(1, Ordering::Relaxed);
+        Ok(auth::userinfo_by_name(Some("alice".to_string())))
+    }
+
+    async fn authorize(
+        &self,
+        catalog: &str,
+        schema: &str,
+        user_info: &UserInfoRef,
+    ) -> auth::error::Result<()> {
+        assert_eq!(DEFAULT_CATALOG_NAME, catalog);
+        assert_eq!(DEFAULT_SCHEMA_NAME, schema);
+        assert_eq!("alice", user_info.username());
+        self.authorizations.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
 
 fn create_postgres_server(
     table: TableRef,
@@ -85,13 +135,14 @@ fn create_postgres_server_with_user_provider(
 
 async fn start_test_server_with_user_provider(
     user_provider: UserProviderRef,
+    tls: TlsOption,
 ) -> Result<(Box<dyn Server>, u16)> {
     common_telemetry::init_default_ut_logging();
     let _ = install_default_crypto_provider();
 
     let table = MemTable::default_numbers_table();
     let mut postgres_server =
-        create_postgres_server_with_user_provider(table, Default::default(), Some(user_provider))?;
+        create_postgres_server_with_user_provider(table, tls, Some(user_provider))?;
     let listening = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
     postgres_server.start(listening).await.unwrap();
     let server_addr = postgres_server.bind_addr().unwrap();
@@ -169,7 +220,7 @@ async fn test_pg_scram_sha256_auth() -> Result<()> {
         user_provider_from_option(&format!("static_user_provider:cmd:greptime={verifier}"))
             .unwrap();
     let (postgres_server, server_port) =
-        start_test_server_with_user_provider(user_provider).await?;
+        start_test_server_with_user_provider(user_provider, Default::default()).await?;
 
     let client = create_plain_connection_with_credentials(server_port, "greptime", "greptime")
         .await
@@ -213,6 +264,27 @@ async fn test_pg_cleartext_auth_fallback() -> Result<()> {
     assert!(wrong_password.is_err());
 
     postgres_server.shutdown().await.unwrap();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_bearer_token_auth_over_cleartext() -> Result<()> {
+    let provider = Arc::new(BearerProvider::default());
+    let (server, port) =
+        start_test_server_with_user_provider(provider.clone(), TlsOption::default()).await?;
+
+    let client = create_plain_connection_with_credentials(port, BEARER_TOKEN_USER, "signed-token")
+        .await
+        .unwrap();
+    let rows = client
+        .simple_query("SELECT uint32s FROM numbers LIMIT 1")
+        .await
+        .unwrap();
+    assert_eq!("0", unwrap_results(&rows)[0]);
+    assert_eq!(1, provider.authentications.load(Ordering::Relaxed));
+    assert_eq!(1, provider.authorizations.load(Ordering::Relaxed));
+
+    server.shutdown().await?;
     Ok(())
 }
 
@@ -461,7 +533,7 @@ async fn do_simple_query(server_tls: TlsOption, client_tls: bool) -> Result<()> 
         let result = client.simple_query("SELECT uint32s FROM numbers").await;
         let _ = result.unwrap();
     } else {
-        let client = create_secure_connection(server_port, false).await.unwrap();
+        let client = create_secure_connection(server_port, None).await.unwrap();
         let result = client.simple_query("SELECT uint32s FROM numbers").await;
         let _ = result.unwrap();
     }
@@ -471,14 +543,15 @@ async fn do_simple_query(server_tls: TlsOption, client_tls: bool) -> Result<()> 
 
 async fn create_secure_connection(
     port: u16,
-    with_pwd: bool,
+    credentials: Option<(&str, &str)>,
 ) -> std::result::Result<Client, PgError> {
-    let url = if with_pwd {
-        format!(
-            "sslmode=require host=127.0.0.1 port={port} user=greptime password=greptime connect_timeout=2, dbname={DEFAULT_SCHEMA_NAME}",
-        )
-    } else {
-        format!("host=127.0.0.1 port={port} connect_timeout=2 dbname={DEFAULT_SCHEMA_NAME}")
+    let url = match credentials {
+        Some((user, password)) => format!(
+            "sslmode=require host=127.0.0.1 port={port} user={user} password={password} connect_timeout=2 dbname={DEFAULT_SCHEMA_NAME}",
+        ),
+        None => {
+            format!("host=127.0.0.1 port={port} connect_timeout=2 dbname={DEFAULT_SCHEMA_NAME}")
+        }
     };
 
     let mut config = rustls::ClientConfig::builder()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request adds bearer-token authentication for MySQL and PostgreSQL, allowing clients to use `*` as the username and supply a token through the password exchange.

- Derive the session identity from the token and use existing authorization checks.
- Authenticate MySQL tokens against the catalog selected in the handshake.
- Add provider-controlled MySQL authentication methods and catalog-aware PostgreSQL authentication selection.
- Expose reusable MySQL and PostgreSQL password-verifier helpers.

The username `*` becomes reserved for token authentication. Providers must explicitly support token validation; TLS requirements remain controlled by server configuration.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
