### PR TITLE
fix(query): restore columnar group-by for dictionary-encoded tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,7 +3744,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "futures",
  "log",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3935,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4009,12 +4009,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4058,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4199,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=d705d4433d2fcbe2bead54e3f1d6cc59727857e1#d705d4433d2fcbe2bead54e3f1d6cc59727857e1"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,7 +3744,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3844,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "futures",
  "log",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3935,7 +3935,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4009,12 +4009,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4058,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4199,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4295,7 +4295,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=be93ffd85cdd8c05912df65c0e37630abd5c91ec#be93ffd85cdd8c05912df65c0e37630abd5c91ec"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=4c8a6bf28347b346348136247eb67dfb933f1147#4c8a6bf28347b346348136247eb67dfb933f1147"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,21 +348,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "d705d4433d2fcbe2bead54e3f1d6cc59727857e1" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,21 +348,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "be93ffd85cdd8c05912df65c0e37630abd5c91ec" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "4c8a6bf28347b346348136247eb67dfb933f1147" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/tests-integration/tests/dict_groupby_sst.rs
+++ b/tests-integration/tests/dict_groupby_sst.rs
@@ -1,0 +1,139 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_query::Output;
+use frontend::instance::Instance;
+use servers::query_handler::sql::SqlQueryHandler;
+use session::context::QueryContext;
+use tests_integration::standalone::GreptimeDbStandaloneBuilder;
+
+async fn execute_sql(instance: &Instance, sql: &str) -> Output {
+    SqlQueryHandler::do_query(instance, sql, QueryContext::arc())
+        .await
+        .remove(0)
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dict_groupby_sst() {
+    common_telemetry::init_default_ut_logging();
+
+    let standalone = GreptimeDbStandaloneBuilder::new("dict_groupby_sst")
+        .build()
+        .await;
+    let frontend = standalone.fe_instance();
+
+    execute_sql(
+        frontend,
+        r#"
+        CREATE TABLE cpu (
+            hostname STRING PRIMARY KEY,
+            usage_user DOUBLE,
+            usage_system DOUBLE,
+            usage_idle DOUBLE,
+            greptime_timestamp TIMESTAMP TIME INDEX
+        ) WITH (append_mode = 'true', sst_format = 'flat')
+        "#,
+    )
+    .await;
+
+    let mut rows = String::new();
+    for index in 0..1200 {
+        if index != 0 {
+            rows.push(',');
+        }
+        let hostname = match index % 3 {
+            0 => "host_a",
+            1 => "host_b",
+            _ => "host_c",
+        };
+        let usage_user = match index % 3 {
+            0 => 10.0,
+            1 => 20.0,
+            _ => 30.0,
+        };
+        let hour = 11 + index / 600;
+        let minute = (index % 600) / 60;
+        let second = index % 60;
+        rows.push_str(&format!(
+            "('{hostname}', {usage_user}, 1.0, 0.0, '2023-06-12T{hour:02}:{minute:02}:{second:02}Z')"
+        ));
+    }
+    execute_sql(frontend, &format!("INSERT INTO cpu VALUES {rows}")).await;
+
+    execute_sql(frontend, "ADMIN FLUSH_TABLE('cpu')").await;
+
+    let count = execute_sql(frontend, "SELECT count(*) FROM cpu")
+        .await
+        .data
+        .pretty_print()
+        .await;
+    assert!(
+        count.contains("| 1200     |"),
+        "unexpected row count:\n{count}"
+    );
+
+    let query = r#"
+        SELECT hostname, avg(usage_user), date_trunc('hour', greptime_timestamp)
+        FROM cpu
+        WHERE greptime_timestamp >= '2023-06-12T00:00:00Z'
+          AND greptime_timestamp < '2023-06-14T00:00:00Z'
+        GROUP BY date_trunc('hour', greptime_timestamp), hostname
+        ORDER BY hostname, date_trunc('hour', greptime_timestamp)
+    "#;
+    let groups = execute_sql(frontend, query).await.data.pretty_print().await;
+    assert_eq!(
+        6,
+        groups
+            .lines()
+            .filter(|line| line.starts_with("| host_"))
+            .count(),
+        "expected one group per hostname and hour:\n{groups}"
+    );
+    for (hostname, average) in [("host_a", "10.0"), ("host_b", "20.0"), ("host_c", "30.0")] {
+        assert_eq!(
+            2,
+            groups.matches(&format!("| {hostname} ")).count(),
+            "expected two hourly groups for {hostname}:\n{groups}"
+        );
+        assert!(
+            groups.contains(average),
+            "expected average {average} for {hostname}:\n{groups}"
+        );
+    }
+
+    let explain = execute_sql(
+        frontend,
+        r#"
+        EXPLAIN ANALYZE VERBOSE
+        SELECT avg(usage_user), date_trunc('hour', greptime_timestamp)
+        FROM cpu
+        WHERE greptime_timestamp >= '2023-06-12T00:00:00Z'
+          AND greptime_timestamp < '2023-06-14T00:00:00Z'
+        GROUP BY date_trunc('hour', greptime_timestamp), hostname
+        "#,
+    )
+    .await
+    .data
+    .pretty_print()
+    .await;
+    assert!(
+        explain.contains("AggregateExec"),
+        "expected aggregate in physical plan:\n{explain}"
+    );
+    assert!(
+        !explain.contains("CastExec") && !explain.contains("CAST(hostname"),
+        "dictionary hostname must not be cast before aggregation:\n{explain}"
+    );
+}

--- a/tests-integration/tests/main.rs
+++ b/tests-integration/tests/main.rs
@@ -16,6 +16,7 @@
 
 mod admin_function_event;
 mod database_ddl_event;
+mod dict_groupby_sst;
 mod event_recorder_test_util;
 #[macro_use]
 mod grpc;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Depends on GreptimeTeam/datafusion#28, which backports apache/datafusion#23187 to the GreptimeDB DataFusion 53.1.0 fork.

## What's changed and what's your intention?

Updates the pinned GreptimeTeam/datafusion revision to `be93ffd85`, which adds `DictionaryGroupValuesColumn` to the DataFusion 53.1.0 fork. Dictionary-encoded GROUP BY keys now remain on the columnar `GroupValuesColumn` path: each batch hashes its dictionary values once and resolves rows by dictionary-key index.

This fixes the TSBS double-groupby regression introduced when mito2 began preserving tag columns as `Dictionary(UInt32, Utf8)`. DataFusion 53.1.0 did not support Dictionary in the multi-column group-by fast path, so these queries fell back to `GroupValuesRows` (+57% group-ID time, +50% peak memory, +38% end-to-end latency in the benchmark).

Adds `dict_groupby_sst`, an end-to-end flat-SST test that flushes dictionary-encoded hostname tags, runs the TSBS-style double GROUP BY, verifies the grouped averages, and asserts no `CastExec` is inserted (the dictionary stays encoded through aggregation).

No SQL API, schema, or stored-data format changes.

## PR Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Validation

- `CARGO_HOME=/mnt/nvme_rust/cargo-home-fix-dict cargo check -p query`
- `CARGO_HOME=/mnt/nvme_rust/cargo-home-fix-dict cargo nextest run -p query` — 653 passed, 2 skipped
- `CARGO_HOME=/mnt/nvme_rust/cargo-home-fix-dict cargo nextest run -p tests-integration dict_groupby` — passed
- Fork validation in GreptimeTeam/datafusion#28: dictionary tests 11 passed; multi_group_by tests 30 passed.