### PR TITLE
feat: add database ingest rate limit hooks

### DIFF
--- a/src/frontend/src/instance/builder.rs
+++ b/src/frontend/src/instance/builder.rs
@@ -34,7 +34,7 @@ use common_meta::procedure_executor::ProcedureExecutorRef;
 use dashmap::DashMap;
 use operator::delete::Deleter;
 use operator::flow::FlowServiceOperator;
-use operator::insert::Inserter;
+use operator::insert::{InsertLimitInterceptorRef, Inserter};
 use operator::procedure::ProcedureServiceOperator;
 use operator::request::Requester;
 #[cfg(feature = "enterprise")]
@@ -222,13 +222,16 @@ impl FrontendBuilder {
                     name: TABLE_FLOWNODE_SET_CACHE_NAME,
                 })?;
 
-        let inserter = Arc::new(Inserter::new(
-            self.catalog_manager.clone(),
-            partition_manager.clone(),
-            node_manager.clone(),
-            table_flownode_cache,
-            self.options.auto_create_table,
-        ));
+        let inserter = Arc::new(
+            Inserter::new(
+                self.catalog_manager.clone(),
+                partition_manager.clone(),
+                node_manager.clone(),
+                table_flownode_cache,
+                self.options.auto_create_table,
+            )
+            .with_insert_limit_interceptor(plugins.get::<InsertLimitInterceptorRef>()),
+        );
         let deleter = Arc::new(Deleter::new(
             self.catalog_manager.clone(),
             partition_manager.clone(),

--- a/src/operator/src/bulk_insert.rs
+++ b/src/operator/src/bulk_insert.rs
@@ -53,6 +53,20 @@ impl Inserter {
             return Ok(0);
         }
 
+        if let Some(interceptor) = &self.insert_limit_interceptor {
+            interceptor
+                .check_ingest(
+                    &table_info.catalog_name,
+                    &table_info.schema_name,
+                    record_batch.num_rows() as u64,
+                )
+                .await
+                .map_err(|source| error::Error::External {
+                    source,
+                    location: snafu::Location::default(),
+                })?;
+        }
+
         let body_size = raw_flight_data.data_body.len();
         // TODO(yingwen): Fill record batch impure default values. Note that we should override `raw_flight_data` if we have to fill defaults.
         // notify flownode to update dirty timestamps if flow is configured.

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -33,6 +33,7 @@ use common_catalog::consts::{
     TRACE_TABLE_NAME_SESSION_KEY, default_engine, is_ddl_reserved_table,
     trace_operations_table_name, trace_services_table_name,
 };
+use common_error::ext::BoxedError;
 use common_grpc_expr::util::ColumnExpr;
 use common_meta::cache::TableFlownodeSetCacheRef;
 use common_meta::node_manager::{AffectedRows, NodeManagerRef};
@@ -82,6 +83,23 @@ use crate::req_convert::insert::{
 };
 use crate::statement::StatementExecutor;
 
+/// Intercepts row inserts right before they are dispatched to datanodes,
+/// e.g. to enforce database-level ingest rate limits.
+/// Registered via `Plugins`; `None` means no interception (OSS default).
+#[async_trait::async_trait]
+pub trait InsertLimitInterceptor: Send + Sync {
+    /// Checks whether `rows` rows may be ingested into `catalog.schema`.
+    /// Returning `Err` rejects the whole request.
+    async fn check_ingest(
+        &self,
+        catalog: &str,
+        schema: &str,
+        rows: u64,
+    ) -> std::result::Result<(), BoxedError>;
+}
+
+pub type InsertLimitInterceptorRef = Arc<dyn InsertLimitInterceptor>;
+
 pub struct Inserter {
     catalog_manager: CatalogManagerRef,
     pub(crate) partition_manager: PartitionRuleManagerRef,
@@ -91,6 +109,7 @@ pub struct Inserter {
     /// When `false`, missing tables are never auto-created regardless of the
     /// per-request `auto_create_table` hint. When `true`, the hint still applies.
     auto_create_table: bool,
+    insert_limit_interceptor: Option<InsertLimitInterceptorRef>,
 }
 
 pub type InserterRef = Arc<Inserter>;
@@ -160,7 +179,18 @@ impl Inserter {
             node_manager,
             table_flownode_set_cache,
             auto_create_table,
+            insert_limit_interceptor: None,
         }
+    }
+
+    /// Sets the [InsertLimitInterceptor] invoked before insert requests are
+    /// dispatched to datanodes. `None` (the default) disables interception.
+    pub fn with_insert_limit_interceptor(
+        mut self,
+        interceptor: Option<InsertLimitInterceptorRef>,
+    ) -> Self {
+        self.insert_limit_interceptor = interceptor;
+        self
     }
 
     pub async fn handle_column_inserts(
@@ -385,6 +415,15 @@ impl Inserter {
     }
 }
 
+/// Counts the total number of rows in a [RegionInsertRequests].
+fn count_region_insert_rows(requests: &RegionInsertRequests) -> u64 {
+    requests
+        .requests
+        .iter()
+        .map(|r| r.rows.as_ref().map(|rows| rows.rows.len()).unwrap_or(0) as u64)
+        .sum()
+}
+
 impl Inserter {
     async fn do_request(
         &self,
@@ -394,6 +433,18 @@ impl Inserter {
     ) -> Result<Output> {
         // Fill impure default values in the request
         let requests = fill_reqs_with_impure_default(table_infos, requests)?;
+
+        if let Some(interceptor) = &self.insert_limit_interceptor {
+            let rows = count_region_insert_rows(&requests.normal_requests)
+                + count_region_insert_rows(&requests.instant_requests);
+            interceptor
+                .check_ingest(ctx.current_catalog(), &ctx.current_schema(), rows)
+                .await
+                .map_err(|source| crate::error::Error::External {
+                    source,
+                    location: snafu::Location::default(),
+                })?;
+        }
 
         let write_cost = write_meter!(
             ctx.current_catalog(),
@@ -1494,12 +1545,14 @@ impl FlowMirrorTask {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use api::helper::ColumnDataTypeWrapper;
     use api::v1::helper::{field_column_schema, time_index_column_schema};
     use api::v1::{RowInsertRequest, Rows, Value};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use common_error::ext::{BoxedError, ErrorExt, PlainError};
+    use common_error::status_code::StatusCode;
     use common_meta::cache::new_table_flownode_set_cache;
     use common_meta::ddl::test_util::datanode_handler::NaiveDatanodeHandler;
     use common_meta::test_util::MockDatanodeManager;
@@ -1514,7 +1567,9 @@ mod tests {
     use table::metadata::{TableInfoBuilder, TableMetaBuilder, TableType};
 
     use super::*;
-    use crate::tests::{create_partition_rule_manager, prepare_mocked_backend};
+    use crate::tests::{
+        create_partition_rule_manager, new_test_table_info, prepare_mocked_backend,
+    };
 
     fn make_table_ref_with_schema(
         ts_name: &str,
@@ -1700,6 +1755,143 @@ mod tests {
 
         assert!(request_is_native_histogram(&request_schema));
         assert!(table_is_native_histogram(&table));
+    }
+
+    struct RejectAllInterceptor;
+
+    #[async_trait::async_trait]
+    impl InsertLimitInterceptor for RejectAllInterceptor {
+        async fn check_ingest(
+            &self,
+            _catalog: &str,
+            _schema: &str,
+            _rows: u64,
+        ) -> std::result::Result<(), BoxedError> {
+            Err(BoxedError::new(PlainError::new(
+                "rate limited for test".to_string(),
+                StatusCode::RateLimited,
+            )))
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingInterceptor {
+        calls: Mutex<Vec<(String, String, u64)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl InsertLimitInterceptor for RecordingInterceptor {
+        async fn check_ingest(
+            &self,
+            catalog: &str,
+            schema: &str,
+            rows: u64,
+        ) -> std::result::Result<(), BoxedError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((catalog.to_string(), schema.to_string(), rows));
+            Ok(())
+        }
+    }
+
+    async fn new_inserter_with_interceptor(
+        interceptor: Option<InsertLimitInterceptorRef>,
+    ) -> Inserter {
+        let kv_backend = prepare_mocked_backend().await;
+        Inserter::new(
+            catalog::memory::MemoryCatalogManager::new(),
+            create_partition_rule_manager(kv_backend.clone()).await,
+            Arc::new(MockDatanodeManager::new(NaiveDatanodeHandler)),
+            Arc::new(new_table_flownode_set_cache(
+                String::new(),
+                Cache::new(100),
+                kv_backend.clone(),
+            )),
+            true,
+        )
+        .with_insert_limit_interceptor(interceptor)
+    }
+
+    fn new_region_insert_requests(
+        table_id: u32,
+        region_number: u32,
+        num_normal_rows: usize,
+        num_instant_rows: usize,
+    ) -> InstantAndNormalInsertRequests {
+        let build = |num_rows: usize| RegionInsertRequests {
+            requests: vec![RegionInsertRequest {
+                region_id: RegionId::new(table_id, region_number).as_u64(),
+                rows: Some(Rows {
+                    schema: vec![],
+                    rows: vec![api::v1::Row { values: vec![] }; num_rows],
+                }),
+                partition_expr_version: None,
+            }],
+        };
+        InstantAndNormalInsertRequests {
+            normal_requests: build(num_normal_rows),
+            instant_requests: build(num_instant_rows),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert_rejected_by_limit_interceptor() {
+        let inserter = new_inserter_with_interceptor(Some(Arc::new(RejectAllInterceptor))).await;
+        let table_id = 1;
+        let table_infos = HashMap::from_iter([(
+            table_id,
+            Arc::new(new_test_table_info(
+                table_id,
+                "test_table",
+                vec![0].into_iter(),
+            )),
+        )]);
+        let requests = new_region_insert_requests(table_id, 0, 3, 0);
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+
+        let err = inserter
+            .do_request(requests, &table_infos, &ctx)
+            .await
+            .unwrap_err();
+        assert_eq!(err.status_code(), StatusCode::RateLimited);
+    }
+
+    #[tokio::test]
+    async fn test_insert_limit_interceptor_receives_total_rows() {
+        let interceptor = Arc::new(RecordingInterceptor::default());
+        let inserter = new_inserter_with_interceptor(Some(interceptor.clone())).await;
+        let table_id = 1;
+        let table_infos = HashMap::from_iter([(
+            table_id,
+            Arc::new(new_test_table_info(
+                table_id,
+                "test_table",
+                vec![0].into_iter(),
+            )),
+        )]);
+        let requests = new_region_insert_requests(table_id, 0, 3, 2);
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+
+        // The interceptor passes; the request then fails downstream because the
+        // mocked backend has no table route. Only the interception is asserted.
+        let _ = inserter.do_request(requests, &table_infos, &ctx).await;
+
+        let calls = interceptor.calls.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            &[(
+                DEFAULT_CATALOG_NAME.to_string(),
+                DEFAULT_SCHEMA_NAME.to_string(),
+                5
+            )]
+        );
     }
 
     #[test]

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -98,6 +98,7 @@ pub trait InsertLimitInterceptor: Send + Sync {
     ) -> std::result::Result<(), BoxedError>;
 }
 
+/// Shared reference to an [InsertLimitInterceptor], registered via `Plugins`.
 pub type InsertLimitInterceptorRef = Arc<dyn InsertLimitInterceptor>;
 
 pub struct Inserter {
@@ -109,7 +110,7 @@ pub struct Inserter {
     /// When `false`, missing tables are never auto-created regardless of the
     /// per-request `auto_create_table` hint. When `true`, the hint still applies.
     auto_create_table: bool,
-    insert_limit_interceptor: Option<InsertLimitInterceptorRef>,
+    pub(crate) insert_limit_interceptor: Option<InsertLimitInterceptorRef>,
 }
 
 pub type InserterRef = Arc<Inserter>;
@@ -437,8 +438,18 @@ impl Inserter {
         if let Some(interceptor) = &self.insert_limit_interceptor {
             let rows = count_region_insert_rows(&requests.normal_requests)
                 + count_region_insert_rows(&requests.instant_requests);
+            // Charge the target table's database, not the session's: fully
+            // qualified inserts (e.g. `INSERT INTO other_db.t`) may target a
+            // different database than the session's current one. All tables in
+            // one batch resolve to the same database, so any entry works; fall
+            // back to the session context when there is no table info.
+            let (catalog, schema) = table_infos
+                .values()
+                .next()
+                .map(|info| (info.catalog_name.clone(), info.schema_name.clone()))
+                .unwrap_or_else(|| (ctx.current_catalog().to_string(), ctx.current_schema()));
             interceptor
-                .check_ingest(ctx.current_catalog(), &ctx.current_schema(), rows)
+                .check_ingest(&catalog, &schema, rows)
                 .await
                 .map_err(|source| crate::error::Error::External {
                     source,
@@ -1865,14 +1876,12 @@ mod tests {
         let interceptor = Arc::new(RecordingInterceptor::default());
         let inserter = new_inserter_with_interceptor(Some(interceptor.clone())).await;
         let table_id = 1;
-        let table_infos = HashMap::from_iter([(
-            table_id,
-            Arc::new(new_test_table_info(
-                table_id,
-                "test_table",
-                vec![0].into_iter(),
-            )),
-        )]);
+        // The target table lives in a different database than the session's;
+        // the limit must be attributed to the table's catalog/schema.
+        let mut table_info = new_test_table_info(table_id, "test_table", vec![0].into_iter());
+        table_info.catalog_name = "other_catalog".to_string();
+        table_info.schema_name = "other_schema".to_string();
+        let table_infos = HashMap::from_iter([(table_id, Arc::new(table_info))]);
         let requests = new_region_insert_requests(table_id, 0, 3, 2);
         let ctx = Arc::new(QueryContext::with(
             DEFAULT_CATALOG_NAME,
@@ -1886,11 +1895,7 @@ mod tests {
         let calls = interceptor.calls.lock().unwrap();
         assert_eq!(
             calls.as_slice(),
-            &[(
-                DEFAULT_CATALOG_NAME.to_string(),
-                DEFAULT_SCHEMA_NAME.to_string(),
-                5
-            )]
+            &[("other_catalog".to_string(), "other_schema".to_string(), 5)]
         );
     }
 

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -1507,6 +1507,18 @@ mod tests {
             }
             _ => unreachable!(),
         }
+
+        let sql = "CREATE DATABASE prometheus with ('ingest_rows_rate_limit'='1000');";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        let stmts = result.unwrap();
+        match &stmts[0] {
+            Statement::CreateDatabase(c) => {
+                assert_eq!(c.name.to_string(), "prometheus");
+                assert_eq!(c.options.get("ingest_rows_rate_limit").unwrap(), "1000");
+            }
+            _ => unreachable!(),
+        }
     }
 
     #[test]

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -101,6 +101,9 @@ pub const DDL_WAIT: &str = "wait";
 
 pub const VALID_DDL_OPTION_KEYS: [&str; 2] = [DDL_TIMEOUT, DDL_WAIT];
 
+/// The key of ingest rows rate limit option (rows per second, cluster-wide) in database options.
+pub const INGEST_ROWS_RATE_LIMIT_KEY: &str = "ingest_rows_rate_limit";
+
 // Valid option keys when creating a db.
 static VALID_DB_OPT_KEYS: Lazy<HashSet<&str>> = Lazy::new(|| {
     let mut set = HashSet::new();
@@ -120,6 +123,7 @@ static VALID_DB_OPT_KEYS: Lazy<HashSet<&str>> = Lazy::new(|| {
     set.insert(TWCS_TRIGGER_FILE_NUM);
     set.insert(TWCS_MAX_OUTPUT_FILE_SIZE);
     set.insert(SST_FORMAT_KEY);
+    set.insert(INGEST_ROWS_RATE_LIMIT_KEY);
     set
 });
 
@@ -539,6 +543,8 @@ mod tests {
             MEMTABLE_BULK_ENCODE_BYTES_THRESHOLD
         ));
         assert!(validate_database_option(MEMTABLE_BULK_MAX_MERGE_GROUPS));
+        assert!(validate_database_option(INGEST_ROWS_RATE_LIMIT_KEY));
+        assert!(validate_database_option("ingest_rows_rate_limit"));
         assert!(!validate_database_option("foo"));
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Enterprise-side feature: database-level ingest rate limiting (design doc in the enterprise repo).

## What's changed and what's your intention?

This PR adds the OSS-side hooks needed by the enterprise **database-level write rate limiting** feature (`ingest_rows_rate_limit`, a cluster-wide rows/sec quota per database, enforced by enterprise plugins). The enforcement itself lives in the enterprise repository; OSS only gains:

1. **A new database option key** `ingest_rows_rate_limit` added to `VALID_DB_OPT_KEYS` (`src/table/src/requests.rs`), so it can be set via `CREATE DATABASE ... WITH('ingest_rows_rate_limit'='1000')` and updated dynamically via `ALTER DATABASE ... SET/UNSET`. Like other database options, it is persisted in `SchemaNameValue.extra_options` and propagated through the existing schema-cache invalidation broadcast. In pure OSS builds the option is stored but inert (no enforcement), same as other enterprise-consumed options.

2. **An `InsertLimitInterceptor` hook on `Inserter`** (`src/operator/src/insert.rs`):
   - `Inserter::do_request` is the single choke point for nearly all write paths (SQL INSERT, gRPC row/column inserts, InfluxDB, OTLP, Prom remote write, OpenTSDB, logs, traces). The interceptor is invoked there with the total row count before dispatch to datanodes.
   - `Inserter::handle_bulk_insert` (Flight DoPut) dispatches directly and bypasses `do_request`, so it gets its own interception call.
   - The charge target is derived from the **target table's** `catalog_name`/`schema_name` (falling back to the session context), so fully-qualified `INSERT INTO other_db.t`, DataFusion DML, and `COPY FROM` cannot bypass a limit by writing cross-database from an unlimited session.
   - Interceptor errors propagate through `Error::External`, so an enterprise-side `StatusCode::RateLimited` maps cleanly to gRPC `ResourceExhausted` / HTTP 429 / MySQL / PostgreSQL error codes.
   - The interceptor defaults to `None` (zero overhead in OSS) and is registered via `Plugins`; the frontend builder wires it with `plugins.get::<InsertLimitInterceptorRef>()`. The `Inserter::new` signature is unchanged, so the flownode call site is unaffected (flow sink writes are intentionally out of scope).

Notes / limitations:
- Instant-TTL rows (mirrored to flownodes only) are counted, as they represent real frontend ingest load.
- Auto-create/alter happens before the check, so a rejected first write may still have created/altered the table.
- Deletes are out of scope (they never pass through `Inserter`).

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
