### PR TITLE
refactor: remove open metrics parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,12 +978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_ops"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9800,17 +9794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openmetrics-parser"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e40a68c62e09c5dfec2f6472af3bd5e8ddf506fcf14c78ece23794ffbb874eca"
-dependencies = [
- "auto_ops",
- "pest",
- "pest_derive",
-]
-
-[[package]]
 name = "opensrv-mysql"
 version = "0.8.0"
 source = "git+https://github.com/GreptimeTeam/opensrv?rev=6c5a451544194b7bb60a8318d155d4f892b49f2c#6c5a451544194b7bb60a8318d155d4f892b49f2c"
@@ -13411,7 +13394,6 @@ dependencies = [
  "notify",
  "object-pool",
  "once_cell",
- "openmetrics-parser",
  "opensrv-mysql",
  "opentelemetry-proto",
  "operator",

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -47,7 +47,7 @@ use servers::http::header::{CONTENT_ENCODING_SNAPPY, CONTENT_TYPE_PROTOBUF, coll
 use servers::http::prom_store::PHYSICAL_TABLE_PARAM;
 use servers::interceptor::{PromStoreProtocolInterceptor, PromStoreProtocolInterceptorRef};
 use servers::pending_rows_batcher::PendingRowsSchemaAlterer;
-use servers::prom_store::{self, Metrics};
+use servers::prom_store;
 use servers::query_handler::{
     PromStoreProtocolHandler, PromStoreProtocolHandlerRef, PromStoreResponse,
 };
@@ -648,10 +648,6 @@ impl PromStoreProtocolHandler for Instance {
             .fail(),
         }
     }
-
-    async fn ingest_metrics(&self, _metrics: Metrics) -> ServerResult<()> {
-        todo!();
-    }
 }
 
 impl Instance {
@@ -789,10 +785,6 @@ impl PromStoreProtocolHandler for ExportMetricHandler {
         _request: ReadRequest,
         _ctx: QueryContextRef,
     ) -> ServerResult<PromStoreResponse> {
-        unreachable!();
-    }
-
-    async fn ingest_metrics(&self, _metrics: Metrics) -> ServerResult<()> {
         unreachable!();
     }
 }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -87,7 +87,6 @@ mysql_common = "0.38"
 notify.workspace = true
 object-pool = "0.5"
 once_cell.workspace = true
-openmetrics-parser = "0.4"
 # Wait for https://github.com/databendlabs/opensrv/pull/81
 opensrv-mysql = { git = "https://github.com/GreptimeTeam/opensrv", rev = "6c5a451544194b7bb60a8318d155d4f892b49f2c" }
 opentelemetry-proto.workspace = true

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -770,7 +770,6 @@ mod tests {
 
     use super::*;
     use crate::prom_remote_write::validation::PromValidationMode;
-    use crate::prom_store::Metrics;
     use crate::query_handler::PromStoreProtocolHandler;
 
     #[test]
@@ -966,10 +965,6 @@ mod tests {
         ) -> Result<PromStoreResponse> {
             unimplemented!()
         }
-
-        async fn ingest_metrics(&self, _metrics: Metrics) -> Result<()> {
-            unimplemented!()
-        }
     }
 
     #[tokio::test]
@@ -1065,10 +1060,6 @@ mod tests {
             _request: ReadRequest,
             _ctx: QueryContextRef,
         ) -> Result<PromStoreResponse> {
-            unimplemented!()
-        }
-
-        async fn ingest_metrics(&self, _metrics: Metrics) -> Result<()> {
             unimplemented!()
         }
     }

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -34,7 +34,6 @@ use datafusion::dataframe::DataFrame;
 use datafusion::prelude::{Expr, col, lit, regexp_match};
 use datafusion_common::ScalarValue;
 use datafusion_expr::LogicalPlan;
-use openmetrics_parser::{MetricsExposition, PrometheusType, PrometheusValue};
 use snafu::{OptionExt, ResultExt, ensure};
 use snap::raw::{Decoder, Encoder};
 
@@ -93,11 +92,6 @@ pub fn is_database_selection_label(label: &str) -> bool {
 /// Check if given label is a physical table selection label
 pub fn is_physical_table_selection_label(label: &str) -> bool {
     label == PHYSICAL_TABLE_LABEL || label == PHYSICAL_TABLE_LABEL_ALT
-}
-
-/// Metrics for push gateway protocol
-pub struct Metrics {
-    pub exposition: MetricsExposition<PrometheusType, PrometheusValue>,
 }
 
 /// Get table name from remote query

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -54,7 +54,6 @@ use crate::error::Result;
 use crate::http::jaeger::QueryTraceParams;
 use crate::influxdb::InfluxdbRequest;
 use crate::opentsdb::codec::DataPoint;
-use crate::prom_store::Metrics;
 pub type OpentsdbProtocolHandlerRef = Arc<dyn OpentsdbProtocolHandler + Send + Sync>;
 pub type InfluxdbLineProtocolHandlerRef = Arc<dyn InfluxdbLineProtocolHandler + Send + Sync>;
 pub type PromStoreProtocolHandlerRef = Arc<dyn PromStoreProtocolHandler + Send + Sync>;
@@ -125,8 +124,6 @@ pub trait PromStoreProtocolHandler {
 
     /// Handling prometheus remote read requests
     async fn read(&self, request: ReadRequest, ctx: QueryContextRef) -> Result<PromStoreResponse>;
-    /// Handling push gateway requests
-    async fn ingest_metrics(&self, metrics: Metrics) -> Result<()>;
 }
 
 #[async_trait]

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -44,7 +44,7 @@ use servers::http::{HttpOptions, HttpServerBuilder};
 use servers::prom_remote_write::v2::test_util as remote_write_v2;
 use servers::prom_remote_write::validation::PromValidationMode;
 use servers::prom_store;
-use servers::prom_store::{Metrics, snappy_compress};
+use servers::prom_store::snappy_compress;
 use servers::query_handler::sql::SqlQueryHandler;
 use servers::query_handler::{PromStoreProtocolHandler, PromStoreResponse};
 use session::context::QueryContextRef;
@@ -145,10 +145,6 @@ impl PromStoreProtocolHandler for DummyInstance {
             resp_metrics: Default::default(),
             body: response.encode_to_vec(),
         })
-    }
-
-    async fn ingest_metrics(&self, _metrics: Metrics) -> Result<()> {
-        unimplemented!();
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch removes unused openmetrics-parser deps.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
