### PR TITLE
chore(flow): add DML Flight terminal diagnostics

### DIFF
--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -1031,15 +1031,13 @@ impl Database {
                 Some((affected_rows_seen, app_metadata_bytes_ref, inline_metrics_bytes)),
                 Some(Ok(FlightMessage::AffectedRows { metrics, .. })),
             ) = (payload_timing.as_ref(), flight_message.as_ref())
+                && !affected_rows_seen.swap(true, Ordering::Relaxed)
             {
-                if !affected_rows_seen.swap(true, Ordering::Relaxed) {
-                    app_metadata_bytes_ref
-                        .store(app_metadata_bytes.unwrap_or(0), Ordering::Relaxed);
-                    inline_metrics_bytes.store(
-                        metrics.as_ref().map_or(0, |metrics| metrics.len()),
-                        Ordering::Relaxed,
-                    );
-                }
+                app_metadata_bytes_ref.store(app_metadata_bytes.unwrap_or(0), Ordering::Relaxed);
+                inline_metrics_bytes.store(
+                    metrics.as_ref().map_or(0, |metrics| metrics.len()),
+                    Ordering::Relaxed,
+                );
             }
             future::ready(flight_message)
         });
@@ -1349,6 +1347,66 @@ mod tests {
     #[test]
     fn test_parse_terminal_metrics_rejects_invalid_json() {
         assert!(parse_terminal_metrics("{not-json}").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_flow_dml_timing_affected_rows_success_path() {
+        let output = output_from_flight_message_stream(
+            futures_util::stream::iter(vec![Ok(FlightMessage::AffectedRows {
+                rows: 3,
+                metrics: None,
+            })] as Vec<Result<FlightMessage>>),
+            Some(FlowDmlFlightTiming::new(
+                "attempt-success".to_string(),
+                None,
+            )),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(output.output.data, OutputData::AffectedRows(3)));
+        assert!(output.metrics.is_ready());
+    }
+
+    #[tokio::test]
+    async fn test_flow_dml_timing_terminal_error_path() {
+        let error = IllegalFlightMessagesSnafu {
+            reason: "terminal test error",
+        }
+        .build();
+        let result = output_from_flight_message_stream(
+            futures_util::stream::iter(vec![
+                Ok(FlightMessage::AffectedRows {
+                    rows: 3,
+                    metrics: None,
+                }),
+                Err(error),
+            ] as Vec<Result<FlightMessage>>),
+            Some(FlowDmlFlightTiming::new("attempt-error".to_string(), None)),
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_flow_dml_timing_schema_disarm_path() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "v",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+        let output = output_from_flight_message_stream(
+            futures_util::stream::iter(vec![Ok(FlightMessage::Schema(
+                schema.arrow_schema().clone(),
+            ))] as Vec<Result<FlightMessage>>),
+            Some(FlowDmlFlightTiming::new("attempt-schema".to_string(), None)),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(output.output.data, OutputData::Stream(_)));
+        assert!(!output.metrics.is_ready());
     }
 
     #[tokio::test]

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -14,9 +14,10 @@
 
 use std::pin::Pin;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use api::v1::auth_header::AuthScheme;
 use api::v1::ddl_request::Expr as DdlExpr;
@@ -43,13 +44,15 @@ use common_query::Output;
 use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, RecordBatchStreamWrapper};
-use common_telemetry::tracing::Span;
+use common_telemetry::tracing::{Level, Span};
 use common_telemetry::tracing_context::W3cTrace;
-use common_telemetry::{error, warn};
+use common_telemetry::{debug, error, warn};
 use futures::future;
 use futures_util::{Stream, StreamExt, TryStreamExt};
 use prost::Message;
+use query::options::{parse_diagnostic_flow_attempt_id, parse_diagnostic_flow_id};
 use snafu::ResultExt;
+use tokio::time::Instant;
 use tonic::metadata::{AsciiMetadataKey, AsciiMetadataValue, MetadataMap, MetadataValue};
 use tonic::transport::Channel;
 
@@ -256,41 +259,198 @@ fn attach_terminal_metrics(output: Output, terminal_metrics: &OutputMetrics) -> 
     Output::new(data, meta)
 }
 
+/// Terminal diagnostic accumulator for a Flow DML Flight response.
+///
+/// It remains inactive for the streamed query path: a Schema first message
+/// disarms it before that stream is returned to its caller.
+struct FlowDmlFlightTiming {
+    attempt_id: String,
+    flow_id: Option<String>,
+    started: Instant,
+    rpc_response_wait: Option<Duration>,
+    affected_rows_wait: Option<Duration>,
+    terminal_wait: Option<Duration>,
+    affected_rows_app_metadata_bytes: Arc<AtomicUsize>,
+    inline_metrics_bytes: Arc<AtomicUsize>,
+    last_completed_stage: &'static str,
+    active_stage: Option<&'static str>,
+    finished: bool,
+}
+
+impl FlowDmlFlightTiming {
+    fn new(attempt_id: String, flow_id: Option<String>) -> Self {
+        Self {
+            attempt_id,
+            flow_id,
+            started: Instant::now(),
+            rpc_response_wait: None,
+            affected_rows_wait: None,
+            terminal_wait: None,
+            affected_rows_app_metadata_bytes: Arc::new(AtomicUsize::new(0)),
+            inline_metrics_bytes: Arc::new(AtomicUsize::new(0)),
+            last_completed_stage: "request_sent",
+            active_stage: None,
+            finished: false,
+        }
+    }
+
+    fn set_active_stage(&mut self, stage: &'static str) {
+        self.active_stage = Some(stage);
+    }
+
+    fn complete_stage(&mut self, stage: &'static str) {
+        self.last_completed_stage = stage;
+        self.active_stage = None;
+    }
+
+    fn record_rpc_response(&mut self, elapsed: Duration) {
+        self.rpc_response_wait = Some(elapsed);
+        self.complete_stage("flight_rpc_response");
+    }
+
+    fn record_affected_rows(&mut self, elapsed: Duration) {
+        self.affected_rows_wait = Some(elapsed);
+        self.complete_stage("affected_rows");
+    }
+
+    fn record_terminal(&mut self, elapsed: Duration) {
+        self.terminal_wait = Some(elapsed);
+        self.complete_stage("terminal_eof");
+    }
+
+    fn finish(&mut self, outcome: &'static str) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        debug!(
+            attempt_id = self.attempt_id.as_str(),
+            flow_id = self.flow_id.as_deref().unwrap_or("unknown"),
+            elapsed_ms = self.started.elapsed().as_millis() as u64,
+            flight_rpc_response_wait_ms = self.rpc_response_wait.map(|d| d.as_millis() as u64),
+            affected_rows_wait_ms = self.affected_rows_wait.map(|d| d.as_millis() as u64),
+            terminal_eof_wait_ms = self.terminal_wait.map(|d| d.as_millis() as u64),
+            affected_rows_app_metadata_bytes = self
+                .affected_rows_app_metadata_bytes
+                .load(Ordering::Relaxed),
+            inline_metrics_bytes = self.inline_metrics_bytes.load(Ordering::Relaxed),
+            last_completed_stage = self.last_completed_stage,
+            active_stage = ?self.active_stage,
+            outcome = outcome,
+            "Flow DML Flight client summary",
+        );
+    }
+
+    fn disarm(&mut self) {
+        self.finished = true;
+    }
+}
+
+impl Drop for FlowDmlFlightTiming {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.finish("dropped");
+        }
+    }
+}
+
 async fn output_from_flight_message_stream<S>(
     mut flight_message_stream: S,
+    mut dml_timing: Option<FlowDmlFlightTiming>,
 ) -> Result<OutputWithMetrics>
 where
     S: Stream<Item = Result<FlightMessage>> + Send + Unpin + 'static,
 {
+    let affected_rows_started = dml_timing.as_mut().map(|timing| {
+        timing.set_active_stage("affected_rows");
+        Instant::now()
+    });
     let Some(first_flight_message) = flight_message_stream.next().await else {
+        if let Some(timing) = dml_timing.as_mut() {
+            timing.record_affected_rows(affected_rows_started.unwrap().elapsed());
+            timing.finish("error");
+        }
         return IllegalFlightMessagesSnafu {
             reason: "Expect the response not to be empty",
         }
         .fail();
     };
 
-    let first_flight_message = first_flight_message?;
+    let first_flight_message = match first_flight_message {
+        Ok(message) => message,
+        Err(e) => {
+            if let Some(timing) = dml_timing.as_mut() {
+                timing.record_affected_rows(affected_rows_started.unwrap().elapsed());
+                timing.finish("error");
+            }
+            return Err(e);
+        }
+    };
+
+    if let Some(timing) = dml_timing.as_mut() {
+        timing.record_affected_rows(affected_rows_started.unwrap().elapsed());
+    }
 
     match first_flight_message {
         FlightMessage::AffectedRows { rows, metrics } => {
             let terminal_metrics = OutputMetrics::new();
             if let Some(metrics) = metrics {
-                terminal_metrics.update(Some(parse_terminal_metrics(&metrics)?));
+                let metrics = match parse_terminal_metrics(&metrics) {
+                    Ok(metrics) => metrics,
+                    Err(e) => {
+                        if let Some(timing) = dml_timing.as_mut() {
+                            timing.finish("error");
+                        }
+                        return Err(e);
+                    }
+                };
+                terminal_metrics.update(Some(metrics));
             }
-            let next_message = flight_message_stream.next().await.transpose()?;
+            let terminal_started = dml_timing.as_mut().map(|timing| {
+                timing.set_active_stage("terminal_eof");
+                Instant::now()
+            });
+            let next_message = match flight_message_stream.next().await.transpose() {
+                Ok(message) => message,
+                Err(e) => {
+                    if let Some(timing) = dml_timing.as_mut() {
+                        timing.record_terminal(terminal_started.unwrap().elapsed());
+                        timing.finish("error");
+                    }
+                    return Err(e);
+                }
+            };
+            if let Some(timing) = dml_timing.as_mut() {
+                timing.record_terminal(terminal_started.unwrap().elapsed());
+            }
             match next_message {
                 None => terminal_metrics.mark_ready(),
                 Some(FlightMessage::Metrics(s)) if terminal_metrics.get().is_none() => {
-                    terminal_metrics.update(Some(parse_terminal_metrics(&s)?));
+                    let metrics = match parse_terminal_metrics(&s) {
+                        Ok(metrics) => metrics,
+                        Err(e) => {
+                            if let Some(timing) = dml_timing.as_mut() {
+                                timing.finish("error");
+                            }
+                            return Err(e);
+                        }
+                    };
+                    terminal_metrics.update(Some(metrics));
                     terminal_metrics.mark_ready();
                 }
                 Some(FlightMessage::Metrics(_)) => {
+                    if let Some(timing) = dml_timing.as_mut() {
+                        timing.finish("error");
+                    }
                     return IllegalFlightMessagesSnafu {
                         reason: "'AffectedRows' Flight metadata already carries Metrics and cannot be followed by another Metrics message",
                     }
                     .fail();
                 }
                 Some(other) => {
+                    if let Some(timing) = dml_timing.as_mut() {
+                        timing.finish("error");
+                    }
                     return IllegalFlightMessagesSnafu {
                         reason: format!(
                             "'AffectedRows' Flight message can only be followed by a Metrics message, got {other:?}"
@@ -299,16 +459,27 @@ where
                     .fail();
                 }
             }
+            if let Some(timing) = dml_timing.as_mut() {
+                timing.finish("ok");
+            }
             Ok(OutputWithMetrics {
                 output: Output::new_with_affected_rows(rows),
                 metrics: terminal_metrics,
             })
         }
-        FlightMessage::RecordBatch(_) | FlightMessage::Metrics(_) => IllegalFlightMessagesSnafu {
-            reason: "The first flight message cannot be a RecordBatch or Metrics message",
+        FlightMessage::RecordBatch(_) | FlightMessage::Metrics(_) => {
+            if let Some(timing) = dml_timing.as_mut() {
+                timing.finish("error");
+            }
+            IllegalFlightMessagesSnafu {
+                reason: "The first flight message cannot be a RecordBatch or Metrics message",
+            }
+            .fail()
         }
-        .fail(),
         FlightMessage::Schema(schema) => {
+            if let Some(timing) = dml_timing.as_mut() {
+                timing.disarm();
+            }
             let metrics = Arc::new(ArcSwapOption::from(None));
             let metrics_ref = metrics.clone();
             let schema = Arc::new(
@@ -784,9 +955,37 @@ impl Database {
         Self::put_flow_extensions(metadata, flow_extensions)?;
         Self::put_snapshot_seqs(metadata, snapshot_seqs)?;
 
-        let mut client = self.client.make_flight_client(false, false)?;
+        let mut dml_timing = if common_telemetry::tracing::enabled!(target: module_path!(), Level::DEBUG)
+        {
+            let flow_extensions = flow_extensions
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                .collect::<std::collections::HashMap<_, _>>();
+            parse_diagnostic_flow_attempt_id(&flow_extensions).map(|attempt_id| {
+                FlowDmlFlightTiming::new(attempt_id, parse_diagnostic_flow_id(&flow_extensions))
+            })
+        } else {
+            None
+        };
+        let mut client = match self.client.make_flight_client(false, false) {
+            Ok(client) => client,
+            Err(e) => {
+                if let Some(timing) = dml_timing.as_mut() {
+                    timing.finish("error");
+                }
+                return Err(e);
+            }
+        };
 
-        let response = client.mut_inner().do_get(request).await.or_else(|e| {
+        let rpc_started = dml_timing.as_mut().map(|timing| {
+            timing.set_active_stage("flight_rpc_response");
+            Instant::now()
+        });
+        let response = client.mut_inner().do_get(request).await;
+        if let Some(timing) = dml_timing.as_mut() {
+            timing.record_rpc_response(rpc_started.unwrap().elapsed());
+        }
+        let response = response.or_else(|e| {
             let tonic_code = e.code();
             let e: Error = e.into();
             error!(
@@ -799,16 +998,53 @@ impl Database {
                 addr: client.addr().to_string(),
                 tonic_code,
             })
-        })?;
+        });
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => {
+                if let Some(timing) = dml_timing.as_mut() {
+                    timing.finish("error");
+                }
+                return Err(e);
+            }
+        };
 
         let flight_data_stream = response.into_inner();
         let mut decoder = FlightDecoder::default();
-
-        let flight_message_stream = flight_data_stream.filter_map(move |flight_data| {
-            future::ready(decode_flight_data(&mut decoder, flight_data))
+        let payload_timing = dml_timing.as_ref().map(|timing| {
+            (
+                Arc::new(AtomicBool::new(false)),
+                timing.affected_rows_app_metadata_bytes.clone(),
+                timing.inline_metrics_bytes.clone(),
+            )
         });
 
-        output_from_flight_message_stream(flight_message_stream).await
+        let flight_message_stream = flight_data_stream.filter_map(move |flight_data| {
+            let app_metadata_bytes = payload_timing.as_ref().and_then(|_| {
+                flight_data
+                    .as_ref()
+                    .ok()
+                    .map(|flight_data| flight_data.app_metadata.len())
+            });
+            let flight_message = decode_flight_data(&mut decoder, flight_data);
+            if let (
+                Some((affected_rows_seen, app_metadata_bytes_ref, inline_metrics_bytes)),
+                Some(Ok(FlightMessage::AffectedRows { metrics, .. })),
+            ) = (payload_timing.as_ref(), flight_message.as_ref())
+            {
+                if !affected_rows_seen.swap(true, Ordering::Relaxed) {
+                    app_metadata_bytes_ref
+                        .store(app_metadata_bytes.unwrap_or(0), Ordering::Relaxed);
+                    inline_metrics_bytes.store(
+                        metrics.as_ref().map_or(0, |metrics| metrics.len()),
+                        Ordering::Relaxed,
+                    );
+                }
+            }
+            future::ready(flight_message)
+        });
+
+        output_from_flight_message_stream(flight_message_stream, dml_timing).await
     }
 
     /// Ingest a stream of [RecordBatch]es that belong to a table, using Arrow Flight's "`DoPut`"
@@ -1117,13 +1353,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_affected_rows_inline_metrics_are_parsed() {
-        let output = output_from_flight_message_stream(futures_util::stream::iter(vec![Ok(
-            FlightMessage::AffectedRows {
+        let output = output_from_flight_message_stream(
+            futures_util::stream::iter(vec![Ok(FlightMessage::AffectedRows {
                 rows: 3,
                 metrics: Some(terminal_metrics_json()),
-            },
-        )]
-            as Vec<Result<FlightMessage>>))
+            })] as Vec<Result<FlightMessage>>),
+            None,
+        )
         .await
         .unwrap();
 
@@ -1138,14 +1374,16 @@ mod tests {
     #[tokio::test]
     async fn test_affected_rows_inline_metrics_rejects_trailing_metrics() {
         let metrics_json = terminal_metrics_json();
-        let err = output_from_flight_message_stream(futures_util::stream::iter(vec![
-            Ok(FlightMessage::AffectedRows {
-                rows: 3,
-                metrics: Some(metrics_json.clone()),
-            }),
-            Ok(FlightMessage::Metrics(metrics_json)),
-        ]
-            as Vec<Result<FlightMessage>>))
+        let err = output_from_flight_message_stream(
+            futures_util::stream::iter(vec![
+                Ok(FlightMessage::AffectedRows {
+                    rows: 3,
+                    metrics: Some(metrics_json.clone()),
+                }),
+                Ok(FlightMessage::Metrics(metrics_json)),
+            ] as Vec<Result<FlightMessage>>),
+            None,
+        )
         .await
         .unwrap_err();
 
@@ -1167,12 +1405,14 @@ mod tests {
             vec![Arc::new(Int32Vector::from_slice([1])) as VectorRef],
         )
         .unwrap();
-        let output = output_from_flight_message_stream(futures_util::stream::iter(vec![
-            Ok(FlightMessage::Schema(schema.arrow_schema().clone())),
-            Ok(FlightMessage::RecordBatch(batch.into_df_record_batch())),
-            Ok(FlightMessage::Metrics("{not-json}".to_string())),
-        ]
-            as Vec<Result<FlightMessage>>))
+        let output = output_from_flight_message_stream(
+            futures_util::stream::iter(vec![
+                Ok(FlightMessage::Schema(schema.arrow_schema().clone())),
+                Ok(FlightMessage::RecordBatch(batch.into_df_record_batch())),
+                Ok(FlightMessage::Metrics("{not-json}".to_string())),
+            ] as Vec<Result<FlightMessage>>),
+            None,
+        )
         .await
         .unwrap();
         let terminal_metrics = output.metrics.clone();
@@ -1211,18 +1451,20 @@ mod tests {
             vec![Arc::new(Int32Vector::from_slice([2])) as VectorRef],
         )
         .unwrap();
-        let output = output_from_flight_message_stream(futures_util::stream::iter(vec![
-            Ok(FlightMessage::Schema(schema.arrow_schema().clone())),
-            Ok(FlightMessage::RecordBatch(
-                first_batch.into_df_record_batch(),
-            )),
-            Ok(FlightMessage::Metrics(terminal_metrics_json_with_seq(1))),
-            Ok(FlightMessage::RecordBatch(
-                second_batch.into_df_record_batch(),
-            )),
-            Ok(FlightMessage::Metrics(terminal_metrics_json_with_seq(2))),
-        ]
-            as Vec<Result<FlightMessage>>))
+        let output = output_from_flight_message_stream(
+            futures_util::stream::iter(vec![
+                Ok(FlightMessage::Schema(schema.arrow_schema().clone())),
+                Ok(FlightMessage::RecordBatch(
+                    first_batch.into_df_record_batch(),
+                )),
+                Ok(FlightMessage::Metrics(terminal_metrics_json_with_seq(1))),
+                Ok(FlightMessage::RecordBatch(
+                    second_batch.into_df_record_batch(),
+                )),
+                Ok(FlightMessage::Metrics(terminal_metrics_json_with_seq(2))),
+            ] as Vec<Result<FlightMessage>>),
+            None,
+        )
         .await
         .unwrap();
         let terminal_metrics = output.metrics.clone();

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -21,6 +21,7 @@ mod planner;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use common_base::Plugins;
@@ -50,6 +51,7 @@ use sqlparser::ast::AnalyzeFormat;
 use table::TableRef;
 use table::requests::{DeleteRequest, InsertRequest};
 use table::table::scan::{REGION_SCAN_EXEC_NAME, RegionScanExec};
+use tokio::time::Instant;
 use tracing::Span;
 
 use crate::analyze::DistAnalyzeExec;
@@ -67,7 +69,9 @@ use crate::metrics::{
     OnDone, QUERY_STAGE_ELAPSED, maybe_attach_region_watermark_metrics,
     should_collect_region_watermark_from_query_ctx,
 };
-use crate::options::ScheduledTimeExtension;
+use crate::options::{
+    ScheduledTimeExtension, parse_diagnostic_flow_attempt_id, parse_diagnostic_flow_id,
+};
 use crate::physical_wrapper::PhysicalPlanWrapperRef;
 use crate::planner::{DfLogicalPlanner, LogicalPlanner};
 use crate::query_engine::{DescribeResult, QueryEngineContext, QueryEngineState};
@@ -138,6 +142,165 @@ fn query_stat_counters(plan: &Arc<dyn ExecutionPlan>) -> Option<RegionQueryStatC
     counters
 }
 
+/// Terminal timing accumulator for one flow `INSERT INTO ... SELECT` DML
+/// statement executed by [`DatafusionQueryEngine`].
+///
+/// Only instantiated when a valid `flow.attempt_id` extension is present;
+/// otherwise the ordinary DML path is untouched. Every field defaults to zero
+/// and exactly one terminal summary is emitted (via [`Self::finish`] on
+/// success or [`Drop`] on cancellation), so returned stream, conversion and
+/// insert failures are reported exactly once.
+struct DmlStageTiming {
+    attempt_id: String,
+    flow_id: Option<String>,
+    table: String,
+    started: Instant,
+    last_completed_stage: &'static str,
+    active_stage: Option<&'static str>,
+    select_poll_total: Duration,
+    select_poll_max: Duration,
+    /// Duration of the `stream.next()` poll that produced the first batch.
+    first_batch: Option<Duration>,
+    /// Duration of the final `stream.next()` poll that observed source EOF.
+    source_eof: Option<Duration>,
+    last_poll: Duration,
+    batch_convert_total: Duration,
+    sink_insert_total: Duration,
+    sink_insert_max: Duration,
+    batch_count: usize,
+    output_rows: usize,
+    max_batch_rows: usize,
+    affected_rows: usize,
+    /// Stage that failed, when the terminal summary reports an error outcome.
+    failed_stage: Option<&'static str>,
+    finished: bool,
+}
+
+impl DmlStageTiming {
+    fn new(attempt_id: String, flow_id: Option<String>, table: String) -> Self {
+        Self {
+            attempt_id,
+            flow_id,
+            table,
+            started: Instant::now(),
+            last_completed_stage: "dml_started",
+            active_stage: None,
+            select_poll_total: Duration::ZERO,
+            select_poll_max: Duration::ZERO,
+            first_batch: None,
+            source_eof: None,
+            last_poll: Duration::ZERO,
+            batch_convert_total: Duration::ZERO,
+            sink_insert_total: Duration::ZERO,
+            sink_insert_max: Duration::ZERO,
+            batch_count: 0,
+            output_rows: 0,
+            max_batch_rows: 0,
+            affected_rows: 0,
+            failed_stage: None,
+            finished: false,
+        }
+    }
+
+    fn set_active_stage(&mut self, stage: &'static str) {
+        self.active_stage = Some(stage);
+    }
+
+    fn complete_stage(&mut self, stage: &'static str) {
+        self.last_completed_stage = stage;
+        self.active_stage = None;
+    }
+
+    /// Records one `stream.next()` await, including the final `None` (EOF)
+    /// poll.
+    fn record_select_poll(&mut self, elapsed: Duration) {
+        self.select_poll_total += elapsed;
+        self.select_poll_max = self.select_poll_max.max(elapsed);
+        self.last_poll = elapsed;
+    }
+
+    /// Records the final source EOF poll.
+    fn record_source_eof(&mut self) {
+        self.source_eof = Some(self.last_poll);
+        self.complete_stage("source_eof");
+    }
+
+    /// Records one successfully decoded batch.
+    fn record_batch(&mut self, rows: usize) {
+        if self.first_batch.is_none() {
+            self.first_batch = Some(self.last_poll);
+            self.complete_stage("source_first_batch");
+        }
+        self.batch_count += 1;
+        self.output_rows += rows;
+        self.max_batch_rows = self.max_batch_rows.max(rows);
+    }
+
+    /// Records the column-vector conversion time of one batch.
+    fn record_conversion(&mut self, elapsed: Duration) {
+        self.batch_convert_total += elapsed;
+        self.complete_stage("batch_convert");
+    }
+
+    /// Records the exact await time of one `self.insert` call.
+    fn record_sink_insert(&mut self, elapsed: Duration) {
+        self.sink_insert_total += elapsed;
+        self.sink_insert_max = self.sink_insert_max.max(elapsed);
+        self.complete_stage("sink_insert");
+    }
+
+    fn record_affected_rows(&mut self, rows: usize) {
+        self.affected_rows += rows;
+        self.complete_stage("dml_affected_rows");
+    }
+
+    /// Marks the attempt finished and emits the single terminal summary.
+    /// Idempotent; the [`Drop`] path then stays silent.
+    fn finish(&mut self, outcome: &str) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.emit(outcome);
+    }
+
+    fn emit(&self, outcome: &str) {
+        let flow_id = self.flow_id.as_deref().unwrap_or("unknown");
+        common_telemetry::debug!(
+            attempt_id = self.attempt_id.as_str(),
+            flow_id = flow_id,
+            table = self.table.as_str(),
+            elapsed_ms = self.started.elapsed().as_millis() as u64,
+            last_completed_stage = self.last_completed_stage,
+            active_stage = ?self.active_stage,
+            select_poll_total_ms = self.select_poll_total.as_millis() as u64,
+            select_poll_max_ms = self.select_poll_max.as_millis() as u64,
+            source_first_batch_ms = self.first_batch.map(|d| d.as_millis() as u64),
+            source_eof_ms = self.source_eof.map(|d| d.as_millis() as u64),
+            batch_convert_total_ms = self.batch_convert_total.as_millis() as u64,
+            sink_insert_total_ms = self.sink_insert_total.as_millis() as u64,
+            sink_insert_max_ms = self.sink_insert_max.as_millis() as u64,
+            batch_count = self.batch_count,
+            output_rows = self.output_rows,
+            max_batch_rows = self.max_batch_rows,
+            affected_rows = self.affected_rows,
+            failed_stage = ?self.failed_stage,
+            outcome = outcome,
+            "Flow DML stage timing",
+        );
+    }
+}
+
+impl Drop for DmlStageTiming {
+    fn drop(&mut self) {
+        // An unfinished future was cancelled or dropped. Returned errors call
+        // `finish("error")` at their failure site instead.
+        if !self.finished {
+            self.emit("dropped");
+        }
+    }
+}
+
 pub struct DatafusionQueryEngine {
     state: Arc<QueryEngineState>,
     plugins: Plugins,
@@ -200,11 +363,63 @@ impl DatafusionQueryEngine {
         let default_catalog = &query_ctx.current_catalog().to_owned();
         let default_schema = &query_ctx.current_schema();
         let table_name = dml.table_name.resolve(default_catalog, default_schema);
-        let table = self.find_table(&table_name, &query_ctx).await?;
 
-        let Output { data, meta } = self
+        // Diagnostic-only flow attempt correlation. Missing/invalid IDs and
+        // disabled DEBUG logging leave the ordinary DML path untouched.
+        let mut dml_timing = if tracing::enabled!(target: module_path!(), tracing::Level::DEBUG) {
+            parse_diagnostic_flow_attempt_id(&query_ctx.extensions()).map(|attempt_id| {
+                DmlStageTiming::new(
+                    attempt_id,
+                    parse_diagnostic_flow_id(&query_ctx.extensions()),
+                    table_name.to_string(),
+                )
+            })
+        } else {
+            None
+        };
+
+        if let Some(timing) = dml_timing.as_mut() {
+            timing.set_active_stage("table_lookup");
+        }
+        let table = match self.find_table(&table_name, &query_ctx).await {
+            Ok(table) => {
+                if let Some(timing) = dml_timing.as_mut() {
+                    timing.complete_stage("table_lookup");
+                }
+                table
+            }
+            Err(e) => {
+                if let Some(timing) = dml_timing.as_mut() {
+                    timing.complete_stage("table_lookup");
+                    timing.failed_stage = Some("table_lookup");
+                    timing.finish("error");
+                }
+                return Err(e);
+            }
+        };
+
+        if let Some(timing) = dml_timing.as_mut() {
+            timing.set_active_stage("source_plan");
+        }
+        let Output { data, meta } = match self
             .exec_query_plan((*dml.input).clone(), query_ctx.clone())
-            .await?;
+            .await
+        {
+            Ok(output) => {
+                if let Some(timing) = dml_timing.as_mut() {
+                    timing.complete_stage("source_plan");
+                }
+                output
+            }
+            Err(e) => {
+                if let Some(timing) = dml_timing.as_mut() {
+                    timing.complete_stage("source_plan");
+                    timing.failed_stage = Some("source_plan");
+                    timing.finish("error");
+                }
+                return Err(e);
+            }
+        };
         let mut stream = match data {
             OutputData::RecordBatches(batches) => batches.as_stream(),
             OutputData::Stream(stream) => stream,
@@ -214,30 +429,100 @@ impl DatafusionQueryEngine {
         let mut affected_rows = 0;
         let mut insert_cost = 0;
 
-        while let Some(batch) = stream.next().await {
-            let batch = batch.context(CreateRecordBatchSnafu)?;
+        loop {
+            let poll_started = dml_timing.as_mut().map(|timing| {
+                timing.set_active_stage("select_poll");
+                Instant::now()
+            });
+            let polled = stream.next().await;
+            if let (Some(timing), Some(poll_started)) = (dml_timing.as_mut(), poll_started) {
+                timing.record_select_poll(poll_started.elapsed());
+            }
+            let Some(batch) = polled else {
+                if let Some(timing) = dml_timing.as_mut() {
+                    timing.record_source_eof();
+                }
+                break;
+            };
+            let batch = batch.context(CreateRecordBatchSnafu);
+            if let Some(timing) = dml_timing.as_mut() {
+                if batch.is_err() {
+                    timing.complete_stage("select_poll");
+                    timing.failed_stage = Some("select_poll");
+                    timing.finish("error");
+                }
+            }
+            let batch = batch?;
+            if let Some(timing) = dml_timing.as_mut() {
+                timing.record_batch(batch.num_rows());
+            }
+
+            let converted_started = dml_timing.as_ref().map(|_| Instant::now());
             let column_vectors = batch
                 .column_vectors(&table_name.to_string(), table.schema())
                 .map_err(BoxedError::new)
-                .context(QueryExecutionSnafu)?;
+                .context(QueryExecutionSnafu);
+            if let Some(timing) = dml_timing.as_mut() {
+                timing.record_conversion(converted_started.unwrap().elapsed());
+                if column_vectors.is_err() {
+                    timing.failed_stage = Some("batch_convert");
+                    timing.finish("error");
+                }
+            }
+            let column_vectors = column_vectors?;
 
             match dml.op {
                 WriteOp::Insert(_) => {
+                    if let Some(timing) = dml_timing.as_mut() {
+                        timing.set_active_stage("sink_insert");
+                    }
+                    let insert_started = dml_timing.as_ref().map(|_| Instant::now());
                     // We ignore the insert op.
                     let output = self
                         .insert(&table_name, column_vectors, query_ctx.clone())
-                        .await?;
+                        .await;
+                    if let Some(timing) = dml_timing.as_mut() {
+                        timing.record_sink_insert(insert_started.unwrap().elapsed());
+                        if output.is_err() {
+                            timing.failed_stage = Some("sink_insert");
+                            timing.finish("error");
+                        }
+                    }
+                    let output = output?;
                     let (rows, cost) = output.extract_rows_and_cost();
                     affected_rows += rows;
                     insert_cost += cost;
                 }
                 WriteOp::Delete => {
-                    affected_rows += self
+                    if let Some(timing) = dml_timing.as_mut() {
+                        timing.set_active_stage("sink_delete");
+                    }
+                    let deleted = self
                         .delete(&table_name, &table, column_vectors, query_ctx.clone())
-                        .await?;
+                        .await;
+                    match deleted {
+                        Ok(rows) => {
+                            if let Some(timing) = dml_timing.as_mut() {
+                                timing.complete_stage("sink_delete");
+                            }
+                            affected_rows += rows;
+                        }
+                        Err(e) => {
+                            if let Some(timing) = dml_timing.as_mut() {
+                                timing.complete_stage("sink_delete");
+                                timing.failed_stage = Some("sink_delete");
+                                timing.finish("error");
+                            }
+                            return Err(e);
+                        }
+                    }
                 }
                 _ => unreachable!("guarded by the 'ensure!' at the beginning"),
             }
+        }
+        if let Some(timing) = dml_timing.as_mut() {
+            timing.record_affected_rows(affected_rows);
+            timing.finish("ok");
         }
         Ok(Output::new(
             OutputData::AffectedRows(affected_rows),
@@ -733,6 +1018,7 @@ mod tests {
     use std::fmt;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use api::v1::SemanticType;
     use arrow::array::{ArrayRef, UInt64Array};
@@ -1344,5 +1630,85 @@ mod tests {
         assert_eq!(0, left_last_filter_len.load(Ordering::Relaxed));
         assert!(right_update_calls.load(Ordering::Relaxed) > 0);
         assert!(right_last_filter_len.load(Ordering::Relaxed) > 0);
+    }
+
+    // --- DmlStageTiming accumulator accounting ---
+
+    #[test]
+    fn test_dml_stage_timing_accumulates_and_finishes() {
+        let mut timing = DmlStageTiming::new(
+            "42-1700000000000-0123456789abcdef".to_string(),
+            Some("7".to_string()),
+            "greptime.public.out".to_string(),
+        );
+
+        // two batches, then EOF
+        timing.record_select_poll(Duration::from_millis(10));
+        timing.record_batch(5);
+        timing.record_conversion(Duration::from_millis(4));
+        timing.record_sink_insert(Duration::from_millis(40));
+
+        timing.record_select_poll(Duration::from_millis(20));
+        timing.record_batch(3);
+        timing.record_conversion(Duration::from_millis(6));
+        timing.record_sink_insert(Duration::from_millis(60));
+
+        // EOF poll is included in select_poll totals
+        timing.record_select_poll(Duration::from_millis(30));
+        timing.record_source_eof();
+
+        timing.record_affected_rows(8);
+        timing.finish("ok");
+
+        assert_eq!(timing.select_poll_total, Duration::from_millis(60));
+        assert_eq!(timing.select_poll_max, Duration::from_millis(30));
+        assert_eq!(timing.first_batch, Some(Duration::from_millis(10)));
+        assert_eq!(timing.source_eof, Some(Duration::from_millis(30)));
+        assert_eq!(timing.batch_convert_total, Duration::from_millis(10));
+        assert_eq!(timing.sink_insert_total, Duration::from_millis(100));
+        assert_eq!(timing.sink_insert_max, Duration::from_millis(60));
+        assert_eq!(timing.batch_count, 2);
+        assert_eq!(timing.output_rows, 8);
+        assert_eq!(timing.max_batch_rows, 5);
+        assert_eq!(timing.affected_rows, 8);
+        assert!(timing.finished);
+    }
+
+    #[test]
+    fn test_dml_stage_timing_finish_is_idempotent() {
+        let mut timing = DmlStageTiming::new("attempt-2".to_string(), None, "t".to_string());
+        timing.finish("ok");
+        timing.finish("ok");
+        assert!(timing.finished);
+    }
+
+    #[test]
+    fn test_dml_stage_timing_empty_stream_reports_no_first_batch() {
+        let mut timing = DmlStageTiming::new("attempt-3".to_string(), None, "t".to_string());
+        // immediate EOF
+        timing.record_select_poll(Duration::from_millis(1));
+        timing.finish("ok");
+
+        assert_eq!(timing.batch_count, 0);
+        assert_eq!(timing.output_rows, 0);
+        assert_eq!(timing.first_batch, None);
+        assert_eq!(timing.select_poll_total, Duration::from_millis(1));
+    }
+
+    #[test]
+    fn test_dml_stage_timing_drop_reports_dropped_with_active_stage() {
+        // An unfinished accumulator represents cancellation/drop, not a
+        // returned error. Keep the active await stage for its Drop summary.
+        let mut timing = DmlStageTiming::new("attempt-4".to_string(), None, "t".to_string());
+        timing.record_select_poll(Duration::from_millis(5));
+        timing.record_batch(1);
+        timing.set_active_stage("sink_insert");
+        assert_eq!(timing.active_stage, Some("sink_insert"));
+        assert_eq!(timing.last_completed_stage, "source_first_batch");
+        drop(timing);
+
+        let mut timing = DmlStageTiming::new("attempt-5".to_string(), None, "t".to_string());
+        timing.finish("ok");
+        drop(timing);
     }
 }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -445,12 +445,12 @@ impl DatafusionQueryEngine {
                 break;
             };
             let batch = batch.context(CreateRecordBatchSnafu);
-            if let Some(timing) = dml_timing.as_mut() {
-                if batch.is_err() {
-                    timing.complete_stage("select_poll");
-                    timing.failed_stage = Some("select_poll");
-                    timing.finish("error");
-                }
+            if let Some(timing) = dml_timing.as_mut()
+                && batch.is_err()
+            {
+                timing.complete_stage("select_poll");
+                timing.failed_stage = Some("select_poll");
+                timing.finish("error");
             }
             let batch = batch?;
             if let Some(timing) = dml_timing.as_mut() {
@@ -1632,8 +1632,6 @@ mod tests {
         assert!(right_last_filter_len.load(Ordering::Relaxed) > 0);
     }
 
-    // --- DmlStageTiming accumulator accounting ---
-
     #[test]
     fn test_dml_stage_timing_accumulates_and_finishes() {
         let mut timing = DmlStageTiming::new(
@@ -1642,7 +1640,6 @@ mod tests {
             "greptime.public.out".to_string(),
         );
 
-        // two batches, then EOF
         timing.record_select_poll(Duration::from_millis(10));
         timing.record_batch(5);
         timing.record_conversion(Duration::from_millis(4));
@@ -1685,14 +1682,16 @@ mod tests {
     #[test]
     fn test_dml_stage_timing_empty_stream_reports_no_first_batch() {
         let mut timing = DmlStageTiming::new("attempt-3".to_string(), None, "t".to_string());
-        // immediate EOF
         timing.record_select_poll(Duration::from_millis(1));
+        timing.record_source_eof();
         timing.finish("ok");
 
         assert_eq!(timing.batch_count, 0);
         assert_eq!(timing.output_rows, 0);
         assert_eq!(timing.first_batch, None);
         assert_eq!(timing.select_poll_total, Duration::from_millis(1));
+        assert_eq!(timing.source_eof, Some(Duration::from_millis(1)));
+        assert_eq!(timing.last_completed_stage, "source_eof");
     }
 
     #[test]

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -32,6 +32,18 @@ pub const FLOW_SINK_TABLE_ID: &str = "flow.sink_table_id";
 /// Query planning, SQL/TQL parsing, range-select rewrite and DataFusion
 /// execution read this extension so `now()` is stable for the whole attempt.
 pub const FLOW_SCHEDULED_TIME_MILLIS: &str = "flow.scheduled_time_millis";
+/// Diagnostic-only flow attempt ID extension propagated by flownode for one
+/// batching `INSERT INTO ... SELECT` attempt. It correlates timing logs across
+/// flownode -> frontend query context -> DataFusion DML -> operator insert.
+/// It never participates in correctness parsing and invalid values never
+/// reject a request.
+pub const FLOW_ATTEMPT_ID: &str = "flow.attempt_id";
+/// Diagnostic-only flow ID extension propagated by flownode alongside
+/// [`FLOW_ATTEMPT_ID`].
+pub const FLOW_ID: &str = "flow.id";
+/// Maximum accepted length (in chars) of a diagnostic flow ID/attempt ID.
+/// Longer or non-ASCII values are treated as absent.
+pub const MAX_DIAGNOSTIC_FLOW_ID_LEN: usize = 64;
 /// Enable by default, set to false to explicitly disable.
 pub const QUERY_ENABLE_REMOTE_DYNAMIC_FILTER_PUSHDOWN: &str =
     "query.enable_remote_dynamic_filter_pushdown";
@@ -334,6 +346,37 @@ pub fn parse_scheduled_time_datetime(
 pub fn scheduled_time_from_ctx(query_ctx: &QueryContextRef) -> Option<DateTime<Utc>> {
     let extensions = query_ctx.extensions();
     parse_scheduled_time_datetime(&extensions).ok().flatten()
+}
+
+/// Parses the diagnostic-only `flow.attempt_id` extension.
+///
+/// Returns `Some` only when the value is present, non-empty, ASCII-only and no
+/// longer than [`MAX_DIAGNOSTIC_FLOW_ID_LEN`]. Missing, malformed or
+/// out-of-bound values return `None` and never reject the request. This is a
+/// diagnostics-only key: it is intentionally excluded from
+/// [`FlowQueryExtensions::parse_flow_extensions`] correctness parsing, so a
+/// request carrying only `flow.attempt_id`/`flow.id` still parses as a
+/// non-flow query.
+pub fn parse_diagnostic_flow_attempt_id(extensions: &HashMap<String, String>) -> Option<String> {
+    parse_diagnostic_flow_id_value(extensions, FLOW_ATTEMPT_ID)
+}
+
+/// Parses the diagnostic-only `flow.id` extension with the same bounded-ASCII
+/// rules as [`parse_diagnostic_flow_attempt_id`].
+pub fn parse_diagnostic_flow_id(extensions: &HashMap<String, String>) -> Option<String> {
+    parse_diagnostic_flow_id_value(extensions, FLOW_ID)
+}
+
+fn parse_diagnostic_flow_id_value(
+    extensions: &HashMap<String, String>,
+    key: &str,
+) -> Option<String> {
+    let value = extensions.get(key)?;
+    let value = value.trim();
+    if value.is_empty() || value.len() > MAX_DIAGNOSTIC_FLOW_ID_LEN || !value.is_ascii() {
+        return None;
+    }
+    Some(value.to_string())
 }
 
 /// Carries the scheduled logical "now" through [`ConfigOptions::extensions`] so

--- a/src/query/src/options.rs
+++ b/src/query/src/options.rs
@@ -688,6 +688,55 @@ mod flow_extension_tests {
         );
     }
 
+    // --- diagnostic flow ID helper tests ---
+
+    #[test]
+    fn test_parse_diagnostic_flow_id_trims_whitespace() {
+        let exts = HashMap::from([(FLOW_ATTEMPT_ID.to_string(), "  attempt-1\t".to_string())]);
+
+        assert_eq!(
+            parse_diagnostic_flow_attempt_id(&exts),
+            Some("attempt-1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_diagnostic_flow_id_empty_input() {
+        assert_eq!(parse_diagnostic_flow_attempt_id(&HashMap::new()), None);
+    }
+
+    #[test]
+    fn test_parse_diagnostic_flow_id_enforces_64_byte_limit() {
+        let exts = HashMap::from([(FLOW_ATTEMPT_ID.to_string(), "a".repeat(64))]);
+        assert_eq!(
+            parse_diagnostic_flow_attempt_id(&exts),
+            Some("a".repeat(64))
+        );
+
+        let exts = HashMap::from([(FLOW_ATTEMPT_ID.to_string(), "a".repeat(65))]);
+        assert_eq!(parse_diagnostic_flow_attempt_id(&exts), None);
+    }
+
+    #[test]
+    fn test_parse_diagnostic_flow_id_rejects_non_ascii() {
+        let exts = HashMap::from([(FLOW_ID.to_string(), "flow-你好".to_string())]);
+
+        assert_eq!(parse_diagnostic_flow_id(&exts), None);
+    }
+
+    #[test]
+    fn test_diagnostic_flow_keys_do_not_activate_flow_correctness_parsing() {
+        let exts = HashMap::from([
+            (FLOW_ATTEMPT_ID.to_string(), "attempt-1".to_string()),
+            (FLOW_ID.to_string(), "flow-1".to_string()),
+        ]);
+
+        assert_eq!(
+            FlowQueryExtensions::parse_flow_extensions(&exts).unwrap(),
+            None
+        );
+    }
+
     // --- scheduled time helper tests ---
 
     #[test]

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -38,7 +38,7 @@ use common_memory_manager::MemoryGuard;
 use common_query::{Output, OutputData};
 use common_recordbatch::DfRecordBatch;
 use common_telemetry::debug;
-use common_telemetry::tracing::info_span;
+use common_telemetry::tracing::{Level, info_span};
 use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use datatypes::arrow::datatypes::SchemaRef;
 use futures::{Stream, future, ready};
@@ -603,9 +603,15 @@ fn to_flight_data_stream(
             Box::pin(stream) as _
         }
         OutputData::AffectedRows(rows) => {
-            let flow_attempt_id = parse_diagnostic_flow_attempt_id(&query_ctx.extensions());
-            let flow_id = parse_diagnostic_flow_id(&query_ctx.extensions());
-            let encode_started = Instant::now();
+            let diagnostic_enabled =
+                common_telemetry::tracing::enabled!(target: module_path!(), Level::DEBUG);
+            let flow_attempt_id = diagnostic_enabled
+                .then(|| parse_diagnostic_flow_attempt_id(&query_ctx.extensions()))
+                .flatten();
+            let flow_id = flow_attempt_id
+                .as_ref()
+                .and_then(|_| parse_diagnostic_flow_id(&query_ctx.extensions()));
+            let encode_started = flow_attempt_id.as_ref().map(|_| Instant::now());
             let terminal_metrics = match terminal_recordbatch_metrics_from_plan_if_requested(
                 output.meta.plan,
                 should_emit_terminal_metrics,
@@ -613,7 +619,9 @@ fn to_flight_data_stream(
                 Some(metrics) => match serde_json::to_string(&metrics) {
                     Ok(metrics) => Some(metrics),
                     Err(e) => {
-                        if let Some(attempt_id) = flow_attempt_id.as_ref() {
+                        if let (Some(attempt_id), Some(encode_started)) =
+                            (flow_attempt_id.as_ref(), encode_started.as_ref())
+                        {
                             debug!(
                                 attempt_id = attempt_id.as_str(),
                                 flow_id = flow_id.as_deref().unwrap_or("unknown"),
@@ -639,7 +647,9 @@ fn to_flight_data_stream(
                 metrics: terminal_metrics,
             });
             let affected_rows_app_metadata_bytes = affected_rows.first().app_metadata.len();
-            if let Some(attempt_id) = flow_attempt_id {
+            if let (Some(attempt_id), Some(encode_started)) =
+                (flow_attempt_id.as_ref(), encode_started.as_ref())
+            {
                 debug!(
                     attempt_id = attempt_id.as_str(),
                     flow_id = flow_id.as_deref().unwrap_or("unknown"),

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Instant;
 
 use api::v1::GreptimeRequest;
 use arrow_flight::flight_service_server::FlightService;
@@ -44,7 +45,9 @@ use futures::{Stream, future, ready};
 use futures_util::{StreamExt, TryStreamExt};
 use prost::Message;
 use query::metrics::terminal_recordbatch_metrics_from_plan_if_requested;
-use query::options::FlowQueryExtensions;
+use query::options::{
+    FlowQueryExtensions, parse_diagnostic_flow_attempt_id, parse_diagnostic_flow_id,
+};
 use session::context::{Channel, QueryContextRef};
 use snafu::{IntoError, ResultExt, ensure};
 use table::table_name::TableName;
@@ -600,6 +603,9 @@ fn to_flight_data_stream(
             Box::pin(stream) as _
         }
         OutputData::AffectedRows(rows) => {
+            let flow_attempt_id = parse_diagnostic_flow_attempt_id(&query_ctx.extensions());
+            let flow_id = parse_diagnostic_flow_id(&query_ctx.extensions());
+            let encode_started = Instant::now();
             let terminal_metrics = match terminal_recordbatch_metrics_from_plan_if_requested(
                 output.meta.plan,
                 should_emit_terminal_metrics,
@@ -607,6 +613,16 @@ fn to_flight_data_stream(
                 Some(metrics) => match serde_json::to_string(&metrics) {
                     Ok(metrics) => Some(metrics),
                     Err(e) => {
+                        if let Some(attempt_id) = flow_attempt_id.as_ref() {
+                            debug!(
+                                attempt_id = attempt_id.as_str(),
+                                flow_id = flow_id.as_deref().unwrap_or("unknown"),
+                                elapsed_ms = encode_started.elapsed().as_millis() as u64,
+                                last_completed_stage = "dml_affected_rows",
+                                outcome = "error",
+                                "Flow DML Flight server summary",
+                            );
+                        }
                         let stream = tokio_stream::once(Err(Status::internal(format!(
                             "Failed to serialize terminal metrics: {e}"
                         ))));
@@ -615,10 +631,28 @@ fn to_flight_data_stream(
                 },
                 None => None,
             };
+            let inline_terminal_metrics_present = terminal_metrics.is_some();
+            let inline_terminal_metrics_json_bytes =
+                terminal_metrics.as_ref().map_or(0, |metrics| metrics.len());
             let affected_rows = FlightEncoder::default().encode(FlightMessage::AffectedRows {
                 rows,
                 metrics: terminal_metrics,
             });
+            let affected_rows_app_metadata_bytes = affected_rows.first().app_metadata.len();
+            if let Some(attempt_id) = flow_attempt_id {
+                debug!(
+                    attempt_id = attempt_id.as_str(),
+                    flow_id = flow_id.as_deref().unwrap_or("unknown"),
+                    affected_rows = rows,
+                    inline_terminal_metrics_present,
+                    inline_terminal_metrics_json_bytes,
+                    affected_rows_app_metadata_bytes,
+                    elapsed_ms = encode_started.elapsed().as_millis() as u64,
+                    last_completed_stage = "flight_affected_rows_encoded",
+                    outcome = "ok",
+                    "Flow DML Flight server summary",
+                );
+            }
             let stream = tokio_stream::iter(affected_rows.into_iter().map(Ok));
             Box::pin(stream) as _
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Related scheduling change: #8875. This PR is intentionally independent of the scheduling behavior change.

## What's changed and what's your intention?

This PR adds diagnostic-only timing and terminal-state observability for distributed Flow DML executed through Arrow Flight.

It records the Flow-correlated DML lifecycle across the client, query execution, and Flight server, including:

- source first-batch and EOF waits;
- batch conversion and sink insert timing;
- affected-row completion;
- Flight response, affected-rows, and terminal EOF waits;
- inline terminal metrics and application metadata sizes;
- active/completed stages and `ok`, `error`, or `dropped` outcomes.

The diagnostic path is enabled only for valid Flow attempt IDs at DEBUG level. It does not change scheduling policy, retry behavior, timeout values, cancellation semantics, Flight framing, or persisted/wire formats. A small diagnostic extension parser in `src/query/src/options.rs` is included because it is required to compile and correlate the logs.

This helps distinguish slow frontend DML or sink writes from a stalled Flight response/terminal stream. Frontend-discovery and additional network-phase diagnostics can be added separately without coupling them to scheduler behavior.

### Verification

Pre-finalization baseline on the same PR worktree:

- `cargo fmt --all -- --check` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-observability-pr cargo check -p client -p query -p servers -p flow` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-observability-pr cargo nextest run -p client -p query -p servers -p flow` — 1406 passed, 2 skipped
- `git diff --check` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-observability-pr cargo clippy -p client -p query -p servers --all-targets -- -D warnings` — FAILED before cleanup on the nested conditional in `src/query/src/datafusion.rs`

Post-finalization verification:

- `cargo fmt --all -- --check` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-observability-pr cargo check -p client -p query -p servers -p flow` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-observability-pr cargo clippy -p client -p query -p servers --all-targets -- -D warnings` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-observability-pr cargo nextest run -p client -p query -p servers -p flow` — 1414 passed, 2 skipped
- `git diff --check` — PASS

The finalization retained the empty-stream EOF boundary test, added diagnostic-ID boundary tests and client timing success/error/schema-disarm tests, and removed only restating test comments. No tests were deleted.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
