### PR TITLE
feat(flow): allow dedicated batching frontends

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -675,6 +675,7 @@
 | `flow.batching_mode.experimental_time_window_merge_threshold` | Integer | `3` | Time window merge distance |
 | `flow.batching_mode.experimental_enable_incremental_read` | Bool | `false` | Whether to enable experimental flow incremental source reads.<br/>When disabled, batching flows always execute full-snapshot queries.<br/>Can be overridden per flow with WITH (experimental_enable_incremental_read = 'true'). |
 | `flow.batching_mode.read_preference` | String | `Leader` | Read preference of the Frontend client. |
+| `flow.batching_mode.experimental_frontend_endpoints` | Array | -- | Optional distributed Flownode batching-DML-only frontend authorities.<br/>When set, batching INSERT INTO SELECT queries use only these host:port<br/>authorities and do not fall back to metasrv-discovered frontends. An empty<br/>list disables it. Standalone and streaming Flow are unaffected. |
 | `flow.batching_mode.frontend_tls` | -- | -- | -- |
 | `flow.batching_mode.frontend_tls.enabled` | Bool | `false` | Whether to enable TLS for client. |
 | `flow.batching_mode.frontend_tls.server_ca_cert_path` | String | Unset | Server Certificate file path. |

--- a/config/flownode.example.toml
+++ b/config/flownode.example.toml
@@ -32,6 +32,11 @@ node_id = 14
 #+experimental_enable_incremental_read=false
 ## Read preference of the Frontend client.
 #+read_preference="Leader"
+## Optional distributed Flownode batching-DML-only frontend authorities.
+## When set, batching INSERT INTO SELECT queries use only these host:port
+## authorities and do not fall back to metasrv-discovered frontends. An empty
+## list disables it. Standalone and streaming Flow are unaffected.
+#+experimental_frontend_endpoints=["127.0.0.1:4001"]
 [flow.batching_mode.frontend_tls]
 ## Whether to enable TLS for client.
 #+enabled=false

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -324,6 +324,89 @@ fn test_load_flownode_example_config() {
 }
 
 #[test]
+fn test_load_flownode_experimental_frontend_endpoints() {
+    let toml = r#"
+        [flow.batching_mode]
+        query_timeout = "600s"
+        slow_query_threshold = "60s"
+        experimental_min_refresh_duration = "5s"
+        grpc_conn_timeout = "5s"
+        experimental_grpc_max_retries = 3
+        experimental_frontend_scan_timeout = "30s"
+        experimental_max_filter_num_per_query = 20
+        experimental_time_window_merge_threshold = 3
+        experimental_enable_incremental_read = false
+        read_preference = "Leader"
+        experimental_frontend_endpoints = ["frontend-dml-a:4001", "frontend-dml-b:4001"]
+    "#;
+    let options: GreptimeOptions<FlownodeOptions> = toml::from_str(toml).unwrap();
+    assert_eq!(
+        Some(vec![
+            "frontend-dml-a:4001".to_string(),
+            "frontend-dml-b:4001".to_string(),
+        ]),
+        options
+            .component
+            .flow
+            .batching_mode
+            .experimental_frontend_endpoints
+    );
+
+    let empty: GreptimeOptions<FlownodeOptions> = toml::from_str(
+        r#"
+        [flow.batching_mode]
+        query_timeout = "600s"
+        slow_query_threshold = "60s"
+        experimental_min_refresh_duration = "5s"
+        grpc_conn_timeout = "5s"
+        experimental_grpc_max_retries = 3
+        experimental_frontend_scan_timeout = "30s"
+        experimental_max_filter_num_per_query = 20
+        experimental_time_window_merge_threshold = 3
+        experimental_enable_incremental_read = false
+        read_preference = "Leader"
+        experimental_frontend_endpoints = []
+        "#,
+    )
+    .unwrap();
+    assert_eq!(
+        Some(vec![]),
+        empty
+            .component
+            .flow
+            .batching_mode
+            .experimental_frontend_endpoints
+    );
+}
+
+#[test]
+fn test_load_flownode_experimental_frontend_endpoints_from_env() {
+    let env_prefix = "FLOW_FRONTEND_ENDPOINTS_UT";
+    let env_key = [
+        env_prefix,
+        "FLOW",
+        "BATCHING_MODE",
+        "EXPERIMENTAL_FRONTEND_ENDPOINTS",
+    ]
+    .join(ENV_VAR_SEP);
+    temp_env::with_var(env_key, Some("frontend-a:4001,frontend-b:4002"), || {
+        let options =
+            GreptimeOptions::<FlownodeOptions>::load_layered_options(None, env_prefix).unwrap();
+        assert_eq!(
+            Some(vec![
+                "frontend-a:4001".to_string(),
+                "frontend-b:4002".to_string(),
+            ]),
+            options
+                .component
+                .flow
+                .batching_mode
+                .experimental_frontend_endpoints
+        );
+    });
+}
+
+#[test]
 fn test_load_standalone_example_config() {
     let example_config = common_test_util::find_workspace_path("config/standalone.example.toml");
     let options =

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -154,6 +154,10 @@ impl Default for FlownodeOptions {
 }
 
 impl Configurable for FlownodeOptions {
+    fn env_list_keys() -> Option<&'static [&'static str]> {
+        Some(["flow.batching_mode.experimental_frontend_endpoints"].as_slice())
+    }
+
     fn validate_sanitize(&mut self) -> common_config::error::Result<()> {
         if self.flow.num_workers == 0 {
             self.flow.num_workers = (get_total_cpu_cores() / 2).max(1);

--- a/src/flow/src/batching_mode.rs
+++ b/src/flow/src/batching_mode.rs
@@ -63,6 +63,12 @@ pub struct BatchingModeOptions {
     pub read_preference: ReadPreference,
     /// TLS option for client connections to frontends.
     pub frontend_tls: Option<ClientTlsOption>,
+    /// Dedicated frontend addresses for batching DML queries.
+    ///
+    /// When set to a non-empty list, batching DML queries use only these
+    /// addresses instead of metasrv-discovered frontends. An empty list is
+    /// treated as unset.
+    pub experimental_frontend_endpoints: Option<Vec<String>>,
 }
 
 impl Default for BatchingModeOptions {
@@ -79,6 +85,7 @@ impl Default for BatchingModeOptions {
             experimental_enable_incremental_read: false,
             read_preference: Default::default(),
             frontend_tls: None,
+            experimental_frontend_endpoints: None,
         }
     }
 }

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -15,6 +15,7 @@
 //! Frontend client to run flow as batching task which is time-window-aware normal query triggered every tick set by user
 
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 
 use api::v1::greptime_request::Request;
@@ -27,6 +28,7 @@ use common_meta::peer::{Peer, PeerDiscovery};
 use common_query::{Output, OutputData};
 use common_telemetry::warn;
 use futures::stream::{FuturesUnordered, StreamExt};
+use http::uri::Authority;
 use meta_client::client::MetaClient;
 use query::datafusion::QUERY_PARALLELISM_HINT;
 use query::metrics::terminal_recordbatch_metrics_from_plan;
@@ -135,6 +137,8 @@ impl FrontendClient {
         query: QueryOptions,
         batch_opts: BatchingModeOptions,
     ) -> Result<Self, Error> {
+        let mut batch_opts = batch_opts;
+        normalize_frontend_endpoints(&mut batch_opts)?;
         common_telemetry::info!("Frontend client build without auth");
         Ok(Self::Distributed {
             meta_client,
@@ -192,6 +196,66 @@ impl DatabaseWithPeer {
             })?;
         Ok(())
     }
+}
+
+fn candidate_frontends(
+    configured_frontends: Option<Vec<Peer>>,
+    discovered_frontends: Vec<Peer>,
+) -> Vec<Peer> {
+    configured_frontends
+        .filter(|frontends| !frontends.is_empty())
+        .unwrap_or(discovered_frontends)
+}
+
+fn normalize_frontend_endpoints(batch_opts: &mut BatchingModeOptions) -> Result<(), Error> {
+    if let Some(endpoints) = batch_opts.experimental_frontend_endpoints.as_mut() {
+        if endpoints.is_empty() {
+            return Ok(());
+        }
+        for endpoint in endpoints {
+            *endpoint = normalize_frontend_endpoint(endpoint)?;
+        }
+    }
+    Ok(())
+}
+
+fn normalize_frontend_endpoint(endpoint: &str) -> Result<String, Error> {
+    let endpoint = endpoint.trim();
+    if endpoint.is_empty() {
+        return UnexpectedSnafu {
+            reason: "experimental_frontend_endpoints contains a blank address",
+        }
+        .fail();
+    }
+    if endpoint.contains("@")
+        || endpoint.contains("/")
+        || endpoint.contains("?")
+        || endpoint.contains("#")
+        || endpoint.contains("://")
+    {
+        return UnexpectedSnafu {
+            reason: format!("Invalid experimental_frontend_endpoints authority `{endpoint}`"),
+        }
+        .fail();
+    }
+
+    let authority = Authority::from_str(endpoint).map_err(|err| {
+        UnexpectedSnafu {
+            reason: format!(
+                "Invalid experimental_frontend_endpoints authority `{endpoint}`: {err}"
+            ),
+        }
+        .build()
+    })?;
+    if authority.host().is_empty() || authority.port_u16().is_none() {
+        return UnexpectedSnafu {
+            reason: format!(
+                "Invalid experimental_frontend_endpoints authority `{endpoint}`: expected host:port"
+            ),
+        }
+        .fail();
+    }
+    Ok(endpoint.to_string())
 }
 
 impl FrontendClient {
@@ -266,11 +330,51 @@ impl FrontendClient {
         Ok(failures)
     }
 
+    /// Return the configured DML frontends, if the option is enabled.
+    ///
+    /// `Some([])` is intentionally treated as unset, preserving the default
+    /// metasrv discovery behavior. Configured values are normalized before
+    /// they are passed to the existing channel manager.
+    pub(crate) fn configured_dml_frontends(&self) -> Result<Option<Vec<Peer>>, Error> {
+        let Self::Distributed { batch_opts, .. } = self else {
+            return Ok(None);
+        };
+        let Some(addrs) = batch_opts.experimental_frontend_endpoints.as_ref() else {
+            return Ok(None);
+        };
+        if addrs.is_empty() {
+            return Ok(None);
+        }
+
+        let peers = addrs
+            .iter()
+            .enumerate()
+            .map(|(id, addr)| {
+                Ok(Peer {
+                    id: id as u64,
+                    addr: addr.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+        Ok(Some(peers))
+    }
+
     /// Get a frontend discovered by metasrv and verified with a query probe.
     async fn get_random_active_frontend(
         &self,
         catalog: &str,
         schema: &str,
+    ) -> Result<DatabaseWithPeer, Error> {
+        self.get_random_frontend(catalog, schema, None).await
+    }
+
+    /// Get a verified frontend from the supplied list. A supplied list is
+    /// authoritative and never falls back to metasrv discovery.
+    async fn get_random_frontend(
+        &self,
+        catalog: &str,
+        schema: &str,
+        configured_frontends: Option<Vec<Peer>>,
     ) -> Result<DatabaseWithPeer, Error> {
         let Self::Distributed {
             meta_client: _,
@@ -288,7 +392,13 @@ impl FrontendClient {
         let mut interval = tokio::time::interval(batch_opts.grpc_conn_timeout);
         interval.tick().await;
         for retry in 0..batch_opts.experimental_grpc_max_retries {
-            let mut frontends = self.scan_for_frontend().await?;
+            let discovered_frontends = if configured_frontends.is_none() {
+                self.scan_for_frontend().await?
+            } else {
+                Vec::new()
+            };
+            let mut frontends =
+                candidate_frontends(configured_frontends.clone(), discovered_frontends);
             // shuffle the frontends to avoid always pick the same one
             frontends.shuffle(&mut rng());
 
@@ -408,7 +518,9 @@ impl FrontendClient {
                     (QUERY_PARALLELISM_HINT, query_parallelism.as_str()),
                     (READ_PREFERENCE_HINT, batch_opts.read_preference.as_ref()),
                 ];
-                let db = self.get_random_active_frontend(catalog, schema).await?;
+                let db = self
+                    .get_random_frontend(catalog, schema, self.configured_dml_frontends()?)
+                    .await?;
                 *peer_desc = Some(PeerDesc::Dist {
                     peer: db.peer.clone(),
                 });
@@ -625,6 +737,7 @@ mod tests {
 
     use arrow_flight::flight_service_server::FlightServiceServer;
     use arrow_flight::{FlightData, Ticket};
+    use common_grpc::flight::{FlightEncoder, FlightMessage};
     use common_query::{Output, OutputData};
     use common_recordbatch::adapter::RecordBatchMetrics;
     use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
@@ -698,6 +811,9 @@ mod tests {
 
     #[derive(Debug)]
     struct RejectUnauthenticatedFlight;
+
+    #[derive(Debug)]
+    struct AffectedRowsFlight;
 
     #[derive(Debug)]
     struct SlowFlight;
@@ -787,6 +903,23 @@ mod tests {
     }
 
     #[async_trait::async_trait]
+    impl FlightCraft for AffectedRowsFlight {
+        async fn do_get(
+            &self,
+            _request: TonicRequest<Ticket>,
+        ) -> std::result::Result<TonicResponse<TonicStream<FlightData>>, Status> {
+            let mut encoder = FlightEncoder::default();
+            let data = encoder.encode(FlightMessage::AffectedRows {
+                rows: 1,
+                metrics: None,
+            });
+            Ok(TonicResponse::new(Box::pin(futures::stream::iter(
+                data.into_iter().map(Ok),
+            ))))
+        }
+    }
+
+    #[async_trait::async_trait]
     impl FlightCraft for SlowFlight {
         async fn do_get(
             &self,
@@ -822,6 +955,186 @@ mod tests {
         });
 
         (addr, server)
+    }
+
+    #[test]
+    fn test_candidate_frontends_source_is_authoritative() {
+        let configured = vec![Peer {
+            id: 1,
+            addr: "configured:4001".to_string(),
+        }];
+        let discovered = vec![Peer {
+            id: 2,
+            addr: "unrelated:4002".to_string(),
+        }];
+        assert_eq!(
+            configured,
+            candidate_frontends(Some(configured.clone()), discovered)
+        );
+        assert_eq!(
+            vec![Peer {
+                id: 2,
+                addr: "unrelated:4002".to_string(),
+            }],
+            candidate_frontends(
+                None,
+                vec![Peer {
+                    id: 2,
+                    addr: "unrelated:4002".to_string(),
+                }]
+            )
+        );
+        assert_eq!(
+            vec![Peer {
+                id: 2,
+                addr: "unrelated:4002".to_string(),
+            }],
+            candidate_frontends(
+                Some(vec![]),
+                vec![Peer {
+                    id: 2,
+                    addr: "unrelated:4002".to_string(),
+                }]
+            )
+        );
+    }
+
+    #[test]
+    fn test_frontend_endpoint_normalization_and_validation() {
+        assert_eq!(
+            "example.com:4001",
+            normalize_frontend_endpoint("  example.com:4001 ").unwrap()
+        );
+        assert_eq!(
+            "[::1]:4001",
+            normalize_frontend_endpoint(" [::1]:4001 ").unwrap()
+        );
+        for invalid in [
+            "",
+            " ",
+            "http://example.com:4001",
+            "https://example.com:4001",
+            "user@example.com:4001",
+            "example.com:4001/path",
+            "example.com:4001?query",
+            "example.com:4001#fragment",
+            "example.com",
+            "example.com:not-a-port",
+            "[::1]",
+            "::1:4001",
+        ] {
+            assert!(
+                normalize_frontend_endpoint(invalid).is_err(),
+                "expected invalid endpoint: {invalid}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_configured_dml_query_uses_only_configured_frontend() {
+        let (configured_addr, server) = start_flight_server(AffectedRowsFlight).await;
+        let client = FrontendClient::from_meta_client(
+            Arc::new(MetaClient::new(0, api::v1::meta::Role::Frontend)),
+            QueryOptions::default(),
+            BatchingModeOptions {
+                experimental_grpc_max_retries: 1,
+                experimental_frontend_endpoints: Some(vec![configured_addr.clone()]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let mut peer_desc = None;
+        let result = client
+            .query_with_terminal_metrics(
+                DEFAULT_CATALOG_NAME,
+                DEFAULT_SCHEMA_NAME,
+                QueryRequest {
+                    query: Some(Query::Sql("SELECT 1".to_string())),
+                },
+                &[],
+                &HashMap::new(),
+                &mut peer_desc,
+            )
+            .await
+            .expect("configured frontend should handle the query");
+        server.abort();
+
+        assert!(matches!(
+            peer_desc,
+            Some(PeerDesc::Dist { peer }) if peer.addr == configured_addr
+        ));
+        assert!(matches!(result.output.data, OutputData::AffectedRows(1)));
+    }
+
+    #[test]
+    fn test_configured_dml_frontends_selection() {
+        let client = FrontendClient::from_meta_client(
+            Arc::new(MetaClient::new(0, api::v1::meta::Role::Frontend)),
+            QueryOptions::default(),
+            BatchingModeOptions {
+                experimental_frontend_endpoints: Some(vec![" dml-only:4001 ".to_string()]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let frontends = client.configured_dml_frontends().unwrap().unwrap();
+        assert_eq!(
+            vec![Peer {
+                id: 0,
+                addr: "dml-only:4001".to_string(),
+            }],
+            frontends
+        );
+    }
+
+    #[test]
+    fn test_empty_dml_frontend_list_is_disabled() {
+        let client = FrontendClient::from_meta_client(
+            Arc::new(MetaClient::new(0, api::v1::meta::Role::Frontend)),
+            QueryOptions::default(),
+            BatchingModeOptions {
+                experimental_frontend_endpoints: Some(vec![]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(client.configured_dml_frontends().unwrap().is_none());
+        assert!(
+            FrontendClient::from_meta_client(
+                Arc::new(MetaClient::new(0, api::v1::meta::Role::Frontend)),
+                QueryOptions::default(),
+                BatchingModeOptions::default(),
+            )
+            .unwrap()
+            .configured_dml_frontends()
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_dml_frontend_endpoint_rejected_at_construction() {
+        for endpoint in [
+            "  ",
+            "http://example.com:4001",
+            "example.com:4001/path",
+            "example.com:invalid",
+            "example.com",
+        ] {
+            let err = FrontendClient::from_meta_client(
+                Arc::new(MetaClient::new(0, api::v1::meta::Role::Frontend)),
+                QueryOptions::default(),
+                BatchingModeOptions {
+                    experimental_frontend_endpoints: Some(vec![endpoint.to_string()]),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+            assert!(
+                err.to_string().contains("experimental_frontend_endpoints"),
+                "unexpected error for {endpoint}: {err}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Experimental follow-up for isolating distributed batching Flow DML from the ordinary frontend pool. Related investigation: #8875 and #8906.

## What's changed and what's your intention?

This PR adds an opt-in configuration for routing distributed batching Flow DML to dedicated frontend internal-gRPC authorities:

```toml
[flow.batching_mode]
experimental_frontend_endpoints = ["flow-frontend-a:4001", "flow-frontend-b:4001"]
```

Behavior:

- an unset or empty list preserves the existing metasrv discovery, shuffle, probe, retry, TLS, and timeout behavior;
- a non-empty list is authoritative for distributed batching `INSERT INTO ... SELECT` execution and never falls back to unrelated metasrv-discovered frontends;
- endpoint authorities are normalized and validated when the Flownode frontend client is constructed;
- the existing `ChannelManager` is reused, including the existing TLS and timeout configuration;
- ordinary Flow DDL, ordinary SQL/non-DML operations, startup/recovery frontend readiness, standalone Flow, and streaming Flow remain unchanged.

The option is default-disabled and intentionally marked `experimental_`. `config/config.md` was regenerated with `make config-docs`.

### Verification

Baseline (`b82052ce2c6cab66a4be402a8c57862c5bf4cf97`):

- `cargo fmt --all -- --check` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo check -p flow -p cmd` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo clippy -p flow -p cmd --all-targets -- -D warnings` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo nextest run -p flow` — 240 passed, 0 skipped
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo nextest run -p cmd --test load_config_test` — 14 passed, 0 skipped
- `git diff --check b882e393dfadcf9406c76d1017fe64e0652f0202..HEAD` — PASS

Post-finalization (`b0ca929e921f2e789496ba8287bc1a0e4330016b`):

- `make config-docs` — PASS
- `cargo fmt --all -- --check` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo check -p flow -p cmd` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo clippy -p flow -p cmd --all-targets -- -D warnings` — PASS
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo nextest run -p flow` — 240 passed, 0 skipped
- `CARGO_TARGET_DIR=/mnt/nvme_rust/rust-targets-2/flow-dml-dedicated-frontends cargo nextest run -p cmd --test load_config_test` — 14 passed, 0 skipped
- `git diff --check b882e393dfadcf9406c76d1017fe64e0652f0202..HEAD` — PASS

Focused coverage includes configured-candidate authority/no-fallback, construction-time endpoint validation, whitespace and IPv6 handling, disabled empty-list behavior, actual configured Flight routing, TOML loading, and comma-separated environment loading. No tests or comments were removed during finalization, and no CI policy was weakened.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
