### PR TITLE
refactor(json2): add bounded auto-expansion to the JSON2 vector builder

### DIFF
--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -39,6 +39,11 @@ use crate::vectors::{Helper, MutableVector, StructVectorBuilder};
 type JsonObjectValue = BTreeMap<String, JsonVariant>;
 
 /// Builds JSON2 vectors from object values.
+///
+/// Legacy mode merges all observed paths into the explicit Struct schema.
+/// Auto-expanding mode always materializes type-hinted paths, selects up to
+/// `max_auto_expanded_paths` compatible unhinted leaf paths by frequency, and stores
+/// conflicting or unselected paths in the Variant remainder field.
 #[derive(Clone)]
 pub(crate) struct JsonVectorBuilder {
     state: JsonVectorBuilderState,
@@ -469,10 +474,8 @@ fn split_to_explicit(
                 explicit.insert(name.clone(), value);
                 continue;
             }
-            let (value, child_remainder) = split_to_explicit(value, data_type)?;
-            if !value.is_empty() {
-                explicit.insert(name.clone(), JsonVariant::Object(value));
-            }
+            let (child_explicit, child_remainder) = split_to_explicit(value, data_type)?;
+            explicit.insert(name.clone(), JsonVariant::Object(child_explicit));
             if !child_remainder.is_empty() {
                 remainder.insert(name.clone(), JsonVariant::Object(child_remainder));
             }
@@ -522,6 +525,9 @@ fn json_variant_into_struct_value(
 fn json_variant_into_value(value: JsonVariant, expected_type: &ConcreteDataType) -> Result<Value> {
     let value = match (value, expected_type) {
         (JsonVariant::Null, _) | (_, ConcreteDataType::Null(_)) => Value::Null,
+        (JsonVariant::Object(object), ConcreteDataType::Struct(struct_type)) => {
+            Value::Struct(json_variant_into_struct_value(object, struct_type.clone())?)
+        }
         (JsonVariant::Object(object), _) if object.is_empty() => Value::Null,
         (JsonVariant::Bool(x), ConcreteDataType::Boolean(_)) => Value::Boolean(x),
         (JsonVariant::Number(x), ConcreteDataType::UInt64(_)) => {
@@ -564,9 +570,6 @@ fn json_variant_into_value(value: JsonVariant, expected_type: &ConcreteDataType)
                 .map(|v| json_variant_into_value(v, &item_type))
                 .collect::<Result<Vec<_>>>()?;
             Value::List(ListValue::new(values, Arc::new(item_type)))
-        }
-        (JsonVariant::Object(value), ConcreteDataType::Struct(struct_type)) => {
-            Value::Struct(json_variant_into_struct_value(value, struct_type.clone())?)
         }
         (value, ConcreteDataType::Binary(_)) => Value::from(encode_json_variant(value)?),
         (value, expected_type) => {
@@ -932,6 +935,40 @@ mod tests {
                 "tie_b": null
             }),
             decode_json_variant(reconstructed.value(2)).unwrap()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reconstruct_nested_remainder_only_value() -> Result<()> {
+        let settings = JsonSettings::try_new(vec![], Some(1))?;
+        let values = [
+            json!({"a": {"hot": 1}}),
+            json!({"a": {"hot": 2}}),
+            json!({"a": {"cold": 3}}),
+        ];
+        let mut builder = JsonVectorBuilder::with_settings(&settings, values.len());
+        for value in values.clone() {
+            let value = settings.encode(value)?;
+            builder.try_push_value_ref(&value.as_value_ref())?;
+        }
+
+        let array = builder.to_vector().to_arrow_array();
+        let field = Field::new("data", array.data_type().clone(), true).with_extension_type(
+            Json2ExtensionType::new(Arc::new(JsonMetadata::new_v2(settings))),
+        );
+        let reconstructed = JsonArray::from(&array).project_to_v2(&field, &DataType::Binary)?;
+        let reconstructed = reconstructed.as_binary::<i32>();
+        assert_eq!(
+            vec![
+                values[0].clone(),
+                values[1].clone(),
+                json!({"a": {"cold": 3, "hot": null}}),
+            ],
+            (0..reconstructed.len())
+                .map(|i| decode_json_variant(reconstructed.value(i)).unwrap())
+                .collect::<Vec<_>>()
         );
 
         Ok(())

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -178,7 +178,7 @@ impl JsonVectorBuilder {
 }
 
 fn build_legacy(values: &mut Vec<JsonVariant>, merged_type: &JsonNativeType) -> Result<VectorRef> {
-    build_explicit(values, merged_type, |value| match value {
+    build_explicit(values, merged_type, false, |value| match value {
         JsonVariant::Null => Ok(None),
         JsonVariant::Object(value) => Ok(Some(value)),
         _ => TryFromValueSnafu {
@@ -193,7 +193,7 @@ fn build_with_remainder(
     expanded_type: &JsonNativeType,
 ) -> Result<VectorRef> {
     let mut remainder = VariantArrayBuilder::new(values.len());
-    let explicit = build_explicit(values, expanded_type, |value| {
+    let explicit = build_explicit(values, expanded_type, true, |value| {
         if matches!(value, JsonVariant::Null) {
             remainder.append_null();
             return Ok(None);
@@ -209,6 +209,9 @@ fn build_with_remainder(
 fn build_explicit(
     values: &mut Vec<JsonVariant>,
     explicit_type: &JsonNativeType,
+    // Temporary compatibility switch for the legacy storage layout. Once JSON2 fully switches to
+    // the v2 storage layout, empty objects should always be preserved instead of treated as null.
+    preserve_empty_structs: bool,
     mut project: impl FnMut(JsonVariant) -> Result<Option<JsonObjectValue>>,
 ) -> Result<VectorRef> {
     let DataType::Struct(fields) = explicit_type.as_arrow_type() else {
@@ -227,7 +230,8 @@ fn build_explicit(
             builder.push_null();
             continue;
         };
-        let value = json_variant_into_struct_value(value, struct_type.clone())?;
+        let value =
+            json_variant_into_struct_value(value, struct_type.clone(), preserve_empty_structs)?;
         builder.push_struct_value_ref(StructValueRef::Ref(&value))?;
     }
     Ok(builder.to_vector())
@@ -489,6 +493,7 @@ fn split_to_explicit(
 fn json_variant_into_struct_value(
     object: JsonObjectValue,
     struct_type: StructType,
+    preserve_empty_structs: bool,
 ) -> Result<StructValue> {
     let mut entries = object.into_iter();
     let mut entry = entries.next();
@@ -497,7 +502,7 @@ fn json_variant_into_struct_value(
         let value = match entry.take() {
             Some((name, value)) if name == field.name() => {
                 entry = entries.next();
-                json_variant_into_value(value, field.data_type())?
+                json_variant_into_value(value, field.data_type(), preserve_empty_structs)?
             }
             Some((name, _)) if name.as_str() < field.name() => {
                 return TryFromValueSnafu {
@@ -522,13 +527,19 @@ fn json_variant_into_struct_value(
     Ok(StructValue::new(values, struct_type))
 }
 
-fn json_variant_into_value(value: JsonVariant, expected_type: &ConcreteDataType) -> Result<Value> {
+fn json_variant_into_value(
+    value: JsonVariant,
+    expected_type: &ConcreteDataType,
+    preserve_empty_structs: bool,
+) -> Result<Value> {
     let value = match (value, expected_type) {
         (JsonVariant::Null, _) | (_, ConcreteDataType::Null(_)) => Value::Null,
-        (JsonVariant::Object(object), ConcreteDataType::Struct(struct_type)) => {
-            Value::Struct(json_variant_into_struct_value(object, struct_type.clone())?)
+        (JsonVariant::Object(object), _) if object.is_empty() && !preserve_empty_structs => {
+            Value::Null
         }
-        (JsonVariant::Object(object), _) if object.is_empty() => Value::Null,
+        (JsonVariant::Object(object), ConcreteDataType::Struct(struct_type)) => Value::Struct(
+            json_variant_into_struct_value(object, struct_type.clone(), preserve_empty_structs)?,
+        ),
         (JsonVariant::Bool(x), ConcreteDataType::Boolean(_)) => Value::Boolean(x),
         (JsonVariant::Number(x), ConcreteDataType::UInt64(_)) => {
             let Some(x) = x.as_u64() else {
@@ -567,7 +578,7 @@ fn json_variant_into_value(value: JsonVariant, expected_type: &ConcreteDataType)
             let item_type = list_type.item_type().clone();
             let values = array
                 .into_iter()
-                .map(|v| json_variant_into_value(v, &item_type))
+                .map(|v| json_variant_into_value(v, &item_type, preserve_empty_structs))
                 .collect::<Result<Vec<_>>>()?;
             Value::List(ListValue::new(values, Arc::new(item_type)))
         }
@@ -1039,12 +1050,26 @@ mod tests {
 
     #[test]
     fn test_json_variant_into_struct_value() -> Result<()> {
+        let struct_type = StructType::new(Arc::new(vec![StructField::new(
+            "value".to_string(),
+            ConcreteDataType::string_datatype(),
+            true,
+        )]));
         assert_eq!(
             json_variant_into_value(
                 JsonVariant::Object(Default::default()),
-                &ConcreteDataType::string_datatype(),
+                &ConcreteDataType::struct_datatype(struct_type.clone()),
+                false,
             )?,
             Value::Null
+        );
+        assert_eq!(
+            json_variant_into_value(
+                JsonVariant::Object(Default::default()),
+                &ConcreteDataType::struct_datatype(struct_type.clone()),
+                true,
+            )?,
+            Value::Struct(StructValue::new(vec![Value::Null], struct_type))
         );
 
         let item_type =
@@ -1087,6 +1112,7 @@ mod tests {
         let value = Value::Struct(json_variant_into_struct_value(
             variant,
             struct_type.clone(),
+            true,
         )?);
 
         assert_eq!(

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -13,72 +13,480 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, StructArray};
 use arrow_schema::DataType;
+use parquet_variant_compute::VariantArrayBuilder;
+use snafu::{ResultExt, ensure};
 
 use crate::data_type::ConcreteDataType;
-use crate::error::{Result, TryFromValueSnafu, UnexpectedSnafu, UnsupportedOperationSnafu};
+use crate::error::{
+    ArrowComputeSnafu, Result, TryFromValueSnafu, UnexpectedSnafu, UnsupportedOperationSnafu,
+};
+use crate::extension::json::JSON2_REMAINDER_FIELD_NAME;
 use crate::json::value::{JsonNumber, JsonVariant, encode_json_variant};
+use crate::json::{JSON2_MAX_STRUCTURED_DEPTH, JsonSettings};
 use crate::prelude::{ValueRef, Vector, VectorRef};
 use crate::types::StructType;
 use crate::types::json_type::{JsonNativeType, is_include};
 use crate::value::{ListValue, StructValue, StructValueRef, Value};
-use crate::vectors::{MutableVector, StructVectorBuilder};
+use crate::vectors::json::variant::{append_json_variant, variant_field};
+use crate::vectors::{Helper, MutableVector, StructVectorBuilder};
 
+type JsonObjectValue = BTreeMap<String, JsonVariant>;
+
+/// Builds JSON2 vectors from object values.
 #[derive(Clone)]
 pub(crate) struct JsonVectorBuilder {
-    merged_type: JsonNativeType,
-    values: Vec<JsonVariant>,
+    state: JsonVectorBuilderState,
+}
+
+#[derive(Clone)]
+enum JsonVectorBuilderState {
+    Legacy {
+        merged_type: JsonNativeType,
+        values: Vec<JsonVariant>,
+    },
+    AutoExpanding {
+        /// Paths declared by type hints and always stored as dedicated Struct fields.
+        explicit_type: JsonNativeType,
+        /// Maximum number of additional paths selected from buffered values.
+        max_auto_expanded_paths: u32,
+        /// Buffered values used to infer auto-expanded paths before building the vector.
+        values: Vec<JsonVariant>,
+    },
+}
+
+impl JsonVectorBuilderState {
+    fn native_type(&self) -> JsonNativeType {
+        match self {
+            Self::Legacy { merged_type, .. } => merged_type.clone(),
+            Self::AutoExpanding {
+                explicit_type,
+                max_auto_expanded_paths,
+                values,
+            } => infer_expanded_type(explicit_type, *max_auto_expanded_paths, values),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Legacy { values, .. } | Self::AutoExpanding { values, .. } => values.len(),
+        }
+    }
+
+    fn try_build(&mut self) -> Result<VectorRef> {
+        match self {
+            Self::Legacy {
+                merged_type,
+                values,
+            } => build_legacy(values, merged_type),
+            Self::AutoExpanding {
+                explicit_type,
+                max_auto_expanded_paths,
+                values,
+            } => {
+                let expanded_type =
+                    infer_expanded_type(explicit_type, *max_auto_expanded_paths, values);
+                build_with_remainder(values, &expanded_type)
+            }
+        }
+    }
+
+    fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
+        let ValueRef::Json(value) = value else {
+            return TryFromValueSnafu {
+                reason: format!("expected JSON value, got {value:?}"),
+            }
+            .fail();
+        };
+        ensure!(
+            value.is_object() || value.is_null(),
+            TryFromValueSnafu {
+                reason: format!("expected JSON object value, got {value:?}"),
+            }
+        );
+        match self {
+            Self::Legacy {
+                merged_type,
+                values,
+            } => {
+                let json_type = value.json_type();
+                if !is_include(merged_type, json_type.as_ref()) {
+                    merged_type.merge(json_type.as_ref());
+                }
+                values.push(JsonVariant::from(value.variant()));
+            }
+            Self::AutoExpanding { values, .. } => {
+                values.push(JsonVariant::from(value.variant()));
+            }
+        }
+        Ok(())
+    }
+
+    fn push_null(&mut self) {
+        match self {
+            Self::Legacy { values, .. } | Self::AutoExpanding { values, .. } => {
+                values.push(JsonVariant::Null)
+            }
+        }
+    }
 }
 
 impl JsonVectorBuilder {
+    /// Creates a builder that merges all observed paths into the explicit schema.
     pub(crate) fn new(initial_native_type: JsonNativeType, capacity: usize) -> Self {
         debug_assert!(matches!(
             initial_native_type,
             JsonNativeType::Object(_) | JsonNativeType::Null
         ));
         Self {
-            merged_type: initial_native_type,
-            values: Vec::with_capacity(capacity),
+            state: JsonVectorBuilderState::Legacy {
+                merged_type: initial_native_type,
+                values: Vec::with_capacity(capacity),
+            },
+        }
+    }
+
+    /// Creates a builder bounded by the JSON settings and their type hints.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn with_settings(settings: &JsonSettings, capacity: usize) -> Self {
+        let mut explicit_type = JsonNativeType::Object(Default::default());
+        for hint in settings.type_hints() {
+            insert_dynamic_type(&mut explicit_type, &hint.path, (&hint.data_type).into());
+        }
+        Self {
+            state: JsonVectorBuilderState::AutoExpanding {
+                explicit_type,
+                max_auto_expanded_paths: settings.max_auto_expanded_paths().unwrap_or(u32::MAX),
+                values: Vec::with_capacity(capacity),
+            },
         }
     }
 
     fn try_build(&mut self) -> Result<VectorRef> {
-        let DataType::Struct(fields) = self.merged_type.as_arrow_type() else {
-            return UnexpectedSnafu {
-                reason: "merged JSON2 type must map to Arrow Struct in JsonVectorBuilder",
-            }
-            .fail();
-        };
-        // TODO(LFC): Direct use Arrow's Struct datatype here.
-        let struct_type = StructType::from(&fields);
-
-        let mut builder =
-            StructVectorBuilder::with_type_and_capacity(struct_type.clone(), self.values.len());
-        for value in std::mem::take(&mut self.values) {
-            if matches!(&value, JsonVariant::Null) {
-                builder.push_null();
-                continue;
-            }
-            let value = json_variant_into_struct_value(value, struct_type.clone())?;
-            builder.push_struct_value_ref(StructValueRef::Ref(&value))?;
-        }
-        Ok(builder.to_vector())
+        self.state.try_build()
     }
 }
 
-fn json_variant_into_struct_value(
-    value: JsonVariant,
-    struct_type: StructType,
-) -> Result<StructValue> {
-    let JsonVariant::Object(object) = value else {
-        return TryFromValueSnafu {
-            reason: format!("expected json object value, got {value:?}"),
+fn build_legacy(values: &mut Vec<JsonVariant>, merged_type: &JsonNativeType) -> Result<VectorRef> {
+    build_explicit(values, merged_type, |value| match value {
+        JsonVariant::Null => Ok(None),
+        JsonVariant::Object(value) => Ok(Some(value)),
+        _ => TryFromValueSnafu {
+            reason: "expected json object value".to_string(),
+        }
+        .fail(),
+    })
+}
+
+fn build_with_remainder(
+    values: &mut Vec<JsonVariant>,
+    expanded_type: &JsonNativeType,
+) -> Result<VectorRef> {
+    let mut remainder = VariantArrayBuilder::new(values.len());
+    let explicit = build_explicit(values, expanded_type, |value| {
+        if matches!(value, JsonVariant::Null) {
+            remainder.append_null();
+            return Ok(None);
+        }
+        let (value, rest) = split_to_explicit(value, expanded_type)?;
+        append_json_variant(&mut remainder, &JsonVariant::Object(rest))
+            .context(ArrowComputeSnafu)?;
+        Ok(Some(value))
+    })?;
+    finish_vector(explicit, ArrayRef::from(remainder.build()))
+}
+
+fn build_explicit(
+    values: &mut Vec<JsonVariant>,
+    explicit_type: &JsonNativeType,
+    mut project: impl FnMut(JsonVariant) -> Result<Option<JsonObjectValue>>,
+) -> Result<VectorRef> {
+    let DataType::Struct(fields) = explicit_type.as_arrow_type() else {
+        return UnexpectedSnafu {
+            reason: "merged JSON2 type must map to Arrow Struct in JsonVectorBuilder",
         }
         .fail();
     };
+    // TODO(LFC): Direct use Arrow's Struct datatype here.
+    let struct_type = StructType::from(&fields);
 
+    let mut builder =
+        StructVectorBuilder::with_type_and_capacity(struct_type.clone(), values.len());
+    for value in std::mem::take(values) {
+        let Some(value) = project(value)? else {
+            builder.push_null();
+            continue;
+        };
+        let value = json_variant_into_struct_value(value, struct_type.clone())?;
+        builder.push_struct_value_ref(StructValueRef::Ref(&value))?;
+    }
+    Ok(builder.to_vector())
+}
+
+fn finish_vector(explicit: VectorRef, remainder: ArrayRef) -> Result<VectorRef> {
+    let explicit = explicit.to_arrow_array();
+    let explicit = explicit.as_struct();
+    let mut children = explicit
+        .fields()
+        .iter()
+        .cloned()
+        .zip(explicit.columns().iter().cloned())
+        .chain(std::iter::once((
+            Arc::new(variant_field(JSON2_REMAINDER_FIELD_NAME, true)),
+            remainder,
+        )))
+        .collect::<Vec<_>>();
+    children.sort_unstable_by(|(x, _), (y, _)| x.name().cmp(y.name()));
+    let (fields, columns): (Vec<_>, Vec<ArrayRef>) = children.into_iter().unzip();
+    let array: ArrayRef = Arc::new(StructArray::new(
+        fields.into(),
+        columns,
+        explicit.nulls().cloned(),
+    ));
+    Helper::try_into_vector(array)
+}
+
+fn infer_expanded_type(
+    explicit_type: &JsonNativeType,
+    max_auto_expanded_paths: u32,
+    values: &[JsonVariant],
+) -> JsonNativeType {
+    if max_auto_expanded_paths == 0 {
+        return explicit_type.clone();
+    }
+
+    let mut stats = HashMap::new();
+    let mut path = Vec::new();
+    init_explicit_path_stats(explicit_type, &mut path, &mut stats);
+    for value in values {
+        count_dynamic_paths(value, &mut path, &mut stats);
+    }
+    let mut candidates = stats
+        .iter()
+        // Explicit paths are already in the output schema and do not consume the dynamic
+        // expansion budget.
+        .filter(|(_, stat)| !stat.is_explicit && stat.is_leaf)
+        // A leaf is eligible only when both itself and every object prefix have one stable
+        // role and type across all observed values.
+        .filter(|(path, _)| {
+            !(1..=path.len())
+                .any(|len| stats.get(&path[..len]).is_some_and(|stats| stats.conflicts))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_unstable_by(|(x_path, x), (y_path, y)| {
+        y.seen_count
+            .cmp(&x.seen_count)
+            .then_with(|| x_path.cmp(y_path))
+    });
+
+    let mut expanded_type = explicit_type.clone();
+    for (path, candidate) in candidates
+        .into_iter()
+        .take(max_auto_expanded_paths as usize)
+    {
+        insert_dynamic_type(
+            &mut expanded_type,
+            path,
+            candidate.expected_leaf_type.clone(),
+        );
+    }
+    expanded_type
+}
+
+/// Aggregated observations for one JSON path.
+///
+/// Schema inference first seeds the map with explicit paths, then walks all input values once.
+/// Objects, including empty objects, are non-leaf paths; every other non-null value is a leaf.
+/// The first dynamic observation fixes the path role and exact leaf type. A later role or type
+/// mismatch sets [`PathStats::conflicts`] permanently. Missing paths and null values do not affect
+/// the statistics.
+///
+/// After collection, dynamic leaves are ranked by [`PathStats::seen_count`]. A candidate is
+/// rejected when it or any parent path conflicts, so candidate selection never rescans the input
+/// values.
+struct PathStats {
+    /// Whether the path came from a type hint and is already part of the output schema.
+    is_explicit: bool,
+    /// Whether the path is a non-object value rather than an object prefix.
+    is_leaf: bool,
+    /// Exact type required for a leaf; unused non-leaf paths keep [`JsonNativeType::Null`].
+    expected_leaf_type: JsonNativeType,
+    /// Number of compatible observations used to rank dynamic leaves.
+    seen_count: usize,
+    /// Whether the path has ever had inconsistent roles or leaf types.
+    conflicts: bool,
+}
+
+/// Seeds path statistics from the configured explicit JSON shape.
+fn init_explicit_path_stats<'a>(
+    explicit_type: &'a JsonNativeType,
+    path: &mut Vec<&'a str>,
+    stats: &mut HashMap<Vec<&'a str>, PathStats>,
+) {
+    let JsonNativeType::Object(fields) = explicit_type else {
+        return;
+    };
+    for (name, data_type) in fields {
+        path.push(name);
+        let is_leaf = !matches!(data_type, JsonNativeType::Object(_));
+        let expected_leaf_type = if is_leaf {
+            data_type.clone()
+        } else {
+            JsonNativeType::default()
+        };
+        stats.insert(
+            path.clone(),
+            PathStats {
+                is_explicit: true,
+                is_leaf,
+                expected_leaf_type,
+                seen_count: 0,
+                conflicts: false,
+            },
+        );
+        init_explicit_path_stats(data_type, path, stats);
+        path.pop();
+    }
+}
+
+/// Collects dynamic path statistics while traversing each input value once.
+fn count_dynamic_paths<'a>(
+    value: &'a JsonVariant,
+    path: &mut Vec<&'a str>,
+    stats: &mut HashMap<Vec<&'a str>, PathStats>,
+) {
+    if matches!(value, JsonVariant::Null) || path.len() > JSON2_MAX_STRUCTURED_DEPTH {
+        return;
+    }
+
+    if !path.is_empty() {
+        let is_leaf = !matches!(value, JsonVariant::Object(_));
+        let conflicts = if let Some(stats) = stats.get_mut(path.as_slice()) {
+            if !stats.conflicts {
+                let role_conflict = stats.is_leaf != is_leaf;
+                let type_conflict = || match (&stats.expected_leaf_type, value) {
+                    // If both objects, they are compatible.
+                    (JsonNativeType::Null | JsonNativeType::Object(_), JsonVariant::Object(_)) => {
+                        false
+                    }
+                    _ => stats.expected_leaf_type != value.native_type(),
+                };
+                if role_conflict || type_conflict() {
+                    stats.conflicts = true;
+                } else {
+                    stats.seen_count += 1;
+                }
+            }
+            stats.conflicts
+        } else {
+            let expected_leaf_type = if is_leaf {
+                value.native_type()
+            } else {
+                JsonNativeType::default()
+            };
+            stats.insert(
+                path.clone(),
+                PathStats {
+                    is_explicit: false,
+                    is_leaf,
+                    expected_leaf_type,
+                    seen_count: 1,
+                    conflicts: false,
+                },
+            );
+            false
+        };
+        if conflicts {
+            return;
+        }
+    }
+
+    if let JsonVariant::Object(object) = value
+        && !object.is_empty()
+    {
+        for (name, value) in object {
+            path.push(name);
+            count_dynamic_paths(value, path, stats);
+            path.pop();
+        }
+    }
+}
+
+fn insert_dynamic_type<S: AsRef<str>>(
+    explicit_type: &mut JsonNativeType,
+    path: &[S],
+    data_type: JsonNativeType,
+) {
+    let JsonNativeType::Object(fields) = explicit_type else {
+        return;
+    };
+    let Some((name, path)) = path.split_first() else {
+        return;
+    };
+    let name = name.as_ref().to_string();
+    if path.is_empty() {
+        fields.insert(name, data_type);
+        return;
+    }
+    insert_dynamic_type(
+        fields
+            .entry(name)
+            .or_insert_with(|| JsonNativeType::Object(Default::default())),
+        path,
+        data_type,
+    )
+}
+
+fn split_to_explicit(
+    value: JsonVariant,
+    explicit_type: &JsonNativeType,
+) -> Result<(JsonObjectValue, JsonObjectValue)> {
+    let JsonVariant::Object(mut remainder) = value else {
+        return TryFromValueSnafu {
+            reason: "expected json object value".to_string(),
+        }
+        .fail();
+    };
+    let JsonNativeType::Object(fields) = explicit_type else {
+        return UnexpectedSnafu {
+            reason: "JSON2 explicit type must be an object",
+        }
+        .fail();
+    };
+    let mut explicit = JsonObjectValue::new();
+
+    for (name, data_type) in fields {
+        let Some(value) = remainder.remove(name) else {
+            continue;
+        };
+        if matches!(data_type, JsonNativeType::Object(_)) {
+            if matches!(value, JsonVariant::Null) {
+                explicit.insert(name.clone(), value);
+                continue;
+            }
+            let (value, child_remainder) = split_to_explicit(value, data_type)?;
+            if !value.is_empty() {
+                explicit.insert(name.clone(), JsonVariant::Object(value));
+            }
+            if !child_remainder.is_empty() {
+                remainder.insert(name.clone(), JsonVariant::Object(child_remainder));
+            }
+        } else {
+            explicit.insert(name.clone(), value);
+        }
+    }
+    Ok((explicit, remainder))
+}
+
+fn json_variant_into_struct_value(
+    object: JsonObjectValue,
+    struct_type: StructType,
+) -> Result<StructValue> {
     let mut entries = object.into_iter();
     let mut entry = entries.next();
     let mut values = Vec::with_capacity(struct_type.fields().len());
@@ -157,7 +565,7 @@ fn json_variant_into_value(value: JsonVariant, expected_type: &ConcreteDataType)
                 .collect::<Result<Vec<_>>>()?;
             Value::List(ListValue::new(values, Arc::new(item_type)))
         }
-        (value @ JsonVariant::Object(_), ConcreteDataType::Struct(struct_type)) => {
+        (JsonVariant::Object(value), ConcreteDataType::Struct(struct_type)) => {
             Value::Struct(json_variant_into_struct_value(value, struct_type.clone())?)
         }
         (value, ConcreteDataType::Binary(_)) => Value::from(encode_json_variant(value)?),
@@ -173,11 +581,11 @@ fn json_variant_into_value(value: JsonVariant, expected_type: &ConcreteDataType)
 
 impl MutableVector for JsonVectorBuilder {
     fn data_type(&self) -> ConcreteDataType {
-        ConcreteDataType::json2(self.merged_type.clone())
+        ConcreteDataType::json2(self.state.native_type())
     }
 
     fn len(&self) -> usize {
-        self.values.len()
+        self.state.len()
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -197,30 +605,11 @@ impl MutableVector for JsonVectorBuilder {
     }
 
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
-        let ValueRef::Json(value) = value else {
-            return TryFromValueSnafu {
-                reason: format!("expected json value, got {value:?}"),
-            }
-            .fail();
-        };
-        let json_type = value.json_type();
-        let json_type = json_type.as_ref();
-        if !matches!(json_type, JsonNativeType::Object(_) | JsonNativeType::Null) {
-            return TryFromValueSnafu {
-                reason: format!("expected json object value, got {value:?}"),
-            }
-            .fail();
-        }
-        if !is_include(&self.merged_type, json_type) {
-            self.merged_type.merge(json_type);
-        }
-
-        self.values.push(JsonVariant::from(value.variant()));
-        Ok(())
+        self.state.try_push_value_ref(value)
     }
 
     fn push_null(&mut self) {
-        self.values.push(JsonVariant::Null)
+        self.state.push_null()
     }
 
     fn extend_slice_of(&mut self, _: &dyn Vector, _: usize, _: usize) -> Result<()> {
@@ -236,13 +625,21 @@ impl MutableVector for JsonVectorBuilder {
 mod tests {
     use std::sync::Arc;
 
+    use arrow_array::cast::AsArray;
+    use arrow_schema::Field;
     use common_base::bytes::Bytes;
+    use serde_json::json;
 
     use super::*;
     use crate::data_type::ConcreteDataType;
+    use crate::extension::json::{Json2ExtensionType, JsonMetadata};
+    use crate::json::JsonTypeHint;
+    use crate::json::value::decode_json_variant;
     use crate::types::StructField;
     use crate::types::json_type::JsonObjectType;
     use crate::value::{ListValue, StructValue, Value, ValueRef};
+    use crate::vectors::json::array::JsonArray;
+    use crate::vectors::json::variant::variant_to_json_values;
 
     #[test]
     fn test_json_vector_builder() -> Result<()> {
@@ -346,7 +743,7 @@ mod tests {
         let err = object_builder
             .try_push_value_ref(&boolean.as_value_ref())
             .unwrap_err();
-        assert!(err.to_string().contains("expected json object value"));
+        assert!(err.to_string().contains("expected JSON object value"));
         object_builder.try_push_value_ref(&object.as_value_ref())?;
 
         // Non-JSON values should be rejected at push time.
@@ -355,7 +752,250 @@ mod tests {
         let err = invalid_builder
             .try_push_value_ref(&ValueRef::Boolean(true))
             .unwrap_err();
-        assert!(err.to_string().contains("expected json value"));
+        assert!(err.to_string().contains("expected JSON value"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_zero_budget_builder_uses_fixed_schema_and_remainder() -> Result<()> {
+        let settings = JsonSettings::try_new(
+            vec![
+                JsonTypeHint {
+                    path: vec!["kind".to_string()],
+                    data_type: ConcreteDataType::string_datatype(),
+                    nullable: true,
+                    default_constraint: None,
+                    inverted_index: false,
+                },
+                JsonTypeHint {
+                    path: vec!["commit".to_string(), "operation".to_string()],
+                    data_type: ConcreteDataType::string_datatype(),
+                    nullable: true,
+                    default_constraint: None,
+                    inverted_index: false,
+                },
+                JsonTypeHint {
+                    path: vec!["time_us".to_string()],
+                    data_type: ConcreteDataType::int64_datatype(),
+                    nullable: true,
+                    default_constraint: None,
+                    inverted_index: false,
+                },
+            ],
+            Some(0),
+        )?;
+        let mut builder = JsonVectorBuilder::with_settings(&settings, 2);
+        let values = [
+            json!({
+                "kind": "record",
+                "commit": {"operation": "create", "collection": "post"},
+                "extra": 1,
+                "time_us": 1
+            }),
+            json!({"kind": "other", "dynamic": true, "time_us": 2}),
+        ];
+        for value in values.clone() {
+            let value = settings.encode(value)?;
+            builder.try_push_value_ref(&value.as_value_ref())?;
+        }
+        let array = builder.to_vector().to_arrow_array();
+        assert_eq!(0, builder.len());
+        let structs = array.as_struct();
+        assert_eq!(
+            vec![JSON2_REMAINDER_FIELD_NAME, "commit", "kind", "time_us"],
+            structs
+                .fields()
+                .iter()
+                .map(|x| x.name().as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            vec![
+                Some(json!({"commit": {"collection": "post"}, "extra": 1})),
+                Some(json!({"dynamic": true})),
+            ],
+            variant_to_json_values(structs.column_by_name(JSON2_REMAINDER_FIELD_NAME).unwrap())?
+        );
+
+        let field = Field::new("data", array.data_type().clone(), true).with_extension_type(
+            Json2ExtensionType::new(Arc::new(JsonMetadata::new_v2(settings))),
+        );
+        let reconstructed = JsonArray::from(&array).project_to_v2(&field, &DataType::Binary)?;
+        let reconstructed = reconstructed.as_binary::<i32>();
+        assert_eq!(
+            values[0],
+            decode_json_variant(reconstructed.value(0)).unwrap()
+        );
+        assert_eq!(
+            json!({
+                "kind": "other",
+                "commit": {"operation": null},
+                "dynamic": true,
+                "time_us": 2
+            }),
+            decode_json_variant(reconstructed.value(1)).unwrap()
+        );
+
+        let settings = JsonSettings::try_new(vec![], Some(0))?;
+        let mut builder = JsonVectorBuilder::with_settings(&settings, 3);
+        for value in [json!({}), json!({"x": 1})] {
+            let value = settings.encode(value)?;
+            builder.try_push_value_ref(&value.as_value_ref())?;
+        }
+        builder.push_null();
+        let array = builder.to_vector().to_arrow_array();
+        let structs = array.as_struct();
+        assert_eq!(1, structs.num_columns());
+        assert_eq!(
+            vec![Some(json!({})), Some(json!({"x": 1})), None],
+            variant_to_json_values(structs.column(0))?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_finite_budget_selects_dynamic_paths() -> Result<()> {
+        let settings = JsonSettings::try_new(
+            vec![JsonTypeHint {
+                path: vec!["hint".to_string()],
+                data_type: ConcreteDataType::string_datatype(),
+                nullable: true,
+                default_constraint: None,
+                inverted_index: false,
+            }],
+            Some(2),
+        )?;
+        let values = [
+            json!({
+                "hint": "first",
+                "conflict": 1,
+                "popular": {"nested": 1},
+                "tie_a": "a",
+                "tie_b": true,
+                "rare": 1
+            }),
+            json!({
+                "hint": "second",
+                "conflict": "string",
+                "popular": {"nested": 2},
+                "tie_a": "b",
+                "tie_b": false
+            }),
+            json!({"hint": "third", "popular": "scalar"}),
+        ];
+        let mut builder = JsonVectorBuilder::with_settings(&settings, values.len());
+        for value in values.clone() {
+            let value = settings.encode(value)?;
+            builder.try_push_value_ref(&value.as_value_ref())?;
+        }
+
+        let array = builder.to_vector().to_arrow_array();
+        let structs = array.as_struct();
+        assert_eq!(
+            vec![JSON2_REMAINDER_FIELD_NAME, "hint", "tie_a", "tie_b"],
+            structs
+                .fields()
+                .iter()
+                .map(|x| x.name().as_str())
+                .collect::<Vec<_>>()
+        );
+        assert!(structs.column_by_name("popular").is_none());
+        assert_eq!(
+            vec![
+                Some(json!({"conflict": 1, "popular": {"nested": 1}, "rare": 1})),
+                Some(json!({"conflict": "string", "popular": {"nested": 2}})),
+                Some(json!({"popular": "scalar"})),
+            ],
+            variant_to_json_values(structs.column_by_name(JSON2_REMAINDER_FIELD_NAME).unwrap())?
+        );
+
+        let field = Field::new("data", array.data_type().clone(), true).with_extension_type(
+            Json2ExtensionType::new(Arc::new(JsonMetadata::new_v2(settings))),
+        );
+        let reconstructed = JsonArray::from(&array).project_to_v2(&field, &DataType::Binary)?;
+        let reconstructed = reconstructed.as_binary::<i32>();
+        assert_eq!(
+            values[0],
+            decode_json_variant(reconstructed.value(0)).unwrap()
+        );
+        assert_eq!(
+            values[1],
+            decode_json_variant(reconstructed.value(1)).unwrap()
+        );
+        assert_eq!(
+            json!({
+                "hint": "third",
+                "popular": "scalar",
+                "tie_a": null,
+                "tie_b": null
+            }),
+            decode_json_variant(reconstructed.value(2)).unwrap()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_dynamic_paths_require_the_same_leaf_type() -> Result<()> {
+        let settings = JsonSettings::try_new(
+            vec![JsonTypeHint {
+                path: vec!["nested".to_string(), "hinted".to_string()],
+                data_type: ConcreteDataType::string_datatype(),
+                nullable: true,
+                default_constraint: None,
+                inverted_index: false,
+            }],
+            Some(8),
+        )?;
+        let values = [
+            json!({
+                "branch": {},
+                "different": [1],
+                "empty": {},
+                "nested": {},
+                "reverse": "scalar",
+                "same": [1]
+            }),
+            json!({
+                "branch": {"leaf": 1},
+                "different": ["x"],
+                "empty": {},
+                "nested": {"hinted": "x", "leaf": 1},
+                "same": [2]
+            }),
+            json!({
+                "branch": {},
+                "different": [2],
+                "empty": {},
+                "nested": {},
+                "reverse": {"leaf": 1},
+                "same": [3]
+            }),
+        ];
+        let mut builder = JsonVectorBuilder::with_settings(&settings, values.len());
+        for value in values {
+            let value = settings.encode(value)?;
+            builder.try_push_value_ref(&value.as_value_ref())?;
+        }
+
+        let JsonNativeType::Object(fields) = builder.state.native_type() else {
+            unreachable!();
+        };
+        assert!(!fields.contains_key("different"));
+        assert!(!fields.contains_key("empty"));
+        assert!(!fields.contains_key("reverse"));
+        assert!(matches!(fields.get("same"), Some(JsonNativeType::Array(_))));
+        assert!(matches!(
+            fields.get("branch"),
+            Some(JsonNativeType::Object(fields)) if fields.contains_key("leaf")
+        ));
+        assert!(matches!(
+            fields.get("nested"),
+            Some(JsonNativeType::Object(fields))
+                if fields.contains_key("hinted") && fields.contains_key("leaf")
+        ));
 
         Ok(())
     }
@@ -394,16 +1034,16 @@ mod tests {
                 true,
             ),
         ]));
-        let variant = JsonVariant::from([
+        let variant = JsonObjectValue::from([
             (
-                "items",
+                "items".to_string(),
                 JsonVariant::Array(vec![
                     JsonVariant::from([("id", JsonVariant::from(1i64))]),
                     JsonVariant::from([("id", JsonVariant::from(2i64))]),
                 ]),
             ),
             (
-                "meta",
+                "meta".to_string(),
                 JsonVariant::from([("name", JsonVariant::from("foo"))]),
             ),
         ]);

--- a/src/datatypes/src/vectors/json/variant.rs
+++ b/src/datatypes/src/vectors/json/variant.rs
@@ -15,10 +15,7 @@
 use std::sync::Arc;
 
 use arrow_array::ArrayRef;
-#[cfg(test)]
-use arrow_schema::ArrowError;
-use arrow_schema::{DataType, Field};
-#[cfg(test)]
+use arrow_schema::{ArrowError, DataType, Field};
 use parquet_variant::{ObjectFieldBuilder, Variant, VariantBuilderExt, VariantDecimal16};
 #[cfg(test)]
 use parquet_variant_compute::VariantArrayBuilder;
@@ -27,7 +24,6 @@ use parquet_variant_json::VariantToJson;
 use snafu::ResultExt;
 
 use crate::error::{ArrowComputeSnafu, Result};
-#[cfg(test)]
 use crate::json::value::{JsonNumber, JsonVariant, decode_json_variant};
 
 /// Returns the canonical Arrow field for an unshredded Parquet Variant array.
@@ -68,8 +64,7 @@ fn json_variants_to_variant(values: &[Option<JsonVariant>]) -> Result<ArrayRef> 
     Ok(ArrayRef::from(builder.build()))
 }
 
-#[cfg(test)]
-fn append_json_variant(
+pub(super) fn append_json_variant(
     builder: &mut impl VariantBuilderExt,
     value: &JsonVariant,
 ) -> std::result::Result<(), ArrowError> {
@@ -115,7 +110,6 @@ fn append_json_variant(
     Ok(())
 }
 
-#[cfg(test)]
 fn append_json_value(
     builder: &mut impl VariantBuilderExt,
     value: &serde_json::Value,
@@ -157,7 +151,6 @@ fn append_json_value(
 
 /// Parquet Variant has no unsigned integer primitive. Treat u64 as i64 first, then use Decimal16
 /// to represent large (larger than i64::MAX) u64.
-#[cfg(test)]
 fn append_large_u64(
     builder: &mut impl VariantBuilderExt,
     value: u64,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
