### PR TITLE
feat(telemetry): correlate flow Flight attempts

### DIFF
--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -44,8 +44,8 @@ use common_recordbatch::adapter::RecordBatchMetrics;
 use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream, RecordBatchStreamWrapper};
 use common_telemetry::tracing::Span;
-use common_telemetry::tracing_context::W3cTrace;
-use common_telemetry::{error, warn};
+use common_telemetry::tracing_context::TracingContext;
+use common_telemetry::{debug, error, warn};
 use futures::future;
 use futures_util::{Stream, StreamExt, TryStreamExt};
 use prost::Message;
@@ -262,14 +262,34 @@ async fn output_from_flight_message_stream<S>(
 where
     S: Stream<Item = Result<FlightMessage>> + Send + Unpin + 'static,
 {
+    debug!(
+        stage = "flight_first_message_wait",
+        "Waiting for the first Flight response message"
+    );
     let Some(first_flight_message) = flight_message_stream.next().await else {
+        debug!(
+            stage = "flight_terminal_eof",
+            outcome = "empty",
+            "Flight response ended before its first message"
+        );
         return IllegalFlightMessagesSnafu {
             reason: "Expect the response not to be empty",
         }
         .fail();
     };
 
-    let first_flight_message = first_flight_message?;
+    let first_flight_message = match first_flight_message {
+        Ok(message) => message,
+        Err(error) => {
+            debug!(stage = "flight_first_message", outcome = "error", error = ?error, "Flight response first message failed");
+            return Err(error);
+        }
+    };
+    debug!(
+        stage = "flight_first_message",
+        outcome = "ok",
+        "Received the first Flight response message"
+    );
 
     match first_flight_message {
         FlightMessage::AffectedRows { rows, metrics } => {
@@ -277,9 +297,22 @@ where
             if let Some(metrics) = metrics {
                 terminal_metrics.update(Some(parse_terminal_metrics(&metrics)?));
             }
-            let next_message = flight_message_stream.next().await.transpose()?;
+            let next_message = match flight_message_stream.next().await.transpose() {
+                Ok(message) => message,
+                Err(error) => {
+                    debug!(stage = "flight_terminal", outcome = "error", error = ?error, "Flight response terminal message failed");
+                    return Err(error);
+                }
+            };
             match next_message {
-                None => terminal_metrics.mark_ready(),
+                None => {
+                    debug!(
+                        stage = "flight_terminal_eof",
+                        outcome = "ok",
+                        "Flight response reached terminal EOF"
+                    );
+                    terminal_metrics.mark_ready()
+                }
                 Some(FlightMessage::Metrics(s)) if terminal_metrics.get().is_none() => {
                     terminal_metrics.update(Some(parse_terminal_metrics(&s)?));
                     terminal_metrics.mark_ready();
@@ -661,8 +694,7 @@ impl Database {
                 authorization: self.ctx.auth_header.clone(),
                 dbname: self.dbname.clone(),
                 timezone: self.timezone.clone(),
-                // TODO(Taylor-lagrange): add client grpc tracing
-                tracing_context: W3cTrace::new(),
+                tracing_context: TracingContext::from_current_span().to_w3c(),
             }),
             request: Some(request),
         }
@@ -869,10 +901,13 @@ mod tests {
     use common_error::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_RETRY_HINT};
     use common_query::OutputData;
     use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
+    use common_telemetry::tracing::info_span;
+    use common_telemetry::tracing_context::current_trace_ids;
     use datatypes::prelude::{ConcreteDataType, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::Int32Vector;
     use futures_util::StreamExt;
+    use prost::Message;
     use tonic::codegen::http::{HeaderMap, HeaderValue};
     use tonic::metadata::MetadataMap;
     use tonic::{Code, Status};
@@ -978,6 +1013,28 @@ mod tests {
             .unwrap();
         let decoded: std::collections::HashMap<u64, u64> = serde_json::from_str(value).unwrap();
         assert_eq!(decoded, snapshot_seqs);
+    }
+
+    #[test]
+    fn test_database_flight_ticket_propagates_active_trace_context() {
+        common_telemetry::init_default_ut_logging();
+        let span = info_span!("client_ticket_parent");
+        let _entered = span.enter();
+        let (trace_id, span_id) = current_trace_ids().expect("test span must have IDs");
+        let database = Database::new("catalog", "schema", Client::default());
+        let request = database.to_rpc_request(Request::Query(QueryRequest {
+            query: Some(Query::Sql("SELECT 1".into())),
+        }));
+        let ticket = Ticket {
+            ticket: request.encode_to_vec().into(),
+        };
+        let decoded = api::v1::GreptimeRequest::decode(ticket.ticket.as_ref()).unwrap();
+        let traceparent = decoded.header.unwrap().tracing_context["traceparent"].clone();
+        let parts: Vec<_> = traceparent.split('-').collect();
+        assert_eq!(
+            parts.as_slice(),
+            ["00", trace_id.as_str(), span_id.as_str(), "01"]
+        );
     }
 
     #[test]

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -25,7 +25,7 @@ use opentelemetry::trace::TracerProvider;
 use opentelemetry::{KeyValue, global};
 use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use opentelemetry_sdk::trace::{Sampler, Tracer};
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider, Tracer};
 use opentelemetry_semantic_conventions::resource;
 use serde::{Deserialize, Serialize};
 use tracing::callsite;
@@ -35,6 +35,7 @@ use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_log::LogTracer;
 use tracing_subscriber::filter::{FilterFn, Targets};
 use tracing_subscriber::fmt::Layer;
+use tracing_subscriber::fmt::format::{FormatEvent, Writer};
 use tracing_subscriber::layer::{Layered, SubscriberExt};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, Registry, filter};
@@ -56,6 +57,57 @@ pub static LOG_RELOAD_HANDLE: OnceCell<tracing_subscriber::reload::Handle<Target
 
 type DynSubscriber = Layered<tracing_subscriber::reload::Layer<Targets, Registry>, Registry>;
 type OtelTraceLayer = tracing_opentelemetry::OpenTelemetryLayer<DynSubscriber, Tracer>;
+
+#[derive(Clone, Copy)]
+struct CorrelatedFormat<F> {
+    inner: F,
+    json: bool,
+}
+
+impl<F> CorrelatedFormat<F> {
+    fn text(inner: F) -> Self {
+        Self { inner, json: false }
+    }
+    fn json(inner: F) -> Self {
+        Self { inner, json: true }
+    }
+}
+
+impl<S, N, F> FormatEvent<S, N> for CorrelatedFormat<F>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    N: for<'a> tracing_subscriber::fmt::FormatFields<'a> + 'static,
+    F: FormatEvent<S, N>,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        let ids = ctx
+            .event_scope()
+            .and_then(|scope| scope.from_root().last())
+            .and_then(|span| crate::tracing_context::current_trace_ids_for_span(Some(&span.id())));
+        let mut rendered = String::new();
+        self.inner
+            .format_event(ctx, Writer::new(&mut rendered), event)?;
+        let Some((trace_id, span_id)) = ids else {
+            return writer.write_str(&rendered);
+        };
+        if self.json {
+            let mut value: serde_json::Value =
+                serde_json::from_str(rendered.trim_end()).map_err(|_| std::fmt::Error)?;
+            let object = value.as_object_mut().ok_or(std::fmt::Error)?;
+            object.insert("trace_id".into(), trace_id.into());
+            object.insert("span_id".into(), span_id.into());
+            writer.write_str(&serde_json::to_string(&value).map_err(|_| std::fmt::Error)?)?;
+            writer.write_char('\n')
+        } else {
+            write!(writer, "trace_id={trace_id} span_id={span_id} {rendered}")
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct TraceReloadHandle {
@@ -231,9 +283,44 @@ pub static TRACE_RELOAD_HANDLE: OnceCell<TraceReloadHandle> = OnceCell::new();
 static TRACER: OnceCell<Mutex<TraceState>> = OnceCell::new();
 
 #[derive(Debug)]
-enum TraceState {
-    Ready(Tracer),
-    Deferred(TraceContext),
+struct TraceState {
+    tracer: Tracer,
+    providers: Vec<SdkTracerProvider>,
+    app_name: String,
+    node_id: String,
+    options: LoggingOptions,
+    otlp_enabled: bool,
+}
+
+impl TraceState {
+    fn new(
+        app_name: &str,
+        node_id: &str,
+        options: &LoggingOptions,
+        provider: SdkTracerProvider,
+        tracer: Tracer,
+    ) -> Self {
+        Self {
+            tracer,
+            providers: vec![provider],
+            app_name: app_name.to_string(),
+            node_id: node_id.to_string(),
+            options: options.clone(),
+            otlp_enabled: options.enable_otlp_tracing,
+        }
+    }
+
+    fn get_or_init_tracer(&mut self) -> Tracer {
+        if !self.otlp_enabled {
+            let mut options = self.options.clone();
+            options.enable_otlp_tracing = true;
+            let (provider, tracer) = create_tracer(&self.app_name, &self.node_id, &options);
+            self.providers.push(provider);
+            self.tracer = tracer;
+            self.otlp_enabled = true;
+        }
+        self.tracer.clone()
+    }
 }
 
 /// The logging options that used to initialize the logger.
@@ -344,13 +431,6 @@ pub enum LogFormat {
     Text,
 }
 
-#[derive(Clone, Debug)]
-struct TraceContext {
-    app_name: String,
-    node_id: String,
-    logging_opts: LoggingOptions,
-}
-
 impl Default for LoggingOptions {
     fn default() -> Self {
         Self {
@@ -443,6 +523,9 @@ pub fn init_global_logging(
                 Some(
                     Layer::new()
                         .json()
+                        .event_format(CorrelatedFormat::json(
+                            tracing_subscriber::fmt::format::json(),
+                        ))
                         .with_writer(writer)
                         .with_ansi(std::io::stdout().is_terminal())
                         .boxed(),
@@ -450,6 +533,7 @@ pub fn init_global_logging(
             } else {
                 Some(
                     Layer::new()
+                        .event_format(CorrelatedFormat::text(tracing_subscriber::fmt::format()))
                         .with_writer(writer)
                         .with_ansi(std::io::stdout().is_terminal())
                         .boxed(),
@@ -481,12 +565,21 @@ pub fn init_global_logging(
                 Some(
                     Layer::new()
                         .json()
+                        .event_format(CorrelatedFormat::json(
+                            tracing_subscriber::fmt::format::json(),
+                        ))
                         .with_writer(writer)
                         .with_ansi(false)
                         .boxed(),
                 )
             } else {
-                Some(Layer::new().with_writer(writer).with_ansi(false).boxed())
+                Some(
+                    Layer::new()
+                        .event_format(CorrelatedFormat::text(tracing_subscriber::fmt::format()))
+                        .with_writer(writer)
+                        .with_ansi(false)
+                        .boxed(),
+                )
             }
         } else {
             None
@@ -512,6 +605,9 @@ pub fn init_global_logging(
                 Some(
                     Layer::new()
                         .json()
+                        .event_format(CorrelatedFormat::json(
+                            tracing_subscriber::fmt::format::json(),
+                        ))
                         .with_writer(writer)
                         .with_ansi(false)
                         .with_filter(filter::LevelFilter::ERROR)
@@ -520,6 +616,7 @@ pub fn init_global_logging(
             } else {
                 Some(
                     Layer::new()
+                        .event_format(CorrelatedFormat::text(tracing_subscriber::fmt::format()))
                         .with_writer(writer)
                         .with_ansi(false)
                         .with_filter(filter::LevelFilter::ERROR)
@@ -550,18 +647,9 @@ pub fn init_global_logging(
             .set(reload_handle)
             .expect("reload handle already set, maybe init_global_logging get called twice?");
 
-        let mut initial_tracer = None;
-        let trace_state = if opts.enable_otlp_tracing {
-            let tracer = create_tracer(app_name, &node_id, opts);
-            initial_tracer = Some(tracer.clone());
-            TraceState::Ready(tracer)
-        } else {
-            TraceState::Deferred(TraceContext {
-                app_name: app_name.to_string(),
-                node_id: node_id.clone(),
-                logging_opts: opts.clone(),
-            })
-        };
+        let (provider, tracer) = create_tracer(app_name, &node_id, opts);
+        let initial_tracer = Some(tracer.clone());
+        let trace_state = TraceState::new(app_name, &node_id, opts, provider, tracer);
 
         TRACER
             .set(Mutex::new(trace_state))
@@ -628,7 +716,11 @@ pub fn init_global_logging(
     guards
 }
 
-fn create_tracer(app_name: &str, node_id: &str, opts: &LoggingOptions) -> Tracer {
+fn create_tracer(
+    app_name: &str,
+    node_id: &str,
+    opts: &LoggingOptions,
+) -> (SdkTracerProvider, Tracer) {
     let sampler = opts
         .tracing_sample_ratio
         .as_ref()
@@ -645,27 +737,25 @@ fn create_tracer(app_name: &str, node_id: &str, opts: &LoggingOptions) -> Tracer
         ])
         .build();
 
-    opentelemetry_sdk::trace::SdkTracerProvider::builder()
-        .with_batch_exporter(build_otlp_exporter(opts))
+    let builder = SdkTracerProvider::builder()
         .with_sampler(sampler)
-        .with_resource(resource)
-        .build()
-        .tracer("greptimedb")
+        .with_resource(resource);
+    let provider = if opts.enable_otlp_tracing {
+        builder
+            .with_batch_exporter(build_otlp_exporter(opts))
+            .build()
+    } else {
+        builder.build()
+    };
+    let tracer = provider.tracer("greptimedb");
+    (provider, tracer)
 }
 
 /// Ensure that the OTLP tracer has been constructed, building it lazily if needed.
 pub fn get_or_init_tracer() -> Result<Tracer, &'static str> {
     let state = TRACER.get().ok_or("trace state is not initialized")?;
     let mut guard = state.lock().expect("trace state lock poisoned");
-
-    match &mut *guard {
-        TraceState::Ready(tracer) => Ok(tracer.clone()),
-        TraceState::Deferred(context) => {
-            let tracer = create_tracer(&context.app_name, &context.node_id, &context.logging_opts);
-            *guard = TraceState::Ready(tracer.clone());
-            Ok(tracer)
-        }
-    }
+    Ok(guard.get_or_init_tracer())
 }
 
 fn build_otlp_exporter(opts: &LoggingOptions) -> SpanExporter {
@@ -749,6 +839,9 @@ where
                 Some(
                     Layer::new()
                         .json()
+                        .event_format(CorrelatedFormat::json(
+                            tracing_subscriber::fmt::format::json(),
+                        ))
                         .with_writer(writer)
                         .with_ansi(false)
                         .with_filter(slow_query_filter)
@@ -757,6 +850,7 @@ where
             } else {
                 Some(
                     Layer::new()
+                        .event_format(CorrelatedFormat::text(tracing_subscriber::fmt::format()))
                         .with_writer(writer)
                         .with_ansi(false)
                         .with_filter(slow_query_filter)
@@ -773,7 +867,123 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use opentelemetry::trace::{Span as OtelSpan, Tracer as _, TracerProvider};
+    use tracing_subscriber::layer::SubscriberExt;
+
     use super::*;
+
+    #[derive(Clone)]
+    struct BufferWriter(Arc<Mutex<Vec<u8>>>);
+    impl<'a> tracing_subscriber::fmt::writer::MakeWriter<'a> for BufferWriter {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self {
+            self.clone()
+        }
+    }
+    impl std::io::Write for BufferWriter {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    fn render_correlated(json: bool) -> (String, String, String) {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let provider = SdkTracerProvider::builder().build();
+        let telemetry = tracing_opentelemetry::layer().with_tracer(provider.tracer("log-test"));
+        let fmt = if json {
+            Layer::new()
+                .json()
+                .event_format(CorrelatedFormat::json(
+                    tracing_subscriber::fmt::format::json(),
+                ))
+                .with_writer(BufferWriter(out.clone()))
+                .boxed()
+        } else {
+            Layer::new()
+                .event_format(CorrelatedFormat::text(tracing_subscriber::fmt::format()))
+                .with_writer(BufferWriter(out.clone()))
+                .boxed()
+        };
+        let sub = Registry::default().with(telemetry).with(fmt);
+        let _g = sub.set_default();
+        let span = tracing::info_span!("known");
+        let _e = span.enter();
+        let ids = crate::tracing_context::current_trace_ids().unwrap();
+        tracing::info!("known");
+        drop(_e);
+        tracing::info!("none");
+        drop(_g);
+        (
+            String::from_utf8(out.lock().unwrap().clone()).unwrap(),
+            ids.0,
+            ids.1,
+        )
+    }
+    #[test]
+    fn test_dynamic_enable_promotes_local_provider_to_otlp_provider() {
+        let local_options = LoggingOptions {
+            enable_otlp_tracing: false,
+            ..Default::default()
+        };
+        let (local_provider, local_tracer) = create_tracer("test", "node", &local_options);
+        let mut state =
+            TraceState::new("test", "node", &local_options, local_provider, local_tracer);
+        assert!(!state.otlp_enabled);
+        let promoted = state.get_or_init_tracer();
+        assert!(state.otlp_enabled);
+        assert_eq!(state.providers.len(), 2);
+        let promoted_span = promoted.start("promoted");
+        assert!(promoted_span.span_context().is_valid());
+        assert!(state.options.otlp_endpoint.is_none());
+    }
+
+    #[test]
+    fn test_disabled_tracing_builds_local_provider_without_exporter() {
+        let opts = LoggingOptions {
+            enable_otlp_tracing: false,
+            ..Default::default()
+        };
+        let (provider, tracer) = create_tracer("test", "node", &opts);
+        let span = tracer.start("local");
+        let context = span.span_context();
+        assert!(context.is_valid());
+        assert_ne!(
+            context.trace_id().to_string(),
+            "00000000000000000000000000000000"
+        );
+        assert_ne!(context.span_id().to_string(), "0000000000000000");
+        // Keeping the provider alive is the lifecycle contract for the SDK tracer.
+        drop(provider);
+        assert!(context.is_valid());
+    }
+    #[test]
+    fn test_text_logs_correlate_only_valid_context() {
+        let (r, t, s) = render_correlated(false);
+        assert!(r.contains(&format!("trace_id={t}")));
+        assert!(r.contains(&format!("span_id={s}")));
+        let no_context = r.lines().last().unwrap();
+        assert!(!no_context.contains("trace_id="));
+        assert!(!no_context.contains("span_id="));
+    }
+    #[test]
+    fn test_json_logs_correlate_only_valid_context() {
+        let (r, t, s) = render_correlated(true);
+        let v: serde_json::Value = serde_json::from_str(r.lines().next().unwrap()).unwrap();
+        assert_eq!(v["trace_id"], t);
+        assert_eq!(v["span_id"], s);
+        let v: serde_json::Value = serde_json::from_str(r.lines().last().unwrap()).unwrap();
+        assert!(v.get("trace_id").is_none());
+        assert!(v.get("span_id").is_none());
+    }
+    #[test]
+    fn test_no_context_has_no_correlation_ids() {
+        assert!(crate::tracing_context::current_trace_ids().is_none());
+    }
 
     #[test]
     fn test_logging_options_deserialization_default() {

--- a/src/common/telemetry/src/tracing_context.rs
+++ b/src/common/telemetry/src/tracing_context.rs
@@ -16,8 +16,9 @@
 use std::collections::HashMap;
 
 use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry::trace::TraceContextExt;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_opentelemetry::{OpenTelemetrySpanExt, get_otel_context};
 
 // An wrapper for `Futures` that provides tracing instrument adapters.
 pub trait FutureExt: std::future::Future + Sized {
@@ -46,6 +47,36 @@ impl<T: std::future::Future> FutureExt for T {
 pub struct TracingContext(opentelemetry::Context);
 
 pub type W3cTrace = HashMap<String, String>;
+
+/// Returns valid identifiers for the current OpenTelemetry span, if one exists.
+/// An absent or invalid context is deliberately represented as `None` so ordinary
+/// logs never manufacture correlation identifiers.
+pub fn current_trace_ids() -> Option<(String, String)> {
+    current_trace_ids_for_span(tracing::Span::current().id().as_ref())
+}
+
+/// Returns identifiers for a span known by the active subscriber. This variant
+/// is used by formatting layers while they are rendering an event.
+pub fn current_trace_ids_for_span(id: Option<&tracing::span::Id>) -> Option<(String, String)> {
+    let current = opentelemetry::Context::current();
+    let span_context = if current.span().span_context().is_valid() {
+        current.span().span_context().clone()
+    } else {
+        id.and_then(|id| {
+            tracing::dispatcher::get_default(|dispatch| get_otel_context(id, dispatch))
+        })
+        .unwrap_or_else(|| tracing::Span::current().context())
+        .span()
+        .span_context()
+        .clone()
+    };
+    span_context.is_valid().then(|| {
+        (
+            span_context.trace_id().to_string(),
+            span_context.span_id().to_string(),
+        )
+    })
+}
 
 impl Default for TracingContext {
     fn default() -> Self {

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -14,14 +14,17 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+#[cfg(test)]
+use std::sync::{Mutex as StdMutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use api::v1::{CreateTableExpr, TableName};
 use catalog::CatalogManagerRef;
 use common_error::ext::BoxedError;
 use common_query::logical_plan::breakup_insert_plan;
-use common_telemetry::tracing::warn;
-use common_telemetry::{debug, info};
+use common_telemetry::debug;
+use common_telemetry::tracing::{Span, field, info, info_span, warn};
+use common_telemetry::tracing_context::FutureExt;
 use common_time::Timestamp;
 use datafusion::datasource::DefaultTableSource;
 use datafusion::sql::unparser::expr_to_sql;
@@ -141,6 +144,68 @@ fn format_insert_target_columns(plan: &LogicalPlan) -> String {
         .map(|field| quote_identifier(field.name()).to_string())
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+#[cfg(test)]
+struct AttemptStartedHook {
+    started: StdMutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    release: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(test)]
+static ATTEMPT_STARTED_HOOK: OnceLock<StdMutex<Option<AttemptStartedHook>>> = OnceLock::new();
+
+#[cfg(test)]
+async fn wait_for_attempt_hook() {
+    let release = ATTEMPT_STARTED_HOOK.get().and_then(|hook| {
+        hook.lock()
+            .unwrap()
+            .as_ref()
+            .map(|hook| hook.release.clone())
+    });
+    if let Some(release) = release {
+        while !release.load(std::sync::atomic::Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    }
+}
+
+struct BatchingAttemptGuard {
+    span: Span,
+    finished: bool,
+}
+
+impl BatchingAttemptGuard {
+    fn new(span: Span) -> Self {
+        span.in_scope(|| info!(event = "flow_batching_attempt_start"));
+        #[cfg(test)]
+        if let Some(hook) = ATTEMPT_STARTED_HOOK.get()
+            && let Some(hook) = hook.lock().unwrap().as_ref()
+        {
+            if let Some(sender) = hook.started.lock().unwrap().take() {
+                let _ = sender.send(());
+            }
+        }
+        Self {
+            span,
+            finished: false,
+        }
+    }
+
+    fn finish(&mut self, outcome: &'static str) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.span
+            .in_scope(|| info!(event = "flow_batching_attempt_finish", outcome));
+    }
+}
+
+impl Drop for BatchingAttemptGuard {
+    fn drop(&mut self) {
+        self.finish("cancelled");
+    }
 }
 
 #[derive(Clone)]
@@ -423,8 +488,29 @@ impl BatchingTask {
         max_window_cnt: Option<usize>,
     ) -> ExecuteOnceOutcome {
         let _execution_guard = self.execution_lock.lock().await;
-        self.execute_once_unlocked(engine, frontend_client, max_window_cnt)
-            .await
+        let flow_id = self.config.flow_id;
+        let span = info_span!(
+            "flow_batching_attempt",
+            flow_id = flow_id,
+            scheduled_time = field::Empty,
+            mode = "batching",
+        );
+        async {
+            let mut attempt = BatchingAttemptGuard::new(Span::current());
+            #[cfg(test)]
+            wait_for_attempt_hook().await;
+            let outcome = self
+                .execute_once_unlocked(engine, frontend_client, max_window_cnt)
+                .await;
+            attempt.finish(if outcome.result.is_ok() {
+                "ok"
+            } else {
+                "error"
+            });
+            outcome
+        }
+        .trace(span)
+        .await
     }
 
     /// Executes one flow evaluation. Caller must hold `execution_lock`.
@@ -1277,9 +1363,28 @@ impl BatchingTask {
             old_ctx: Some(old_ctx),
         };
 
-        let outcome = self
-            .execute_once_unlocked(engine, frontend_client, None)
-            .await;
+        let span = info_span!(
+            "flow_batching_attempt",
+            flow_id = self.config.flow_id,
+            scheduled_time = scheduled_time_secs,
+            mode = "batching",
+        );
+        let outcome = async {
+            let mut attempt = BatchingAttemptGuard::new(Span::current());
+            #[cfg(test)]
+            wait_for_attempt_hook().await;
+            let outcome = self
+                .execute_once_unlocked(engine, frontend_client, None)
+                .await;
+            attempt.finish(if outcome.result.is_ok() {
+                "ok"
+            } else {
+                "error"
+            });
+            outcome
+        }
+        .trace(span)
+        .await;
 
         // Restore while still holding `execution_lock` so no future manual
         // flush can observe the temporary scheduled time. The guard also

--- a/src/flow/src/batching_mode/task.rs
+++ b/src/flow/src/batching_mode/task.rs
@@ -181,10 +181,9 @@ impl BatchingAttemptGuard {
         #[cfg(test)]
         if let Some(hook) = ATTEMPT_STARTED_HOOK.get()
             && let Some(hook) = hook.lock().unwrap().as_ref()
+            && let Some(sender) = hook.started.lock().unwrap().take()
         {
-            if let Some(sender) = hook.started.lock().unwrap().take() {
-                let _ = sender.send(());
-            }
+            let _ = sender.send(());
         }
         Self {
             span,

--- a/src/flow/src/batching_mode/task/test.rs
+++ b/src/flow/src/batching_mode/task/test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
 
 use catalog::RegisterTableRequest;
 use catalog::memory::MemoryCatalogManager;
@@ -24,6 +25,13 @@ use common_error::status_code::StatusCode;
 use common_query::Output;
 use common_recordbatch::RecordBatch;
 use common_recordbatch::adapter::{RecordBatchMetrics, RegionWatermarkEntry};
+use common_telemetry::tracing::field::{Field, Visit};
+use common_telemetry::tracing::{self, Subscriber};
+use common_telemetry::tracing_subscriber::Registry;
+use common_telemetry::tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+use common_telemetry::tracing_subscriber::registry::LookupSpan;
+use common_telemetry::tracing_subscriber::util::SubscriberInitExt;
+use common_time::Timestamp;
 use datatypes::data_type::ConcreteDataType as CDT;
 use datatypes::schema::ColumnSchema;
 use datatypes::vectors::{
@@ -46,6 +54,95 @@ use crate::batching_mode::checkpoint::{
 use crate::batching_mode::state::CheckpointMode;
 use crate::batching_mode::time_window::find_time_window_expr;
 use crate::test_utils::create_test_query_engine;
+
+#[derive(Clone)]
+struct AttemptEvents(Arc<Mutex<Vec<(String, String)>>>);
+
+impl<S> Layer<S> for AttemptEvents
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = AttemptEventVisitor::default();
+        event.record(&mut visitor);
+        if let Some(event_name) = visitor.event {
+            self.0
+                .lock()
+                .unwrap()
+                .push((event_name, visitor.outcome.unwrap_or_default()));
+        }
+    }
+}
+
+#[derive(Default)]
+struct AttemptEventVisitor {
+    event: Option<String>,
+    outcome: Option<String>,
+}
+
+impl Visit for AttemptEventVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "event" => self.event = Some(value.to_string()),
+            "outcome" => self.outcome = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let value = format!("{value:?}").trim_matches('"').to_string();
+        match field.name() {
+            "event" => self.event = Some(value),
+            "outcome" => self.outcome = Some(value),
+            _ => {}
+        }
+    }
+}
+
+fn capture_attempt_events() -> Arc<Mutex<Vec<(String, String)>>> {
+    Arc::new(Mutex::new(Vec::new()))
+}
+
+fn assert_attempt_events(finish: Option<&'static str>) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = Registry::default().with(AttemptEvents(events.clone()));
+    let _default = subscriber.set_default();
+    let span = info_span!("flow_batching_attempt_test");
+    let _entered = span.enter();
+    let mut guard = BatchingAttemptGuard::new(Span::current());
+    if let Some(outcome) = finish {
+        guard.finish(outcome);
+    }
+    drop(guard);
+    let events = events.lock().unwrap().clone();
+    assert_eq!(events.len(), 2);
+    assert_eq!(
+        events[0],
+        ("flow_batching_attempt_start".into(), String::new())
+    );
+    assert_eq!(
+        events[1],
+        (
+            "flow_batching_attempt_finish".into(),
+            finish.unwrap_or("cancelled").into()
+        )
+    );
+}
+
+#[test]
+fn test_batching_attempt_lifecycle_cardinality_success() {
+    assert_attempt_events(Some("ok"));
+}
+
+#[test]
+fn test_batching_attempt_lifecycle_cardinality_error() {
+    assert_attempt_events(Some("error"));
+}
+
+#[test]
+fn test_batching_attempt_lifecycle_cardinality_cancellation() {
+    assert_attempt_events(None);
+}
 
 fn incremental_batch_opts() -> Arc<BatchingModeOptions> {
     Arc::new(BatchingModeOptions {
@@ -159,6 +256,101 @@ async fn test_dirty_time_windows_uses_batch_opts() {
     let state = task.state.read().unwrap();
     assert_eq!(7, state.dirty_time_windows.max_filter_num_per_query());
     assert_eq!(11, state.dirty_time_windows.time_window_merge_threshold());
+}
+
+#[tokio::test]
+async fn test_execute_once_serialized_emits_one_error_finish() {
+    let TestTaskParts {
+        task, query_engine, ..
+    } = new_test_task_engine_and_plan_with_query(
+        "SELECT number, ts FROM numbers_with_ts",
+        "missing_sink",
+    )
+    .await;
+    let events = capture_attempt_events();
+    let subscriber = Registry::default().with(AttemptEvents(events.clone()));
+    let _default = subscriber.set_default();
+    let (frontend_client, _handler) =
+        FrontendClient::from_empty_grpc_handler(QueryOptions::default());
+    let result = task
+        .execute_once_serialized(&query_engine, &Arc::new(frontend_client), None)
+        .await;
+    assert!(result.is_err());
+    let events = events.lock().unwrap();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| e.0 == "flow_batching_attempt_start")
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| e.0 == "flow_batching_attempt_finish")
+            .count(),
+        1
+    );
+    assert_eq!(events[1].1, "error");
+}
+
+#[tokio::test]
+async fn test_execute_once_serialized_can_be_dropped_with_cancelled_finish() {
+    let TestTaskParts {
+        task, query_engine, ..
+    } = new_test_task_engine_and_plan_with_query(
+        "SELECT number, ts FROM numbers_with_ts",
+        "missing_sink",
+    )
+    .await;
+    let events = capture_attempt_events();
+    let subscriber = Registry::default().with(AttemptEvents(events.clone()));
+    let _default = subscriber.set_default();
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let release = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let hook = ATTEMPT_STARTED_HOOK.get_or_init(|| Mutex::new(None));
+    *hook.lock().unwrap() = Some(AttemptStartedHook {
+        started: Mutex::new(Some(started_tx)),
+        release: release.clone(),
+    });
+    let task = task.clone();
+    let client = Arc::new(FrontendClient::from_empty_grpc_handler(QueryOptions::default()).0);
+    let handle = tokio::spawn(async move {
+        let _ = task
+            .execute_once_serialized(&query_engine, &client, None)
+            .await;
+    });
+    tokio::time::timeout(Duration::from_secs(1), started_rx)
+        .await
+        .expect("production attempt should start after emitting start event")
+        .expect("attempt start hook should remain connected");
+    handle.abort();
+    release.store(true, std::sync::atomic::Ordering::Release);
+    let _ = handle.await;
+    let events = events.lock().unwrap();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| e.0 == "flow_batching_attempt_start")
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| e.0 == "flow_batching_attempt_finish")
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .find(|e| e.0 == "flow_batching_attempt_finish")
+            .unwrap()
+            .1,
+        "cancelled"
+    );
+    *ATTEMPT_STARTED_HOOK.get().unwrap().lock().unwrap() = None;
 }
 
 #[tokio::test]

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -64,6 +64,17 @@ use crate::{error, hint_headers};
 
 pub type TonicStream<T> = Pin<Box<dyn Stream<Item = TonicResult<T>> + Send + 'static>>;
 
+fn flight_request_span(
+    request: &GreptimeRequest,
+    context: TracingContext,
+) -> common_telemetry::tracing::Span {
+    context.attach(info_span!(
+        "GreptimeRequestHandler::do_get",
+        protocol = "grpc",
+        request_type = get_request_type(request)
+    ))
+}
+
 /// A subset of [FlightService]
 #[async_trait]
 pub trait FlightCraft: Send + Sync + 'static {
@@ -204,6 +215,11 @@ impl FlightCraft for GreptimeRequestHandler {
             GreptimeRequest::decode(ticket.as_ref()).context(error::InvalidFlightTicketSnafu)?;
         let query_ctx =
             create_query_context(Channel::Grpc, request.header.as_ref(), hints, snapshot_seqs)?;
+        let incoming_context = request
+            .header
+            .as_ref()
+            .map(|header| TracingContext::from_w3c(&header.tracing_context))
+            .unwrap_or_default();
         // Validate flow hint syntax at the transport boundary before dispatching the request.
         // This does not authorize or execute anything; `handle_request()` below still performs
         // the normal frontend handling and auth checks before query execution.
@@ -214,13 +230,14 @@ impl FlightCraft for GreptimeRequestHandler {
             .is_some_and(|extensions| extensions.should_collect_region_watermark());
 
         // The Grpc protocol pass query by Flight. It needs to be wrapped under a span, in order to record stream
-        let span = info_span!(
-            "GreptimeRequestHandler::do_get",
-            protocol = "grpc",
-            request_type = get_request_type(&request)
-        );
+        let span = flight_request_span(&request, incoming_context);
         let flight_compression = self.flight_compression;
         async {
+            debug!(
+                protocol = "grpc",
+                event = "flight_admission",
+                "Flight request admitted"
+            );
             let output = self
                 .handle_request_with_query_ctx(request, query_ctx.clone())
                 .await?;
@@ -230,6 +247,11 @@ impl FlightCraft for GreptimeRequestHandler {
                 flight_compression,
                 query_ctx,
                 should_emit_terminal_metrics,
+            );
+            debug!(
+                protocol = "grpc",
+                event = "flight_response_stream_created",
+                "Flight response stream created"
             );
             Ok(Response::new(stream))
         }
@@ -631,6 +653,27 @@ mod tests {
     use tonic::metadata::{AsciiMetadataValue, MetadataMap};
 
     use super::*;
+
+    #[test]
+    fn test_flight_request_span_inherits_inbound_context() {
+        common_telemetry::init_default_ut_logging();
+        let trace_id = "0123456789abcdef0123456789abcdef";
+        let parent_span_id = "0123456789abcdef";
+        let header = api::v1::RequestHeader {
+            tracing_context: std::collections::HashMap::from([(
+                "traceparent".to_string(),
+                format!("00-{trace_id}-{parent_span_id}-01"),
+            )]),
+            ..Default::default()
+        };
+        let incoming = TracingContext::from_w3c(&header.tracing_context);
+        let request = GreptimeRequest::default();
+        let span = flight_request_span(&request, incoming);
+        let _child = span.enter();
+        let ids = common_telemetry::tracing_context::current_trace_ids().unwrap();
+        assert_eq!(ids.0, trace_id);
+        assert_ne!(ids.1, parent_span_id);
+    }
 
     #[test]
     fn test_extract_flow_extensions_preserves_comma_bearing_values() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

No related PR or issue link.

## What's changed and what's your intention?

This change adds trace correlation for Flow Flight batching attempts.

- Batching attempts record a lifecycle span and a single terminal status.
- W3C trace context is propagated through existing request metadata.
- Related request spans preserve the parent-child relationship.
- Log formatters emit trace and span identifiers when tracing context is available.
- The change does not alter query behavior, wire schemas, scheduling, retry behavior, or persisted data.

The intention is to improve diagnostics while preserving existing API and data compatibility. Tests cover lifecycle events, context propagation, log formatting, and tracing configuration behavior.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
