### PR TITLE
fix: record timed out EXPLAIN ANALYZE VERBOSE over HTTP SQL

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -567,7 +567,7 @@ fn derive_timeout(stmt: &Statement, query_ctx: &QueryContextRef) -> Option<Durat
         return None;
     }
     match query_ctx.channel() {
-        Channel::Mysql if stmt.is_readonly() => Some(query_timeout),
+        Channel::Mysql | Channel::HttpSql if stmt.is_readonly() => Some(query_timeout),
         Channel::Postgres => Some(query_timeout),
         _ => None,
     }
@@ -580,7 +580,7 @@ fn derive_timeout_for_plan(plan: &LogicalPlan, query_ctx: &QueryContextRef) -> O
         return None;
     }
     match query_ctx.channel() {
-        Channel::Mysql if is_readonly_plan(plan) => Some(query_timeout),
+        Channel::Mysql | Channel::HttpSql if is_readonly_plan(plan) => Some(query_timeout),
         Channel::Postgres => Some(query_timeout),
         _ => None,
     }
@@ -721,6 +721,9 @@ impl Instance {
         let catalog_name = query_ctx.current_catalog().to_string();
         let schema_name = query_ctx.current_schema();
         let slow_query_timer = self.statement_slow_query_timer(&stmt, schema_name.clone());
+        // The statement is guaranteed to be EXPLAIN ANALYZE VERBOSE here, so
+        // attach a recorder to capture plan metrics if the stream times out.
+        let timeout_recorder = slow_query_timer.as_ref().map(SlowQueryTimer::recorder);
         let ticket = self.process_manager.register_query(
             catalog_name,
             vec![schema_name],
@@ -729,8 +732,12 @@ impl Instance {
             Some(query_ctx.process_id()),
             slow_query_timer,
         );
-        let query_fut =
-            self.exec_statement_with_timeout(stmt, query_ctx.clone(), query_interceptor, None);
+        let query_fut = self.exec_statement_with_timeout(
+            stmt,
+            query_ctx.clone(),
+            query_interceptor,
+            timeout_recorder,
+        );
         let output = CancellableFuture::new(query_fut, ticket.cancellation_handle.clone())
             .await
             .map_err(|_| error::CancelledSnafu.build())??;
@@ -2247,6 +2254,31 @@ mod tests {
                 .as_array()
                 .is_some_and(|metrics| !metrics.is_empty())
         );
+    }
+
+    #[test]
+    fn test_derive_timeout_for_http_sql_channel() {
+        let query_ctx = Arc::new(
+            QueryContextBuilder::default()
+                .channel(Channel::HttpSql)
+                .build(),
+        );
+        query_ctx.set_query_timeout(Duration::from_secs(10));
+
+        // Readonly statements are wrapped with the query timeout.
+        let explain = parse_one_sql("EXPLAIN ANALYZE VERBOSE SELECT 1");
+        assert_eq!(
+            derive_timeout(&explain, &query_ctx),
+            Some(Duration::from_secs(10))
+        );
+
+        // Non-readonly statements are not wrapped.
+        let insert = parse_one_sql("INSERT INTO demo VALUES (1)");
+        assert_eq!(derive_timeout(&insert, &query_ctx), None);
+
+        // Zero timeout disables the wrapper.
+        query_ctx.set_query_timeout(Duration::ZERO);
+        assert_eq!(derive_timeout(&explain, &query_ctx), None);
     }
 
     struct PendingDataSource {

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -1713,7 +1713,7 @@ mod tests {
     use std::pin::Pin;
     use std::sync::Arc;
     use std::task::{Context, Poll};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use api::prom_store::remote::label_matcher::Type as PromMatcherType;
     use api::prom_store::remote::{
@@ -2325,12 +2325,19 @@ mod tests {
         );
         let explain = parse_one_sql("EXPLAIN ANALYZE VERBOSE SELECT 1");
 
-        // Only the request-level timeout is set.
-        query_ctx.set_request_timeout(Duration::from_secs(30));
-        assert_eq!(
-            derive_timeout(&explain, &query_ctx),
-            Some(Duration::from_secs(30))
-        );
+        // The request deadline is an absolute instant; the derived timeout is
+        // the remaining budget at derivation time.
+        let assert_remaining = |expected: Duration| {
+            let derived = derive_timeout(&explain, &query_ctx).unwrap();
+            assert!(
+                derived > expected - Duration::from_secs(1) && derived <= expected,
+                "derived timeout {derived:?} should be close to {expected:?}"
+            );
+        };
+
+        // Only the request-level deadline is set.
+        query_ctx.set_request_deadline(Instant::now() + Duration::from_secs(30));
+        assert_remaining(Duration::from_secs(30));
 
         // The tighter of session and request timeout wins.
         query_ctx.set_query_timeout(Duration::from_secs(10));
@@ -2339,18 +2346,12 @@ mod tests {
             Some(Duration::from_secs(10))
         );
         query_ctx.set_query_timeout(Duration::from_secs(60));
-        assert_eq!(
-            derive_timeout(&explain, &query_ctx),
-            Some(Duration::from_secs(30))
-        );
+        assert_remaining(Duration::from_secs(30));
 
         // A zero session timeout is treated as unset and does not disable
         // the request-level timeout.
         query_ctx.set_query_timeout(Duration::ZERO);
-        assert_eq!(
-            derive_timeout(&explain, &query_ctx),
-            Some(Duration::from_secs(30))
-        );
+        assert_remaining(Duration::from_secs(30));
     }
 
     struct PendingDataSource {

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -57,7 +57,7 @@ use common_query::Output;
 use common_recordbatch::RecordBatchStreamWrapper;
 use common_recordbatch::error::StreamTimeoutSnafu;
 use common_telemetry::logging::SlowQueryOptions;
-use common_telemetry::{debug, error, tracing};
+use common_telemetry::{debug, error, info, tracing};
 use dashmap::DashMap;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_expr::LogicalPlan;
@@ -608,6 +608,29 @@ fn record_explain_analyze_timeout(
     let metrics = plan
         .and_then(|plan| query::analyze_plan_metrics_to_json_value(plan, true).ok())
         .unwrap_or_else(|| serde_json::json!([]));
+    // Helps diagnose whether remote (stage 1) metrics were captured: a zero
+    // `remote_stage_count` on a distributed plan usually means live analyze
+    // metrics were not enabled, so only stale per-batch metrics were available.
+    let (stage_count, remote_stage_count) = metrics
+        .as_array()
+        .map(|stages| {
+            (
+                stages.len(),
+                stages
+                    .iter()
+                    .filter(|stage| {
+                        stage.get("stage").and_then(serde_json::Value::as_u64) == Some(1)
+                    })
+                    .count(),
+            )
+        })
+        .unwrap_or((0, 0));
+    info!(
+        plan_present = plan.is_some(),
+        stage_count = stage_count,
+        remote_stage_count = remote_stage_count,
+        "Recorded metrics for timed out EXPLAIN ANALYZE VERBOSE"
+    );
     recorder.force_record_with_payload(serde_json::json!({
         "timed_out": true,
         "metrics": metrics,

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -561,27 +561,39 @@ fn cache_legacy_mode(
 
 /// If the relevant variables are set, the timeout is enforced for all PostgreSQL statements.
 /// For MySQL, it applies only to read-only statements.
+/// Computes the effective query timeout for the current channel.
+///
+/// For HTTP SQL requests the tighter of the session-level statement timeout
+/// and the endpoint-level request timeout applies, so that a query can time
+/// out gracefully (and record diagnostics) before the HTTP layer aborts the
+/// request. Zero timeouts are treated as unset.
+fn effective_query_timeout(query_ctx: &QueryContextRef) -> Option<Duration> {
+    let request_timeout = match query_ctx.channel() {
+        Channel::HttpSql => query_ctx.request_timeout(),
+        _ => None,
+    };
+    [query_ctx.query_timeout(), request_timeout]
+        .into_iter()
+        .flatten()
+        .filter(|timeout| !timeout.is_zero())
+        .min()
+}
+
 fn derive_timeout(stmt: &Statement, query_ctx: &QueryContextRef) -> Option<Duration> {
-    let query_timeout = query_ctx.query_timeout()?;
-    if query_timeout.is_zero() {
-        return None;
-    }
+    let timeout = effective_query_timeout(query_ctx)?;
     match query_ctx.channel() {
-        Channel::Mysql | Channel::HttpSql if stmt.is_readonly() => Some(query_timeout),
-        Channel::Postgres => Some(query_timeout),
+        Channel::Mysql | Channel::HttpSql if stmt.is_readonly() => Some(timeout),
+        Channel::Postgres => Some(timeout),
         _ => None,
     }
 }
 
 /// Derives timeout for plan execution.
 fn derive_timeout_for_plan(plan: &LogicalPlan, query_ctx: &QueryContextRef) -> Option<Duration> {
-    let query_timeout = query_ctx.query_timeout()?;
-    if query_timeout.is_zero() {
-        return None;
-    }
+    let timeout = effective_query_timeout(query_ctx)?;
     match query_ctx.channel() {
-        Channel::Mysql | Channel::HttpSql if is_readonly_plan(plan) => Some(query_timeout),
-        Channel::Postgres => Some(query_timeout),
+        Channel::Mysql | Channel::HttpSql if is_readonly_plan(plan) => Some(timeout),
+        Channel::Postgres => Some(timeout),
         _ => None,
     }
 }
@@ -2279,6 +2291,43 @@ mod tests {
         // Zero timeout disables the wrapper.
         query_ctx.set_query_timeout(Duration::ZERO);
         assert_eq!(derive_timeout(&explain, &query_ctx), None);
+    }
+
+    #[test]
+    fn test_derive_timeout_http_sql_combines_session_and_request_timeout() {
+        let query_ctx = Arc::new(
+            QueryContextBuilder::default()
+                .channel(Channel::HttpSql)
+                .build(),
+        );
+        let explain = parse_one_sql("EXPLAIN ANALYZE VERBOSE SELECT 1");
+
+        // Only the request-level timeout is set.
+        query_ctx.set_request_timeout(Duration::from_secs(30));
+        assert_eq!(
+            derive_timeout(&explain, &query_ctx),
+            Some(Duration::from_secs(30))
+        );
+
+        // The tighter of session and request timeout wins.
+        query_ctx.set_query_timeout(Duration::from_secs(10));
+        assert_eq!(
+            derive_timeout(&explain, &query_ctx),
+            Some(Duration::from_secs(10))
+        );
+        query_ctx.set_query_timeout(Duration::from_secs(60));
+        assert_eq!(
+            derive_timeout(&explain, &query_ctx),
+            Some(Duration::from_secs(30))
+        );
+
+        // A zero session timeout is treated as unset and does not disable
+        // the request-level timeout.
+        query_ctx.set_query_timeout(Duration::ZERO);
+        assert_eq!(
+            derive_timeout(&explain, &query_ctx),
+            Some(Duration::from_secs(30))
+        );
     }
 
     struct PendingDataSource {

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -552,7 +552,7 @@ impl StatementExecutor {
 
             "CLIENT_ENCODING" => validate_client_encoding(set_var)?,
             "@@SESSION.MAX_EXECUTION_TIME" | "MAX_EXECUTION_TIME" => match query_ctx.channel() {
-                Channel::Mysql => set_query_timeout(set_var.value, query_ctx)?,
+                Channel::Mysql | Channel::HttpSql => set_query_timeout(set_var.value, query_ctx)?,
                 Channel::Postgres => {
                     warn!(
                         "Unsupported set variable {} for channel {:?}",
@@ -569,7 +569,9 @@ impl StatementExecutor {
                 }
             },
             "STATEMENT_TIMEOUT" => match query_ctx.channel() {
-                Channel::Postgres => set_query_timeout(set_var.value, query_ctx)?,
+                Channel::Postgres | Channel::HttpSql => {
+                    set_query_timeout(set_var.value, query_ctx)?
+                }
                 Channel::Mysql => {
                     warn!(
                         "Unsupported set variable {} for channel {:?}",

--- a/src/operator/src/statement/set.rs
+++ b/src/operator/src/statement/set.rs
@@ -19,7 +19,7 @@ use common_time::Timezone;
 use lazy_static::lazy_static;
 use regex::Regex;
 use session::ReadPreference;
-use session::context::Channel::Postgres;
+use session::context::Channel::{HttpSql, Postgres};
 use session::context::QueryContextRef;
 use session::session_config::{PGByteaOutputValue, PGDateOrder, PGDateTimeStyle, PGIntervalStyle};
 use snafu::{OptionExt, ResultExt, ensure};
@@ -328,7 +328,9 @@ pub fn set_query_timeout(exprs: Vec<Expr>, ctx: QueryContextRef) -> Result<()> {
             value: Value::DoubleQuotedString(timeout),
             ..
         }) => {
-            if ctx.channel() != Postgres {
+            // HTTP SQL defaults to the PostgreSQL dialect, so it accepts the
+            // same time-unit strings as the Postgres channel.
+            if ctx.channel() != Postgres && ctx.channel() != HttpSql {
                 return NotSupportedSnafu {
                     feat: format!("Invalid timeout expr {} in set variable statement", timeout),
                 }

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -116,15 +116,9 @@ struct AnalyzeStreamState {
 /// Propagates the HTTP request deadline resolved by `DynamicTimeoutLayer`
 /// into the query context, so that statement execution can time out (and
 /// record diagnostics) before the HTTP layer aborts the request.
-fn apply_request_deadline(
-    query_ctx: &QueryContext,
-    deadline: Option<Extension<RequestDeadline>>,
-) {
+fn apply_request_deadline(query_ctx: &QueryContext, deadline: Option<Extension<RequestDeadline>>) {
     if let Some(Extension(deadline)) = deadline {
-        let remaining = deadline.remaining();
-        if !remaining.is_zero() {
-            query_ctx.set_request_timeout(remaining);
-        }
+        query_ctx.set_request_deadline(deadline.0);
     }
 }
 

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -148,6 +148,12 @@ pub async fn sql(
     let db = query_ctx.get_db_string();
 
     query_ctx.set_channel(Channel::HttpSql);
+    // Enable heartbeat-based live analyze metrics so that a timed out
+    // EXPLAIN ANALYZE VERBOSE can snapshot fresh execution metrics, instead
+    // of only the metrics received with the last record batch. All consumers
+    // additionally gate on `explain_verbose`, so this is a no-op for other
+    // statements.
+    query_ctx.enable_live_analyze_metrics();
     apply_request_deadline(&query_ctx, deadline);
     let query_ctx = Arc::new(query_ctx);
 

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -54,6 +54,7 @@ use crate::http::{
     ApiState, Epoch, GreptimeOptionsConfigState, GreptimeQueryOutput, HttpRecordsOutput,
     HttpResponse, ResponseFormat,
 };
+use crate::http::timeout::RequestDeadline;
 use crate::metrics_handler::MetricsHandler;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 
@@ -112,6 +113,21 @@ struct AnalyzeStreamState {
     done: bool,
 }
 
+/// Propagates the HTTP request deadline resolved by `DynamicTimeoutLayer`
+/// into the query context, so that statement execution can time out (and
+/// record diagnostics) before the HTTP layer aborts the request.
+fn apply_request_deadline(
+    query_ctx: &QueryContext,
+    deadline: Option<Extension<RequestDeadline>>,
+) {
+    if let Some(Extension(deadline)) = deadline {
+        let remaining = deadline.remaining();
+        if !remaining.is_zero() {
+            query_ctx.set_request_timeout(remaining);
+        }
+    }
+}
+
 /// Handler to execute sql
 #[axum_macros::debug_handler]
 #[tracing::instrument(skip_all, fields(protocol = "http", request_type = "sql"))]
@@ -119,6 +135,7 @@ pub async fn sql(
     State(state): State<ApiState>,
     Query(query_params): Query<SqlQuery>,
     Extension(mut query_ctx): Extension<QueryContext>,
+    deadline: Option<Extension<RequestDeadline>>,
     Form(form_params): Form<SqlQuery>,
 ) -> HttpResponse {
     let start = Instant::now();
@@ -131,6 +148,7 @@ pub async fn sql(
     let db = query_ctx.get_db_string();
 
     query_ctx.set_channel(Channel::HttpSql);
+    apply_request_deadline(&query_ctx, deadline);
     let query_ctx = Arc::new(query_ctx);
 
     let _timer = crate::metrics::METRIC_HTTP_SQL_ELAPSED
@@ -210,6 +228,7 @@ pub async fn sql_analyze_stream(
     State(state): State<ApiState>,
     Query(query_params): Query<SqlQuery>,
     Extension(mut query_ctx): Extension<QueryContext>,
+    deadline: Option<Extension<RequestDeadline>>,
     form_params: std::result::Result<Form<SqlQuery>, FormRejection>,
 ) -> Response {
     let start = Instant::now();
@@ -235,6 +254,7 @@ pub async fn sql_analyze_stream(
     }
     query_ctx.set_channel(Channel::HttpSql);
     query_ctx.enable_live_analyze_metrics();
+    apply_request_deadline(&query_ctx, deadline);
     let query_ctx = Arc::new(query_ctx);
 
     let Some(sql) = query_params.sql.or(form_params.sql) else {

--- a/src/servers/src/http/timeout.rs
+++ b/src/servers/src/http/timeout.rs
@@ -46,14 +46,7 @@ pub struct ResponseFuture<T> {
 /// extensions by [`DynamicTimeout`] so that downstream handlers can bound
 /// their work (e.g. derive a query timeout) before the request is aborted.
 #[derive(Debug, Clone, Copy)]
-pub struct RequestDeadline(pub Instant);
-
-impl RequestDeadline {
-    /// Returns the remaining time until the deadline.
-    pub fn remaining(&self) -> Duration {
-        self.0.saturating_duration_since(Instant::now())
-    }
-}
+pub struct RequestDeadline(pub std::time::Instant);
 
 impl<T> ResponseFuture<T> {
     pub(crate) fn new(inner: T, sleep: Sleep, status_code: StatusCode) -> Self {
@@ -176,9 +169,9 @@ where
             .unwrap_or(self.default_timeout);
         let mut request = request;
         if !timeout.is_zero() {
-            let deadline = Instant::now() + timeout;
             // Expose the resolved deadline to downstream handlers so they can
             // bound their work before this layer aborts the request.
+            let deadline = std::time::Instant::now() + timeout;
             let _ = request.extensions_mut().insert(RequestDeadline(deadline));
             let response = self.inner.call(request);
             let sleep = tokio::time::sleep(timeout);

--- a/src/servers/src/http/timeout.rs
+++ b/src/servers/src/http/timeout.rs
@@ -42,6 +42,19 @@ pub struct ResponseFuture<T> {
     status_code: StatusCode,
 }
 
+/// The resolved deadline of the in-flight HTTP request, inserted into request
+/// extensions by [`DynamicTimeout`] so that downstream handlers can bound
+/// their work (e.g. derive a query timeout) before the request is aborted.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestDeadline(pub Instant);
+
+impl RequestDeadline {
+    /// Returns the remaining time until the deadline.
+    pub fn remaining(&self) -> Duration {
+        self.0.saturating_duration_since(Instant::now())
+    }
+}
+
 impl<T> ResponseFuture<T> {
     pub(crate) fn new(inner: T, sleep: Sleep, status_code: StatusCode) -> Self {
         ResponseFuture {
@@ -61,13 +74,20 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 
+        // Poll the inner future first: if it can complete (e.g. with a query
+        // timeout error carrying diagnostics) in the same tick the sleep
+        // expires, prefer its response over a bare timeout response.
+        if let Poll::Ready(output) = this.inner.poll(cx) {
+            return Poll::Ready(output);
+        }
+
         if this.sleep.poll(cx).is_ready() {
             let mut res = Response::default();
             *res.status_mut() = *this.status_code;
             return Poll::Ready(Ok(res));
         }
 
-        this.inner.poll(cx)
+        Poll::Pending
     }
 }
 
@@ -154,15 +174,73 @@ where
                     .and_then(|value| humantime::parse_duration(value).ok())
             })
             .unwrap_or(self.default_timeout);
-        let response = self.inner.call(request);
-
-        if timeout.is_zero() {
-            // 30 years. See `Instant::far_future`.
-            let far_future = Instant::now() + Duration::from_secs(86400 * 365 * 30);
-            ResponseFuture::new(response, tokio::time::sleep_until(far_future), status_code)
-        } else {
+        let mut request = request;
+        if !timeout.is_zero() {
+            let deadline = Instant::now() + timeout;
+            // Expose the resolved deadline to downstream handlers so they can
+            // bound their work before this layer aborts the request.
+            let _ = request.extensions_mut().insert(RequestDeadline(deadline));
+            let response = self.inner.call(request);
             let sleep = tokio::time::sleep(timeout);
             ResponseFuture::new(response, sleep, status_code)
+        } else {
+            let response = self.inner.call(request);
+            // 30 years. See `Instant::far_future`.
+            let far_future = Instant::now() + Duration::from_secs(86400 * 365 * 30);
+            ResponseFuture::new(
+                response,
+                tokio::time::sleep_until(far_future),
+                status_code,
+            )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use axum::http::Request;
+    use tower::Service;
+    use tower::service_fn;
+
+    use super::*;
+    use crate::http::header::constants::GREPTIME_DB_HEADER_TIMEOUT;
+
+    fn deadline_echo_service() -> DynamicTimeout<
+        impl Service<Request<Body>, Response = Response, Error = Infallible> + Clone,
+    > {
+        let svc = service_fn(|req: Request<Body>| async move {
+            let status = if req.extensions().get::<RequestDeadline>().is_some() {
+                StatusCode::OK
+            } else {
+                StatusCode::NO_CONTENT
+            };
+            Ok::<_, Infallible>(Response::builder().status(status).body(Body::empty()).unwrap())
+        });
+        DynamicTimeout::new(svc, Duration::from_secs(30), |_| {
+            StatusCode::REQUEST_TIMEOUT
+        })
+    }
+
+    #[tokio::test]
+    async fn test_request_deadline_extension_is_inserted() {
+        let mut svc = deadline_echo_service();
+        let res = svc
+            .call(Request::new(Body::empty()))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_request_deadline_extension_skipped_when_timeout_disabled() {
+        let mut svc = deadline_echo_service();
+        let req = Request::builder()
+            .header(GREPTIME_DB_HEADER_TIMEOUT, "0s")
+            .body(Body::empty())
+            .unwrap();
+        let res = svc.call(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -175,6 +175,7 @@ async fn test_sql_not_provided() {
             State(api_state.clone()),
             Query(query),
             axum::Extension(ctx.clone()),
+            None,
             Form(http_handler::SqlQuery::default()),
         )
         .await
@@ -206,6 +207,7 @@ async fn test_sql_output_rows() {
             State(api_state.clone()),
             query,
             axum::Extension(ctx.clone()),
+            None,
             Form(http_handler::SqlQuery::default()),
         )
         .await;
@@ -312,6 +314,7 @@ async fn test_dashboard_sql_limit() {
             State(api_state.clone()),
             query,
             axum::Extension(ctx.clone()),
+            None,
             Form(http_handler::SqlQuery::default()),
         )
         .await;
@@ -359,6 +362,7 @@ async fn test_sql_form() {
             State(api_state.clone()),
             Query(http_handler::SqlQuery::default()),
             axum::Extension(ctx.clone()),
+            None,
             form,
         )
         .await;

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -481,6 +481,17 @@ impl QueryContext {
         self.mutable_session_data.write().unwrap().query_timeout = Some(timeout);
     }
 
+    /// Returns the request-level timeout imposed by the serving endpoint
+    /// (e.g. the HTTP server request timeout), if any.
+    pub fn request_timeout(&self) -> Option<Duration> {
+        self.mutable_session_data.read().unwrap().request_timeout
+    }
+
+    /// Sets the request-level timeout imposed by the serving endpoint.
+    pub fn set_request_timeout(&self, timeout: Duration) {
+        self.mutable_session_data.write().unwrap().request_timeout = Some(timeout);
+    }
+
     pub fn insert_cursor(&self, name: String, rb: RecordBatchStreamCursor) {
         let mut guard = self.mutable_session_data.write().unwrap();
         guard.cursors.insert(name, Arc::new(rb));

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use api::v1::ExplainOptions;
 use api::v1::region::RegionRequestHeader;
@@ -481,15 +481,21 @@ impl QueryContext {
         self.mutable_session_data.write().unwrap().query_timeout = Some(timeout);
     }
 
-    /// Returns the request-level timeout imposed by the serving endpoint
-    /// (e.g. the HTTP server request timeout), if any.
+    /// Returns the remaining time until the request-level deadline imposed
+    /// by the serving endpoint (e.g. the HTTP server request timeout), if
+    /// any. Computing the remainder on read keeps the derived query timeout
+    /// aligned with the endpoint's own request deadline.
     pub fn request_timeout(&self) -> Option<Duration> {
-        self.mutable_session_data.read().unwrap().request_timeout
+        self.mutable_session_data
+            .read()
+            .unwrap()
+            .request_deadline
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
     }
 
-    /// Sets the request-level timeout imposed by the serving endpoint.
-    pub fn set_request_timeout(&self, timeout: Duration) {
-        self.mutable_session_data.write().unwrap().request_timeout = Some(timeout);
+    /// Sets the request-level deadline imposed by the serving endpoint.
+    pub fn set_request_deadline(&self, deadline: Instant) {
+        self.mutable_session_data.write().unwrap().request_deadline = Some(deadline);
     }
 
     pub fn insert_cursor(&self, name: String, rb: RecordBatchStreamCursor) {

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -59,6 +59,10 @@ pub(crate) struct MutableInner {
     user_info: UserInfoRef,
     timezone: Timezone,
     query_timeout: Option<Duration>,
+    /// Request-level timeout imposed by the serving endpoint (e.g. the HTTP
+    /// server request timeout). Unlike `query_timeout` which is set via
+    /// session variables, this is injected by the protocol layer.
+    request_timeout: Option<Duration>,
     read_preference: ReadPreference,
     #[debug(skip)]
     pub(crate) cursors: HashMap<String, Arc<RecordBatchStreamCursor>>,
@@ -73,6 +77,7 @@ impl Default for MutableInner {
             user_info: auth::userinfo_by_name(None),
             timezone: get_timezone(None).clone(),
             query_timeout: None,
+            request_timeout: None,
             read_preference: ReadPreference::Leader,
             cursors: HashMap::with_capacity(0),
             warnings: VecDeque::new(),

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -22,7 +22,7 @@ pub mod table_name;
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use auth::UserInfoRef;
 use common_catalog::build_db_string;
@@ -59,10 +59,13 @@ pub(crate) struct MutableInner {
     user_info: UserInfoRef,
     timezone: Timezone,
     query_timeout: Option<Duration>,
-    /// Request-level timeout imposed by the serving endpoint (e.g. the HTTP
+    /// Request-level deadline imposed by the serving endpoint (e.g. the HTTP
     /// server request timeout). Unlike `query_timeout` which is set via
-    /// session variables, this is injected by the protocol layer.
-    request_timeout: Option<Duration>,
+    /// session variables, this is injected by the protocol layer. Stored as
+    /// an absolute deadline so the remaining budget can be computed at the
+    /// moment statement execution starts, keeping the derived query timeout
+    /// aligned with the endpoint's own request deadline.
+    request_deadline: Option<Instant>,
     read_preference: ReadPreference,
     #[debug(skip)]
     pub(crate) cursors: HashMap<String, Arc<RecordBatchStreamCursor>>,
@@ -77,7 +80,7 @@ impl Default for MutableInner {
             user_info: auth::userinfo_by_name(None),
             timezone: get_timezone(None).clone(),
             query_timeout: None,
-            request_timeout: None,
+            request_deadline: None,
             read_preference: ReadPreference::Leader,
             cursors: HashMap::with_capacity(0),
             warnings: VecDeque::new(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up of #8668.

## What's changed and what's your intention?

#8668 records plan metrics for timed out `EXPLAIN ANALYZE VERBOSE` statements, but the recording never triggers for the HTTP SQL interface. This PR fixes that end to end:

- **Apply statement timeouts to the HTTP SQL channel.** `derive_timeout`/`derive_timeout_for_plan` previously only matched the MySQL (readonly) and Postgres channels, so HTTP requests never got the `attach_timeout` stream wrapper where the timeout recording hooks in. The `HttpSql` channel is now handled like MySQL (readonly statements only), and `SET statement_timeout` / `SET max_execution_time` are accepted over HTTP so clients can set a session-level query timeout (including PG-style values like `'50ms'`).
- **Derive a query timeout from the HTTP request timeout.** Without an explicit `SET`, HTTP requests had no query-level timeout at all. `DynamicTimeoutLayer` now exposes the resolved request deadline (honoring the `x-greptime-timeout` header override) via a `RequestDeadline` request extension, and the `/v1/sql` and `/v1/sql/analyze/stream` handlers store the absolute deadline in the query context. For the `HttpSql` channel, the derived query timeout is the tighter of the session statement timeout and the remaining request budget. The deadline is stored as an absolute instant (and the remaining budget computed at derivation time) so both deadlines coincide exactly; together with polling the inner future before the sleep in `ResponseFuture`, the query-side timeout error (with the forced slow query record) wins the same-tick race instead of the request being aborted with a bare 408.
- **Enable live analyze metrics for `/v1/sql`.** Without the `query.live_analyze_metrics` extension, both the Flight stream and the in-process region query paths only snapshot execution metrics after each produced record batch, so a query stalled mid-scan would record stale or empty remote (stage 1) metrics. All consumers additionally gate on `explain_verbose`, so this is a no-op for other statements.
- Add an info log when a timed out `EXPLAIN ANALYZE VERBOSE` is recorded, reporting whether the physical plan was present and how many local/remote stages the metrics snapshot contains.
- `do_analyze_stream_query_inner` now passes a real `SlowQueryRecorder` instead of `None`, so the `/v1/sql/analyze/stream` endpoint also records metrics on timeout.

No API or data compatibility changes: the slow query event payload shape is unchanged, and HTTP requests that do not time out behave exactly as before.

Verified on a distributed cluster (`http.timeout = "10s"`, slow query enabled): a plain `EXPLAIN ANALYZE VERBOSE` via `/v1/sql` now fails with a proper `Stream timeout` error and is force-recorded in `greptime_private.slow_queries` with `{"timed_out": true, "metrics": [...]}` containing both frontend (stage 0) and datanode (stage 1) operator metrics.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
