### PR TITLE
fix(mysql): respect session timezone for prepared timestamps

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -25,6 +25,7 @@ use common_catalog::parse_optional_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
 use common_query::Output;
 use common_telemetry::{debug, error, tracing, warn};
+use common_time::Timezone;
 use datafusion_common::ParamValues;
 use datafusion_expr::LogicalPlan;
 use datatypes::prelude::ConcreteDataType;
@@ -290,9 +291,12 @@ impl MysqlInstanceShim {
                 }
 
                 let replaced_plan = match params {
-                    Params::ProtocolParams(params) => {
-                        replace_params_with_values(&plan, param_types, &params)
-                    }
+                    Params::ProtocolParams(params) => replace_params_with_values(
+                        &plan,
+                        param_types,
+                        &params,
+                        &query_ctx.timezone(),
+                    ),
                     Params::CliParams(params) => {
                         replace_params_with_exprs(&plan, param_types, &params)
                     }
@@ -807,6 +811,7 @@ fn replace_params_with_values(
     plan: &LogicalPlan,
     param_types: HashMap<String, Option<ConcreteDataType>>,
     params: &[ParamValue],
+    timezone: &Timezone,
 ) -> Result<LogicalPlan> {
     debug_assert_eq!(param_types.len(), params.len());
 
@@ -824,7 +829,7 @@ fn replace_params_with_values(
 
     for (i, param) in params.iter().enumerate() {
         if let Some(Some(t)) = param_types.get(&format_placeholder(i + 1)) {
-            let value = helper::convert_value(param, t)?;
+            let value = helper::convert_value(param, t, timezone)?;
 
             values.push(value.into());
         }

--- a/src/servers/src/mysql/helper.rs
+++ b/src/servers/src/mysql/helper.rs
@@ -18,7 +18,8 @@ use std::time::Duration;
 use chrono::NaiveDate;
 use common_query::prelude::ScalarValue;
 use common_sql::convert::sql_value_to_value;
-use common_time::{Date, Timestamp};
+use common_time::timestamp::TimeUnit;
+use common_time::{Date, Timestamp, Timezone};
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::schema::ColumnSchema;
 use datatypes::types::TimestampType;
@@ -137,11 +138,15 @@ where
 
 /// Convert [`ParamValue`] into [`Value`] according to param type.
 /// It will try it's best to do type conversions if possible
-pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarValue> {
+pub fn convert_value(
+    param: &ParamValue,
+    t: &ConcreteDataType,
+    timezone: &Timezone,
+) -> Result<ScalarValue> {
     if let ConcreteDataType::Dictionary(dictionary) = t {
         return Ok(ScalarValue::Dictionary(
             Box::new(dictionary.key_type().as_arrow_type()),
-            Box::new(convert_value(param, dictionary.value_type())?),
+            Box::new(convert_value(param, dictionary.value_type(), timezone)?),
         ));
     }
 
@@ -221,7 +226,9 @@ pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarV
                 }
             }
             ConcreteDataType::Binary(_) => Ok(ScalarValue::Binary(Some(b.to_vec()))),
-            ConcreteDataType::Timestamp(ts_type) => convert_bytes_to_timestamp(b, ts_type),
+            ConcreteDataType::Timestamp(ts_type) => {
+                convert_bytes_to_timestamp(b, ts_type, timezone)
+            }
             ConcreteDataType::Date(_) => convert_bytes_to_date(b),
             _ => error::PreparedStmtTypeMismatchSnafu {
                 expected: t,
@@ -234,15 +241,29 @@ pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarV
             Ok(ScalarValue::Date32(Some(date.val())))
         }
         ValueInner::Datetime(_) => {
-            let timestamp_millis = to_naive_datetime(param.value)
+            let datetime = to_naive_datetime(param.value)
                 .map_err(|e| {
                     error::MysqlValueConversionSnafu {
                         err_msg: e.to_string(),
                     }
                     .build()
                 })?
-                .and_utc()
-                .timestamp_millis();
+                .to_string();
+            let timestamp_millis = Timestamp::from_str(&datetime, Some(timezone))
+                .map_err(|e| {
+                    error::MysqlValueConversionSnafu {
+                        err_msg: e.to_string(),
+                    }
+                    .build()
+                })?
+                .convert_to(TimeUnit::Millisecond)
+                .ok_or_else(|| {
+                    error::MysqlValueConversionSnafu {
+                        err_msg: "Overflow when converting timestamp to milliseconds".to_string(),
+                    }
+                    .build()
+                })?
+                .value();
 
             match t {
                 ConcreteDataType::Timestamp(_) => Ok(ScalarValue::TimestampMillisecond(
@@ -308,8 +329,12 @@ pub fn convert_expr_to_scalar_value(param: &Expr, t: &ConcreteDataType) -> Resul
     }
 }
 
-fn convert_bytes_to_timestamp(bytes: &[u8], ts_type: &TimestampType) -> Result<ScalarValue> {
-    let ts = Timestamp::from_str_utc(&String::from_utf8_lossy(bytes))
+fn convert_bytes_to_timestamp(
+    bytes: &[u8],
+    ts_type: &TimestampType,
+    timezone: &Timezone,
+) -> Result<ScalarValue> {
+    let ts = Timestamp::from_str(&String::from_utf8_lossy(bytes), Some(timezone))
         .map_err(|e| {
             error::MysqlValueConversionSnafu {
                 err_msg: e.to_string(),
@@ -502,6 +527,7 @@ mod tests {
 
     #[test]
     fn test_convert_bytes_to_timestamp() {
+        let timezone = Timezone::from_tz_string("UTC").unwrap();
         let test_cases = vec![
             // input unix timestamp in seconds -> nanosecond.
             (
@@ -578,9 +604,21 @@ mod tests {
         ];
 
         for (input, ts_type, expected) in test_cases {
-            let result = convert_bytes_to_timestamp(input.as_bytes(), &ts_type).unwrap();
+            let result = convert_bytes_to_timestamp(input.as_bytes(), &ts_type, &timezone).unwrap();
             assert_eq!(result, expected);
         }
+
+        let timezone = Timezone::from_tz_string("+08:00").unwrap();
+        let result = convert_bytes_to_timestamp(
+            b"2024-12-26 12:00:00",
+            &TimestampType::Millisecond(TimestampMillisecondType),
+            &timezone,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            ScalarValue::TimestampMillisecond(Some(1735185600000), None)
+        );
     }
 
     #[test]

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -669,6 +669,47 @@ async fn test_mysql_binary_protocol_timestamp_controls() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_mysql_prepared_timestamp_uses_session_timezone() -> Result<()> {
+    let timestamp = Timestamp::from_str_utc("2024-12-26 04:00:00")
+        .unwrap()
+        .value();
+    let (table, _) = timestamp_table("prepared_timestamp_with_session_timezone", Some(timestamp));
+    let query_handler = Arc::new(SessionTimezoneQueryHandler {
+        inner: create_testing_sql_query_handler(table),
+    });
+    let mut mysql_server =
+        create_mysql_server_with_query_handler(query_handler, Default::default())?;
+    let listening = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
+    mysql_server.start(listening).await.unwrap();
+
+    let server_addr = mysql_server.bind_addr().unwrap();
+    let mut connection = create_connection_default_db_name(server_addr.port(), false).await?;
+    connection.query_drop("SET time_zone = '+08:00'").await?;
+
+    let text_result: Option<i32> = connection
+        .query_first(
+            "SELECT id FROM prepared_timestamp_with_session_timezone \
+             WHERE ts = '2024-12-26 12:00:00'",
+        )
+        .await?;
+    assert_eq!(Some(7), text_result);
+
+    let statement = connection
+        .prep("SELECT id FROM prepared_timestamp_with_session_timezone WHERE ts = ?")
+        .await?;
+    let binary_result: Option<i32> = connection
+        .exec_first(
+            statement,
+            vec![mysql_async::Value::Date(2024, 12, 26, 12, 0, 0, 0)],
+        )
+        .await?;
+    assert_eq!(Some(7), binary_result);
+
+    mysql_server.shutdown().await.unwrap();
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_mysql_timestamp_precision_slot_isolation() -> Result<()> {
     let (result, health_check) = query_mysql_text_protocol(
         precision_timestamp_table("precision_timestamps"),

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -683,26 +683,34 @@ async fn test_mysql_prepared_timestamp_uses_session_timezone() -> Result<()> {
     mysql_server.start(listening).await.unwrap();
 
     let server_addr = mysql_server.bind_addr().unwrap();
-    let mut connection = create_connection_default_db_name(server_addr.port(), false).await?;
-    connection.query_drop("SET time_zone = '+08:00'").await?;
+    let mut connection = create_connection_default_db_name(server_addr.port(), false)
+        .await
+        .unwrap();
+    connection
+        .query_drop("SET time_zone = '+08:00'")
+        .await
+        .unwrap();
 
     let text_result: Option<i32> = connection
         .query_first(
             "SELECT id FROM prepared_timestamp_with_session_timezone \
              WHERE ts = '2024-12-26 12:00:00'",
         )
-        .await?;
+        .await
+        .unwrap();
     assert_eq!(Some(7), text_result);
 
     let statement = connection
         .prep("SELECT id FROM prepared_timestamp_with_session_timezone WHERE ts = ?")
-        .await?;
+        .await
+        .unwrap();
     let binary_result: Option<i32> = connection
         .exec_first(
             statement,
             vec![mysql_async::Value::Date(2024, 12, 26, 12, 0, 0, 0)],
         )
-        .await?;
+        .await
+        .unwrap();
     assert_eq!(Some(7), binary_result);
 
     mysql_server.shutdown().await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link

Refs #8879

## What's changed and what's your intention?

MySQL server-side prepared timestamp parameters were interpreted as UTC even when the connection session used another timezone. This caused binary prepared values to differ from equivalent text timestamp literals.

This change passes the query session timezone into MySQL prepared-parameter conversion. Binary datetime values and byte-form timestamp parameters now use the session timezone while preserving explicit timestamp offsets. Storage remains UTC.

A regression test compares text and binary prepared timestamp predicates under `+08:00`.

Validation:
- `cargo +1.97.1 fmt --all -- --check`
- `git diff --check`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.