### PR TITLE
fix: respect session timezone in MySQL prepared statements

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -25,6 +25,7 @@ use common_catalog::parse_optional_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
 use common_query::Output;
 use common_telemetry::{debug, error, tracing, warn};
+use common_time::Timezone;
 use datafusion_common::ParamValues;
 use datafusion_expr::LogicalPlan;
 use datatypes::prelude::ConcreteDataType;
@@ -289,12 +290,13 @@ impl MysqlInstanceShim {
                     .fail();
                 }
 
+                let timezone = query_ctx.timezone();
                 let replaced_plan = match params {
                     Params::ProtocolParams(params) => {
-                        replace_params_with_values(&plan, param_types, &params)
+                        replace_params_with_values(&plan, param_types, &params, &timezone)
                     }
                     Params::CliParams(params) => {
-                        replace_params_with_exprs(&plan, param_types, &params)
+                        replace_params_with_exprs(&plan, param_types, &params, &timezone)
                     }
                 }?;
 
@@ -807,6 +809,7 @@ fn replace_params_with_values(
     plan: &LogicalPlan,
     param_types: HashMap<String, Option<ConcreteDataType>>,
     params: &[ParamValue],
+    timezone: &Timezone,
 ) -> Result<LogicalPlan> {
     debug_assert_eq!(param_types.len(), params.len());
 
@@ -824,7 +827,7 @@ fn replace_params_with_values(
 
     for (i, param) in params.iter().enumerate() {
         if let Some(Some(t)) = param_types.get(&format_placeholder(i + 1)) {
-            let value = helper::convert_value(param, t)?;
+            let value = helper::convert_value(param, t, timezone)?;
 
             values.push(value.into());
         }
@@ -839,6 +842,7 @@ fn replace_params_with_exprs(
     plan: &LogicalPlan,
     param_types: HashMap<String, Option<ConcreteDataType>>,
     params: &[sql::ast::Expr],
+    timezone: &Timezone,
 ) -> Result<LogicalPlan> {
     debug_assert_eq!(param_types.len(), params.len());
 
@@ -853,7 +857,7 @@ fn replace_params_with_exprs(
 
     for (i, param) in params.iter().enumerate() {
         if let Some(Some(t)) = param_types.get(&format_placeholder(i + 1)) {
-            let value = helper::convert_expr_to_scalar_value(param, t)?;
+            let value = helper::convert_expr_to_scalar_value(param, t, timezone)?;
 
             values.push(value.into());
         }

--- a/src/servers/src/mysql/helper.rs
+++ b/src/servers/src/mysql/helper.rs
@@ -15,10 +15,11 @@
 use std::ops::ControlFlow;
 use std::time::Duration;
 
-use chrono::NaiveDate;
+use chrono::{LocalResult, NaiveDate};
 use common_query::prelude::ScalarValue;
 use common_sql::convert::sql_value_to_value;
-use common_time::{Date, Timestamp};
+use common_time::util::datetime_to_utc;
+use common_time::{Date, Timestamp, Timezone};
 use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::schema::ColumnSchema;
 use datatypes::types::TimestampType;
@@ -137,11 +138,15 @@ where
 
 /// Convert [`ParamValue`] into [`Value`] according to param type.
 /// It will try it's best to do type conversions if possible
-pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarValue> {
+pub fn convert_value(
+    param: &ParamValue,
+    t: &ConcreteDataType,
+    timezone: &Timezone,
+) -> Result<ScalarValue> {
     if let ConcreteDataType::Dictionary(dictionary) = t {
         return Ok(ScalarValue::Dictionary(
             Box::new(dictionary.key_type().as_arrow_type()),
-            Box::new(convert_value(param, dictionary.value_type())?),
+            Box::new(convert_value(param, dictionary.value_type(), timezone)?),
         ));
     }
 
@@ -221,7 +226,9 @@ pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarV
                 }
             }
             ConcreteDataType::Binary(_) => Ok(ScalarValue::Binary(Some(b.to_vec()))),
-            ConcreteDataType::Timestamp(ts_type) => convert_bytes_to_timestamp(b, ts_type),
+            ConcreteDataType::Timestamp(ts_type) => {
+                convert_bytes_to_timestamp(b, ts_type, timezone)
+            }
             ConcreteDataType::Date(_) => convert_bytes_to_date(b),
             _ => error::PreparedStmtTypeMismatchSnafu {
                 expected: t,
@@ -234,15 +241,25 @@ pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarV
             Ok(ScalarValue::Date32(Some(date.val())))
         }
         ValueInner::Datetime(_) => {
-            let timestamp_millis = to_naive_datetime(param.value)
-                .map_err(|e| {
-                    error::MysqlValueConversionSnafu {
-                        err_msg: e.to_string(),
+            let naive_datetime = to_naive_datetime(param.value).map_err(|e| {
+                error::MysqlValueConversionSnafu {
+                    err_msg: e.to_string(),
+                }
+                .build()
+            })?;
+            let timestamp_millis = match datetime_to_utc(&naive_datetime, timezone) {
+                LocalResult::None => {
+                    return error::MysqlValueConversionSnafu {
+                        err_msg: format!(
+                            "Invalid datetime '{naive_datetime}' for the session timezone"
+                        ),
                     }
-                    .build()
-                })?
-                .and_utc()
-                .timestamp_millis();
+                    .fail();
+                }
+                LocalResult::Single(utc) | LocalResult::Ambiguous(utc, _) => {
+                    utc.and_utc().timestamp_millis()
+                }
+            };
 
             match t {
                 ConcreteDataType::Timestamp(_) => Ok(ScalarValue::TimestampMillisecond(
@@ -264,13 +281,18 @@ pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarV
 
 /// Convert an MySQL expression to a scalar value.
 /// It automatically handles the conversion of strings to numeric values.
-pub fn convert_expr_to_scalar_value(param: &Expr, t: &ConcreteDataType) -> Result<ScalarValue> {
+pub fn convert_expr_to_scalar_value(
+    param: &Expr,
+    t: &ConcreteDataType,
+    timezone: &Timezone,
+) -> Result<ScalarValue> {
     if let ConcreteDataType::Dictionary(dictionary) = t {
         return Ok(ScalarValue::Dictionary(
             Box::new(dictionary.key_type().as_arrow_type()),
             Box::new(convert_expr_to_scalar_value(
                 param,
                 dictionary.value_type(),
+                timezone,
             )?),
         ));
     }
@@ -278,7 +300,7 @@ pub fn convert_expr_to_scalar_value(param: &Expr, t: &ConcreteDataType) -> Resul
     let column_schema = ColumnSchema::new("", t.clone(), true);
     match param {
         Expr::Value(v) => {
-            let v = sql_value_to_value(&column_schema, &v.value, None, None, true);
+            let v = sql_value_to_value(&column_schema, &v.value, Some(timezone), None, true);
             match v {
                 Ok(v) => v
                     .try_to_scalar_value(t)
@@ -290,7 +312,7 @@ pub fn convert_expr_to_scalar_value(param: &Expr, t: &ConcreteDataType) -> Resul
             }
         }
         Expr::UnaryOp { op, expr } if let Expr::Value(v) = &**expr => {
-            let v = sql_value_to_value(&column_schema, &v.value, None, Some(*op), true);
+            let v = sql_value_to_value(&column_schema, &v.value, Some(timezone), Some(*op), true);
             match v {
                 Ok(v) => v
                     .try_to_scalar_value(t)
@@ -308,8 +330,12 @@ pub fn convert_expr_to_scalar_value(param: &Expr, t: &ConcreteDataType) -> Resul
     }
 }
 
-fn convert_bytes_to_timestamp(bytes: &[u8], ts_type: &TimestampType) -> Result<ScalarValue> {
-    let ts = Timestamp::from_str_utc(&String::from_utf8_lossy(bytes))
+fn convert_bytes_to_timestamp(
+    bytes: &[u8],
+    ts_type: &TimestampType,
+    timezone: &Timezone,
+) -> Result<ScalarValue> {
+    let ts = Timestamp::from_str(&String::from_utf8_lossy(bytes), Some(timezone))
         .map_err(|e| {
             error::MysqlValueConversionSnafu {
                 err_msg: e.to_string(),
@@ -446,19 +472,20 @@ mod tests {
 
     #[test]
     fn test_convert_expr_to_scalar_value() {
+        let tz = Timezone::from_tz_string("UTC").unwrap();
         let expr = Expr::Value(ValueExpr::Number("123".to_string(), false).into());
         let t = ConcreteDataType::int32_datatype();
-        let v = convert_expr_to_scalar_value(&expr, &t).unwrap();
+        let v = convert_expr_to_scalar_value(&expr, &t, &tz).unwrap();
         assert_eq!(ScalarValue::Int32(Some(123)), v);
 
         let expr = Expr::Value(ValueExpr::Number("123.456789".to_string(), false).into());
         let t = ConcreteDataType::float64_datatype();
-        let v = convert_expr_to_scalar_value(&expr, &t).unwrap();
+        let v = convert_expr_to_scalar_value(&expr, &t, &tz).unwrap();
         assert_eq!(ScalarValue::Float64(Some(123.456789)), v);
 
         let expr = Expr::Value(ValueExpr::SingleQuotedString("2001-01-02".to_string()).into());
         let t = ConcreteDataType::date_datatype();
-        let v = convert_expr_to_scalar_value(&expr, &t).unwrap();
+        let v = convert_expr_to_scalar_value(&expr, &t, &tz).unwrap();
         let scalar_v = ScalarValue::Utf8(Some("2001-01-02".to_string()))
             .cast_to(&arrow_schema::DataType::Date32)
             .unwrap();
@@ -467,7 +494,7 @@ mod tests {
         let expr =
             Expr::Value(ValueExpr::SingleQuotedString("2001-01-02 03:04:05".to_string()).into());
         let t = ConcreteDataType::timestamp_microsecond_datatype();
-        let v = convert_expr_to_scalar_value(&expr, &t).unwrap();
+        let v = convert_expr_to_scalar_value(&expr, &t, &tz).unwrap();
         let scalar_v = ScalarValue::Utf8(Some("2001-01-02 03:04:05".to_string()))
             .cast_to(&arrow_schema::DataType::Timestamp(
                 arrow_schema::TimeUnit::Microsecond,
@@ -478,14 +505,14 @@ mod tests {
 
         let expr = Expr::Value(ValueExpr::SingleQuotedString("hello".to_string()).into());
         let t = ConcreteDataType::string_datatype();
-        let v = convert_expr_to_scalar_value(&expr, &t).unwrap();
+        let v = convert_expr_to_scalar_value(&expr, &t, &tz).unwrap();
         assert_eq!(ScalarValue::Utf8(Some("hello".to_string())), v);
 
         let t = ConcreteDataType::dictionary_datatype(
             ConcreteDataType::uint32_datatype(),
             ConcreteDataType::string_datatype(),
         );
-        let v = convert_expr_to_scalar_value(&expr, &t).unwrap();
+        let v = convert_expr_to_scalar_value(&expr, &t, &tz).unwrap();
         assert_eq!(
             ScalarValue::Dictionary(
                 Box::new(arrow_schema::DataType::UInt32),
@@ -496,7 +523,7 @@ mod tests {
 
         let expr = Expr::Value(ValueExpr::Null.into());
         let t = ConcreteDataType::time_microsecond_datatype();
-        let v = convert_expr_to_scalar_value(&expr, &t).unwrap();
+        let v = convert_expr_to_scalar_value(&expr, &t, &tz).unwrap();
         assert_eq!(ScalarValue::Time64Microsecond(None), v);
     }
 
@@ -577,10 +604,35 @@ mod tests {
             ),
         ];
 
+        let tz = Timezone::from_tz_string("UTC").unwrap();
         for (input, ts_type, expected) in test_cases {
-            let result = convert_bytes_to_timestamp(input.as_bytes(), &ts_type).unwrap();
+            let result = convert_bytes_to_timestamp(input.as_bytes(), &ts_type, &tz).unwrap();
             assert_eq!(result, expected);
         }
+    }
+
+    #[test]
+    fn test_convert_bytes_to_timestamp_with_timezone() {
+        // The client sends wall-clock time in the session timezone; a session
+        // timezone of +08:00 must shift the stored instant to the matching UTC value.
+        let tz = Timezone::from_tz_string("+08:00").unwrap();
+        let result = convert_bytes_to_timestamp(
+            "2024-12-26 12:00:00".as_bytes(),
+            &TimestampType::Second(TimestampSecondType),
+            &tz,
+        )
+        .unwrap();
+        // 2024-12-26 12:00:00 +08:00 == 2024-12-26 04:00:00 UTC == 1735185600
+        assert_eq!(ScalarValue::TimestampSecond(Some(1735185600), None), result);
+
+        // A string with an explicit offset must ignore the session timezone.
+        let result = convert_bytes_to_timestamp(
+            "2024-12-26 12:00:00+08:00".as_bytes(),
+            &TimestampType::Second(TimestampSecondType),
+            &tz,
+        )
+        .unwrap();
+        assert_eq!(ScalarValue::TimestampSecond(Some(1735185600), None), result);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In `src/servers/src/mysql/helper.rs`, prepared-statement parameters are converted to timestamps without considering the session timezone:

- `ValueInner::Datetime` calls `.and_utc()` on the naive wall-clock datetime the client sent, hard-coding UTC;
- `convert_bytes_to_timestamp` parses bytes strings via `Timestamp::from_str_utc`.

For any session whose timezone is not UTC, the wall-clock values are interpreted at the wrong offset, so the stored instant is off by the session offset.

## Fix

Thread the session timezone through the parameter-conversion chain:

- `do_execute` reads `query_ctx.timezone()` and passes it to `replace_params_with_values` / `replace_params_with_exprs`;
- `helper::convert_value` and `helper::convert_expr_to_scalar_value` take a `&Timezone`;
- the `Datetime` path converts with `datetime_to_utc` (the same `from_local_datetime`-based conversion `Timestamp::from_str` already uses) instead of `.and_utc()`, returning a clear error for wall-clock times that don't exist in the session timezone;
- `convert_bytes_to_timestamp` parses with `Timestamp::from_str(s, Some(&timezone))`;
- the CLI path `convert_expr_to_scalar_value` now forwards the timezone to `sql_value_to_value` (previously `None`).

## Tests

- `test_convert_bytes_to_timestamp_with_timezone`: a `+08:00` session shifts a wall-clock string to the matching UTC instant, while strings with explicit offsets keep their own offset.

Closes #8879
