### PR TITLE
fix(mito2): fail region open when WAL replay cannot apply an entry

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -457,6 +457,16 @@ pub enum Error {
     #[snafu(display("Failed to write region"))]
     WriteGroup { source: Arc<Error> },
 
+    /// The mutation was already written to the WAL but could not be applied to
+    /// the memtable, so its durability is unknown to the caller. This must
+    /// never use a definitive-rejection status class (e.g. `InvalidArguments`):
+    /// the row may still exist after a restart, or be gone permanently if a
+    /// flush truncates the WAL first.
+    #[snafu(display(
+        "Failed to apply a mutation to the memtable after writing to the WAL: {source}"
+    ))]
+    MemtableApply { source: Box<Error> },
+
     #[snafu(display("Invalid parquet SST file {}, reason: {}", file, reason))]
     InvalidParquet {
         file: String,
@@ -1525,6 +1535,9 @@ impl ErrorExt for Error {
 
             WriteParquet { .. } => StatusCode::StorageUnavailable,
             WriteGroup { source, .. } => source.status_code(),
+            // The mutation is durable in the WAL regardless of the apply
+            // outcome, so the caller cannot treat this as a rejection.
+            MemtableApply { .. } => StatusCode::Internal,
             InvalidBatch { .. } => StatusCode::InvalidArguments,
             InvalidRecordBatch { .. } => StatusCode::InvalidArguments,
             ConvertVector { source, .. } => source.status_code(),
@@ -1673,6 +1686,8 @@ impl ErrorExt for Error {
             | EditRegion { source, .. }
             | ScanSeries { source, .. }
             | PruneFile { source, .. } => source.retry_hint(),
+
+            MemtableApply { source, .. } => source.retry_hint(),
 
             DataTypeMismatch { source, .. }
             | ConvertVector { source, .. }

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -483,24 +483,18 @@ impl Memtable for BulkMemtable {
 
             let fragment_size = fragment.estimated_size();
             // Routes small parts to unordered_part based on row and byte thresholds.
-            if bulk_parts.unordered_part.should_accept(fragment.num_rows())
+            // The compaction of `unordered_part` is fallible; keep its result so
+            // the stats below are updated before any error is propagated.
+            let compact_result = if bulk_parts.unordered_part.should_accept(fragment.num_rows())
                 && fragment_size <= self.config.encode_bytes_threshold
             {
                 bulk_parts.unordered_part.push(fragment);
 
                 // Compacts unordered_part if the row or byte threshold is exceeded.
-                if bulk_parts.should_compact_unordered_part(self.config.encode_bytes_threshold)
-                    && let Some(bulk_part) =
-                        bulk_parts.unordered_part.to_bulk_part(&self.metadata)?
-                {
-                    bulk_parts.parts.push(BulkPartWrapper {
-                        part: PartToMerge::Bulk {
-                            part: bulk_part,
-                            file_id: FileId::random(),
-                        },
-                        merging: false,
-                    });
-                    bulk_parts.unordered_part.clear();
+                if bulk_parts.should_compact_unordered_part(self.config.encode_bytes_threshold) {
+                    bulk_parts.unordered_part.to_bulk_part(&self.metadata)
+                } else {
+                    Ok(None)
                 }
             } else {
                 bulk_parts.parts.push(BulkPartWrapper {
@@ -510,13 +504,29 @@ impl Memtable for BulkMemtable {
                     },
                     merging: false,
                 });
-            }
+                Ok(None)
+            };
 
             // Since this operation should be fast, we do it in parts lock scope.
             // This ensure the statistics in `ranges()` are correct. What's more,
             // it guarantees no rows are out of the time range so we don't need to
             // prune rows by time range again in the iterator of the MemtableRange.
+            //
+            // The fragment is buffered in `unordered_part` regardless of the
+            // compaction outcome, so the stats must be updated even when the
+            // compaction fails — otherwise rows would be present but unaccounted
+            // and `ranges()` could prune them away by time range.
             self.update_stats(local_metrics);
+            if let Some(bulk_part) = compact_result? {
+                bulk_parts.parts.push(BulkPartWrapper {
+                    part: PartToMerge::Bulk {
+                        part: bulk_part,
+                        file_id: FileId::random(),
+                    },
+                    merging: false,
+                });
+                bulk_parts.unordered_part.clear();
+            }
         }
 
         if self.should_compact() {

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -312,17 +312,31 @@ impl Memtable for TimeSeriesMemtable {
         }
 
         let mut local_stats = WriteMetrics::default();
+        let mut last_applied_sequence = 0;
 
-        for kv in kvs.iter() {
-            self.write_key_value(kv, &mut local_stats)?;
+        for (num_applied, kv) in kvs.iter().enumerate() {
+            if let Err(e) = self.write_key_value(kv, &mut local_stats) {
+                // The failed key-value itself has no side effects (the primary
+                // key length check and encoding both precede `push_to_series`),
+                // but any previously applied prefix is already visible in the
+                // series set. Count it so the stats always agree with the
+                // memtable contents; otherwise `ranges()` may prune those rows
+                // by time range even though they are still present.
+                if num_applied > 0 {
+                    local_stats.value_bytes += num_applied
+                        * (std::mem::size_of::<Timestamp>() + std::mem::size_of::<OpType>());
+                    local_stats.max_sequence = last_applied_sequence;
+                    local_stats.num_rows = num_applied;
+                    self.update_stats(local_stats);
+                }
+                return Err(e);
+            }
+            last_applied_sequence = kv.sequence();
         }
         local_stats.value_bytes += kvs.num_rows() * std::mem::size_of::<Timestamp>();
         local_stats.value_bytes += kvs.num_rows() * std::mem::size_of::<OpType>();
         local_stats.max_sequence = kvs.max_sequence();
         local_stats.num_rows = kvs.num_rows();
-        // TODO(hl): this maybe inaccurate since for-iteration may return early.
-        // We may lift the primary key length check out of Memtable::write
-        // so that we can ensure writing to memtable will succeed.
         self.update_stats(local_stats);
         Ok(())
     }

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -43,7 +43,7 @@ use store_api::metadata::{
 use store_api::region_engine::RegionRole;
 use store_api::region_request::{PathType, RegionRequirements};
 use store_api::storage::{ColumnId, RegionId};
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, oneshot};
 
 use crate::access_layer::AccessLayer;
 use crate::cache::file_cache::{FileCache, FileType, IndexKey};
@@ -69,7 +69,7 @@ use crate::region::{
     RegionStats,
 };
 use crate::region_write_ctx::RegionWriteCtx;
-use crate::request::OptionOutputTx;
+use crate::request::{OptionOutputTx, OutputTx};
 use crate::schedule::scheduler::SchedulerRef;
 use crate::series_index::{IndexFilePurger, load_version_control};
 use crate::sst::FormatType;
@@ -940,17 +940,26 @@ where
             // For WAL replay, we don't need to track the write bytes rate.
             None,
         );
+        // Replay must be fail-closed: an entry that cannot be applied has to
+        // fail the region open instead of silently dropping the rows. The
+        // write context only surfaces apply failures through its output
+        // senders (the notifiers deliver on drop), so hand each replayed
+        // mutation a real oneshot channel and collect the results afterwards.
+        let mut entry_rows = 0usize;
+        let mut replay_results = Vec::new();
         for mutation in entry.mutations {
-            rows_replayed += mutation
+            entry_rows += mutation
                 .rows
                 .as_ref()
                 .map(|rows| rows.rows.len())
                 .unwrap_or(0);
+            let (tx, rx) = oneshot::channel();
+            replay_results.push(rx);
             region_write_ctx.push_mutation(
                 mutation.op_type,
                 mutation.rows,
                 mutation.write_hint,
-                OptionOutputTx::none(),
+                OptionOutputTx::new(Some(OutputTx::new(tx))),
                 // We should respect the sequence in WAL during replay.
                 Some(mutation.sequence),
                 false,
@@ -968,12 +977,14 @@ where
             if region_metadata.primary_key_encoding != PrimaryKeyEncoding::Sparse {
                 part.fill_missing_columns(&region_metadata)?;
             }
-            rows_replayed += part.num_rows();
+            entry_rows += part.num_rows();
             // During replay, we should adopt the sequence from WAL.
             let bulk_sequence_from_wal = part.sequence;
+            let (tx, rx) = oneshot::channel();
+            replay_results.push(rx);
             ensure!(
                 region_write_ctx.push_bulk(
-                    OptionOutputTx::none(),
+                    OptionOutputTx::new(Some(OutputTx::new(tx))),
                     part,
                     Some(bulk_sequence_from_wal)
                 ),
@@ -991,6 +1002,42 @@ where
         // Publish the replayed sequences only after all rows (including bulk
         // parts) are installed, matching the write path ordering.
         region_write_ctx.publish_sequence_and_entry_id();
+
+        // Flush the notifiers by dropping the write context, then collect the
+        // apply results. Any failure fails the region open (fail-closed): the
+        // WAL entry stays durable, so opening "successfully" with the rows
+        // missing would silently lose acknowledged data. The operator must fix
+        // the underlying cause, or open the region with `skip_wal_replay`.
+        drop(region_write_ctx);
+        for rx in replay_results {
+            match rx.await {
+                Ok(Ok(_)) => {}
+                Ok(Err(err)) => {
+                    error!(
+                        "Failed to apply a replayed WAL entry (entry id: {}, region id: {}) to the memtable: {}. Failing the region open to avoid silently losing acknowledged rows; recover by fixing the cause or opening the region with `skip_wal_replay`.",
+                        entry_id, region_id, err
+                    );
+                    return Err(err);
+                }
+                // The notifier always sends before drop; a closed channel means
+                // the result is unknown, which must also fail the open.
+                Err(_) => {
+                    error!(
+                        "Lost the apply result for a replayed WAL entry (entry id: {}, region id: {}). Failing the region open; recover by opening the region with `skip_wal_replay`.",
+                        entry_id, region_id
+                    );
+                    return RegionCorruptedSnafu {
+                        region_id,
+                        reason: format!(
+                            "apply result channel closed for replayed entry {entry_id}"
+                        ),
+                    }
+                    .fail();
+                }
+            }
+        }
+        // Only rows from entries that applied successfully are counted.
+        rows_replayed += entry_rows;
     }
 
     // TODO(weny): We need to update `flushed_entry_id` in the region manifest
@@ -1399,6 +1446,9 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use api::v1::helper::{tag_column_schema, time_index_column_schema};
+    use api::v1::value::ValueData;
+    use api::v1::{self, ColumnDataType, Mutation, OpType, Row, Rows, WalEntry};
     use arrow_schema::extension::ExtensionType;
     use common_base::readable_size::ReadableSize;
     use common_error::ext::WhateverResult;
@@ -1412,29 +1462,37 @@ mod tests {
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
     use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
+    use futures::future::FutureExt;
     use object_store::ObjectStore;
     use object_store::services::{Fs, Memory, S3};
     use parquet::arrow::ArrowWriter;
     use parquet::file::metadata::{KeyValue, PageIndexPolicy};
     use parquet::file::properties::WriterProperties;
+    use prost::Message;
+    use store_api::logstore::entry::{Entry, NaiveEntry};
+    use store_api::logstore::provider::Provider;
     use store_api::metadata::RegionMetadataBuilder;
     use store_api::region_request::PathType;
     use store_api::storage::{FileId, RegionId};
 
     use super::{
         initial_pruned_entry_id, maybe_upgrade_json2_layout, preload_parquet_meta_cache_for_files,
-        sanitize_region_options, supports_open_region_object_storage_requirement,
+        replay_memtable, sanitize_region_options, supports_open_region_object_storage_requirement,
     };
     use crate::cache::CacheManager;
     use crate::cache::file_cache::{FileType, IndexKey};
     use crate::manifest::action::{RegionManifest, RemovedFilesRecord};
-    use crate::region::options::RegionOptions;
+    use crate::memtable::time_series::TimeSeriesMemtableBuilder;
+    use crate::region::options::{MergeMode, RegionOptions};
     use crate::sst::FormatType;
     use crate::sst::file::{FileHandle, FileMeta};
     use crate::sst::file_purger::NoopFilePurger;
     use crate::sst::parquet::PARQUET_METADATA_KEY;
-    use crate::test_util::TestEnv;
     use crate::test_util::sst_util::sst_region_metadata;
+    use crate::test_util::version_util::VersionControlBuilder;
+    use crate::test_util::wal_util::MockRawEntryStream;
+    use crate::test_util::{TestEnv, ts_ms_value};
+    use crate::wal::entry_reader::LogStoreEntryReader;
 
     fn build_test_manifest(sst_format: FormatType) -> RegionManifest {
         RegionManifest {
@@ -1829,6 +1887,147 @@ mod tests {
                 .get_compact_sst_meta_data(region_file_id, PageIndexPolicy::Optional)
                 .await
                 .is_some()
+        );
+    }
+
+    fn build_mock_wal_reader(
+        provider: &Provider,
+        region_id: RegionId,
+        entries: Vec<(u64, WalEntry)>,
+    ) -> Box<LogStoreEntryReader<MockRawEntryStream>> {
+        Box::new(LogStoreEntryReader::new(MockRawEntryStream {
+            entries: entries
+                .into_iter()
+                .map(|(entry_id, wal_entry)| {
+                    Entry::Naive(NaiveEntry {
+                        provider: provider.clone(),
+                        region_id,
+                        entry_id,
+                        data: wal_entry.encode_to_vec(),
+                    })
+                })
+                .collect(),
+        }))
+    }
+
+    /// Builds a mutation whose primary key value cannot be encoded: the schema
+    /// declares `tag_0` as a string but the row carries an i64. `WriteRequest::new`
+    /// rejects such rows today, but nothing re-validates WAL contents on replay.
+    fn poison_mutation(sequence: u64) -> Mutation {
+        Mutation {
+            op_type: OpType::Put as i32,
+            sequence,
+            rows: Some(Rows {
+                schema: vec![
+                    time_index_column_schema("ts", ColumnDataType::TimestampMillisecond),
+                    tag_column_schema("tag_0", ColumnDataType::String),
+                ],
+                rows: vec![Row {
+                    values: vec![
+                        ts_ms_value(1),
+                        v1::Value {
+                            value_data: Some(ValueData::I64Value(42)),
+                        },
+                    ],
+                }],
+            }),
+            write_hint: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_replay_fails_closed_on_mutation_failing_memtable_write() {
+        let mut builder = VersionControlBuilder::new();
+        builder.set_memtable_builder(Arc::new(TimeSeriesMemtableBuilder::new(
+            None,
+            true,
+            MergeMode::LastRow,
+        )));
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let provider = Provider::raft_engine_provider(region_id.as_u64());
+
+        let wal_entry = WalEntry {
+            mutations: vec![poison_mutation(1)],
+            bulk_entries: vec![],
+        };
+        let reader = build_mock_wal_reader(&provider, region_id, vec![(1, wal_entry)]);
+
+        let result = replay_memtable(
+            &provider,
+            reader,
+            region_id,
+            0,
+            &version_control,
+            false,
+            |_, _, _| async { Ok(()) }.boxed(),
+        )
+        .await;
+
+        // Fail-closed: the region open must fail instead of opening "successfully"
+        // with the acknowledged row silently missing.
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_replay_applies_valid_mutation() {
+        let mut builder = VersionControlBuilder::new();
+        builder.set_memtable_builder(Arc::new(TimeSeriesMemtableBuilder::new(
+            None,
+            true,
+            MergeMode::LastRow,
+        )));
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let provider = Provider::raft_engine_provider(region_id.as_u64());
+
+        let wal_entry = WalEntry {
+            mutations: vec![Mutation {
+                op_type: OpType::Put as i32,
+                sequence: 1,
+                rows: Some(Rows {
+                    schema: vec![
+                        time_index_column_schema("ts", ColumnDataType::TimestampMillisecond),
+                        tag_column_schema("tag_0", ColumnDataType::String),
+                    ],
+                    rows: vec![Row {
+                        values: vec![
+                            ts_ms_value(1),
+                            v1::Value {
+                                value_data: Some(ValueData::StringValue("tag_1".to_string())),
+                            },
+                        ],
+                    }],
+                }),
+                write_hint: None,
+            }],
+            bulk_entries: vec![],
+        };
+        let reader = build_mock_wal_reader(&provider, region_id, vec![(1, wal_entry)]);
+
+        let last_entry_id = replay_memtable(
+            &provider,
+            reader,
+            region_id,
+            0,
+            &version_control,
+            false,
+            |_, _, _| async { Ok(()) }.boxed(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(1, last_entry_id);
+        // The committed sequence covers the replayed entry...
+        assert_eq!(1, version_control.committed_sequence());
+        // ...and the row is actually present in the mutable memtable.
+        assert!(
+            !version_control
+                .current()
+                .version
+                .memtables
+                .mutable
+                .is_empty()
         );
     }
 }

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -17,13 +17,15 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use api::v1::{BulkWalEntry, Mutation, OpType, Rows, WalEntry, WriteHint};
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use futures::stream::{FuturesUnordered, StreamExt};
-use snafu::ResultExt;
+use snafu::{IntoError, ResultExt};
 use store_api::logstore::LogStore;
 use store_api::logstore::provider::Provider;
 use store_api::storage::{RegionId, SequenceNumber};
 
-use crate::error::{Error, Result, WriteGroupSnafu};
+use crate::error::{Error, MemtableApplySnafu, Result, WriteGroupSnafu};
 use crate::memtable::KeyValues;
 use crate::memtable::bulk::part::BulkPart;
 use crate::metrics;
@@ -221,6 +223,19 @@ impl RegionWriteCtx {
             || (self.wal_entry.mutations.is_empty() && self.wal_entry.bulk_entries.is_empty())
     }
 
+    /// Maps an error raised while applying a mutation to the memtable after the
+    /// WAL write. Such an error cannot guarantee the mutation is not durable, so
+    /// it must never be surfaced as a definitive rejection (e.g.
+    /// `InvalidArguments`): the row may still exist after a restart, or be gone
+    /// after a flush. The caller sees an internal error, i.e. the outcome of the
+    /// write is unknown.
+    fn map_apply_error(err: Error) -> Error {
+        match err.status_code() {
+            StatusCode::InvalidArguments => MemtableApplySnafu {}.into_error(Box::new(err)),
+            _ => err,
+        }
+    }
+
     /// Sets error and marks all write operations are failed.
     pub(crate) fn set_error(&mut self, err: Arc<Error>) {
         // Set error for all notifiers.
@@ -287,7 +302,7 @@ impl RegionWriteCtx {
 
         if mutations.len() == 1 {
             if let Err(err) = mutable_memtable.write(&mutations[0].1) {
-                mutations[0].0.err = Some(Arc::new(err));
+                mutations[0].0.err = Some(Arc::new(Self::map_apply_error(err)));
             }
         } else {
             let mut tasks = FuturesUnordered::new();
@@ -301,7 +316,7 @@ impl RegionWriteCtx {
             while let Some((notify, result)) = tasks.next().await {
                 // First unwrap the result from `spawn` above.
                 if let Err(err) = result.unwrap() {
-                    notify.err = Some(Arc::new(err));
+                    notify.err = Some(Arc::new(Self::map_apply_error(err)));
                 }
             }
         }
@@ -362,7 +377,7 @@ impl RegionWriteCtx {
             let part = self.bulk_parts.swap_remove(0);
             let num_rows = part.num_rows();
             if let Err(e) = self.version.memtables.mutable.write_bulk(part) {
-                self.bulk_notifiers[0].err = Some(Arc::new(e));
+                self.bulk_notifiers[0].err = Some(Arc::new(Self::map_apply_error(e)));
             } else {
                 self.put_num += num_rows;
             }
@@ -381,7 +396,7 @@ impl RegionWriteCtx {
             // first unwrap the result from `spawn` above
             let (i, result, num_rows) = result.unwrap();
             if let Err(err) = result {
-                self.bulk_notifiers[i].err = Some(Arc::new(err));
+                self.bulk_notifiers[i].err = Some(Arc::new(Self::map_apply_error(err)));
             } else {
                 self.put_num += num_rows;
             }


### PR DESCRIPTION
## Summary

During region open, a WAL entry that could not be applied to the memtable was silently skipped: the rows stayed acknowledged in the WAL but never made it into memory, and `rows_replayed` counted them anyway. This PR makes replay fail-closed and fixes the two stats inconsistencies that let such failures go unnoticed.

### Replay fails closed (`src/mito2/src/region/opener.rs`)

`replay_memtable` previously pushed each replayed mutation/bulk with `OptionOutputTx::none()`, discarding the apply result. Now each entry gets a real oneshot channel and, after dropping the write context to flush the notifiers, any apply error or lost result fails the region open. `rows_replayed` counts only entries that applied successfully. Recovery is either fixing the cause or opening the region with `skip_wal_replay`.

### Stats stay consistent with memtable contents

- `TimeSeriesMemtable::write` (`memtable/time_series.rs`): on a mid-iteration failure it now counts the already-applied prefix, so `ranges()` cannot mis-prune rows that are present.
- `BulkMemtable::write_bulk` (`memtable/bulk.rs`): stats are updated before a compaction error propagates, since the fragment is already buffered in `unordered_part`.

### Apply errors after the WAL write map to Internal (`region_write_ctx.rs`, `error.rs`)

An error raised while applying an already-durable mutation cannot guarantee the write is rejected — the row may still exist after a restart. `map_apply_error` wraps `InvalidArguments` in the new `MemtableApply` variant (`StatusCode::Internal`), so callers never mistake an unknown-durability write for a definitive rejection.

## Tests

- `test_replay_fails_closed_on_mutation_failing_memtable_write`: a WAL entry whose row cannot be encoded into the schema fails the region open (previously it opened "successfully" with the row missing).
- `test_replay_applies_valid_mutation`: a valid entry still replays, publishes the sequence, and lands in the mutable memtable.
- Full `mito2` library suite: 1131 passed, 0 failed.

Closes #8809