### PR TITLE
fix(servers): anchor pending-rows flush to batch creation time

### DIFF
--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -941,14 +941,25 @@ fn start_worker(
     flush_semaphore: Arc<Semaphore>,
 ) {
     tokio::spawn(async move {
-        let mut batch = None;
-        let mut interval = tokio::time::interval(flush_interval);
+        let mut batch: Option<PendingBatch> = None;
         let mut shutdown_rx = shutdown.subscribe();
         let idle_deadline = tokio::time::Instant::now() + worker_idle_timeout;
         let idle_timer = tokio::time::sleep_until(idle_deadline);
         tokio::pin!(idle_timer);
 
         loop {
+            // Anchor the flush deadline to the batch's creation time rather than
+            // to a worker-aligned tick. A batch created at any point between two
+            // ticks used to wait for the next tick — up to almost 2× the flush
+            // interval after its creation — before its flush even started (#8641).
+            // Anchoring on `created_at` makes the queueing delay a stable
+            // `flush_interval` and, being recomputed every iteration from the
+            // batch's original creation time, does not slide as new submissions
+            // arrive.
+            let flush_deadline = batch
+                .as_ref()
+                .map(|batch| tokio::time::Instant::from(batch.created_at) + flush_interval);
+
             tokio::select! {
                 cmd = rx.recv() => {
                     match cmd {
@@ -1014,19 +1025,24 @@ fn start_worker(
                     );
                     break;
                 }
-                _ = interval.tick() => {
-                    if batch
-                        .as_ref()
-                        .is_some_and(|batch| batch.created_at.elapsed() >= flush_interval)
-                        && let Some(flush) = drain_batch(&mut batch) {
-                            spawn_flush(
-                                flush,
-                                partition_manager.clone(),
-                                node_manager.clone(),
-                                catalog_manager.clone(),
-                                flow_notification_tx.clone(),
-                                flush_semaphore.clone(),
-                            ).await;
+                _ = async {
+                    match flush_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                        // No batch pending: stay inactive until a submission
+                        // creates one, at which point the loop top re-arms the
+                        // deadline from its creation time.
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    if let Some(flush) = drain_batch(&mut batch) {
+                        spawn_flush(
+                            flush,
+                            partition_manager.clone(),
+                            node_manager.clone(),
+                            catalog_manager.clone(),
+                            flow_notification_tx.clone(),
+                            flush_semaphore.clone(),
+                        ).await;
                     }
                 }
                 _ = shutdown_rx.recv() => {


### PR DESCRIPTION
## Summary

The pending-rows worker flushes a batch on a **worker-aligned** `tokio::time::interval(flush_interval)` tick, but the age check reads `created_at` from the **first `Submit`**. Because the tick schedule and the batch creation time are decoupled, a batch created at `t ∈ (n·fi, (n+1)·fi)` always fails the age check at tick `(n+1)·fi` and is only flushed at `(n+2)·fi`. The queueing delay is therefore `(flush_interval, 2·flush_interval)`, not `flush_interval`.

With synchronous batching (`PENDING_ROWS_BATCH_SYNC`, the default), `submit()` blocks on the flush result, so `/v1/prometheus/write` latency includes up to ~2× the interval of pure queueing. A timeout budget sized as `flush_interval + margin` (e.g. the `flush_interval + 1s` fallback from #8639) can expire before the flush even starts, causing avoidable 504s and client retries. Low-traffic periods — where `max_batch_rows` never triggers an early flush — are the most exposed.

### Fix (option 1 from the issue)

Replace the worker-aligned `interval` with a deadline anchored to `batch.created_at + flush_interval`, recomputed at the top of each loop iteration from the batch's **original** creation time. Two properties follow:

- The queueing delay becomes a stable `flush_interval` regardless of when between ticks the batch was created.
- The deadline does **not** slide as new submissions arrive (it is derived from `created_at`, not `now()`), preserving the "flush `flush_interval` after the batch was first seen" semantics.

The change is local to `start_worker` (`src/servers/src/pending_rows_batcher.rs`), +31/−15.

## Testing

Ran the `pending_rows_batcher` module suite: **39 passed, 0 failed**. No regression to the existing flush/notification/partition tests.

A dedicated wall-clock timing test (asserting the flush fires at `fi` rather than `2·fi`) would need to drive the worker with mocked `PartitionRuleManager`/`CatalogManager` under `tokio::time::pause`, which this crate has no existing scaffolding for (the flush dependencies are concrete manager refs, not the testable `PhysicalFlush*Provider` traits). Given the change is a single local transformation with clear semantics, I kept the PR to the implementation plus the existing suite — happy to add the timing test if you'd prefer, e.g. as a follow-up that threads the flush dependencies through the existing trait adapters.

Closes #8641