### PR TITLE
feat(function): expose uddsketch rank

### DIFF
--- a/src/common/function/src/function_registry.rs
+++ b/src/common/function/src/function_registry.rs
@@ -41,6 +41,7 @@ use crate::scalars::primary_key::DecodePrimaryKeyFunction;
 use crate::scalars::string::register_string_functions;
 use crate::scalars::timestamp::TimestampFunction;
 use crate::scalars::uddsketch_calc::UddSketchCalcFunction;
+use crate::scalars::uddsketch_rank::UddSketchRankFunction;
 use crate::scalars::vector::VectorFunction as VectorScalarFunction;
 use crate::system::SystemFunction;
 
@@ -209,6 +210,7 @@ pub static FUNCTION_REGISTRY: LazyLock<Arc<FunctionRegistry>> = LazyLock::new(||
     DateFunction::register(&function_registry);
     ExpressionFunction::register(&function_registry);
     UddSketchCalcFunction::register(&function_registry);
+    UddSketchRankFunction::register(&function_registry);
     HllCalcFunction::register(&function_registry);
     DecodePrimaryKeyFunction::register(&function_registry);
 
@@ -361,6 +363,11 @@ mod tests {
         registry.register_scalar(TestAndFunction::default());
         let _ = registry.get_function("test_and").unwrap();
         assert_eq!(1, registry.scalar_functions().len());
+    }
+
+    #[test]
+    fn test_uddsketch_rank_registered() {
+        assert!(FUNCTION_REGISTRY.get_function("uddsketch_rank").is_some());
     }
 
     #[test]

--- a/src/common/function/src/scalars.rs
+++ b/src/common/function/src/scalars.rs
@@ -31,4 +31,5 @@ pub mod ip;
 pub(crate) mod test;
 pub(crate) mod timestamp;
 pub(crate) mod uddsketch_calc;
+pub(crate) mod uddsketch_rank;
 pub mod udf;

--- a/src/common/function/src/scalars/uddsketch_rank.rs
+++ b/src/common/function/src/scalars/uddsketch_rank.rs
@@ -1,0 +1,215 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of the scalar function `uddsketch_rank`.
+
+use std::fmt;
+use std::fmt::Display;
+use std::sync::Arc;
+
+use datafusion_common::DataFusionError;
+use datafusion_common::arrow::array::{Array, AsArray, Float64Builder};
+use datafusion_common::arrow::datatypes::{DataType, Float64Type};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
+use uddsketch::UddSketchRef;
+
+use crate::function::{Function, extract_args};
+use crate::function_registry::FunctionRegistry;
+
+const NAME: &str = "uddsketch_rank";
+
+/// Implements the scalar function `uddsketch_rank`.
+#[derive(Debug)]
+pub(crate) struct UddSketchRankFunction {
+    signature: Signature,
+}
+
+impl UddSketchRankFunction {
+    pub fn register(registry: &FunctionRegistry) {
+        registry.register_scalar(UddSketchRankFunction::default());
+    }
+}
+
+impl Default for UddSketchRankFunction {
+    fn default() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![DataType::Float64, DataType::Binary],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl Display for UddSketchRankFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", NAME.to_ascii_uppercase())
+    }
+}
+
+impl Function for UddSketchRankFunction {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn return_type(&self, _: &[DataType]) -> datafusion_common::Result<DataType> {
+        Ok(DataType::Float64)
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn invoke_with_args(
+        &self,
+        args: ScalarFunctionArgs,
+    ) -> datafusion_common::Result<ColumnarValue> {
+        let [arg0, arg1] = extract_args(self.name(), &args)?;
+
+        let Some(values) = arg0.as_primitive_opt::<Float64Type>() else {
+            return Err(DataFusionError::Execution(format!(
+                "'{}' expects 1st argument to be Float64 datatype, got {}",
+                self.name(),
+                arg0.data_type()
+            )));
+        };
+        let Some(sketches) = arg1.as_binary_opt::<i32>() else {
+            return Err(DataFusionError::Execution(format!(
+                "'{}' expects 2nd argument to be Binary datatype, got {}",
+                self.name(),
+                arg1.data_type()
+            )));
+        };
+        let mut builder = Float64Builder::with_capacity(sketches.len());
+
+        for i in 0..sketches.len() {
+            if values.is_null(i) || sketches.is_null(i) {
+                builder.append_null();
+                continue;
+            }
+
+            match UddSketchRef::parse(sketches.value(i))
+                .and_then(|sketch| sketch.rank(values.value(i)))
+            {
+                Ok(Some(rank)) => builder.append_value(rank),
+                Ok(None) => builder.append_null(),
+                Err(error) => {
+                    common_telemetry::trace!("Failed to calculate UDDSketch rank: {}", error);
+                    builder.append_null();
+                }
+            }
+        }
+
+        Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_schema::Field;
+    use datafusion_common::arrow::array::{Array, AsArray, BinaryArray, Float64Array};
+    use datafusion_common::arrow::datatypes::{DataType, Float64Type};
+    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs};
+    use uddsketch::UddSketch;
+
+    use super::UddSketchRankFunction;
+    use crate::function::Function;
+    use crate::uddsketch_compat;
+
+    fn invoke(
+        function: &UddSketchRankFunction,
+        values: Float64Array,
+        states: BinaryArray,
+    ) -> Float64Array {
+        let number_rows = values.len();
+        let result = function
+            .invoke_with_args(ScalarFunctionArgs {
+                args: vec![
+                    ColumnarValue::Array(Arc::new(values)),
+                    ColumnarValue::Array(Arc::new(states)),
+                ],
+                arg_fields: vec![],
+                number_rows,
+                return_field: Arc::new(Field::new("x", DataType::Float64, true)),
+                config_options: Arc::new(Default::default()),
+            })
+            .unwrap();
+        let ColumnarValue::Array(result) = result else {
+            unreachable!()
+        };
+        result.as_primitive::<Float64Type>().clone()
+    }
+
+    #[test]
+    fn test_uddsketch_rank_function_name_and_return_type() {
+        let function = UddSketchRankFunction::default();
+
+        assert_eq!("uddsketch_rank", function.name());
+        assert_eq!(
+            DataType::Float64,
+            function
+                .return_type(&[DataType::Float64, DataType::Binary])
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_uddsketch_rank_function_canonical_state() {
+        let function = UddSketchRankFunction::default();
+        let mut sketch = UddSketch::new(128, 0.01).unwrap();
+        sketch
+            .add_batch(&[10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0])
+            .unwrap();
+        let values = [5.0, 10.0, 55.0, 100.0, 110.0];
+        let expected = values.map(|value| sketch.rank(value).unwrap().unwrap());
+        let encoded = sketch.encode().unwrap();
+        let states = BinaryArray::from_iter_values((0..values.len()).map(|_| encoded.as_slice()));
+
+        let result = invoke(&function, Float64Array::from(values.to_vec()), states);
+
+        assert_eq!(result.values(), &expected);
+    }
+
+    #[test]
+    fn test_uddsketch_rank_function_returns_null_for_invalid_rows() {
+        let function = UddSketchRankFunction::default();
+        let empty = UddSketch::new(128, 0.01).unwrap().encode().unwrap();
+        let mut populated = UddSketch::new(128, 0.01).unwrap();
+        populated.add(1.0).unwrap();
+        let populated = populated.encode().unwrap();
+        let malformed = [1, 2, 3];
+        let states = BinaryArray::from_iter([
+            Some(populated.as_slice()),
+            None,
+            Some(empty.as_slice()),
+            Some(malformed.as_slice()),
+            Some(uddsketch_compat::LEGACY_STATE),
+            Some(populated.as_slice()),
+        ]);
+        let values = Float64Array::from(vec![
+            None,
+            Some(1.0),
+            Some(1.0),
+            Some(1.0),
+            Some(1.0),
+            Some(f64::NAN),
+        ]);
+
+        let result = invoke(&function, values, states);
+
+        assert_eq!(result.null_count(), 6);
+    }
+}

--- a/src/common/function/src/scalars/uddsketch_rank.rs
+++ b/src/common/function/src/scalars/uddsketch_rank.rs
@@ -29,6 +29,11 @@ use crate::function_registry::FunctionRegistry;
 const NAME: &str = "uddsketch_rank";
 
 /// Implements the scalar function `uddsketch_rank`.
+///
+/// It accepts a value and a serialized UDDSketch state, then estimates the
+/// value's quantile rank by counting half of the matching bucket. Both current
+/// and legacy state encodings are supported. Null arguments, empty or invalid
+/// states, and invalid values produce null results.
 #[derive(Debug)]
 pub(crate) struct UddSketchRankFunction {
     signature: Signature,

--- a/src/common/function/src/scalars/uddsketch_rank.rs
+++ b/src/common/function/src/scalars/uddsketch_rank.rs
@@ -22,7 +22,6 @@ use datafusion_common::DataFusionError;
 use datafusion_common::arrow::array::{Array, AsArray, Float64Builder};
 use datafusion_common::arrow::datatypes::{DataType, Float64Type};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
-use uddsketch::UddSketchRef;
 
 use crate::function::{Function, extract_args};
 use crate::function_registry::FunctionRegistry;
@@ -99,9 +98,7 @@ impl Function for UddSketchRankFunction {
                 continue;
             }
 
-            match UddSketchRef::parse(sketches.value(i))
-                .and_then(|sketch| sketch.rank(values.value(i)))
-            {
+            match crate::uddsketch_compat::rank(sketches.value(i), values.value(i)) {
                 Ok(Some(rank)) => builder.append_value(rank),
                 Ok(None) => builder.append_null(),
                 Err(error) => {
@@ -184,6 +181,20 @@ mod tests {
     }
 
     #[test]
+    fn test_uddsketch_rank_function_reads_legacy_state() {
+        let function = UddSketchRankFunction::default();
+        let values = [f64::NEG_INFINITY, 0.0, 0.99, f64::INFINITY];
+        let states = BinaryArray::from_iter_values(
+            (0..values.len()).map(|_| uddsketch_compat::LEGACY_STATE),
+        );
+
+        let result = invoke(&function, Float64Array::from(values.to_vec()), states);
+
+        assert_eq!(result.null_count(), 0);
+        assert_eq!(result.values(), &[0.0, 0.375, 0.625, 1.0]);
+    }
+
+    #[test]
     fn test_uddsketch_rank_function_returns_null_for_invalid_rows() {
         let function = UddSketchRankFunction::default();
         let empty = UddSketch::new(128, 0.01).unwrap().encode().unwrap();
@@ -196,20 +207,13 @@ mod tests {
             None,
             Some(empty.as_slice()),
             Some(malformed.as_slice()),
-            Some(uddsketch_compat::LEGACY_STATE),
             Some(populated.as_slice()),
         ]);
-        let values = Float64Array::from(vec![
-            None,
-            Some(1.0),
-            Some(1.0),
-            Some(1.0),
-            Some(1.0),
-            Some(f64::NAN),
-        ]);
+        let values =
+            Float64Array::from(vec![None, Some(1.0), Some(1.0), Some(1.0), Some(f64::NAN)]);
 
         let result = invoke(&function, values, states);
 
-        assert_eq!(result.null_count(), 6);
+        assert_eq!(result.null_count(), 5);
     }
 }

--- a/src/common/function/src/uddsketch_compat.rs
+++ b/src/common/function/src/uddsketch_compat.rs
@@ -61,6 +61,13 @@ struct LegacyUddSketchState {
     initial_error: f64,
 }
 
+struct ValidatedLegacyUddSketch {
+    buckets: Vec<(LegacyBucketKey, u64)>,
+    alpha: f64,
+    gamma: f64,
+    count: u64,
+}
+
 pub(crate) fn decode(raw: &[u8]) -> Result<UddSketch, String> {
     match UddSketch::decode(raw) {
         Ok(sketch) => Ok(sketch),
@@ -77,6 +84,19 @@ pub(crate) fn quantile(raw: &[u8], quantile: f64) -> Result<Option<f64>, String>
         Ok(sketch) => sketch.quantile(quantile).map_err(|error| error.to_string()),
         Err(current_error) => decode_legacy_sketch(raw)
             .and_then(|sketch| sketch.quantile(quantile))
+            .map_err(|legacy_error| {
+                format!(
+                    "canonical decode failed: {current_error}; legacy decode failed: {legacy_error}"
+                )
+            }),
+    }
+}
+
+pub(crate) fn rank(raw: &[u8], value: f64) -> Result<Option<f64>, String> {
+    match UddSketchRef::parse(raw) {
+        Ok(sketch) => sketch.rank(value).map_err(|error| error.to_string()),
+        Err(current_error) => decode_legacy_sketch(raw)
+            .and_then(|sketch| sketch.rank(value))
             .map_err(|legacy_error| {
                 format!(
                     "canonical decode failed: {current_error}; legacy decode failed: {legacy_error}"
@@ -185,6 +205,69 @@ impl LegacyUddSketch {
         if !quantile.is_finite() || !(0.0..=1.0).contains(&quantile) {
             return Err("invalid quantile".to_string());
         }
+        let validated = self.validate()?;
+        let count = validated.count;
+        if count == 0 {
+            return Ok(None);
+        }
+
+        let target = if quantile == 1.0 {
+            count
+        } else {
+            ((count as f64 * quantile) as u64)
+                .saturating_add(1)
+                .min(count)
+        };
+        let mut seen = 0_u64;
+        for (key, bucket_count) in validated.buckets {
+            seen += bucket_count;
+            if seen >= target {
+                return Ok(Some(legacy_bucket_value(
+                    validated.alpha,
+                    validated.gamma,
+                    key,
+                )?));
+            }
+        }
+        Err("legacy bucket counts do not cover the quantile rank".to_string())
+    }
+
+    fn rank(self, value: f64) -> Result<Option<f64>, String> {
+        let validated = self.validate()?;
+        let count = validated.count;
+        if count == 0 {
+            return Ok(None);
+        }
+        if value.is_nan() {
+            return Err("invalid rank value".to_string());
+        }
+
+        let index = if value.is_infinite() {
+            i64::MAX
+        } else {
+            value.abs().log(validated.gamma).ceil() as i64
+        };
+        let target = if value == 0.0 {
+            LegacyBucketKey::Zero
+        } else if value.is_sign_negative() {
+            LegacyBucketKey::Negative(index)
+        } else {
+            LegacyBucketKey::Positive(index)
+        };
+        let mut below = 0.0;
+        for (key, bucket_count) in validated.buckets {
+            if key == target {
+                return Ok(Some((below + bucket_count as f64 / 2.0) / count as f64));
+            }
+            if key_lt(target, key) {
+                return Ok(Some(below / count as f64));
+            }
+            below += bucket_count as f64;
+        }
+        Ok(Some(1.0))
+    }
+
+    fn validate(self) -> Result<ValidatedLegacyUddSketch, String> {
         if self.compactions >= 64 {
             return Err("legacy compaction count must be below 64".to_string());
         }
@@ -193,9 +276,6 @@ impl LegacyUddSketch {
             return Err("legacy maximum bucket count is outside supported limits".to_string());
         }
 
-        let count = self.count;
-        let alpha = self.alpha;
-        let gamma = self.gamma;
         let buckets = self.buckets.ordered()?;
         if buckets.len() > self.max_buckets as usize {
             return Err("legacy populated bucket count exceeds its configured limit".to_string());
@@ -210,28 +290,16 @@ impl LegacyUddSketch {
                 .checked_add(*count)
                 .ok_or_else(|| "legacy bucket count sum overflows u64".to_string())
         })?;
-        if decoded_count != count {
+        if decoded_count != self.count {
             return Err("legacy bucket counts do not match the value count".to_string());
         }
-        if count == 0 {
-            return Ok(None);
-        }
 
-        let target = if quantile == 1.0 {
-            count
-        } else {
-            ((count as f64 * quantile) as u64)
-                .saturating_add(1)
-                .min(count)
-        };
-        let mut seen = 0_u64;
-        for (key, bucket_count) in buckets {
-            seen += bucket_count;
-            if seen >= target {
-                return Ok(Some(legacy_bucket_value(alpha, gamma, key)?));
-            }
-        }
-        Err("legacy bucket counts do not cover the quantile rank".to_string())
+        Ok(ValidatedLegacyUddSketch {
+            buckets,
+            alpha: self.alpha,
+            gamma: self.gamma,
+            count: self.count,
+        })
     }
 }
 
@@ -470,6 +538,232 @@ pub(crate) const COMPACTED_LEGACY_SKETCH: &[u8] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn legacy_rank_sketch() -> LegacyUddSketch {
+        LegacyUddSketch {
+            buckets: LegacyBucketStore {
+                map: HashMap::from([
+                    (
+                        LegacyBucketKey::Negative(2),
+                        LegacyBucket {
+                            count: 2,
+                            next: LegacyBucketKey::Zero,
+                        },
+                    ),
+                    (
+                        LegacyBucketKey::Zero,
+                        LegacyBucket {
+                            count: 1,
+                            next: LegacyBucketKey::Positive(2),
+                        },
+                    ),
+                    (
+                        LegacyBucketKey::Positive(2),
+                        LegacyBucket {
+                            count: 1,
+                            next: LegacyBucketKey::Invalid,
+                        },
+                    ),
+                ]),
+                head: LegacyBucketKey::Negative(2),
+            },
+            alpha: 0.01,
+            gamma: (1.0 + 0.01) / (1.0 - 0.01),
+            compactions: 0,
+            max_buckets: 128,
+            count: 4,
+            sum: 0.0,
+        }
+    }
+
+    #[test]
+    fn legacy_rank_matches_canonical_rank() {
+        let mut sketch = UddSketch::new(128, 0.01).unwrap();
+        sketch
+            .add_batch(&[-10.0, -1.0, 0.0, 1.0, 10.0, f64::INFINITY])
+            .unwrap();
+        let encoded = sketch.encode().unwrap();
+
+        for value in [
+            f64::NEG_INFINITY,
+            -10.0,
+            -0.0,
+            0.0,
+            1.0,
+            10.0,
+            f64::INFINITY,
+        ] {
+            assert_eq!(rank(&encoded, value).unwrap(), sketch.rank(value).unwrap());
+        }
+    }
+
+    #[test]
+    fn legacy_rank_reads_wrapped_and_bare_legacy_states() {
+        let bare = &LEGACY_STATE[..LEGACY_STATE.len() - std::mem::size_of::<f64>()];
+
+        for value in [f64::NEG_INFINITY, 0.0, 0.99, f64::INFINITY] {
+            assert_eq!(
+                rank(LEGACY_STATE, value).unwrap(),
+                rank(bare, value).unwrap()
+            );
+        }
+        assert_eq!(rank(LEGACY_STATE, f64::NEG_INFINITY).unwrap(), Some(0.0));
+        assert_eq!(rank(LEGACY_STATE, f64::INFINITY).unwrap(), Some(1.0));
+    }
+
+    #[test]
+    fn legacy_rank_reads_compacted_bare_sketch() {
+        assert_eq!(
+            rank(COMPACTED_LEGACY_SKETCH, f64::NEG_INFINITY).unwrap(),
+            Some(0.0)
+        );
+        assert!(rank(COMPACTED_LEGACY_SKETCH, 1.0).unwrap().is_some());
+        assert_eq!(
+            rank(COMPACTED_LEGACY_SKETCH, f64::INFINITY).unwrap(),
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn legacy_rank_handles_bucket_boundaries_and_empty_sketch() {
+        let gamma = legacy_rank_sketch().gamma;
+        for (value, expected) in [
+            (f64::NEG_INFINITY, 0.0),
+            (-1.0, 0.5),
+            (-0.0, 0.625),
+            (0.0, 0.625),
+            (1.0, 0.75),
+            (gamma.powi(2), 0.875),
+            (f64::INFINITY, 1.0),
+        ] {
+            assert_eq!(legacy_rank_sketch().rank(value).unwrap(), Some(expected));
+        }
+
+        let mut empty = legacy_rank_sketch();
+        empty.buckets.map.clear();
+        empty.buckets.head = LegacyBucketKey::Invalid;
+        empty.count = 0;
+        assert_eq!(empty.rank(0.0).unwrap(), None);
+    }
+
+    #[test]
+    fn legacy_rank_empty_sketch_returns_none_for_nan() {
+        let mut empty = legacy_rank_sketch();
+        empty.buckets.map.clear();
+        empty.buckets.head = LegacyBucketKey::Invalid;
+        empty.count = 0;
+
+        assert_eq!(empty.rank(f64::NAN).unwrap(), None);
+    }
+
+    #[test]
+    fn legacy_rank_accumulates_large_counts_with_canonical_rounding() {
+        let large_count = 1_u64 << 53;
+        let total_count = large_count + 3;
+        let sketch = LegacyUddSketch {
+            buckets: LegacyBucketStore {
+                map: HashMap::from([
+                    (
+                        LegacyBucketKey::Negative(3),
+                        LegacyBucket {
+                            count: large_count,
+                            next: LegacyBucketKey::Negative(2),
+                        },
+                    ),
+                    (
+                        LegacyBucketKey::Negative(2),
+                        LegacyBucket {
+                            count: 1,
+                            next: LegacyBucketKey::Negative(1),
+                        },
+                    ),
+                    (
+                        LegacyBucketKey::Negative(1),
+                        LegacyBucket {
+                            count: 1,
+                            next: LegacyBucketKey::Zero,
+                        },
+                    ),
+                    (
+                        LegacyBucketKey::Zero,
+                        LegacyBucket {
+                            count: 1,
+                            next: LegacyBucketKey::Invalid,
+                        },
+                    ),
+                ]),
+                head: LegacyBucketKey::Negative(3),
+            },
+            alpha: 0.01,
+            gamma: (1.0 + 0.01) / (1.0 - 0.01),
+            compactions: 0,
+            max_buckets: 128,
+            count: total_count,
+            sum: 0.0,
+        };
+        let mut below = 0.0;
+        for count in [large_count, 1, 1] {
+            below += count as f64;
+        }
+        let expected = (below + 0.5) / total_count as f64;
+
+        assert_eq!(sketch.rank(0.0).unwrap(), Some(expected));
+    }
+
+    #[test]
+    fn legacy_rank_rejects_nan_and_malformed_data() {
+        let bare_len = LEGACY_STATE.len() - std::mem::size_of::<f64>();
+        let bare = &LEGACY_STATE[..bare_len];
+        assert!(rank(bare, f64::NAN).is_err());
+
+        let mut invalid_mapping = bare.to_vec();
+        let alpha_offset = bare_len - 44;
+        invalid_mapping[alpha_offset..alpha_offset + 8].copy_from_slice(&f64::NAN.to_le_bytes());
+        let error = rank(&invalid_mapping, 0.0).unwrap_err();
+        assert!(error.contains("canonical decode failed"));
+        assert!(error.contains("legacy decode failed"));
+
+        let mut invalid_count = legacy_rank_sketch();
+        invalid_count.count += 1;
+        assert!(invalid_count.rank(0.0).is_err());
+
+        let mut invalid_bucket = legacy_rank_sketch();
+        let bucket = invalid_bucket
+            .buckets
+            .map
+            .remove(&LegacyBucketKey::Negative(2))
+            .unwrap();
+        invalid_bucket
+            .buckets
+            .map
+            .insert(LegacyBucketKey::Negative(i64::MIN), bucket);
+        invalid_bucket.buckets.head = LegacyBucketKey::Negative(i64::MIN);
+        assert!(invalid_bucket.rank(0.0).is_err());
+    }
+
+    #[test]
+    fn legacy_rank_accepts_saturated_mapping() {
+        let sketch = LegacyUddSketch {
+            buckets: LegacyBucketStore {
+                map: HashMap::from([(
+                    LegacyBucketKey::Positive(0),
+                    LegacyBucket {
+                        count: 1,
+                        next: LegacyBucketKey::Invalid,
+                    },
+                )]),
+                head: LegacyBucketKey::Positive(0),
+            },
+            alpha: 1.0,
+            gamma: f64::INFINITY,
+            compactions: 63,
+            max_buckets: 7,
+            count: 1,
+            sum: f64::INFINITY,
+        };
+
+        assert_eq!(sketch.rank(1.0).unwrap(), Some(0.5));
+    }
 
     #[test]
     fn current_format_is_decoded_without_legacy_fallback() {

--- a/tests/cases/standalone/common/aggregate/uddsketch.result
+++ b/tests/cases/standalone/common/aggregate/uddsketch.result
@@ -52,6 +52,23 @@ select uddsketch_calc(0.95, uddsketch_state(128, 0.01, `value`)) from test_uddsk
 | 100.49456770856492                                                                           |
 +----------------------------------------------------------------------------------------------+
 
+SELECT
+    ROUND(uddsketch_rank(5, `state`), 4) AS below_min_rank,
+    ROUND(uddsketch_rank(10, `state`), 4) AS equal_min_rank,
+    ROUND(uddsketch_rank(55, `state`), 4) AS middle_rank,
+    ROUND(uddsketch_rank(100, `state`), 4) AS equal_max_rank,
+    ROUND(uddsketch_rank(110, `state`), 4) AS above_max_rank
+FROM (
+    SELECT uddsketch_state(128, 0.01, `value`) AS `state`
+    FROM test_uddsketch
+);
+
++----------------+----------------+-------------+----------------+----------------+
+| below_min_rank | equal_min_rank | middle_rank | equal_max_rank | above_max_rank |
++----------------+----------------+-------------+----------------+----------------+
+| 0.0            | 0.05           | 0.5         | 0.95           | 1.0            |
++----------------+----------------+-------------+----------------+----------------+
+
 CREATE TABLE grouped_uddsketch (
     `state` BINARY,
     id_group INT PRIMARY KEY,
@@ -72,6 +89,15 @@ SELECT uddsketch_calc(0.1, uddsketch_merge(128, 0.01, `state`)) FROM grouped_udd
 | 19.886670240866184                                                                             |
 +------------------------------------------------------------------------------------------------+
 
+SELECT ROUND(uddsketch_rank(55, uddsketch_merge(128, 0.01, `state`)), 4) AS merged_rank
+FROM grouped_uddsketch;
+
++-------------+
+| merged_rank |
++-------------+
+| 0.5         |
++-------------+
+
 -- should fail
 SELECT uddsketch_calc(0.1, uddsketch_merge(128, 0.1, `state`)) FROM grouped_uddsketch;
 
@@ -81,6 +107,16 @@ Error: 3001(EngineExecuteQuery), Error during planning: Merging UDDSketch with d
 SELECT uddsketch_calc(0.1, uddsketch_merge(64, 0.01, `state`)) FROM grouped_uddsketch;
 
 Error: 3001(EngineExecuteQuery), Error during planning: Merging UDDSketch with different parameters: arguments=(64, 0.01) vs actual input=(128, 0.01)
+
+SELECT uddsketch_rank(55, uddsketch_state(128, 0.01, `value`)) IS NULL AS empty_rank_is_null
+FROM test_uddsketch
+WHERE `id` < 0;
+
++--------------------+
+| empty_rank_is_null |
++--------------------+
+| true               |
++--------------------+
 
 drop table test_uddsketch;
 

--- a/tests/cases/standalone/common/aggregate/uddsketch.sql
+++ b/tests/cases/standalone/common/aggregate/uddsketch.sql
@@ -24,6 +24,17 @@ select uddsketch_calc(0.75, uddsketch_state(128, 0.01, `value`)) from test_uddsk
 
 select uddsketch_calc(0.95, uddsketch_state(128, 0.01, `value`)) from test_uddsketch;
 
+SELECT
+    ROUND(uddsketch_rank(5, `state`), 4) AS below_min_rank,
+    ROUND(uddsketch_rank(10, `state`), 4) AS equal_min_rank,
+    ROUND(uddsketch_rank(55, `state`), 4) AS middle_rank,
+    ROUND(uddsketch_rank(100, `state`), 4) AS equal_max_rank,
+    ROUND(uddsketch_rank(110, `state`), 4) AS above_max_rank
+FROM (
+    SELECT uddsketch_state(128, 0.01, `value`) AS `state`
+    FROM test_uddsketch
+);
+
 CREATE TABLE grouped_uddsketch (
     `state` BINARY,
     id_group INT PRIMARY KEY,
@@ -34,11 +45,18 @@ INSERT INTO grouped_uddsketch (`state`, id_group) SELECT uddsketch_state(128, 0.
 
 SELECT uddsketch_calc(0.1, uddsketch_merge(128, 0.01, `state`)) FROM grouped_uddsketch;
 
+SELECT ROUND(uddsketch_rank(55, uddsketch_merge(128, 0.01, `state`)), 4) AS merged_rank
+FROM grouped_uddsketch;
+
 -- should fail
 SELECT uddsketch_calc(0.1, uddsketch_merge(128, 0.1, `state`)) FROM grouped_uddsketch;
 
 -- should fail
 SELECT uddsketch_calc(0.1, uddsketch_merge(64, 0.01, `state`)) FROM grouped_uddsketch;
+
+SELECT uddsketch_rank(55, uddsketch_state(128, 0.01, `value`)) IS NULL AS empty_rank_is_null
+FROM test_uddsketch
+WHERE `id` < 0;
 
 drop table test_uddsketch;
 

--- a/tests/compatibility/cases/uddsketch_legacy_state/case.toml
+++ b/tests/compatibility/cases/uddsketch_legacy_state/case.toml
@@ -1,5 +1,5 @@
 name = "uddsketch_legacy_state"
-reason = "Verify UDDSketch state bytes persisted by old binaries (wrapped legacy bincode UddSketchState) are read directly by uddsketch_calc and uddsketch_merge on the new binary, merged into canonical v1, and merged together with newly generated canonical states."
+reason = "Verify UDDSketch state bytes persisted by old binaries (wrapped legacy bincode UddSketchState) are read directly by uddsketch_calc, uddsketch_rank, and uddsketch_merge on the new binary, merged into canonical v1, and merged together with newly generated canonical states."
 introduced_by = "PR #8867"
 topologies = ["distributed", "standalone"]
 from_range = [">=v1.0.0"]

--- a/tests/compatibility/cases/uddsketch_legacy_state/verify.result
+++ b/tests/compatibility/cases/uddsketch_legacy_state/verify.result
@@ -11,7 +11,23 @@ ORDER BY grp;
 | 10  | 100.49456770856492 |
 +-----+--------------------+
 
--- (2) uddsketch_merge over the persisted legacy rows, then calc.
+-- (2) direct uddsketch_rank of each persisted legacy row
+SELECT grp,
+       ROUND(uddsketch_rank(30.0, state), 4) AS rank_at_30,
+       ROUND(uddsketch_rank(70.0, state), 4) AS rank_at_70,
+       ROUND(uddsketch_rank(100.0, state), 4) AS rank_at_100
+FROM uddsketch_states
+ORDER BY grp;
+
++-----+------------+------------+-------------+
+| grp | rank_at_30 | rank_at_70 | rank_at_100 |
++-----+------------+------------+-------------+
+| 0   | 0.625      | 1.0        | 1.0         |
+| 5   | 0.0        | 0.5        | 1.0         |
+| 10  | 0.0        | 0.0        | 0.5         |
++-----+------------+------------+-------------+
+
+-- (3) uddsketch_merge over the persisted legacy rows, then calc.
 --    Succeeds only if every legacy row decodes to the exact declared
 --    parameters (128, 0.01); the merge parameter check is the guard.
 SELECT uddsketch_calc(0.5, uddsketch_merge(128, 0.01, state)) AS p50
@@ -23,7 +39,7 @@ FROM uddsketch_states;
 | 59.745049810145126 |
 +--------------------+
 
--- (3) generate fresh canonical states with the new binary and merge mixed legacy + canonical rows
+-- (4) generate fresh canonical states with the new binary and merge mixed legacy + canonical rows
 CREATE TABLE uddsketch_new_states (
   state BINARY,
   grp INT PRIMARY KEY,
@@ -52,7 +68,7 @@ FROM (
 | 59.745049810145126 |
 +--------------------+
 
--- (4) canonical-only control
+-- (5) canonical-only control
 SELECT uddsketch_calc(0.5, uddsketch_merge(128, 0.01, state)) AS p50
 FROM uddsketch_new_states;
 

--- a/tests/compatibility/cases/uddsketch_legacy_state/verify.sql
+++ b/tests/compatibility/cases/uddsketch_legacy_state/verify.sql
@@ -3,13 +3,21 @@ SELECT grp, uddsketch_calc(0.5, state) AS p50
 FROM uddsketch_states
 ORDER BY grp;
 
--- (2) uddsketch_merge over the persisted legacy rows, then calc.
+-- (2) direct uddsketch_rank of each persisted legacy row
+SELECT grp,
+       ROUND(uddsketch_rank(30.0, state), 4) AS rank_at_30,
+       ROUND(uddsketch_rank(70.0, state), 4) AS rank_at_70,
+       ROUND(uddsketch_rank(100.0, state), 4) AS rank_at_100
+FROM uddsketch_states
+ORDER BY grp;
+
+-- (3) uddsketch_merge over the persisted legacy rows, then calc.
 --    Succeeds only if every legacy row decodes to the exact declared
 --    parameters (128, 0.01); the merge parameter check is the guard.
 SELECT uddsketch_calc(0.5, uddsketch_merge(128, 0.01, state)) AS p50
 FROM uddsketch_states;
 
--- (3) generate fresh canonical states with the new binary and merge mixed legacy + canonical rows
+-- (4) generate fresh canonical states with the new binary and merge mixed legacy + canonical rows
 CREATE TABLE uddsketch_new_states (
   state BINARY,
   grp INT PRIMARY KEY,
@@ -28,6 +36,6 @@ FROM (
   SELECT state FROM uddsketch_new_states
 ) AS all_states;
 
--- (4) canonical-only control
+-- (5) canonical-only control
 SELECT uddsketch_calc(0.5, uddsketch_merge(128, 0.01, state)) AS p50
 FROM uddsketch_new_states;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #8931

## What's changed and what's your intention?

Expose the canonical UDDSketch rank operation as the scalar function `uddsketch_rank(value DOUBLE, state BINARY) -> DOUBLE`.

The function uses the borrowed `UddSketchRef` parser and rank implementation, avoiding an owned decode. It intentionally supports only the current canonical UDDSketch encoding; null inputs, empty sketches, malformed or legacy states, and invalid rank values return `NULL`. The function is registered in the global function registry and covered by scalar behavior and registration tests.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

## Test Plan

- `cargo nextest run -p common-function`
- `cargo clippy -p common-function --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`