### PR TITLE
fix(mito2): use target sequence for foreign SSTs

### DIFF
--- a/src/mito2/src/engine/apply_staging_manifest_test.rs
+++ b/src/mito2/src/engine/apply_staging_manifest_test.rs
@@ -12,20 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::{assert_matches, fs};
 
 use api::v1::Rows;
+use api::v1::region::{StrictWindow, compact_request};
 use common_function::utils::partition_expr_version;
 use common_recordbatch::RecordBatches;
+use datatypes::arrow::array::AsArray;
+use datatypes::arrow::datatypes::Float64Type;
 use datatypes::value::Value;
 use partition::expr::{PartitionExpr, col};
 use store_api::region_engine::{
     RegionEngine, RegionRole, RemapManifestsRequest, SettableRegionRoleState,
 };
 use store_api::region_request::{
-    ApplyStagingManifestRequest, EnterStagingRequest, RegionFlushRequest, RegionPutRequest,
-    RegionRequest, StagingPartitionDirective,
+    ApplyStagingManifestRequest, EnterStagingRequest, RegionCompactRequest, RegionFlushRequest,
+    RegionPutRequest, RegionRequest, StagingPartitionDirective,
 };
 use store_api::storage::{FileId, RegionId};
 
@@ -37,12 +41,200 @@ use crate::manifest::action::{
 };
 use crate::sst::FormatType;
 use crate::sst::file::FileMeta;
-use crate::test_util::{CreateRequestBuilder, TestEnv, build_rows, put_rows, rows_schema};
+use crate::test_util::{
+    CreateRequestBuilder, TestEnv, build_rows, build_rows_for_key, put_rows, rows_schema,
+};
 
 fn range_expr(col_name: &str, start: i64, end: i64) -> PartitionExpr {
     col(col_name)
         .gt_eq(Value::Int64(start))
         .and(col(col_name).lt(Value::Int64(end)))
+}
+
+#[tokio::test]
+async fn test_apply_staging_manifest_sequence_domain() {
+    common_telemetry::init_default_ut_logging();
+    test_apply_staging_manifest_sequence_domain_with_format(false).await;
+    test_apply_staging_manifest_sequence_domain_with_format(true).await;
+}
+
+async fn test_apply_staging_manifest_sequence_domain_with_format(flat_format: bool) {
+    let mut env = TestEnv::with_prefix("apply-staging-sequence-domain").await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: flat_format,
+            ..Default::default()
+        })
+        .await;
+    let source = RegionId::new(1, 1);
+    let target = RegionId::new(1, 2);
+    let request = CreateRequestBuilder::new().build();
+    let schema = rows_schema(&request);
+
+    engine
+        .handle_request(source, RegionRequest::Create(request.clone()))
+        .await
+        .unwrap();
+    for value in 0..3 {
+        put_rows(
+            &engine,
+            source,
+            Rows {
+                schema: schema.clone(),
+                rows: build_rows_for_key("0", 0, 1, value),
+            },
+        )
+        .await;
+    }
+    engine
+        .handle_request(source, RegionRequest::Flush(RegionFlushRequest::default()))
+        .await
+        .unwrap();
+    let source_manifest = engine
+        .get_region(source)
+        .unwrap()
+        .manifest_ctx
+        .manifest()
+        .await;
+    assert_eq!(source_manifest.files.len(), 1);
+    assert_eq!(
+        source_manifest.files.values().next().unwrap().sequence,
+        Some(std::num::NonZeroU64::new(3).unwrap())
+    );
+
+    engine
+        .set_region_role_state_gracefully(source, SettableRegionRoleState::StagingLeader)
+        .await
+        .unwrap();
+    let partition_expr = float_range_expr("field_0", 0.1, 100.1)
+        .as_json_str()
+        .unwrap();
+    let result = engine
+        .remap_manifests(RemapManifestsRequest {
+            region_id: source,
+            input_regions: vec![source],
+            region_mapping: [(source, vec![target])].into_iter().collect(),
+            new_partition_exprs: [(target, partition_expr.clone())].into_iter().collect(),
+        })
+        .await
+        .unwrap();
+    engine
+        .handle_request(target, RegionRequest::Create(request.clone()))
+        .await
+        .unwrap();
+    engine
+        .handle_request(
+            target,
+            RegionRequest::EnterStaging(EnterStagingRequest {
+                partition_directive: StagingPartitionDirective::UpdatePartitionExpr(
+                    partition_expr.clone(),
+                ),
+            }),
+        )
+        .await
+        .unwrap();
+    engine
+        .handle_request(
+            target,
+            RegionRequest::ApplyStagingManifest(ApplyStagingManifestRequest {
+                partition_expr,
+                central_region_id: source,
+                manifest_path: result.manifest_paths[&target].clone(),
+            }),
+        )
+        .await
+        .unwrap();
+
+    let manifest = engine
+        .get_region(target)
+        .unwrap()
+        .manifest_ctx
+        .manifest()
+        .await;
+    assert_eq!(manifest.files.len(), 1);
+    assert_eq!(manifest.committed_sequence, Some(1));
+    assert_eq!(
+        manifest.files.values().next().unwrap().sequence,
+        Some(std::num::NonZeroU64::new(1).unwrap())
+    );
+
+    put_rows(
+        &engine,
+        target,
+        Rows {
+            schema: schema.clone(),
+            rows: build_rows_for_key("0", 0, 1, 99),
+        },
+    )
+    .await;
+    assert_target_value(&engine, target, 99.0).await;
+
+    engine
+        .handle_request(target, RegionRequest::Flush(RegionFlushRequest::default()))
+        .await
+        .unwrap();
+    let input_ids = current_file_ids(&engine, target);
+    assert_eq!(
+        input_ids.len(),
+        2,
+        "imported and target-write SSTs must both exist"
+    );
+
+    engine
+        .handle_request(
+            target,
+            RegionRequest::Compact(RegionCompactRequest {
+                options: compact_request::Options::StrictWindow(StrictWindow {
+                    window_seconds: 60,
+                }),
+                parallelism: None,
+                time_range: None,
+            }),
+        )
+        .await
+        .unwrap();
+    let output_ids = current_file_ids(&engine, target);
+    assert_eq!(output_ids.len(), 1);
+    assert!(
+        input_ids.iter().all(|id| !output_ids.contains(id)),
+        "real compaction must replace both input SSTs"
+    );
+    assert_target_value(&engine, target, 99.0).await;
+}
+
+fn current_file_ids(engine: &crate::engine::MitoEngine, region_id: RegionId) -> HashSet<FileId> {
+    engine
+        .get_region(region_id)
+        .unwrap()
+        .version()
+        .ssts
+        .levels()
+        .iter()
+        .flat_map(|level| level.files.values())
+        .map(|file| file.meta_ref().file_id)
+        .collect()
+}
+
+async fn assert_target_value(
+    engine: &crate::engine::MitoEngine,
+    region_id: RegionId,
+    expected: f64,
+) {
+    let scan = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(scan).await.unwrap();
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        1
+    );
+    let batch = batches.iter().next().unwrap();
+    let values = batch
+        .column_by_name("field_0")
+        .unwrap()
+        .as_primitive::<Float64Type>();
+    assert_eq!(values.value(0), expected);
 }
 
 fn float_range_expr(col_name: &str, start: f64, end: f64) -> PartitionExpr {

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -825,39 +825,6 @@ pub(crate) fn parquet_row_group_time_range(
     Some((Timestamp::new(min, unit), Timestamp::new(max, unit)))
 }
 
-/// Checks if sequence override is needed based on all row groups' statistics.
-/// Returns true if ALL row groups have sequence min-max values of 0.
-pub(crate) fn need_override_sequence(parquet_meta: &ParquetMetaData) -> bool {
-    let num_columns = parquet_meta.file_metadata().schema_descr().num_columns();
-    if num_columns < FIXED_POS_COLUMN_NUM {
-        return false;
-    }
-
-    // The sequence column is the second-to-last column (before op_type)
-    let sequence_pos = num_columns - 2;
-
-    // Check all row groups - all must have sequence min-max of 0
-    for row_group in parquet_meta.row_groups() {
-        if let Some(Statistics::Int64(value_stats)) = row_group.column(sequence_pos).statistics() {
-            if let (Some(min_val), Some(max_val)) = (value_stats.min_opt(), value_stats.max_opt()) {
-                // If any row group doesn't have min=0 and max=0, return false
-                if *min_val != 0 || *max_val != 0 {
-                    return false;
-                }
-            } else {
-                // If any row group doesn't have statistics, return false
-                return false;
-            }
-        } else {
-            // If any row group doesn't have Int64 statistics, return false
-            return false;
-        }
-    }
-
-    // All row groups have sequence min-max of 0, or there are no row groups
-    !parquet_meta.row_groups().is_empty()
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -81,7 +81,7 @@ use crate::sst::parquet::file_range::{
     FileRangeContext, FileRangeContextRef, PartitionFilterContext, PreFilterMode, RangeBase,
 };
 use crate::sst::parquet::flat_format::{FlatReadFormat, primary_key_column_index};
-use crate::sst::parquet::format::{INTERNAL_COLUMN_NUM, need_override_sequence};
+use crate::sst::parquet::format::INTERNAL_COLUMN_NUM;
 use crate::sst::parquet::json_align::{NestedSchemaAligner, ProjectedRecordBatchStream};
 use crate::sst::parquet::metadata::MetadataLoader;
 use crate::sst::parquet::prefilter::{
@@ -471,10 +471,7 @@ impl ParquetReaderBuilder {
             &file_path,
             skip_auto_convert,
         )?;
-        if need_override_sequence(&parquet_meta) {
-            read_format
-                .set_override_sequence(self.file_handle.meta_ref().sequence.map(|x| x.get()));
-        }
+        read_format.set_override_sequence(self.file_handle.meta_ref().sequence.map(|x| x.get()));
 
         // Computes the projection mask.
         let parquet_read_cols = read_format.parquet_read_columns();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Prerequisite for #8865.

## What's changed and what's your intention?

SSTs installed by repartition's ApplyStaging path retain the creator region in their `FileHandle`, while the target manifest assigns them a target-local admission sequence in `FileMeta.sequence`. Their physical row sequences belong to the source region and have no ordering meaning in the target region. Previously those non-zero source sequences participated in target-region deduplication and compaction.

This change uses the existing file-handle provenance to apply the target-local sequence only to foreign SSTs:

- a file is foreign when `FileHandle::region_id()` differs from the current target region metadata;
- foreign files use the target manifest's `FileMeta.sequence` as their logical sequence;
- local SSTs keep their physical row sequences unchanged;
- the existing all-zero sequence compatibility override remains unchanged;
- shared physical SST bytes are never rewritten.

Normal scans and compaction already supply target region metadata to the Parquet reader. Index rebuild is also region-scoped and can read foreign handles, so this PR wires its current target metadata into the same reader path.

Regression coverage includes:

- local all-zero, local non-zero, absent metadata sequence, and foreign-file reader behavior in both SST formats;
- ApplyStaging assigning a target-local barrier to a source-owned handle, followed by a target write and a real StrictWindow compaction;
- compaction replacing both inputs with a target-owned output while preserving the target write as the winner;
- index rebuild applying target partition metadata to a foreign SST. The focused test is mutation-checked: removing the target metadata wiring changes the indexed row count from 100 to 200.

This PR does not change persisted or wire formats. `copy_region_from` deliberately remaps file metadata to the target region and is outside this focused foreign-handle fix.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (No new public API.)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
