### PR TITLE
feat(cmd): improve parquet rewrite fidelity and scanbench output

### DIFF
--- a/docs/parquet-tools.md
+++ b/docs/parquet-tools.md
@@ -89,7 +89,9 @@ Supported compression names are `uncompressed`, `snappy`, `gzip`, `lzo`,
 
 The `[writer]` table also accepts `compression_level`,
 `data_page_size_limit`, `data_page_row_count_limit`, and
-`dictionary_page_size_limit`. A `[[columns]]` entry overrides dictionary,
+`dictionary_page_size_limit`. It also accepts
+`column_index_truncate_length` and `statistics_truncate_length`; set either to
+zero to disable that truncation. A `[[columns]]` entry overrides dictionary,
 compression, compression level, or encoding for its column path. Unknown TOML
 fields are rejected. Compression levels are supported for `gzip`, `brotli`, and
 `zstd`. A column-level `compression_level` without `compression` inherits the

--- a/src/cmd/src/datanode/parquet_meta.rs
+++ b/src/cmd/src/datanode/parquet_meta.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 
 use clap::{Parser, ValueEnum};
 use parquet::file::metadata::ParquetMetaData;
+use parquet::file::page_index::offset_index::PageLocation;
 use serde::Serialize;
 use snafu::ResultExt;
 
@@ -78,6 +79,7 @@ struct ColumnChunkMetaView {
     dictionary_page_offset: Option<i64>,
     dictionary_page_bytes: Option<i64>,
     data_pages: Option<usize>,
+    max_data_page_row_count: Option<i64>,
     has_statistics: bool,
     column_index_offset: Option<i64>,
     column_index_length: Option<i32>,
@@ -123,10 +125,14 @@ fn build_file_meta_view(path: &Path, metadata: &ParquetMetaData) -> FileMetaView
                 .iter()
                 .enumerate()
                 .map(|(column_idx, column)| {
-                    let data_pages = offset_index
+                    let page_locations = offset_index
                         .and_then(|index| index.get(row_group_idx))
                         .and_then(|columns| columns.get(column_idx))
-                        .map(|index| index.page_locations().len());
+                        .map(|index| index.page_locations());
+                    let data_pages = page_locations.map(|locations| locations.len());
+                    let max_data_page_row_count = page_locations.and_then(|locations| {
+                        max_data_page_row_count(locations, row_group.num_rows())
+                    });
                     let dictionary_page_bytes = dictionary_page_bytes(
                         column.dictionary_page_offset(),
                         column.data_page_offset(),
@@ -149,6 +155,7 @@ fn build_file_meta_view(path: &Path, metadata: &ParquetMetaData) -> FileMetaView
                         dictionary_page_offset: column.dictionary_page_offset(),
                         dictionary_page_bytes,
                         data_pages,
+                        max_data_page_row_count,
                         has_statistics: column.statistics().is_some(),
                         column_index_offset: column.column_index_offset(),
                         column_index_length: column.column_index_length(),
@@ -219,7 +226,7 @@ fn print_meta_text(view: &FileMetaView) {
         );
         for column in &row_group.columns {
             println!(
-                "  column[{}] path={}: type={}, compression={}, encodings=[{}], values={}, uncompressed_size={}, compressed_size={}, compression_ratio={}, data_pages={}, dictionary_page_offset={}, dictionary_page_bytes={}, data_page_offset={}, statistics={}, column_index={}/{}, offset_index={}/{}, bloom_filter={}/{}",
+                "  column[{}] path={}: type={}, compression={}, encodings=[{}], values={}, uncompressed_size={}, compressed_size={}, compression_ratio={}, data_pages={}, max_data_page_row_count={}, dictionary_page_offset={}, dictionary_page_bytes={}, data_page_offset={}, statistics={}, column_index={}/{}, offset_index={}/{}, bloom_filter={}/{}",
                 column.index,
                 column.path,
                 column.physical_type,
@@ -230,6 +237,7 @@ fn print_meta_text(view: &FileMetaView) {
                 column.compressed_size,
                 format_ratio(column.compression_ratio),
                 format_optional_usize(column.data_pages),
+                format_optional_i64(column.max_data_page_row_count),
                 format_optional_i64(column.dictionary_page_offset),
                 column
                     .dictionary_page_bytes
@@ -246,6 +254,33 @@ fn print_meta_text(view: &FileMetaView) {
             );
         }
     }
+}
+
+fn max_data_page_row_count(
+    page_locations: &[PageLocation],
+    row_group_row_count: i64,
+) -> Option<i64> {
+    if page_locations.is_empty() {
+        return Some(0);
+    }
+    if page_locations.first()?.first_row_index != 0 {
+        return None;
+    }
+
+    let mut max_row_count = 0;
+    for locations in page_locations.windows(2) {
+        let row_count = locations[1].first_row_index - locations[0].first_row_index;
+        if row_count < 0 {
+            return None;
+        }
+        max_row_count = max_row_count.max(row_count);
+    }
+
+    let last_page_row_count = row_group_row_count - page_locations.last()?.first_row_index;
+    if last_page_row_count < 0 {
+        return None;
+    }
+    Some(max_row_count.max(last_page_row_count))
 }
 
 fn dictionary_page_bytes(
@@ -301,7 +336,7 @@ mod tests {
     fn test_meta_view_unknown_page_count() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("input.parquet");
-        write_test_parquet(&path);
+        write_test_parquet(&path, None);
 
         let metadata = load_local_parquet_metadata(&path).unwrap();
         let view = build_file_meta_view(&path, &metadata);
@@ -313,7 +348,21 @@ mod tests {
         assert_eq!(view.row_groups[0].columns.len(), 2);
     }
 
-    fn write_test_parquet(path: &Path) {
+    #[test]
+    fn test_meta_view_reports_max_data_page_row_count() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("input.parquet");
+        write_test_parquet(&path, Some(2));
+
+        let metadata = load_local_parquet_metadata(&path).unwrap();
+        let view = build_file_meta_view(&path, &metadata);
+
+        for column in &view.row_groups[0].columns {
+            assert_eq!(Some(2), column.max_data_page_row_count);
+        }
+    }
+
+    fn write_test_parquet(path: &Path, data_page_row_count_limit: Option<usize>) {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
             Field::new("host", DataType::Utf8, false),
@@ -326,12 +375,17 @@ mod tests {
             ],
         )
         .unwrap();
-        let props = WriterProperties::builder()
-            .set_key_value_metadata(Some(vec![KeyValue::new(
+        let mut props =
+            WriterProperties::builder().set_key_value_metadata(Some(vec![KeyValue::new(
                 "greptime:test".to_string(),
                 "value".to_string(),
-            )]))
-            .build();
+            )]));
+        if let Some(limit) = data_page_row_count_limit {
+            props = props
+                .set_write_batch_size(limit)
+                .set_data_page_row_count_limit(limit);
+        }
+        let props = props.build();
         let mut writer =
             ArrowWriter::try_new(File::create(path).unwrap(), schema, Some(props)).unwrap();
         writer.write(&batch).unwrap();

--- a/src/cmd/src/datanode/parquet_rewrite.rs
+++ b/src/cmd/src/datanode/parquet_rewrite.rs
@@ -77,6 +77,8 @@ struct WriterConfig {
     data_page_size_limit: Option<usize>,
     data_page_row_count_limit: Option<usize>,
     dictionary_page_size_limit: Option<usize>,
+    column_index_truncate_length: Option<usize>,
+    statistics_truncate_length: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -234,6 +236,8 @@ fn infer_rewrite_properties(metadata: &ParquetMetaData) -> RewriteProperties {
             data_page_size_limit: None,
             data_page_row_count_limit: None,
             dictionary_page_size_limit: None,
+            column_index_truncate_length: None,
+            statistics_truncate_length: None,
         },
         columns,
     }
@@ -286,6 +290,16 @@ fn build_writer_properties(
     }
     if let Some(dictionary_page_size_limit) = config.writer.dictionary_page_size_limit {
         builder = builder.set_dictionary_page_size_limit(dictionary_page_size_limit);
+    }
+    if let Some(column_index_truncate_length) = config.writer.column_index_truncate_length {
+        builder = builder.set_column_index_truncate_length(
+            (column_index_truncate_length > 0).then_some(column_index_truncate_length),
+        );
+    }
+    if let Some(statistics_truncate_length) = config.writer.statistics_truncate_length {
+        builder = builder.set_statistics_truncate_length(
+            (statistics_truncate_length > 0).then_some(statistics_truncate_length),
+        );
     }
 
     for column in config.columns {

--- a/src/cmd/src/datanode/parquet_rewrite.rs
+++ b/src/cmd/src/datanode/parquet_rewrite.rs
@@ -191,6 +191,15 @@ impl ParquetRewriteCommand {
 }
 
 fn infer_rewrite_properties(metadata: &ParquetMetaData) -> RewriteProperties {
+    let is_greptime_sst = metadata
+        .file_metadata()
+        .key_value_metadata()
+        .is_some_and(|key_values| {
+            key_values
+                .iter()
+                .any(|key_value| key_value.key == mito2::sst::parquet::PARQUET_METADATA_KEY)
+        });
+    let truncate_length = is_greptime_sst.then_some(0);
     let first_column = metadata
         .row_groups()
         .first()
@@ -236,8 +245,8 @@ fn infer_rewrite_properties(metadata: &ParquetMetaData) -> RewriteProperties {
             data_page_size_limit: None,
             data_page_row_count_limit: None,
             dictionary_page_size_limit: None,
-            column_index_truncate_length: None,
-            statistics_truncate_length: None,
+            column_index_truncate_length: truncate_length,
+            statistics_truncate_length: truncate_length,
         },
         columns,
     }
@@ -506,7 +515,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let input = dir.path().join("input.parquet");
         let output = dir.path().join("output.parquet");
-        write_test_parquet(&input, true);
+        write_test_parquet(&input, true, Some("greptime:test"));
 
         let metadata = load_local_parquet_metadata(&input).unwrap();
         let mut properties = infer_rewrite_properties(&metadata);
@@ -543,6 +552,37 @@ mod tests {
     }
 
     #[test]
+    fn test_infer_truncation_settings_for_greptime_sst() {
+        let dir = tempdir().unwrap();
+        let greptime_sst = dir.path().join("greptime.parquet");
+        let generic_parquet = dir.path().join("generic.parquet");
+        write_test_parquet(
+            &greptime_sst,
+            true,
+            Some(mito2::sst::parquet::PARQUET_METADATA_KEY),
+        );
+        write_test_parquet(&generic_parquet, true, None);
+
+        let metadata = load_local_parquet_metadata(&greptime_sst).unwrap();
+        let config = infer_rewrite_properties(&metadata);
+        assert_eq!(Some(0), config.writer.column_index_truncate_length);
+        assert_eq!(Some(0), config.writer.statistics_truncate_length);
+
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(serialized.contains("column_index_truncate_length = 0"));
+        assert!(serialized.contains("statistics_truncate_length = 0"));
+
+        let properties = build_writer_properties(config, None).unwrap();
+        assert_eq!(None, properties.column_index_truncate_length());
+        assert_eq!(None, properties.statistics_truncate_length());
+
+        let metadata = load_local_parquet_metadata(&generic_parquet).unwrap();
+        let config = infer_rewrite_properties(&metadata);
+        assert_eq!(None, config.writer.column_index_truncate_length);
+        assert_eq!(None, config.writer.statistics_truncate_length);
+    }
+
+    #[test]
     fn test_column_compression_level_inherits_writer_compression() {
         let path = ColumnPath::new(vec!["host".to_string()]);
         let config = RewriteProperties {
@@ -565,7 +605,7 @@ mod tests {
         );
     }
 
-    fn write_test_parquet(path: &Path, dictionary_enabled: bool) {
+    fn write_test_parquet(path: &Path, dictionary_enabled: bool, metadata_key: Option<&str>) {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
             Field::new("host", DataType::Utf8, false),
@@ -578,12 +618,11 @@ mod tests {
             ],
         )
         .unwrap();
+        let key_value_metadata =
+            metadata_key.map(|key| vec![KeyValue::new(key.to_string(), "value".to_string())]);
         let props = WriterProperties::builder()
             .set_dictionary_enabled(dictionary_enabled)
-            .set_key_value_metadata(Some(vec![KeyValue::new(
-                "greptime:test".to_string(),
-                "value".to_string(),
-            )]))
+            .set_key_value_metadata(key_value_metadata)
             .build();
         let mut writer =
             ArrowWriter::try_new(File::create(path).unwrap(), schema, Some(props)).unwrap();

--- a/src/cmd/src/datanode/scanbench.rs
+++ b/src/cmd/src/datanode/scanbench.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -31,6 +32,7 @@ use datafusion::logical_expr::{BinaryExpr, Expr as DfExpr, ExprSchemable, Operat
 use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
 use datafusion_common::{DFSchemaRef, ScalarValue, ToDFSchema};
 use datafusion_physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion_physical_plan::{DisplayAs, DisplayFormatType};
 use datatypes::arrow::compute;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -60,6 +62,15 @@ use crate::datanode::tool_util::{
     build_object_store, format_bytes, parse_config, parse_path_type, parse_region_id,
 };
 use crate::error;
+
+/// Displays a scanner using DataFusion's verbose explain format.
+struct VerboseScannerDisplay<'a, T: ?Sized>(&'a T);
+
+impl<T: DisplayAs + ?Sized> fmt::Display for VerboseScannerDisplay<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt_as(DisplayFormatType::Verbose, f)
+    }
+}
 
 /// Scan benchmark command - benchmarks scanning a region directly from storage.
 #[derive(Debug, Parser)]
@@ -687,6 +698,14 @@ impl ScanbenchCommand {
                 format_bytes(total_array_mem_size),
                 format_bytes(total_estimated_size),
             );
+
+            if self.verbose {
+                println!(
+                    "  {} Scanner explain: {}",
+                    "ℹ".blue(),
+                    VerboseScannerDisplay(scanner.as_ref())
+                );
+            }
 
             // Start profiling after the first iteration (warmup) if pprof_after_warmup is set
             #[cfg(unix)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What changed and what is your intention?

This PR improves the datanode developer tools used to inspect and benchmark SSTs:

- Preserve Parquet column-index and statistics truncation settings during rewrites. A configured value of zero disables truncation, matching the Parquet writer behavior used by Mito.
- Report the maximum data-page row count from offset-index metadata in `parquet-meta` output, making rewritten page sizing directly verifiable.
- Document the new rewrite configuration fields and their zero-value behavior.
- Print the scanner with DataFusion verbose explain formatting when `scanbench --verbose` is enabled, exposing scanner metrics during benchmark runs.

The changes are limited to developer-tool behavior and do not modify persisted schemas or wire formats.

Validation:

- `cargo fmt --all -- --check`
- `cargo nextest run --retries 0 -p cmd --features dev-tools` (109 passed)
- `cargo clippy -p cmd --features dev-tools --all-targets -- -D warnings`

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.