### PR TITLE
chore: bump version from 0.12.1 to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "async-trait",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "catalog",
  "common-error",
@@ -1348,7 +1348,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arrow",
@@ -1661,7 +1661,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "auth",
@@ -1703,7 +1703,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "table",
  "tempfile",
  "tokio",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1739,7 +1739,7 @@ dependencies = [
  "rand",
  "serde_json",
  "snafu 0.8.5",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "substrait 0.37.3",
  "tokio",
  "tokio-stream",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "auth",
@@ -1841,7 +1841,7 @@ dependencies = [
  "similar-asserts",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "table",
  "temp-env",
  "tempfile",
@@ -1887,7 +1887,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anymap2",
  "async-trait",
@@ -1909,11 +1909,11 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.12.1"
+version = "0.12.2"
 
 [[package]]
 name = "common-config"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "common-base",
  "common-error",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bigdecimal 0.4.5",
  "common-error",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "http 1.1.0",
  "snafu 0.8.5",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "approx 0.5.1",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "common-base",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anymap2",
  "api",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "common-grpc",
  "humantime-serde",
@@ -2211,11 +2211,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.12.1"
+version = "0.12.2"
 
 [[package]]
 name = "common-pprof"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "async-trait",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "atty",
  "backtrace",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "client",
  "common-query",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arrow",
  "chrono",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "build-data",
  "const_format",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "common-base",
  "common-error",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3388,7 +3388,7 @@ dependencies = [
  "session",
  "snafu 0.8.5",
  "store-api",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "table",
  "tokio",
  "toml 0.8.19",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "async-trait",
@@ -4151,7 +4151,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arrow",
@@ -4212,7 +4212,7 @@ dependencies = [
  "snafu 0.8.5",
  "store-api",
  "strum 0.25.0",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "table",
  "tokio",
  "tonic 0.12.3",
@@ -4267,7 +4267,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -6318,7 +6318,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "log-query"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "chrono",
  "common-error",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -6834,7 +6834,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -7828,7 +7828,7 @@ dependencies = [
  "sql",
  "sqlparser 0.52.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=71dd86058d2af97b9925093d40c4e03360403170)",
  "store-api",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "table",
  "tokio",
  "tokio-util",
@@ -8065,7 +8065,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "async-trait",
@@ -8333,7 +8333,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "auth",
  "clap 4.5.19",
@@ -8735,7 +8735,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -8980,7 +8980,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-compression 0.4.13",
  "async-trait",
@@ -9021,7 +9021,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -9086,7 +9086,7 @@ dependencies = [
  "sqlparser 0.52.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=71dd86058d2af97b9925093d40c4e03360403170)",
  "statrs",
  "store-api",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "table",
  "tokio",
  "tokio-stream",
@@ -10431,7 +10431,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -10547,7 +10547,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -10856,7 +10856,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "chrono",
@@ -10910,7 +10910,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "clap 4.5.19",
@@ -11226,7 +11226,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -11356,7 +11356,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11537,7 +11537,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "async-trait",
@@ -11788,7 +11788,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -11832,7 +11832,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -11898,7 +11898,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.12.1",
+ "substrait 0.12.2",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

v0.12.1 -> v0.12.2

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
