### PR TITLE
fix(query): add global fetch above multi-partition aggregate soft limit

### DIFF
--- a/src/query/src/optimizer/global_limit.rs
+++ b/src/query/src/optimizer/global_limit.rs
@@ -128,17 +128,32 @@ impl EnsureGlobalLimitForFetch {
     }
 }
 
-/// Returns the soft limit of a `FinalPartitioned` [`AggregateExec`], if any.
+/// Returns the soft limit of a multi-partition-capable [`AggregateExec`], if any.
 ///
 /// The `lim` hint pushed down by DataFusion's `LimitedDistinctAggregation` rule
 /// is only enforced per partition (see `group_values_soft_limit` in
 /// `GroupedHashAggregateStream`), so a multi-partition final aggregate needs a
 /// global fetch on top, just like a multi-partition [`FilterExec`].
+///
+/// Only unordered soft limits (`FinalPartitioned` or `SinglePartitioned` mode)
+/// qualify. Ordered limits come from `TopKAggregation`, where each partition
+/// keeps its local top-N candidates and the global top-N is chosen by the sort
+/// machinery above; truncating the merged candidates with a coalesce fetch
+/// would drop true top-N rows.
 fn aggregate_soft_limit(plan: &Arc<dyn ExecutionPlan>) -> Option<usize> {
     plan.as_any()
         .downcast_ref::<AggregateExec>()
-        .filter(|agg| matches!(agg.mode(), AggregateMode::FinalPartitioned))
-        .and_then(|agg| agg.limit_options().map(|options| options.limit()))
+        .filter(|agg| {
+            matches!(
+                agg.mode(),
+                AggregateMode::FinalPartitioned | AggregateMode::SinglePartitioned
+            )
+        })
+        .and_then(|agg| {
+            agg.limit_options()
+                .filter(|options| options.descending().is_none())
+                .map(|options| options.limit())
+        })
 }
 
 #[derive(Clone)]
@@ -330,6 +345,43 @@ mod tests {
             EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
 
         assert!(optimized.as_any().is::<AggregateExec>());
+    }
+
+    #[test]
+    fn ignores_topk_ordered_aggregate_limit() {
+        // Ordered limit options come from TopKAggregation: each partition only
+        // keeps its local top-N candidates, and the global top-N is chosen by
+        // the sort machinery above. Truncating the merged candidates with a
+        // coalesce fetch would drop true top-N rows.
+        let agg = agg_with_limit_options(
+            unordered_input(),
+            AggregateMode::FinalPartitioned,
+            LimitOptions::new_with_order(1, true),
+        );
+
+        let optimized =
+            EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
+
+        assert!(optimized.as_any().is::<AggregateExec>());
+    }
+
+    #[test]
+    fn adds_global_limit_for_single_partitioned_aggregate_soft_limit() {
+        // CombinePartialFinalAggregate rewrites FinalPartitioned into
+        // SinglePartitioned while preserving limit_options; its output can
+        // still have multiple partitions.
+        let agg = agg_with_limit_options(
+            unordered_input(),
+            AggregateMode::SinglePartitioned,
+            LimitOptions::new(1),
+        );
+
+        let optimized =
+            EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
+
+        assert!(optimized.as_any().is::<CoalescePartitionsExec>());
+        assert_eq!(optimized.fetch(), Some(1));
+        assert_eq!(optimized.output_partitioning().partition_count(), 1);
     }
 
     #[test]
@@ -649,6 +701,14 @@ mod tests {
         mode: AggregateMode,
         limit: usize,
     ) -> Arc<dyn ExecutionPlan> {
+        agg_with_limit_options(input, mode, LimitOptions::new(limit))
+    }
+
+    fn agg_with_limit_options(
+        input: Arc<dyn ExecutionPlan>,
+        mode: AggregateMode,
+        limit_options: LimitOptions,
+    ) -> Arc<dyn ExecutionPlan> {
         let schema = input.schema();
         let group_by = PhysicalGroupBy::new_single(vec![(
             col("a", schema.as_ref()).unwrap(),
@@ -657,7 +717,7 @@ mod tests {
         Arc::new(
             AggregateExec::try_new(mode, group_by, vec![], vec![], input, schema)
                 .unwrap()
-                .with_limit_options(Some(LimitOptions::new(limit))),
+                .with_limit_options(Some(limit_options)),
         )
     }
 

--- a/src/query/src/optimizer/global_limit.rs
+++ b/src/query/src/optimizer/global_limit.rs
@@ -285,6 +285,7 @@ mod tests {
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::execution::TaskContext;
     use datafusion::physical_expr::expressions::{col, lit};
+    use datafusion::physical_optimizer::combine_partial_final_agg::CombinePartialFinalAggregate;
     use datafusion::physical_plan::aggregates::{
         AggregateExec, AggregateMode, LimitOptions, PhysicalGroupBy,
     };
@@ -418,23 +419,55 @@ mod tests {
         assert_eq!(values, vec![1]);
     }
 
-    #[test]
-    fn adds_global_limit_for_single_partitioned_aggregate_soft_limit() {
-        // CombinePartialFinalAggregate rewrites FinalPartitioned into
-        // SinglePartitioned while preserving limit_options; its output can
-        // still have multiple partitions.
-        let agg = agg_with_limit_options(
-            unordered_input(),
-            AggregateMode::SinglePartitioned,
-            LimitOptions::new(1),
+    #[tokio::test]
+    async fn single_partitioned_soft_limit_returns_one_row_globally() {
+        // Production-like shape: CombinePartialFinalAggregate rewrites
+        // FinalPartitioned + Partial into SinglePartitioned while preserving
+        // limit_options, when the Partial's output is already hash-partitioned
+        // by the group key. The duplicate key across raw partitions exercises
+        // the hash merge.
+        let schema = schema();
+        let first = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let second = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 4, 5]))],
+        )
+        .unwrap();
+        let scan = Arc::new(
+            TestMemoryExec::try_new(&[vec![first], vec![second]], schema.clone(), None).unwrap(),
         );
+        let repartition = hash_repartition(scan);
+        let partial = agg_with_limit(repartition, AggregateMode::Partial, 1);
+        let final_agg = agg_with_limit(partial, AggregateMode::FinalPartitioned, 1);
+
+        let combined = CombinePartialFinalAggregate::new()
+            .optimize(final_agg, &ConfigOptions::new())
+            .unwrap();
+        let agg = combined.as_any().downcast_ref::<AggregateExec>().unwrap();
+        assert!(matches!(agg.mode(), AggregateMode::SinglePartitioned));
+        assert_eq!(agg.limit_options().map(|options| options.limit()), Some(1));
+        assert_eq!(combined.output_partitioning().partition_count(), 3);
 
         let optimized =
-            EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
+            EnsureGlobalLimitForFetch::optimize_plan(combined, ParentContext::default()).unwrap();
 
+        // A global fetch must be installed above the multi-partition
+        // SinglePartitioned aggregate...
         assert!(optimized.as_any().is::<CoalescePartitionsExec>());
         assert_eq!(optimized.fetch(), Some(1));
-        assert_eq!(optimized.output_partitioning().partition_count(), 1);
+
+        // ...and the executed plan must return one row globally, not one row
+        // per partition.
+        let batches =
+            datafusion::physical_plan::collect(optimized, Arc::new(TaskContext::default()))
+                .await
+                .unwrap();
+        let rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+        assert_eq!(rows, 1);
     }
 
     #[test]

--- a/src/query/src/optimizer/global_limit.rs
+++ b/src/query/src/optimizer/global_limit.rs
@@ -19,7 +19,7 @@ use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::filter::FilterExec;
-use datafusion::physical_plan::limit::GlobalLimitExec;
+use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
@@ -63,6 +63,10 @@ impl EnsureGlobalLimitForFetch {
             let maintains_input_order = plan.maintains_input_order();
             let child_parent = ParentContext {
                 global_fetch: provided_global_fetch(&plan),
+                local_fetch: plan
+                    .as_any()
+                    .downcast_ref::<LocalLimitExec>()
+                    .map(LocalLimitExec::fetch),
                 required_ordering: None,
                 required_distribution: Distribution::UnspecifiedDistribution,
                 partitioning_to_restore: None,
@@ -113,6 +117,11 @@ impl EnsureGlobalLimitForFetch {
         if parent
             .global_fetch
             .is_some_and(|parent_fetch| parent_fetch <= fetch)
+            || aggregate_limit.is_some_and(|aggregate_fetch| {
+                parent
+                    .local_fetch
+                    .is_some_and(|local_fetch| local_fetch <= aggregate_fetch)
+            })
             || !(plan.as_any().is::<FilterExec>() || aggregate_limit.is_some())
             || plan.output_partitioning().partition_count() <= 1
         {
@@ -159,6 +168,7 @@ fn aggregate_soft_limit(plan: &Arc<dyn ExecutionPlan>) -> Option<usize> {
 #[derive(Clone)]
 struct ParentContext {
     global_fetch: Option<usize>,
+    local_fetch: Option<usize>,
     required_ordering: Option<OrderingRequirements>,
     required_distribution: Distribution,
     partitioning_to_restore: Option<Partitioning>,
@@ -169,6 +179,7 @@ impl Default for ParentContext {
     fn default() -> Self {
         Self {
             global_fetch: None,
+            local_fetch: None,
             required_ordering: None,
             required_distribution: Distribution::UnspecifiedDistribution,
             partitioning_to_restore: None,
@@ -291,7 +302,7 @@ mod tests {
     };
     use datafusion::physical_plan::filter::FilterExecBuilder;
     use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
-    use datafusion::physical_plan::limit::GlobalLimitExec;
+    use datafusion::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
     use datafusion::physical_plan::projection::ProjectionExec;
     use datafusion::physical_plan::repartition::RepartitionExec;
     use datafusion::physical_plan::sorts::sort::SortExec;
@@ -468,6 +479,44 @@ mod tests {
                 .unwrap();
         let rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
         assert_eq!(rows, 1);
+    }
+
+    #[tokio::test]
+    async fn local_limit_preserves_per_partition_aggregate_soft_limit() {
+        let schema = schema();
+        let input = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from((0..100).collect::<Vec<_>>()))],
+        )
+        .unwrap();
+        let scan = Arc::new(TestMemoryExec::try_new(&[vec![input]], schema, None).unwrap());
+        // A tighter local limit must retain its per-partition scope.
+        let agg = agg_with_limit(hash_repartition(scan), AggregateMode::SinglePartitioned, 2);
+        let local_limit = Arc::new(LocalLimitExec::new(agg, 1)) as Arc<dyn ExecutionPlan>;
+
+        let optimized = EnsureGlobalLimitForFetch::optimize_plan(
+            Arc::clone(&local_limit),
+            ParentContext::default(),
+        )
+        .unwrap();
+
+        let original_batches =
+            datafusion::physical_plan::collect(local_limit, Arc::new(TaskContext::default()))
+                .await
+                .unwrap();
+        let optimized_batches = datafusion::physical_plan::collect(
+            Arc::clone(&optimized),
+            Arc::new(TaskContext::default()),
+        )
+        .await
+        .unwrap();
+        let original_rows: usize = original_batches.iter().map(|batch| batch.num_rows()).sum();
+        let optimized_rows: usize = optimized_batches.iter().map(|batch| batch.num_rows()).sum();
+
+        assert_eq!(original_rows, 3);
+        assert_eq!(optimized_rows, 3);
+        assert!(optimized.as_any().is::<LocalLimitExec>());
+        assert!(optimized.children()[0].as_any().is::<AggregateExec>());
     }
 
     #[test]

--- a/src/query/src/optimizer/global_limit.rs
+++ b/src/query/src/optimizer/global_limit.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use datafusion::config::ConfigOptions;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::limit::GlobalLimitExec;
@@ -104,14 +105,15 @@ impl EnsureGlobalLimitForFetch {
             plan.with_new_children(children)?
         };
 
-        let Some(fetch) = plan.fetch() else {
+        let aggregate_limit = aggregate_soft_limit(&plan);
+        let Some(fetch) = plan.fetch().or(aggregate_limit) else {
             return Ok(plan);
         };
 
         if parent
             .global_fetch
             .is_some_and(|parent_fetch| parent_fetch <= fetch)
-            || !plan.as_any().is::<FilterExec>()
+            || !(plan.as_any().is::<FilterExec>() || aggregate_limit.is_some())
             || plan.output_partitioning().partition_count() <= 1
         {
             return Ok(plan);
@@ -124,6 +126,19 @@ impl EnsureGlobalLimitForFetch {
             parent.partitioning_to_restore,
         )
     }
+}
+
+/// Returns the soft limit of a `FinalPartitioned` [`AggregateExec`], if any.
+///
+/// The `lim` hint pushed down by DataFusion's `LimitedDistinctAggregation` rule
+/// is only enforced per partition (see `group_values_soft_limit` in
+/// `GroupedHashAggregateStream`), so a multi-partition final aggregate needs a
+/// global fetch on top, just like a multi-partition [`FilterExec`].
+fn aggregate_soft_limit(plan: &Arc<dyn ExecutionPlan>) -> Option<usize> {
+    plan.as_any()
+        .downcast_ref::<AggregateExec>()
+        .filter(|agg| matches!(agg.mode(), AggregateMode::FinalPartitioned))
+        .and_then(|agg| agg.limit_options().map(|options| options.limit()))
 }
 
 #[derive(Clone)]
@@ -254,6 +269,9 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::physical_expr::expressions::{col, lit};
+    use datafusion::physical_plan::aggregates::{
+        AggregateExec, AggregateMode, LimitOptions, PhysicalGroupBy,
+    };
     use datafusion::physical_plan::filter::FilterExecBuilder;
     use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
     use datafusion::physical_plan::limit::GlobalLimitExec;
@@ -264,6 +282,55 @@ mod tests {
     use datafusion_physical_expr::{LexOrdering, Partitioning, PhysicalSortExpr};
 
     use super::*;
+
+    #[test]
+    fn adds_global_limit_for_multi_partition_aggregate_soft_limit() {
+        let agg = final_partitioned_agg_with_limit(unordered_input(), 1);
+
+        let optimized =
+            EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
+
+        assert!(optimized.as_any().is::<CoalescePartitionsExec>());
+        assert_eq!(optimized.fetch(), Some(1));
+        assert_eq!(optimized.output_partitioning().partition_count(), 1);
+    }
+
+    #[test]
+    fn keeps_aggregate_soft_limit_under_parent_global_fetch() {
+        let agg = final_partitioned_agg_with_limit(unordered_input(), 1);
+        let coalesce = Arc::new(CoalescePartitionsExec::new(agg).with_fetch(Some(1)))
+            as Arc<dyn ExecutionPlan>;
+
+        let optimized =
+            EnsureGlobalLimitForFetch::optimize_plan(coalesce, ParentContext::default()).unwrap();
+
+        // Idempotent: no extra coalesce is inserted under the existing one.
+        assert!(optimized.as_any().is::<CoalescePartitionsExec>());
+        assert!(optimized.children()[0].as_any().is::<AggregateExec>());
+    }
+
+    #[test]
+    fn ignores_partial_aggregate_soft_limit() {
+        let agg = partial_agg_with_limit(unordered_input(), 1);
+
+        let optimized =
+            EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
+
+        assert!(optimized.as_any().is::<AggregateExec>());
+    }
+
+    #[test]
+    fn ignores_single_partition_aggregate_soft_limit() {
+        let schema = schema();
+        let batch = batch(schema.clone());
+        let input = Arc::new(TestMemoryExec::try_new(&[vec![batch]], schema, None).unwrap());
+        let agg = final_partitioned_agg_with_limit(input, 1);
+
+        let optimized =
+            EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
+
+        assert!(optimized.as_any().is::<AggregateExec>());
+    }
 
     #[test]
     fn adds_global_limit_for_multi_partition_filter_fetch() {
@@ -561,6 +628,37 @@ mod tests {
         let batch = batch(schema.clone());
         let partitions = vec![vec![batch.clone()], vec![batch.clone()], vec![batch]];
         Arc::new(TestMemoryExec::try_new(&partitions, schema, None).unwrap())
+    }
+
+    fn final_partitioned_agg_with_limit(
+        input: Arc<dyn ExecutionPlan>,
+        limit: usize,
+    ) -> Arc<dyn ExecutionPlan> {
+        agg_with_limit(input, AggregateMode::FinalPartitioned, limit)
+    }
+
+    fn partial_agg_with_limit(
+        input: Arc<dyn ExecutionPlan>,
+        limit: usize,
+    ) -> Arc<dyn ExecutionPlan> {
+        agg_with_limit(input, AggregateMode::Partial, limit)
+    }
+
+    fn agg_with_limit(
+        input: Arc<dyn ExecutionPlan>,
+        mode: AggregateMode,
+        limit: usize,
+    ) -> Arc<dyn ExecutionPlan> {
+        let schema = input.schema();
+        let group_by = PhysicalGroupBy::new_single(vec![(
+            col("a", schema.as_ref()).unwrap(),
+            "a".to_string(),
+        )]);
+        Arc::new(
+            AggregateExec::try_new(mode, group_by, vec![], vec![], input, schema)
+                .unwrap()
+                .with_limit_options(Some(LimitOptions::new(limit))),
+        )
     }
 
     fn ordered_input() -> (Arc<dyn ExecutionPlan>, LexOrdering) {

--- a/src/query/src/optimizer/global_limit.rs
+++ b/src/query/src/optimizer/global_limit.rs
@@ -279,10 +279,11 @@ fn inherited_partitioning_to_restore(
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::array::Int32Array;
+    use datafusion::arrow::array::{Array, Int32Array};
     use datafusion::arrow::compute::SortOptions;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::execution::TaskContext;
     use datafusion::physical_expr::expressions::{col, lit};
     use datafusion::physical_plan::aggregates::{
         AggregateExec, AggregateMode, LimitOptions, PhysicalGroupBy,
@@ -292,6 +293,7 @@ mod tests {
     use datafusion::physical_plan::limit::GlobalLimitExec;
     use datafusion::physical_plan::projection::ProjectionExec;
     use datafusion::physical_plan::repartition::RepartitionExec;
+    use datafusion::physical_plan::sorts::sort::SortExec;
     use datafusion::physical_plan::test::TestMemoryExec;
     use datafusion_common::{JoinType, NullEquality};
     use datafusion_physical_expr::{LexOrdering, Partitioning, PhysicalSortExpr};
@@ -347,22 +349,73 @@ mod tests {
         assert!(optimized.as_any().is::<AggregateExec>());
     }
 
-    #[test]
-    fn ignores_topk_ordered_aggregate_limit() {
+    #[tokio::test]
+    async fn topk_ordered_aggregate_limit_returns_global_winner() {
         // Ordered limit options come from TopKAggregation: each partition only
         // keeps its local top-N candidates, and the global top-N is chosen by
         // the sort machinery above. Truncating the merged candidates with a
         // coalesce fetch would drop true top-N rows.
-        let agg = agg_with_limit_options(
-            unordered_input(),
-            AggregateMode::FinalPartitioned,
-            LimitOptions::new_with_order(1, true),
+        //
+        // Partition 0 holds a losing candidate (100), partition 1 the global
+        // winner (1) of the ascending TopK. The global sort must see both.
+        let schema = schema();
+        let losing =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![100]))])
+                .unwrap();
+        let winning =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))])
+                .unwrap();
+        let input = Arc::new(
+            TestMemoryExec::try_new(&[vec![losing], vec![winning]], schema.clone(), None).unwrap(),
         );
+        let agg = agg_with_limit_options(
+            input,
+            AggregateMode::FinalPartitioned,
+            LimitOptions::new_with_order(1, false),
+        );
+        // Mirrors the real plan shape after EnforceDistribution: the global
+        // sort reads a single partition merged from the multi-partition
+        // aggregate. The merged stream must contain candidates from all
+        // aggregate partitions.
+        let merge = Arc::new(CoalescePartitionsExec::new(agg)) as Arc<dyn ExecutionPlan>;
+        let ordering = LexOrdering::new([PhysicalSortExpr::new(
+            col("a", schema.as_ref()).unwrap(),
+            SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+        )])
+        .unwrap();
+        let sort =
+            Arc::new(SortExec::new(ordering, merge).with_fetch(Some(1))) as Arc<dyn ExecutionPlan>;
 
         let optimized =
-            EnsureGlobalLimitForFetch::optimize_plan(agg, ParentContext::default()).unwrap();
+            EnsureGlobalLimitForFetch::optimize_plan(sort, ParentContext::default()).unwrap();
 
-        assert!(optimized.as_any().is::<AggregateExec>());
+        // The rule must not insert any candidate-truncating node below the
+        // merge...
+        let merge = optimized.children()[0].clone();
+        assert!(merge.as_any().is::<CoalescePartitionsExec>());
+        assert!(merge.children()[0].as_any().is::<AggregateExec>());
+
+        // ...and the executed plan must return the global winner.
+        let batches =
+            datafusion::physical_plan::collect(optimized, Arc::new(TaskContext::default()))
+                .await
+                .unwrap();
+        let values = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec![1]);
     }
 
     #[test]

--- a/tests/cases/standalone/common/information_schema/ssts.result
+++ b/tests/cases/standalone/common/information_schema/ssts.result
@@ -227,6 +227,21 @@ SELECT * FROM information_schema.ssts_storage order by file_path;
 | data/greptime/public/<TABLE_ID>/<REGION_ID>_<REGION_NUMBER>/index/<UUID>.puffin |<NUM>| <DATETIME>|<NUM>|
 +---------------------------------------------------------------------------------------------+-----------+-------------------------+---------+
 
+-- Regression: DISTINCT + LIMIT must not return more rows than the limit
+-- (the per-partition soft limit on AggregateExec needs a global fetch on top).
+SELECT COUNT(*) AS distinct_limited_rows
+FROM (
+  SELECT DISTINCT region_id
+  FROM information_schema.ssts_manifest
+  LIMIT 1
+);
+
++-----------------------+
+| distinct_limited_rows |
++-----------------------+
+| 1                     |
++-----------------------+
+
 DROP TABLE sst_case;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/information_schema/ssts.sql
+++ b/tests/cases/standalone/common/information_schema/ssts.sql
@@ -72,4 +72,13 @@ SELECT * FROM information_schema.ssts_index_meta ORDER BY meta_json;
 -- SQLNESS REPLACE (/public/\d+/\d+_\d+) /public/<TABLE_ID>/<REGION_ID>_<REGION_NUMBER>
 SELECT * FROM information_schema.ssts_storage order by file_path;
 
+-- Regression: DISTINCT + LIMIT must not return more rows than the limit
+-- (the per-partition soft limit on AggregateExec needs a global fetch on top).
+SELECT COUNT(*) AS distinct_limited_rows
+FROM (
+  SELECT DISTINCT region_id
+  FROM information_schema.ssts_manifest
+  LIMIT 1
+);
+
 DROP TABLE sst_case;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #8958.

## What's changed and what's your intention?

**Summary**: `SELECT DISTINCT ... FROM information_schema.ssts_manifest LIMIT 1` could return up to `limit * target_partitions` rows instead of `limit` rows. This PR extends the `EnsureGlobalLimitForFetch` physical optimizer rule to restore the missing global limit.

**Root cause**: the `lim` hint that DataFusion's `LimitedDistinctAggregation` rule pushes into `AggregateExec` is only a *per-partition* soft limit (`group_values_soft_limit` in `GroupedHashAggregateStream`). Correctness depends on a global limit node above the final aggregate (`GlobalLimitExec` / `CoalescePartitionsExec: fetch=N`). For information_schema inspect tables, the `MergeScan` local-execution fallback (`DistExtensionPlanner::plan_extension`) plans the remote input with `planner.create_physical_plan()` — which runs the whole physical optimizer pipeline — and the outer planner then optimizes the same plan **a second time**. In that second pass, upstream DataFusion's `EnforceDistribution::remove_dist_changing_operators` strips the fetch-carrying `CoalescePartitionsExec` as an "unnecessary" shuffle, losing the global limit. (Reproducible with vanilla DataFusion 53.1.0 by running the physical optimizer pipeline twice; a follow-up fix to the fork's `remove_dist_changing_operators` is planned.)

**How this PR works**: `EnsureGlobalLimitForFetch` already guards the per-partition `fetch` of `FilterExec` by adding a `CoalescePartitionsExec` with the fetch on top when the output has multiple partitions and no parent provides a global fetch. This PR makes it also treat the soft limit of a `FinalPartitioned` `AggregateExec` as a fetch:

- multi-partition final aggregate with `lim` and no parent global fetch → wrap with `CoalescePartitionsExec::with_fetch(lim)`;
- idempotent: no-op when a parent already provides an equal-or-tighter global fetch (verified by test);
- `Partial` aggregates and single-partition outputs are left untouched.

**Compatibility**: no API or data format changes; only query plans gain a correct global limit node.

**Tests**:
- 4 new unit tests in `src/query/src/optimizer/global_limit.rs`;
- new sqlness regression case in `tests/cases/standalone/common/information_schema/ssts.sql` (verified end-to-end: returns 3 rows without the fix, 1 row with it);
- `cargo nextest run -p query` (660 passed), `cargo clippy -p query --all-targets --all-features -- -D warnings`, `make fmt`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.