### PR TITLE
fix(flow): avoid insert select HTTP/2 stalls

### DIFF
--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -436,6 +436,8 @@ impl StartCommand {
         // Some queries are expected to take long time.
         let mut channel_config = opts.datanode.client.channel_config();
         channel_config.timeout = None;
+        // Source Flight streams and sink unary responses share pooled connections.
+        channel_config.http2_adaptive_window = Some(true);
         if opts.grpc.flight_compression.transport_compression() {
             channel_config.accept_compression = true;
             channel_config.send_compression = true;

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -44,6 +44,7 @@ use datafusion_expr::{
 use datatypes::prelude::VectorRef;
 use datatypes::schema::Schema;
 use futures_util::StreamExt;
+use futures_util::future::try_join;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt, ensure};
 use sqlparser::ast::AnalyzeFormat;
@@ -214,30 +215,57 @@ impl DatafusionQueryEngine {
         let mut affected_rows = 0;
         let mut insert_cost = 0;
 
-        while let Some(batch) = stream.next().await {
-            let batch = batch.context(CreateRecordBatchSnafu)?;
-            let column_vectors = batch
-                .column_vectors(&table_name.to_string(), table.schema())
-                .map_err(BoxedError::new)
-                .context(QueryExecutionSnafu)?;
-
-            match dml.op {
-                WriteOp::Insert(_) => {
-                    // We ignore the insert op.
-                    let output = self
-                        .insert(&table_name, column_vectors, query_ctx.clone())
-                        .await?;
-                    let (rows, cost) = output.extract_rows_and_cost();
-                    affected_rows += rows;
-                    insert_cost += cost;
-                }
-                WriteOp::Delete => {
+        match dml.op {
+            WriteOp::Insert(_) => {
+                // An unbounded queue keeps draining source RPCs while sink RPCs on a shared
+                // HTTP/2 connection are pending, trading bounded memory for request liveness.
+                let (batch_tx, mut batch_rx) = tokio::sync::mpsc::unbounded_channel();
+                let producer = async move {
+                    while let Some(batch) = stream.next().await {
+                        let batch = batch.context(CreateRecordBatchSnafu);
+                        let is_err = batch.is_err();
+                        if batch_tx.send(batch).is_err() {
+                            break;
+                        }
+                        if is_err {
+                            break;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                    Ok::<_, crate::error::Error>(())
+                };
+                let consumer = async {
+                    while let Some(batch) = batch_rx.recv().await {
+                        let batch = batch?;
+                        let column_vectors = batch
+                            .column_vectors(&table_name.to_string(), table.schema())
+                            .map_err(BoxedError::new)
+                            .context(QueryExecutionSnafu)?;
+                        // We ignore the insert op.
+                        let output = self
+                            .insert(&table_name, column_vectors, query_ctx.clone())
+                            .await?;
+                        let (rows, cost) = output.extract_rows_and_cost();
+                        affected_rows += rows;
+                        insert_cost += cost;
+                    }
+                    Ok::<_, crate::error::Error>(())
+                };
+                try_join(producer, consumer).await?;
+            }
+            WriteOp::Delete => {
+                while let Some(batch) = stream.next().await {
+                    let batch = batch.context(CreateRecordBatchSnafu)?;
+                    let column_vectors = batch
+                        .column_vectors(&table_name.to_string(), table.schema())
+                        .map_err(BoxedError::new)
+                        .context(QueryExecutionSnafu)?;
                     affected_rows += self
                         .delete(&table_name, &table, column_vectors, query_ctx.clone())
                         .await?;
                 }
-                _ => unreachable!("guarded by the 'ensure!' at the beginning"),
             }
+            _ => unreachable!("guarded by the 'ensure!' at the beginning"),
         }
         Ok(Output::new(
             OutputData::AffectedRows(affected_rows),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Concurrent batching `INSERT ... SELECT` requests can enter a cross-stream HTTP/2 flow-control deadlock and remain pending until their common deadline when source Region Flight streams and sink Region writes reuse the same frontend-to-datanode connection.

The existing INSERT loop polls one source batch, awaits its sink write, and only then polls the source again. With enough concurrent multi-batch aggregate results, unread source response DATA can consume the shared connection receive window. The sink response cannot make progress on that connection, while the frontend cannot resume reading the source until that sink response arrives.

### Reproduction

This was reproduced against the exact affected build:

- version: `1.2.0-beta.1`
- commit: `144bdc2911ced5a0565b39bb7e4c99203748d3e6`
- local distributed topology: one metasrv, one datanode, one frontend, and two flownodes
- 14 batching Flows, distributed 7/7 across the two flownodes, all sent to one frontend
- one source region and one sink region per Flow; source and sinks all resolve to datanode peer 1
- `max_concurrent_queries = 0`, so no datanode query semaphore or permit wait is involved
- no `SIGSTOP`, write-buffer pressure, network proxy, or other fault injection
- source aggregation is fully pushed down to the datanode and produces multiple result batches; DataFusion's aggregate output batch size is 8,192 rows

The source used high-cardinality rows with unique group keys. Timestamps were numeric epoch nanoseconds with an explicit cast, for example:

```sql
CREATE TABLE src (
  ts TIMESTAMP(9) TIME INDEX,
  k STRING,
  v DOUBLE,
  PRIMARY KEY (k)
);

-- Generated in bounded INSERT requests after the Flows were created.
INSERT INTO src VALUES
  ((1700000000000000000)::timestamp(9), 'k0', 1.0),
  ((1700000000000000001)::timestamp(9), 'k1', 1.0);
```

Each of the 14 Flows had its own sink and the same batching query shape:

```sql
CREATE TABLE sink_01 (
  k STRING,
  total DOUBLE,
  window_start TIMESTAMP(9) TIME INDEX,
  PRIMARY KEY (k)
);

CREATE FLOW flow_01 SINK TO sink_01 AS
SELECT
  k,
  sum(v) AS total,
  date_bin(INTERVAL '1 nanosecond', ts) AS window_start
FROM src
GROUP BY k, date_bin(INTERVAL '1 nanosecond', ts);
```

After creating all 14 Flows and loading the source rows, the trigger was 14 concurrent requests equivalent to:

```sql
ADMIN FLUSH_FLOW('flow_01');
-- ... through flow_14, issued concurrently
```

The group-count threshold was repeatable:

| Groups per Flow | Deadline | Result before this fix |
| ---: | ---: | --- |
| 1,024 | 60s | 14/14 completed in 4.17–6.40s |
| 8,192 | 60s | 14/14 completed in 0.879–1.152s |
| 16,384 | 60s | 14/14 completed in 1.074–1.355s |
| 32,768 | 60s | 14/14 timed out together in 60.166–60.237s |
| 131,072 | 20s | 14/14 timed out together in 20.158–20.192s |
| 131,072 | 60s | 14/14 still timed out together in 60.273–60.375s |

Increasing the 131,072-group deadline from 20s to 60s only moved the cohort cancellation point; it did not allow natural recovery. Immediately after each cohort was cancelled, retrying one Flow completed normally in 1.123s for 32,768 groups and 3.402–3.570s for 131,072 groups.

A separate 32,768-group/20s stage-inspection run provided the clearest progress evidence:

- `SELECT 1` against the frontend completed in 19ms while all 14 Flow requests were stalled, so the frontend/runtime was not frozen;
- after timeout and before retry, 10 sink tables contained exactly 8,192 rows and four contained zero rows;
- nevertheless, all 14 DML requests stayed pending until the same deadline;
- the exact 8,192-row prefix is one DataFusion aggregate output batch.

This shows that at least 10 requests had received and committed their first source batch, but response/source progress could not continue. Dropping all timed-out streams released HTTP/2 capacity, after which a single Flow recovered immediately.

### Why it deadlocks

Source Region Flight reads and sink Region unary writes use the same frontend-local `NodeClients`, `ChannelManager`, address-keyed tonic channel, and therefore the same HTTP/2 connection when source and sink are on the same datanode.

The old execution order creates this cycle:

```text
frontend receives one source batch
  -> frontend awaits the sink write response and stops polling source
  -> unread source Flight DATA consumes the shared connection receive window
  -> the sink response cannot advance on that connection
  -> frontend cannot resume source polling until the sink response arrives
```

The query deadline breaks the cycle by cancelling and dropping the streams; merely extending the deadline does not restore progress.

### Fix

This change addresses both transport headroom and the application-level wait cycle:

- enable tonic/h2 adaptive receive windows for distributed frontend datanode clients;
- decouple INSERT source reads from sequential sink writes with a cooperatively polled producer/consumer pair;
- use an unbounded in-memory queue so sink latency never applies source backpressure that could recreate the same shared-connection cycle;
- preserve source batch order, sequential sink writes, affected-row/cost accounting, FIFO source error delivery, and statement cancellation by keeping both futures in the same DML future without detached tasks.

The intentional tradeoff is that a sink substantially slower than its source can accumulate queued `RecordBatch` values in frontend memory. This turns an implicit connection-level liveness failure into visible memory pressure.

There are no API, persisted-schema, or wire-format changes.

### Verification after the fix

Local checks:

- `git diff --check`
- `cargo fmt --check -- src/cmd/src/frontend.rs src/query/src/datafusion.rs`
- `cargo check -p cmd`
- `cargo test -p query datafusion --lib`

The same exact-version distributed topology and 14-Flow workload completed with exact row counts:

| Groups per Flow | Result after this fix | Sink verification |
| ---: | --- | --- |
| 32,768 | 14/14 completed in 7.259–11.419s | all 14 sinks contained exactly 32,768 rows |
| 131,072 | 14/14 completed in 30.011–42.249s | all 14 sinks contained exactly 131,072 rows |

## PR Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
