### PR TITLE
fix(cmd): configure meta client in frontend plugin test

### DIFF
--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -685,10 +685,14 @@ mod tests {
         let extensions = FrontendHeartbeatExtensions::default();
         let shared_extensions = extensions.clone();
 
+        let options = frontend::frontend::FrontendOptions {
+            meta_client: Some(MetaClientOptions::default()),
+            ..Default::default()
+        };
         let plugins = prepare_frontend_plugins(
             plugins_with_heartbeat_extensions(extensions),
             &[],
-            &frontend::frontend::FrontendOptions::default(),
+            &options,
             None,
         )
         .await


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The frontend heartbeat extension regression test calls pre-build plugin setup with default frontend options. This works with the OSS plugin implementation, but enterprise builds substitute `plugins` with `ent-plugins`, where distributed frontend setup correctly requires a configured meta client.

This PR gives `test_prefilled_heartbeat_extensions_survive_pre_build_setup` a default `MetaClientOptions`. It keeps the regression coverage and production validation intact while making the test configuration valid for both OSS and enterprise plugin implementations.

Tested with:

```shell
cargo nextest run -p cmd test_prefilled_heartbeat_extensions_survive_pre_build_setup --all-features
```

## PR Checklist

- [x] I have written the necessary rustdoc comments, or no rustdoc changes are required.
- [x] I have added the necessary unit tests and integration tests, or the change updates an existing test.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
