### PR TITLE
fix(mito2): avoid chained L1 rewrites in TWCS

### DIFF
--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -184,35 +184,32 @@ impl TwcsPicker {
             }
         }
 
-        let num_l0_files = files_to_merge
-            .iter()
-            .filter(|file| file.level() == 0)
-            .count();
-        let num_l1_files = files_to_merge.len() - num_l0_files;
+        let (mut l0_files, l1_files): (Vec<_>, Vec<_>) = files_to_merge
+            .into_iter()
+            .partition(|file| file.level() == 0);
+        let num_l0_files = l0_files.len();
+        let num_l1_files = l1_files.len();
         // Keep fresh L0 data and compacted L1 data in separate tasks whenever either
         // level can trigger compaction on its own. This prevents each L0 batch from
         // pulling the previous L1 output into another rewrite.
-        let require_mixed_levels;
-        if num_l0_files >= self.trigger_file_num {
-            files_to_merge.retain(|file| file.level() == 0);
-            require_mixed_levels = false;
+        let (inputs, found_runs) = if num_l0_files >= self.trigger_file_num {
+            let l0_pick =
+                pick_candidate_files(l0_files, self.max_output_file_size, pick_count_first);
+            if l0_pick.0.is_empty() && num_l1_files >= self.trigger_file_num {
+                pick_candidate_files(l1_files, self.max_output_file_size, pick_count_first)
+            } else {
+                l0_pick
+            }
         } else if num_l1_files >= self.trigger_file_num {
-            files_to_merge.retain(|file| file.level() != 0);
-            require_mixed_levels = false;
+            pick_candidate_files(l1_files, self.max_output_file_size, pick_count_first)
         } else {
-            require_mixed_levels = num_l0_files > 0 && num_l1_files > 0;
-        }
-
-        let sorted_runs = if files_to_merge.len() < 1024 {
-            find_sorted_runs(&mut files_to_merge)
-        } else {
-            find_sorted_runs_by_time_range(&mut files_to_merge)
-        };
-        let found_runs = sorted_runs.len();
-        let inputs = if require_mixed_levels {
-            pick_mixed_count_first(sorted_runs, self.max_output_file_size)
-        } else {
-            pick_count_first(sorted_runs, self.max_output_file_size)
+            l0_files.extend(l1_files);
+            let picker = if num_l0_files > 0 && num_l1_files > 0 {
+                pick_mixed_count_first
+            } else {
+                pick_count_first
+            };
+            pick_candidate_files(l0_files, self.max_output_file_size, picker)
         };
         let filter_deleted = !self.append_mode
             && !window_has_overlap(files, windows)
@@ -233,6 +230,20 @@ impl TwcsPicker {
         }
         (inputs, filter_deleted)
     }
+}
+
+fn pick_candidate_files(
+    mut files: Vec<FileHandle>,
+    max_output_file_size: Option<u64>,
+    picker: fn(Vec<SortedRun<FileHandle>>, Option<u64>) -> Vec<FileHandle>,
+) -> (Vec<FileHandle>, usize) {
+    let sorted_runs = if files.len() < 1024 {
+        find_sorted_runs(&mut files)
+    } else {
+        find_sorted_runs_by_time_range(&mut files)
+    };
+    let found_runs = sorted_runs.len();
+    (picker(sorted_runs, max_output_file_size), found_runs)
 }
 
 #[derive(Debug)]
@@ -2274,6 +2285,52 @@ mod tests {
                 "{case}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_picker_falls_back_to_l1_when_triggered_l0_cannot_make_progress() {
+        let mut files = (0..4)
+            .map(|idx| {
+                let start = idx * 20;
+                new_file_handle_with_size_and_sequence(
+                    FileId::random(),
+                    start,
+                    start + 9,
+                    0,
+                    idx as u64 + 1,
+                    600,
+                )
+            })
+            .collect::<Vec<_>>();
+        files.extend((0..4).map(|idx| {
+            let start = idx * 20 + 100;
+            new_file_handle_with_size_and_sequence(
+                FileId::random(),
+                start,
+                start + 9,
+                1,
+                idx as u64 + 10,
+                100,
+            )
+        }));
+        let windows = assign_to_windows(files.iter(), 1);
+        let picker = TwcsPicker {
+            trigger_file_num: 4,
+            time_window_seconds: Some(1),
+            max_output_file_size: Some(512),
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(1), None)
+            .await
+            .unwrap();
+
+        assert_eq!(1, output.len());
+        assert_eq!(4, output[0].inputs.len());
+        assert!(output[0].inputs.iter().all(|file| file.level() == 1));
     }
 
     #[test]

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -40,6 +40,9 @@ use crate::sst::version::LevelMeta;
 
 const LEVEL_COMPACTED: Level = 1;
 
+/// A mixed L0/L1 compaction may rewrite at most this many L1 rows per L0 row.
+const MAX_L1_L0_ROW_RATIO: usize = 2;
+
 /// Default maximum number of input SST files in one compaction input.
 const DEFAULT_MAX_INPUT_FILES: usize = 32;
 
@@ -181,13 +184,36 @@ impl TwcsPicker {
             }
         }
 
+        let num_l0_files = files_to_merge
+            .iter()
+            .filter(|file| file.level() == 0)
+            .count();
+        let num_l1_files = files_to_merge.len() - num_l0_files;
+        // Keep fresh L0 data and compacted L1 data in separate tasks whenever either
+        // level can trigger compaction on its own. This prevents each L0 batch from
+        // pulling the previous L1 output into another rewrite.
+        let require_mixed_levels;
+        if num_l0_files >= self.trigger_file_num {
+            files_to_merge.retain(|file| file.level() == 0);
+            require_mixed_levels = false;
+        } else if num_l1_files >= self.trigger_file_num {
+            files_to_merge.retain(|file| file.level() != 0);
+            require_mixed_levels = false;
+        } else {
+            require_mixed_levels = num_l0_files > 0 && num_l1_files > 0;
+        }
+
         let sorted_runs = if files_to_merge.len() < 1024 {
             find_sorted_runs(&mut files_to_merge)
         } else {
             find_sorted_runs_by_time_range(&mut files_to_merge)
         };
         let found_runs = sorted_runs.len();
-        let inputs = pick_count_first(sorted_runs, self.max_output_file_size);
+        let inputs = if require_mixed_levels {
+            pick_mixed_count_first(sorted_runs, self.max_output_file_size)
+        } else {
+            pick_count_first(sorted_runs, self.max_output_file_size)
+        };
         let filter_deleted = !self.append_mode
             && !window_has_overlap(files, windows)
             && !selected_overlaps_unselected(&inputs, files);
@@ -229,6 +255,14 @@ struct Candidate {
     /// Files in the interval that overlap another interval file from a different
     /// sorted run. Resolving these overlaps is what reduces sorted runs.
     overlap_participants: usize,
+    /// Number of rows contributed by uncompacted files.
+    l0_rows: usize,
+    /// Number of rows contributed by compacted files.
+    l1_rows: usize,
+    has_l0: bool,
+    has_l1: bool,
+    /// Whether at least one file uses 0 to represent an unknown row count.
+    has_unknown_rows: bool,
 }
 
 impl Candidate {
@@ -245,6 +279,7 @@ impl Candidate {
         let file_size = file.file.size() as usize;
         self.total_size += file_size;
         self.largest_file_size = self.largest_file_size.max(file_size);
+        self.absorb_level_rows(file.file);
 
         let mut participates = false;
         for (offset, other) in preceding.iter().enumerate() {
@@ -259,6 +294,18 @@ impl Candidate {
         participations.push(participates);
         if participates {
             self.overlap_participants += 1;
+        }
+    }
+
+    fn absorb_level_rows(&mut self, file: &FileHandle) {
+        let num_rows = file.num_rows();
+        self.has_unknown_rows |= num_rows == 0;
+        if file.level() == 0 {
+            self.has_l0 = true;
+            self.l0_rows = self.l0_rows.saturating_add(num_rows);
+        } else {
+            self.has_l1 = true;
+            self.l1_rows = self.l1_rows.saturating_add(num_rows);
         }
     }
 
@@ -285,6 +332,19 @@ impl Candidate {
     /// the same amount of data, so every rewrite moves it into a larger size tier.
     fn is_balanced(&self) -> bool {
         self.largest_file_size <= self.total_size - self.largest_file_size
+    }
+
+    /// Bounds rewrite amplification for mixed L0/L1 candidates. Legacy files with
+    /// unknown row counts retain the byte-balance behavior above.
+    fn has_balanced_level_rows(&self) -> bool {
+        !self.has_l0
+            || !self.has_l1
+            || self.has_unknown_rows
+            || self.l1_rows <= self.l0_rows.saturating_mul(MAX_L1_L0_ROW_RATIO)
+    }
+
+    fn has_mixed_levels(&self) -> bool {
+        self.has_l0 && self.has_l1
     }
 
     /// A candidate is worth compacting only if it makes progress on at least one
@@ -332,6 +392,7 @@ impl CandidateScore {
 ///
 /// - holds at least 2 files,
 /// - is balanced: no single file dominates it (`largest <= sum of the others`),
+/// - when mixing levels with known row counts, has at most twice as many L1 rows as L0 rows,
 /// - makes progress on at least one axis: it reduces the physical file count given
 ///   the output split threshold `max_output_file_size`, or it resolves at least one
 ///   overlap between sorted runs.
@@ -340,6 +401,25 @@ impl CandidateScore {
 fn pick_count_first(
     sorted_runs: Vec<SortedRun<FileHandle>>,
     max_output_file_size: Option<u64>,
+) -> Vec<FileHandle> {
+    pick_count_first_where(sorted_runs, max_output_file_size, |_| true)
+}
+
+fn pick_mixed_count_first(
+    sorted_runs: Vec<SortedRun<FileHandle>>,
+    max_output_file_size: Option<u64>,
+) -> Vec<FileHandle> {
+    pick_count_first_where(
+        sorted_runs,
+        max_output_file_size,
+        Candidate::has_mixed_levels,
+    )
+}
+
+fn pick_count_first_where(
+    sorted_runs: Vec<SortedRun<FileHandle>>,
+    max_output_file_size: Option<u64>,
+    is_eligible: impl Fn(&Candidate) -> bool,
 ) -> Vec<FileHandle> {
     let files = ordered_files(&sorted_runs);
 
@@ -352,6 +432,8 @@ fn pick_count_first(
             candidate.absorb(&files[right], &files[left..right], &mut participations);
             if candidate.num_files < 2
                 || !candidate.is_balanced()
+                || !is_eligible(&candidate)
+                || !candidate.has_balanced_level_rows()
                 || !candidate.makes_progress(max_output_file_size)
             {
                 continue;
@@ -1290,7 +1372,9 @@ mod tests {
                     output_level: 1,
                 },
                 ExpectedOutput {
-                    input_files: vec![0, 1, 4],
+                    // L1 reaches the trigger on its own, so compact it without
+                    // rewriting the L0 tail. A chained pick can handle the tail.
+                    input_files: vec![0, 1],
                     output_level: 1,
                 },
             ],
@@ -1456,6 +1540,33 @@ mod tests {
             output.is_empty(),
             "Should return empty output when no runs are found after filtering"
         );
+    }
+
+    #[tokio::test]
+    async fn test_append_mode_can_pick_remaining_single_level_files() {
+        let files = [
+            new_file_handle_with_size_and_sequence(FileId::random(), 0, 9, 0, 1, 100),
+            new_file_handle_with_size_and_sequence(FileId::random(), 20, 29, 0, 2, 100),
+            new_file_handle_with_size_and_sequence(FileId::random(), 40, 49, 0, 3, 100),
+            new_file_handle_with_size_and_sequence(FileId::random(), 60, 69, 0, 4, 2_000),
+        ];
+        let windows = assign_to_windows(files.iter(), 1);
+        let picker = TwcsPicker {
+            trigger_file_num: 4,
+            time_window_seconds: Some(1),
+            max_output_file_size: Some(1_000),
+            append_mode: true,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        let output = picker
+            .build_output_with_time_range(RegionId::from_u64(1), windows, Some(1), None)
+            .await
+            .unwrap();
+
+        assert_eq!(1, output.len());
+        assert_eq!(3, output[0].inputs.len());
     }
 
     #[tokio::test]
@@ -1978,6 +2089,27 @@ mod tests {
         new_file_handle_with_size_and_sequence(FileId::random(), start, end, 0, sequence, file_size)
     }
 
+    fn new_file_with_level_and_rows(
+        start: i64,
+        end: i64,
+        level: Level,
+        sequence: u64,
+        file_size: u64,
+        num_rows: u64,
+    ) -> FileHandle {
+        let file = new_file_handle_with_size_and_sequence(
+            FileId::random(),
+            start,
+            end,
+            level,
+            sequence,
+            file_size,
+        );
+        let mut meta = file.meta_ref().clone();
+        meta.num_rows = num_rows;
+        FileHandle::new(meta, crate::test_util::new_noop_file_purger())
+    }
+
     fn picked_ranges(files: &[FileHandle]) -> Vec<(i64, i64)> {
         files
             .iter()
@@ -2066,6 +2198,102 @@ mod tests {
         assert_eq!(DEFAULT_MAX_INPUT_FILES, ranges.len());
         assert!(!ranges.contains(&(0, 9)));
         assert!(ranges.contains(&(690, 710)));
+    }
+
+    #[tokio::test]
+    async fn test_picker_avoids_chained_l1_rewrites_by_compacting_levels_separately() {
+        let mut enough_l0 = (0..DEFAULT_MAX_INPUT_FILES)
+            .map(|idx| {
+                let start = idx as i64 * 20;
+                new_file_handle_with_size_and_sequence(
+                    FileId::random(),
+                    start,
+                    start + 9,
+                    0,
+                    idx as u64 + 1,
+                    10,
+                )
+            })
+            .collect::<Vec<_>>();
+        enough_l0.push(new_file_handle_with_size_and_sequence(
+            FileId::random(),
+            0,
+            700,
+            1,
+            100,
+            100,
+        ));
+        let mut enough_l1 = (0..4)
+            .map(|idx| {
+                new_file_handle_with_size_and_sequence(
+                    FileId::random(),
+                    idx * 100,
+                    idx * 100 + 99,
+                    1,
+                    idx as u64 + 1,
+                    100,
+                )
+            })
+            .collect::<Vec<_>>();
+        enough_l1.extend((0..3).map(|idx| {
+            new_file_handle_with_size_and_sequence(
+                FileId::random(),
+                idx * 20,
+                idx * 20 + 9,
+                0,
+                idx as u64 + 10,
+                10,
+            )
+        }));
+        let picker = TwcsPicker {
+            trigger_file_num: 4,
+            time_window_seconds: Some(1),
+            max_output_file_size: None,
+            append_mode: false,
+            max_background_tasks: None,
+            time_range: None,
+        };
+
+        for (case, files, expected_level, expected_len) in [
+            ("L0 reaches trigger", enough_l0, 0, DEFAULT_MAX_INPUT_FILES),
+            ("L1 reaches trigger", enough_l1, 1, 4),
+        ] {
+            let windows = assign_to_windows(files.iter(), 1);
+            let output = picker
+                .build_output_with_time_range(RegionId::from_u64(1), windows, Some(1), None)
+                .await
+                .unwrap();
+
+            assert_eq!(1, output.len(), "{case}");
+            assert_eq!(expected_len, output[0].inputs.len(), "{case}");
+            assert!(
+                output[0]
+                    .inputs
+                    .iter()
+                    .all(|file| file.level() == expected_level),
+                "{case}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mixed_candidate_row_balance() {
+        for (case, l1_rows, l0_rows, expected_len) in [
+            ("L1 rows dominate", 1_000_000, 10_000, 0),
+            ("L1 rows meet ratio", 60_000, 10_000, 4),
+            ("L0 rows are unknown", 1_000_000, 0, 4),
+        ] {
+            let files = vec![
+                new_file_with_level_and_rows(0, 99, 1, 1, 100, l1_rows),
+                new_file_with_level_and_rows(0, 9, 0, 2, 100, l0_rows),
+                new_file_with_level_and_rows(20, 29, 0, 3, 100, l0_rows),
+                new_file_with_level_and_rows(40, 49, 0, 4, 100, l0_rows),
+            ];
+
+            let picked = pick_mixed_count_first(vec![SortedRun::from(files)], None);
+
+            assert_eq!(expected_len, picked.len(), "{case}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- Follow-up to #8765
- #8575

## What's changed and what's your intention?

### Problem

The TWCS picker can repeatedly include L1 files produced by the previous compaction when new L0 files arrive. In the benchmark described in the analysis document, 62 of 118 compactions were chained tasks and L1 rows were reread at 384% of the ingested row count, resulting in 4.84x row-level write amplification.

<img width="934" height="509" alt="image" src="https://github.com/user-attachments/assets/a132ad68-9d70-432b-ad72-e4c128575117" />


### Why L0 and L1 have different densities

L0 and L1 have similar uncompressed bytes per row, approximately 680 B/row and 758 B/row respectively, but very different compressed densities:

- L0 files have about 1 row per series because flushes are split by series count. Primary-key values therefore differ on almost every row, leaving little opportunity for dictionary and RLE encoding. They compress to about 22.3 B/row, or roughly 32x compression.
- L1 files contain about 9.9 rows per series after compaction. Adjacent rows share primary-key and tag values, so these columns compress much more effectively. They compress to about 3.0 B/row, or roughly 420x compression.

This means an L1 file can contain 5-10 times as many rows as a much larger-looking set of L0 files while occupying fewer compressed bytes.

### Why the existing size-balance gate misses this

The existing gate requires the largest file compressed size to be no greater than the sum of the remaining groups. It assumes compressed output size grows roughly with input data volume.

That assumption does not hold for sparse time-series workloads. L0 files are byte-heavy because they compress poorly, while dense L1 files are byte-light despite containing many more rows. A large L1 file can therefore pass the byte-based gate alongside a small amount of new L0 data. Once it passes, its broad time range gives the mixed candidate more overlap participants, so the picker selects and rewrites the same L1 file repeatedly. This creates chained compactions and high write amplification without advancing the L1 file into a larger byte tier.

### Fix

This PR makes candidate selection level-aware:

- Prefer L0-only candidates when the number of L0 files reaches `trigger_file_num`.
- Otherwise prefer L1-only candidates when the number of L1 files reaches `trigger_file_num`, allowing accumulated L1 files to converge at the end of the window.
- Only consider mixed L0/L1 candidates when neither level reaches the trigger.
- For mixed candidates with known row counts, require total L1 rows to be no more than twice total L0 rows.
- Preserve the existing byte-balance fallback for legacy files whose `num_rows` is unknown (`0`).

This produces a two-stage compaction shape: L0 files compact independently during ingestion, then accumulated L1 files converge once near the end of the window.

<img width="918" height="448" alt="image" src="https://github.com/user-attachments/assets/dd472fd9-e3cd-4e28-9727-694fa735b1f6" />


### Validation and effect

The same 850M-row backfill benchmark was rerun after the fix:

| Metric | Before | After | Effect |
| --- | ---: | ---: | ---: |
| Chained tasks | 62/118 (53%) | 4/104 (4%) | Nearly eliminated |
| L0-only tasks | 45 | 100 | Became the dominant path |
| L1 rereads / ingested rows | 384% | 99% | -285 percentage points |
| Row-level write amplification | 4.84x | 1.98x | -59% |
| Compaction bytes written | 5834 MiB | 4721 MiB | -19% |
| Compaction task count | 118 | 104 | -12% |

The four remaining tasks involving L1 were the expected final L1-only convergence, one per region. The trade-off is that L1 files accumulate until convergence: peak window file count increased from 254 to 317 (+25%), and merge CPU increased from 141 to 156 minutes (+10%) because 32-file L0-only tasks are dominated by serial input-read latency.

Real world metrics ingestion workload:
Before: Cumulative compaction output: 5.78GB
<img width="843" height="298" alt="image" src="https://github.com/user-attachments/assets/1df3380f-8802-4219-8d68-2ba64c47173e" />

After: Cumulative compaction output: 4.61GB (-20%)

<img width="1097" height="306" alt="image" src="https://github.com/user-attachments/assets/77a85142-1809-4f4b-b70c-48e7d31b0255" />



### Compatibility

This changes only automatic TWCS candidate selection. It does not change APIs, schemas, persisted metadata, or wire formats.

## PR Checklist

- [ ] I have written the necessary rustdoc comments. (N/A: no public API added)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.

