### PR TITLE
fix(cmd): gate daemon integration test on Unix

### DIFF
--- a/src/cmd/tests/standalone_daemon.rs
+++ b/src/cmd/tests/standalone_daemon.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(unix)]
+
 use std::net::TcpStream;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Related to #8985.

## What's changed and what's your intention?

The Windows Release job compiles `src/cmd/tests/standalone_daemon.rs` with warnings denied. Although its test function was Unix-only, the Unix-specific imports and `DaemonGuard` helper were still compiled on Windows, producing unused-import and dead-code errors.

Gate the entire integration-test crate with `#![cfg(unix)]`. The test starts and signals a Unix daemon, so it has no Windows behavior to preserve.

Verification:
- `cargo fmt --all -- --check`
- `cargo check -p cmd --tests`
- `cargo nextest run -p cmd --test standalone_daemon` (1 passed)
- pre-commit hooks (typos, formatting, license headers, and Clippy)

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.