### PR TITLE
perf(table): filter decoded rows with dynamic predicates

### DIFF
--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -27,9 +27,12 @@ use common_error::status_code::StatusCode;
 use common_recordbatch::{DfRecordBatch, RecordBatches};
 use common_test_util::flight::encode_to_flight_data;
 use common_time::Timestamp;
+use datafusion::physical_plan::expressions::{
+    BinaryExpr, Column, DynamicFilterPhysicalExpr, lit as physical_lit,
+};
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{col, lit};
+use datafusion_expr::{Operator, col, lit};
 use datatypes::arrow::array::{
     ArrayRef, AsArray, Float64Array, StringArray, TimestampMillisecondArray,
 };
@@ -1043,6 +1046,22 @@ async fn test_series_scan_with_format(flat_format: bool) {
     expected_rows.sort_by(|a, b| a.0.cmp(&b.0).then(a.2.cmp(&b.2)));
 
     assert_eq!(expected_rows, actual_rows);
+
+    scanner.reset_state();
+    assert_eq!("legacy", scanner.mode());
+    assert_eq!(
+        vec![1, 1, 1],
+        scanner
+            .properties()
+            .partitions
+            .iter()
+            .map(Vec::len)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        expected_rows,
+        collect_partition_rows_round_robin(&scanner, 3).await
+    );
 }
 
 #[tokio::test]
@@ -1226,6 +1245,51 @@ async fn test_two_phase_series_scan() {
     assert_eq!(Some(&0), series_to_partition.get("c"));
     assert_eq!(Some(&2), series_to_partition.get("b"));
     assert_eq!(Some(&2), series_to_partition.get("d"));
+
+    scanner.reset_state();
+    assert_eq!("two_phase", scanner.mode());
+    assert_eq!(
+        vec![1, 0, 0],
+        scanner
+            .properties()
+            .partitions
+            .iter()
+            .map(Vec::len)
+            .collect::<Vec<_>>()
+    );
+    let replay_batches = try_join_all((0..3).map(|partition| {
+        let stream = scanner
+            .scan_partition(&context, &metrics_set, partition)
+            .unwrap();
+        async move { stream.try_collect::<Vec<_>>().await }
+    }))
+    .await
+    .unwrap();
+    let mut replay_rows = Vec::new();
+    for batches in replay_batches {
+        for batch in batches {
+            let tags = batch.column_by_name("tag_0").unwrap();
+            let fields = batch
+                .column_by_name("field_0")
+                .unwrap()
+                .as_primitive::<UInt64Type>();
+            let timestamps = batch
+                .column_by_name("ts")
+                .unwrap()
+                .as_primitive::<TimestampMillisecondType>();
+            for row in 0..batch.num_rows() {
+                replay_rows.push((
+                    datatypes::arrow_array::string_array_value_at_index(tags, row)
+                        .unwrap()
+                        .to_string(),
+                    fields.value(row),
+                    timestamps.value(row),
+                ));
+            }
+        }
+    }
+    replay_rows.sort();
+    assert_eq!(actual_rows, replay_rows);
 }
 
 /// Scans all partitions in round-robin fashion and returns rows sorted by (tag, ts).
@@ -3174,4 +3238,129 @@ async fn test_range_cache_key_separates_sequence_ranges() {
         second,
         "different (C, H] shared a range-cache entry"
     );
+}
+
+#[tokio::test]
+async fn test_reset_state_discards_dynamic_field_pruning() {
+    for (append_mode, expected_scanner_name) in [(false, "SeqScan"), (true, "UnorderedScan")] {
+        let mut env = TestEnv::with_prefix(if append_mode {
+            "test_reset_state_discards_dynamic_field_pruning_unordered"
+        } else {
+            "test_reset_state_discards_dynamic_field_pruning_seq"
+        })
+        .await;
+        let engine = env.create_engine(MitoConfig::default()).await;
+        let region_id = RegionId::new(1, u32::from(append_mode) + 1);
+        let request = CreateRequestBuilder::new()
+            .insert_option("append_mode", &append_mode.to_string())
+            // Keep a third row group unconsumed after the first execution so its
+            // file-range builder remains cached by the old pruner.
+            .insert_option("max_row_group_row_count", "2")
+            .build();
+        let column_schemas = test_util::rows_schema(&request);
+
+        engine
+            .handle_request(region_id, RegionRequest::Create(request))
+            .await
+            .unwrap();
+        test_util::put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: column_schemas,
+                rows: test_util::build_rows(0, 6),
+            },
+        )
+        .await;
+        test_util::flush_region(&engine, region_id, None).await;
+
+        let scanner = engine
+            .scanner(
+                region_id,
+                ScanRequest {
+                    // The static physical-field predicate must survive reset.
+                    filters: vec![col("field_0").gt_eq(lit(1.0_f64))],
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let mut scanner: Box<dyn RegionScanner> = match scanner {
+            Scanner::Seq(scanner) => {
+                assert_eq!(expected_scanner_name, "SeqScan");
+                assert_eq!(3, scanner.input().files[0].meta_ref().num_row_groups);
+                Box::new(scanner)
+            }
+            Scanner::Unordered(scanner) => {
+                assert_eq!(expected_scanner_name, "UnorderedScan");
+                assert_eq!(3, scanner.input().files[0].meta_ref().num_row_groups);
+                Box::new(scanner)
+            }
+            Scanner::Series(_) => panic!("scanner should not be a series scan"),
+        };
+        assert_eq!(expected_scanner_name, scanner.name());
+
+        let field = Arc::new(Column::new("field_0", 1));
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![field.clone()],
+            physical_lit(true),
+        ));
+        assert_eq!(
+            vec![true],
+            scanner.add_dyn_filter_to_predicate(vec![dynamic_filter.clone()])
+        );
+        dynamic_filter
+            .update(Arc::new(BinaryExpr::new(
+                field,
+                Operator::Gt,
+                physical_lit(2.0_f64),
+            )))
+            .unwrap();
+
+        // Dynamic pruning skips the first row group but does not filter individual
+        // rows in the second. Drop before consuming the third row group.
+        let mut stream = scanner
+            .scan_partition(&Default::default(), &ExecutionPlanMetricsSet::default(), 0)
+            .unwrap();
+        let first_batch = stream.try_next().await.unwrap().unwrap();
+        assert_eq!(
+            vec![2.0, 3.0],
+            scan_field_values(std::slice::from_ref(&first_batch))
+        );
+        drop(stream);
+
+        scanner.reset_state();
+        // This producer belongs to the old execution. Its later update must not
+        // affect the reset scanner or restore the old cached pruning decision.
+        dynamic_filter.update(physical_lit(false)).unwrap();
+
+        let mut values = Vec::new();
+        for partition in 0..scanner.properties().num_partitions() {
+            let stream = scanner
+                .scan_partition(
+                    &Default::default(),
+                    &ExecutionPlanMetricsSet::default(),
+                    partition,
+                )
+                .unwrap();
+            values.extend(scan_field_values(
+                &stream.try_collect::<Vec<_>>().await.unwrap(),
+            ));
+        }
+        values.sort_by(f64::total_cmp);
+        assert_eq!(vec![1.0, 2.0, 3.0, 4.0, 5.0], values);
+    }
+}
+
+fn scan_field_values(batches: &[common_recordbatch::RecordBatch]) -> Vec<f64> {
+    batches
+        .iter()
+        .flat_map(|batch| {
+            let fields = batch
+                .column_by_name("field_0")
+                .unwrap()
+                .as_primitive::<Float64Type>();
+            (0..batch.num_rows()).map(move |row| fields.value(row))
+        })
+        .collect()
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -2242,6 +2242,12 @@ impl PredicateGroup {
         self.predicate_without_region.add_dyn_filters(dyn_filters);
     }
 
+    /// Removes dynamic filters while preserving the static and region predicates.
+    pub(crate) fn clear_dyn_filters(&self) {
+        self.predicate_all.clear_dyn_filters();
+        self.predicate_without_region.clear_dyn_filters();
+    }
+
     /// Returns the region partition expr from metadata, if any.
     pub(crate) fn region_partition_expr(&self) -> Option<&PartitionExpr> {
         self.region_partition_expr.as_ref()
@@ -2793,6 +2799,27 @@ mod tests {
     }
 
     #[test]
+    fn test_clear_dyn_filters_preserves_predicate_group_static_filters() {
+        let metadata = Arc::new(metadata_with_primary_key(vec![0, 1], false));
+        let static_filters = vec![col("k0").eq(lit("foo"))];
+        let predicate_group = PredicateGroup::new(metadata.as_ref(), &static_filters).unwrap();
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(vec![], physical_lit(true)));
+        predicate_group.add_dyn_filters(vec![dynamic_filter.clone()]);
+
+        predicate_group.clear_dyn_filters();
+        // Updating the old producer cannot add its wrapper to a new execution.
+        dynamic_filter.update(physical_lit(false)).unwrap();
+
+        for predicate in [
+            predicate_group.predicate().unwrap(),
+            predicate_group.predicate_without_region().unwrap(),
+        ] {
+            assert_eq!(predicate.exprs(), static_filters);
+            assert!(predicate.dyn_filters().is_empty());
+        }
+    }
+
+    #[test]
     fn test_file_level_pruning_stats_prunes_old_file() {
         let ts_col_name = "ts";
         let predicate = Predicate::new(vec![col(ts_col_name).gt(ts_lit(1000))]);
@@ -2963,6 +2990,8 @@ mod tests {
         dyn_filter.update(updated).unwrap();
 
         assert!(input.can_manifest_prune_file(&file));
+        input.predicate.clear_dyn_filters();
+        assert!(!input.can_manifest_prune_file(&file));
     }
 
     #[tokio::test]

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -576,6 +576,13 @@ impl RegionScanner for SeqScan {
         self.stream_ctx.add_dyn_filter_to_predicate(filter_exprs)
     }
 
+    fn reset_state(&mut self) {
+        self.stream_ctx.input.predicate.clear_dyn_filters();
+        let num_workers = common_stat::get_total_cpu_cores().max(1);
+        self.pruner = Arc::new(Pruner::new(self.stream_ctx.clone(), num_workers));
+        self.metrics_list = PartitionMetricsList::default();
+    }
+
     fn set_logical_region(&mut self, logical_region: bool) {
         self.properties.set_logical_region(logical_region);
     }

--- a/src/mito2/src/read/series_scan.rs
+++ b/src/mito2/src/read/series_scan.rs
@@ -587,6 +587,25 @@ impl RegionScanner for SeriesScan {
         self.stream_ctx.add_dyn_filter_to_predicate(filter_exprs)
     }
 
+    fn reset_state(&mut self) {
+        self.stream_ctx.input.predicate.clear_dyn_filters();
+        let num_workers = common_stat::get_total_cpu_cores().max(1);
+        self.pruner = match self.mode {
+            SeriesScanMode::Legacy => Arc::new(Pruner::new(self.stream_ctx.clone(), num_workers)),
+            SeriesScanMode::TwoPhase => Arc::new(Pruner::new_with_options(
+                self.stream_ctx.clone(),
+                num_workers,
+                PrunerOptions {
+                    retain_builders: true,
+                    enable_predicate_prefilter: false,
+                },
+            )),
+        };
+        self.legacy_receivers.lock().unwrap().clear();
+        self.candidate_receivers.lock().unwrap().clear();
+        self.metrics_list = Arc::new(PartitionMetricsList::default());
+    }
+
     fn set_logical_region(&mut self, logical_region: bool) {
         self.properties.set_logical_region(logical_region);
     }

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -360,6 +360,13 @@ impl RegionScanner for UnorderedScan {
         self.stream_ctx.add_dyn_filter_to_predicate(filter_exprs)
     }
 
+    fn reset_state(&mut self) {
+        self.stream_ctx.input.predicate.clear_dyn_filters();
+        let num_workers = common_stat::get_total_cpu_cores().max(1);
+        self.pruner = Arc::new(Pruner::new(self.stream_ctx.clone(), num_workers));
+        self.metrics_list = PartitionMetricsList::default();
+    }
+
     fn set_logical_region(&mut self, logical_region: bool) {
         self.properties.set_logical_region(logical_region);
     }

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -496,6 +496,14 @@ pub trait RegionScanner: Debug + DisplayAs + Send {
         filter_exprs: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Vec<bool>;
 
+    /// Resets execution state after streams from the previous execution have been dropped.
+    ///
+    /// Callers must not concurrently execute, reset, or install filters through scanner aliases.
+    /// Implementations retaining dynamic predicates must discard them and derived pruning state,
+    /// while preserving static predicates, the source snapshot, and prepared properties.
+    /// The default is a no-op and does not make inherently one-shot sources replayable.
+    fn reset_state(&mut self) {}
+
     /// Sets whether the scanner is reading a logical region.
     fn set_logical_region(&mut self, logical_region: bool);
 

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -108,6 +108,11 @@ impl Predicate {
         });
     }
 
+    /// Removes dynamic filters while preserving the static logical expressions.
+    pub fn clear_dyn_filters(&self) {
+        self.dyn_filters.store(Arc::new(vec![]));
+    }
+
     /// Returns the logical exprs.
     pub fn exprs(&self) -> &[Expr] {
         &self.exprs
@@ -838,6 +843,24 @@ mod tests {
         assert_eq!(expect, res);
     }
 
+    #[test]
+    fn test_clear_dyn_filters_preserves_static_predicates() {
+        use datafusion_physical_expr::expressions::lit as physical_lit;
+
+        let static_exprs = vec![col("a").eq(lit(1_i32))];
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(vec![], physical_lit(true)));
+        let predicate =
+            Predicate::with_dyn_filters(static_exprs.clone(), vec![dynamic_filter.clone()]);
+
+        predicate.clear_dyn_filters();
+        // An update from the old producer must not put its wrapper back into this execution.
+        dynamic_filter.update(physical_lit(false)).unwrap();
+
+        assert_eq!(predicate.exprs(), static_exprs);
+        assert!(predicate.dyn_filters().is_empty());
+        assert!(predicate.dyn_filter_phy_exprs().unwrap().is_empty());
+    }
+
     #[tokio::test]
     async fn test_dynamic_pruning_keeps_null_row_group() {
         use datafusion_physical_expr::expressions::{
@@ -887,6 +910,48 @@ mod tests {
         assert_eq!(
             predicate.prune_with_stats(&stats, &arrow_schema),
             vec![true, false, true],
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clear_dyn_filters_restores_static_row_group_pruning() {
+        use datafusion_physical_expr::expressions::{
+            Column as PhysicalColumn, lit as physical_lit,
+        };
+
+        let dir = create_temp_dir("dynamic_pruning_reset");
+        let (path, arrow_schema) = gen_test_parquet_file(&dir, 30).await;
+        let schema = Arc::new(datatypes::schema::Schema::try_from(arrow_schema.clone()).unwrap());
+        let builder =
+            ParquetRecordBatchStreamBuilder::new(tokio::fs::File::open(path).await.unwrap())
+                .await
+                .unwrap();
+        let stats = RowGroupPruningStatistics::new(builder.metadata().row_groups(), &schema);
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(PhysicalColumn::new("cnt", 1))],
+            physical_lit(true),
+        ));
+        let predicate = Predicate::with_dyn_filters(
+            vec![col("cnt").gt_eq(lit(10_i32))],
+            vec![dynamic_filter.clone()],
+        );
+
+        dynamic_filter
+            .update(
+                Predicate::to_physical_expr(&col("cnt").gt(lit(100_i32)), &arrow_schema).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            predicate.prune_with_stats(&stats, &arrow_schema),
+            vec![false; 3]
+        );
+
+        // Reset after the prior stream is dropped: no dynamic filter remains, while the
+        // static predicate still excludes only the first row group.
+        predicate.clear_dyn_filters();
+        assert_eq!(
+            predicate.prune_with_stats(&stats, &arrow_schema),
+            vec![false, true, true]
         );
     }
 

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -27,7 +27,9 @@ use datafusion_common::tree_node::TreeNode;
 use datafusion_expr::expr::{Expr, InList};
 use datafusion_expr::{Between, BinaryExpr, Operator};
 use datafusion_physical_expr::execution_props::ExecutionProps;
-use datafusion_physical_expr::expressions::DynamicFilterPhysicalExpr;
+use datafusion_physical_expr::expressions::{
+    BinaryExpr as PhysicalBinaryExpr, DynamicFilterPhysicalExpr, is_null,
+};
 use datafusion_physical_expr::{PhysicalExpr, create_physical_expr};
 use datatypes::arrow;
 use datatypes::value::scalar_value_to_timestamp;
@@ -123,7 +125,18 @@ impl Predicate {
         self.dyn_filters
             .load()
             .iter()
-            .map(|e| e.current())
+            .map(|e| {
+                // Pruning must preserve NULL inputs just like decoded dynamic filtering.
+                e.children()
+                    .into_iter()
+                    .try_fold(e.current()?, |expr, child| {
+                        Ok(Arc::new(PhysicalBinaryExpr::new(
+                            expr,
+                            Operator::Or,
+                            is_null(child.clone())?,
+                        )) as Arc<dyn PhysicalExpr>)
+                    })
+            })
             .collect::<Result<Vec<_>, _>>()
             .context(error::DatafusionSnafu)
     }
@@ -823,6 +836,58 @@ mod tests {
         let stats = RowGroupPruningStatistics::new(row_groups, &schema);
         let res = arrow_predicate.prune_with_stats(&stats, &arrow_schema);
         assert_eq!(expect, res);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_pruning_keeps_null_row_group() {
+        use datafusion_physical_expr::expressions::{
+            Column as PhysicalColumn, lit as physical_lit,
+        };
+
+        let dir = create_temp_dir("dynamic_pruning_nulls");
+        let path = dir.path().join("nullable.parquet");
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let file = std::fs::File::create(&path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema.clone(), None).unwrap();
+        for values in [[None, Some(1)], [Some(1), Some(1)], [None, None]] {
+            let batch = RecordBatch::try_new(
+                arrow_schema.clone(),
+                vec![Arc::new(Int32Array::from(values.to_vec()))],
+            )
+            .unwrap();
+            writer.write(&batch).unwrap();
+            writer.flush().unwrap();
+        }
+        writer.close().unwrap();
+        let builder =
+            ParquetRecordBatchStreamBuilder::new(tokio::fs::File::open(path).await.unwrap())
+                .await
+                .unwrap();
+        let schema = Arc::new(datatypes::schema::Schema::try_from(arrow_schema.clone()).unwrap());
+        let stats = RowGroupPruningStatistics::new(builder.metadata().row_groups(), &schema);
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(PhysicalColumn::new("a", 0))],
+            physical_lit(true),
+        ));
+        let predicate = Predicate::with_dyn_filters(vec![], vec![filter.clone()]);
+        assert_eq!(
+            predicate.prune_with_stats(&stats, &arrow_schema),
+            vec![true; 3]
+        );
+        filter
+            .update(
+                Predicate::to_physical_expr(
+                    &col("a").gt_eq(lit(10_i32)).and(col("a").lt_eq(lit(10_i32))),
+                    &arrow_schema,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        // NULL inputs must reach decoded filtering; non-NULL misses can still be pruned.
+        assert_eq!(
+            predicate.prune_with_stats(&stats, &arrow_schema),
+            vec![true, false, true],
+        );
     }
 
     fn gen_predicate(max_val: i32, op: Operator) -> Vec<Expr> {

--- a/src/table/src/table/metrics.rs
+++ b/src/table/src/table/metrics.rs
@@ -33,6 +33,8 @@ pub struct StreamMetrics {
     poll_elapsed: Time,
     /// Elapsed time used to `.await`ing the stream
     await_elapsed: Time,
+    /// Time spent evaluating and applying decoded dynamic filters.
+    dynamic_filter_cost: Time,
 }
 
 impl StreamMetrics {
@@ -47,6 +49,8 @@ impl StreamMetrics {
             output_bytes: MetricBuilder::new(metrics).output_bytes(partition),
             poll_elapsed: MetricBuilder::new(metrics).subset_time("elapsed_poll", partition),
             await_elapsed: MetricBuilder::new(metrics).subset_time("elapsed_await", partition),
+            dynamic_filter_cost: MetricBuilder::new(metrics)
+                .subset_time("dynamic_filter_cost", partition),
         }
     }
 
@@ -68,6 +72,10 @@ impl StreamMetrics {
     /// Return a timer guard that records the time elapsed in poll
     pub fn poll_timer(&self) -> ScopedTimerGuard<'_> {
         self.poll_elapsed.timer()
+    }
+
+    pub fn dynamic_filter_timer(&self) -> ScopedTimerGuard<'_> {
+        self.dynamic_filter_cost.timer()
     }
 
     pub fn record_await_duration(&self, duration: Duration) {

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -29,8 +29,9 @@ use common_telemetry::tracing_context::TracingContext;
 use common_telemetry::warn;
 use datafusion::error::Result as DfResult;
 use datafusion::execution::context::TaskContext;
-use datafusion::logical_expr::ColumnarValue;
+use datafusion::logical_expr::Operator;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::filter::batch_filter;
 use datafusion::physical_plan::filter_pushdown::{
     ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
 };
@@ -39,15 +40,14 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
     RecordBatchStream as DfRecordBatchStream,
 };
-use datafusion_common::cast::as_boolean_array;
 use datafusion_common::stats::Precision;
-use datafusion_common::{ColumnStatistics, DataFusionError, ScalarValue, Statistics, internal_err};
-use datafusion_physical_expr::expressions::{Column, DynamicFilterPhysicalExpr};
+use datafusion_common::{ColumnStatistics, DataFusionError, Statistics};
+use datafusion_physical_expr::expressions::{
+    BinaryExpr, Column, DynamicFilterPhysicalExpr, is_null,
+};
 use datafusion_physical_expr::{
     EquivalenceProperties, Partitioning, PhysicalExpr, PhysicalSortExpr, conjunction,
 };
-use datatypes::arrow::array::{Array, BooleanArray};
-use datatypes::arrow::compute::filter_record_batch;
 use datatypes::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datatypes::compute::SortOptions;
 use futures::{Stream, StreamExt};
@@ -445,7 +445,21 @@ impl ExecutionPlan for RegionScanExec {
         drop(enter);
         let dyn_filter = {
             let filters = self.pushed_dyn_filters.lock().unwrap().clone();
-            (!filters.is_empty()).then(|| conjunction(filters))
+            let guarded_filters = filters.into_iter().map(|filter| {
+                filter.children().iter().try_fold(
+                    filter.clone() as Arc<dyn PhysicalExpr>,
+                    |acc, child| {
+                        let guarded: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+                            acc,
+                            Operator::Or,
+                            is_null((*child).clone())?,
+                        ));
+                        Ok::<_, datafusion_common::DataFusionError>(guarded)
+                    },
+                )
+            });
+            let guarded_filters = guarded_filters.collect::<DfResult<Vec<_>>>()?;
+            (!guarded_filters.is_empty()).then(|| conjunction(guarded_filters))
         };
         let stream_metrics = StreamMetrics::new(&self.metric, partition);
         Ok(Box::pin(StreamWithMetricWrapper {
@@ -579,49 +593,6 @@ pub struct StreamWithMetricWrapper {
     dyn_filter: Option<Arc<dyn PhysicalExpr>>,
 }
 
-/// Applies a dynamic predicate conservatively: only rows whose result is definitely false
-/// are removed. Unlike a SQL WHERE filter, NULL results must remain in the scan output because
-/// the predicate is an optimization filter and may be updated while the stream is running.
-fn conservative_dynamic_filter(
-    batch: &DfRecordBatch,
-    predicate: &Arc<dyn PhysicalExpr>,
-) -> DfResult<Option<DfRecordBatch>> {
-    match predicate.evaluate(batch)? {
-        ColumnarValue::Scalar(ScalarValue::Boolean(Some(true)))
-        | ColumnarValue::Scalar(ScalarValue::Boolean(None))
-        | ColumnarValue::Scalar(ScalarValue::Null) => Ok(None),
-        ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))) => Ok(Some(batch.slice(0, 0))),
-        ColumnarValue::Scalar(_) => {
-            internal_err!("Cannot create filter_array from non-boolean predicates")
-        }
-        ColumnarValue::Array(array) => {
-            let boolean_array = match as_boolean_array(&array) {
-                Ok(boolean_array) => boolean_array,
-                Err(_) if array.data_type() == &datatypes::arrow::datatypes::DataType::Null => {
-                    return Ok(None);
-                }
-                Err(_) => {
-                    return internal_err!("Cannot create filter_array from non-boolean predicates");
-                }
-            };
-
-            // Avoid constructing a mask and copying the batch when there is no definite FALSE.
-            if (0..boolean_array.len())
-                .all(|index| boolean_array.is_null(index) || boolean_array.value(index))
-            {
-                return Ok(None);
-            }
-
-            let mask = BooleanArray::from(
-                (0..boolean_array.len())
-                    .map(|index| boolean_array.is_null(index) || boolean_array.value(index))
-                    .collect::<Vec<_>>(),
-            );
-            Ok(Some(filter_record_batch(batch, &mask)?))
-        }
-    }
-}
-
 impl Stream for StreamWithMetricWrapper {
     type Item = DfResult<DfRecordBatch>;
 
@@ -643,13 +614,11 @@ impl Stream for StreamWithMetricWrapper {
                         // we don't record elapsed time here
                         // since it's calling storage api involving I/O ops
                         let record_batch = if let Some(predicate) = &this.dyn_filter {
-                            let schema = record_batch.schema.clone();
-                            match conservative_dynamic_filter(
-                                record_batch.df_record_batch(),
-                                predicate,
-                            ) {
-                                Ok(Some(batch)) => RecordBatch::from_df_record_batch(schema, batch),
-                                Ok(None) => record_batch,
+                            match batch_filter(record_batch.df_record_batch(), predicate) {
+                                Ok(batch) => RecordBatch::from_df_record_batch(
+                                    record_batch.schema.clone(),
+                                    batch,
+                                ),
                                 Err(error) => return Poll::Ready(Some(Err(error))),
                             }
                         } else {
@@ -692,8 +661,7 @@ mod test {
     use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
     use datafusion::physical_plan::metrics::MetricValue;
     use datafusion::prelude::SessionContext;
-    use datatypes::arrow::array::{BooleanArray, Int32Array, NullArray};
-    use datatypes::arrow::datatypes::{DataType, Field, Schema as DfSchema};
+    use datatypes::arrow::array::Array;
     use datatypes::data_type::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
     use datatypes::vectors::{Int32Vector, TimestampMillisecondVector, VectorRef};
@@ -703,71 +671,6 @@ mod test {
     use store_api::storage::RegionId;
 
     use super::*;
-
-    #[test]
-    fn test_conservative_dynamic_filter_branch_discrimination() {
-        let schema = Arc::new(DfSchema::new(vec![
-            Field::new("predicate", DataType::Boolean, true),
-            Field::new("nulls", DataType::Null, true),
-            Field::new("integer", DataType::Int32, false),
-        ]));
-        let batch = DfRecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(BooleanArray::from(vec![Some(true), None])),
-                Arc::new(NullArray::new(2)),
-                Arc::new(Int32Array::from(vec![1, 2])),
-            ],
-        )
-        .unwrap();
-
-        for predicate in [
-            lit(true),
-            lit(ScalarValue::Boolean(None)),
-            lit(ScalarValue::Null),
-        ] {
-            assert!(
-                conservative_dynamic_filter(&batch, &predicate)
-                    .unwrap()
-                    .is_none()
-            );
-        }
-        assert!(matches!(
-            conservative_dynamic_filter(&batch, &lit(false)).unwrap(),
-            Some(batch) if batch.num_rows() == 0
-        ));
-        let predicate: Arc<dyn PhysicalExpr> = Arc::new(Column::new("predicate", 0));
-        assert!(
-            conservative_dynamic_filter(&batch, &predicate)
-                .unwrap()
-                .is_none()
-        );
-        assert!(
-            conservative_dynamic_filter(
-                &batch,
-                &conjunction(vec![lit(true), lit(ScalarValue::Boolean(None))]),
-            )
-            .unwrap()
-            .is_none()
-        );
-        assert!(matches!(
-            conservative_dynamic_filter(
-                &batch,
-                &conjunction(vec![lit(false), lit(ScalarValue::Boolean(None))]),
-            )
-            .unwrap(),
-            Some(batch) if batch.num_rows() == 0
-        ));
-        let nulls: Arc<dyn PhysicalExpr> = Arc::new(Column::new("nulls", 1));
-        assert!(
-            conservative_dynamic_filter(&batch, &nulls)
-                .unwrap()
-                .is_none()
-        );
-        assert!(conservative_dynamic_filter(&batch, &lit(1_i32)).is_err());
-        let integer: Arc<dyn PhysicalExpr> = Arc::new(Column::new("integer", 2));
-        assert!(conservative_dynamic_filter(&batch, &integer).is_err());
-    }
 
     fn dynamic_filter_fixture(region_number: u32) -> (SchemaRef, RegionScanExec) {
         dynamic_filter_fixture_with_nulls(region_number, false)
@@ -967,37 +870,103 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_scalar_dynamic_filter_fast_paths() {
-        for (value, expected_rows) in [(true, 4), (false, 0)] {
-            let ctx = SessionContext::new();
-            let (_, plan) = dynamic_filter_fixture(5682 + expected_rows as u32);
-            let filter = Arc::new(DynamicFilterPhysicalExpr::new(
-                vec![Arc::new(Column::new("a", 0))],
-                lit(true),
-            ));
-            plan.handle_child_pushdown_result(
-                FilterPushdownPhase::Post,
-                ChildPushdownResult {
-                    parent_filters: vec![ChildFilterPushdownResult {
-                        filter: filter.clone(),
-                        child_results: vec![PushedDown::No],
-                    }],
-                    self_filters: vec![],
-                },
-                &datafusion::config::ConfigOptions::default(),
-            )
+    async fn test_multi_child_dynamic_filter_guards_each_child() {
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new("a", ConcreteDataType::int32_datatype(), true),
+            ColumnSchema::new("b", ConcreteDataType::int32_datatype(), true),
+            ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+        ]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Vector::from(vec![Some(1), None, Some(3)])) as _,
+                Arc::new(Int32Vector::from(vec![Some(10), Some(20), None])) as _,
+                Arc::new(TimestampMillisecondVector::from_slice([1, 2, 3])) as _,
+            ],
+        )
+        .unwrap();
+        let recordbatches = RecordBatches::try_new(schema.clone(), vec![batch]).unwrap();
+        let mut builder = RegionMetadataBuilder::new(RegionId::new(1234, 5683));
+        builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new("a", ConcreteDataType::int32_datatype(), true),
+                semantic_type: SemanticType::Field,
+                column_id: 1,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new("b", ConcreteDataType::int32_datatype(), true),
+                semantic_type: SemanticType::Field,
+                column_id: 2,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Timestamp,
+                column_id: 3,
+            })
+            .primary_key(vec![]);
+        let metadata = Arc::new(builder.build().unwrap());
+        let scanner = Box::new(SinglePartitionScanner::new(
+            recordbatches.as_stream(),
+            false,
+            metadata,
+            None,
+        ));
+        let plan = RegionScanExec::new(scanner, ScanRequest::default(), None).unwrap();
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![
+                Arc::new(Column::new("a", 0)),
+                Arc::new(BinaryExpr::new(
+                    Arc::new(Column::new("b", 1)),
+                    Operator::Plus,
+                    lit(1_i32),
+                )),
+            ],
+            lit(true),
+        ));
+        plan.handle_child_pushdown_result(
+            FilterPushdownPhase::Post,
+            ChildPushdownResult {
+                parent_filters: vec![ChildFilterPushdownResult {
+                    filter: filter.clone(),
+                    child_results: vec![PushedDown::No],
+                }],
+                self_filters: vec![],
+            },
+            &datafusion::config::ConfigOptions::default(),
+        )
+        .unwrap();
+        filter
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::Eq,
+                lit(datafusion_common::ScalarValue::Int32(None)),
+            )))
             .unwrap();
-            filter.update(lit(value)).unwrap();
 
-            let batches = plan
-                .execute(0, ctx.task_ctx())
-                .unwrap()
-                .try_collect::<Vec<_>>()
-                .await
-                .unwrap();
-            assert_eq!(batches.len(), 1);
-            assert_eq!(batches[0].num_rows(), expected_rows);
-        }
+        let batches = plan
+            .execute(0, ctx.task_ctx())
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let values = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datatypes::arrow::array::Int32Array>()
+            .unwrap();
+        assert_eq!(values.len(), 2);
+        assert!(values.is_null(0));
+        assert_eq!(values.value(1), 3);
     }
 
     #[tokio::test]

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -20,9 +20,10 @@ use std::time::Instant;
 
 use common_error::ext::BoxedError;
 use common_recordbatch::adapter::RegionQueryStatCounters;
+use common_recordbatch::filter::batch_filter;
 use common_recordbatch::{
     DfRecordBatch, DfSendableRecordBatchStream, MemoryTrackedStream, QueryMemoryTracker,
-    SendableRecordBatchStream,
+    RecordBatch, SendableRecordBatchStream,
 };
 use common_telemetry::tracing::Span;
 use common_telemetry::tracing_context::TracingContext;
@@ -40,9 +41,9 @@ use datafusion::physical_plan::{
 };
 use datafusion_common::stats::Precision;
 use datafusion_common::{ColumnStatistics, DataFusionError, Statistics};
-use datafusion_physical_expr::expressions::Column;
+use datafusion_physical_expr::expressions::{Column, DynamicFilterPhysicalExpr};
 use datafusion_physical_expr::{
-    EquivalenceProperties, Partitioning, PhysicalExpr, PhysicalSortExpr,
+    EquivalenceProperties, Partitioning, PhysicalExpr, PhysicalSortExpr, conjunction,
 };
 use datatypes::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datatypes::compute::SortOptions;
@@ -74,6 +75,9 @@ pub struct RegionScanExec {
     distribution: Option<TimeSeriesDistribution>,
     explain_verbose: bool,
     query_memory_tracker: Option<QueryMemoryTracker>,
+    /// Dynamic filters accepted by the scanner and applied to decoded output batches.
+    /// The wrappers themselves remain live and are updated by their producers.
+    pushed_dyn_filters: Arc<Mutex<Vec<Arc<dyn PhysicalExpr>>>>,
 }
 
 impl std::fmt::Debug for RegionScanExec {
@@ -89,6 +93,7 @@ impl std::fmt::Debug for RegionScanExec {
             .field("is_partition_set", &self.is_partition_set)
             .field("distribution", &self.distribution)
             .field("explain_verbose", &self.explain_verbose)
+            .field("pushed_dyn_filters", &self.pushed_dyn_filters)
             .finish()
     }
 }
@@ -234,6 +239,7 @@ impl RegionScanExec {
             distribution: request.distribution,
             explain_verbose: false,
             query_memory_tracker,
+            pushed_dyn_filters: Arc::new(Mutex::new(Vec::new())),
         })
     }
 
@@ -307,6 +313,7 @@ impl RegionScanExec {
             distribution: self.distribution,
             explain_verbose: self.explain_verbose,
             query_memory_tracker: self.query_memory_tracker.clone(),
+            pushed_dyn_filters: self.pushed_dyn_filters.clone(),
         })
     }
 
@@ -433,12 +440,17 @@ impl ExecutionPlan for RegionScanExec {
         };
 
         drop(enter);
+        let dyn_filter = {
+            let filters = self.pushed_dyn_filters.lock().unwrap().clone();
+            (!filters.is_empty()).then(|| conjunction(filters))
+        };
         let stream_metrics = StreamMetrics::new(&self.metric, partition);
         Ok(Box::pin(StreamWithMetricWrapper {
             stream,
             metric: stream_metrics,
             span,
             await_timer: None,
+            dyn_filter,
         }))
     }
 
@@ -490,8 +502,54 @@ impl ExecutionPlan for RegionScanExec {
             .map(|f| f.filter)
             .collect::<Vec<_>>();
 
-        let supported = self.add_dyn_filters_to_predicate(parent_filters);
-        // datafusion api require to clone self after mutate, even though we are only mutate inside mutex
+        // Keep live wrappers for exact filtering, while also giving the scanner their expressions
+        // for statistics pruning. Exact acceptance is independent of scanner pruning support.
+        // Avoid registering an already accepted wrapper when pushdown is revisited.
+        let mut scanner_filters = Vec::with_capacity(parent_filters.len());
+        let mut scanner_filter_indices = Vec::with_capacity(parent_filters.len());
+        let mut supported = vec![false; parent_filters.len()];
+        {
+            let mut exact_filters = self.pushed_dyn_filters.lock().unwrap();
+            for (index, filter) in parent_filters.iter().enumerate() {
+                if filter
+                    .as_any()
+                    .downcast_ref::<DynamicFilterPhysicalExpr>()
+                    .is_some()
+                {
+                    if exact_filters.iter().any(|existing| existing == filter) {
+                        supported[index] = true;
+                    } else {
+                        exact_filters.push(filter.clone());
+                        supported[index] = true;
+                        scanner_filter_indices.push(index);
+                        scanner_filters.push(filter.clone());
+                    }
+                } else {
+                    scanner_filter_indices.push(index);
+                    scanner_filters.push(filter.clone());
+                }
+            }
+        }
+
+        // Do not hold the exact-filter lock while calling into the scanner. Scanner
+        // implementations may do arbitrary work while installing pruning predicates.
+        let scanner_supported = if scanner_filters.is_empty() {
+            vec![]
+        } else {
+            self.add_dyn_filters_to_predicate(scanner_filters)
+        };
+        for (index, is_supported) in scanner_filter_indices.into_iter().zip(scanner_supported) {
+            if parent_filters[index]
+                .as_any()
+                .downcast_ref::<DynamicFilterPhysicalExpr>()
+                .is_none()
+            {
+                supported[index] = is_supported;
+            }
+        }
+
+        // DataFusion requires an updated node after this mutation; the scan consumes dynamic
+        // filters itself.
         let new_self = Arc::new(self.clone());
 
         Ok(FilterPushdownPropagation {
@@ -519,6 +577,7 @@ pub struct StreamWithMetricWrapper {
     metric: StreamMetrics,
     span: Span,
     await_timer: Option<Instant>,
+    dyn_filter: Option<Arc<dyn PhysicalExpr>>,
 }
 
 impl Stream for StreamWithMetricWrapper {
@@ -541,8 +600,19 @@ impl Stream for StreamWithMetricWrapper {
                     Ok(record_batch) => {
                         // we don't record elapsed time here
                         // since it's calling storage api involving I/O ops
-                        let batch_bytes = record_batch.logical_slice_memory_size();
-                        this.metric.record_output_bytes(batch_bytes);
+                        let record_batch = if let Some(predicate) = &this.dyn_filter {
+                            let schema = record_batch.schema.clone();
+                            let batch =
+                                match batch_filter(record_batch.df_record_batch(), predicate) {
+                                    Ok(batch) => batch,
+                                    Err(error) => return Poll::Ready(Some(Err(error))),
+                                };
+                            RecordBatch::from_df_record_batch(schema, batch)
+                        } else {
+                            record_batch
+                        };
+                        this.metric
+                            .record_output_bytes(record_batch.logical_slice_memory_size());
                         this.metric.record_output(record_batch.num_rows());
                         Poll::Ready(Some(Ok(record_batch.into_df_record_batch())))
                     }
@@ -571,6 +641,12 @@ mod test {
 
     use api::v1::SemanticType;
     use common_recordbatch::{RecordBatch, RecordBatches};
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{
+        BinaryExpr, Column, DynamicFilterPhysicalExpr, lit,
+    };
+    use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
+    use datafusion::physical_plan::metrics::MetricValue;
     use datafusion::prelude::SessionContext;
     use datatypes::data_type::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
@@ -581,6 +657,201 @@ mod test {
     use store_api::storage::RegionId;
 
     use super::*;
+
+    fn dynamic_filter_fixture(region_number: u32) -> (SchemaRef, RegionScanExec) {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new("a", ConcreteDataType::int32_datatype(), false),
+            ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+        ]));
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Vector::from_slice([1, 2, 3, 4])) as _,
+                Arc::new(TimestampMillisecondVector::from_slice([1, 2, 3, 4])) as _,
+            ],
+        )
+        .unwrap();
+        let recordbatches = RecordBatches::try_new(schema.clone(), vec![batch]).unwrap();
+        let mut builder = RegionMetadataBuilder::new(RegionId::new(1234, region_number));
+        builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new("a", ConcreteDataType::int32_datatype(), false),
+                semantic_type: SemanticType::Field,
+                column_id: 1,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    "ts",
+                    ConcreteDataType::timestamp_millisecond_datatype(),
+                    false,
+                ),
+                semantic_type: SemanticType::Timestamp,
+                column_id: 2,
+            })
+            .primary_key(vec![]);
+        let metadata = Arc::new(builder.build().unwrap());
+        let scanner = Box::new(SinglePartitionScanner::new(
+            recordbatches.as_stream(),
+            false,
+            metadata,
+            None,
+        ));
+        (
+            schema,
+            RegionScanExec::new(scanner, ScanRequest::default(), None).unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_live_dynamic_filter_is_applied_after_stream_creation() {
+        let ctx = SessionContext::new();
+        let (schema, plan) = dynamic_filter_fixture(5679);
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        let static_filter = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("a", 0)),
+            Operator::Gt,
+            lit(0_i32),
+        ));
+        let propagation = plan
+            .handle_child_pushdown_result(
+                FilterPushdownPhase::Post,
+                ChildPushdownResult {
+                    parent_filters: vec![
+                        ChildFilterPushdownResult {
+                            filter: filter.clone(),
+                            child_results: vec![PushedDown::No],
+                        },
+                        ChildFilterPushdownResult {
+                            filter: static_filter,
+                            child_results: vec![PushedDown::No],
+                        },
+                    ],
+                    self_filters: vec![],
+                },
+                &datafusion::config::ConfigOptions::default(),
+            )
+            .unwrap();
+        assert!(matches!(
+            propagation.filters.as_slice(),
+            [PushedDown::Yes, PushedDown::No]
+        ));
+        assert!(
+            propagation
+                .updated_node
+                .as_ref()
+                .unwrap()
+                .as_any()
+                .downcast_ref::<RegionScanExec>()
+                .is_some()
+        );
+        assert_eq!(plan.pushed_dyn_filters.lock().unwrap().len(), 1);
+        let repeated = plan
+            .handle_child_pushdown_result(
+                FilterPushdownPhase::Post,
+                ChildPushdownResult {
+                    parent_filters: vec![ChildFilterPushdownResult {
+                        filter: filter.clone(),
+                        child_results: vec![PushedDown::No],
+                    }],
+                    self_filters: vec![],
+                },
+                &datafusion::config::ConfigOptions::default(),
+            )
+            .unwrap();
+        assert!(matches!(repeated.filters.as_slice(), [PushedDown::Yes]));
+        assert_eq!(plan.pushed_dyn_filters.lock().unwrap().len(), 1);
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        filter
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::Gt,
+                lit(2_i32),
+            )))
+            .unwrap();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let values = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datatypes::arrow::array::Int32Array>()
+            .unwrap();
+        assert_eq!(values.values(), &[3, 4]);
+        let metrics = plan.metrics().unwrap();
+        assert_eq!(metrics.output_rows(), Some(2));
+        let output_bytes = metrics.iter().find_map(|metric| match metric.value() {
+            MetricValue::OutputBytes(count) => Some(count.value()),
+            _ => None,
+        });
+        assert_eq!(
+            output_bytes,
+            Some(
+                RecordBatch::from_df_record_batch(schema, batches[0].clone())
+                    .logical_slice_memory_size(),
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_dynamic_filters_are_conjoined() {
+        let ctx = SessionContext::new();
+        let (_, plan) = dynamic_filter_fixture(5680);
+        let lower = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        let upper = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        let propagation = plan
+            .handle_child_pushdown_result(
+                FilterPushdownPhase::Post,
+                ChildPushdownResult {
+                    parent_filters: vec![
+                        ChildFilterPushdownResult {
+                            filter: lower.clone(),
+                            child_results: vec![PushedDown::No],
+                        },
+                        ChildFilterPushdownResult {
+                            filter: upper.clone(),
+                            child_results: vec![PushedDown::No],
+                        },
+                    ],
+                    self_filters: vec![],
+                },
+                &datafusion::config::ConfigOptions::default(),
+            )
+            .unwrap();
+        assert!(matches!(
+            propagation.filters.as_slice(),
+            [PushedDown::Yes, PushedDown::Yes]
+        ));
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        lower
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::Gt,
+                lit(2_i32),
+            )))
+            .unwrap();
+        upper
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::Lt,
+                lit(3_i32),
+            )))
+            .unwrap();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 0);
+        assert_eq!(plan.pushed_dyn_filters.lock().unwrap().len(), 2);
+    }
 
     #[tokio::test]
     async fn test_simple_table_scan() {

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -20,7 +20,6 @@ use std::time::Instant;
 
 use common_error::ext::BoxedError;
 use common_recordbatch::adapter::RegionQueryStatCounters;
-use common_recordbatch::filter::batch_filter;
 use common_recordbatch::{
     DfRecordBatch, DfSendableRecordBatchStream, MemoryTrackedStream, QueryMemoryTracker,
     RecordBatch, SendableRecordBatchStream,
@@ -30,6 +29,7 @@ use common_telemetry::tracing_context::TracingContext;
 use common_telemetry::warn;
 use datafusion::error::Result as DfResult;
 use datafusion::execution::context::TaskContext;
+use datafusion::logical_expr::ColumnarValue;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::filter_pushdown::{
     ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
@@ -39,12 +39,15 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
     RecordBatchStream as DfRecordBatchStream,
 };
+use datafusion_common::cast::as_boolean_array;
 use datafusion_common::stats::Precision;
-use datafusion_common::{ColumnStatistics, DataFusionError, Statistics};
+use datafusion_common::{ColumnStatistics, DataFusionError, ScalarValue, Statistics, internal_err};
 use datafusion_physical_expr::expressions::{Column, DynamicFilterPhysicalExpr};
 use datafusion_physical_expr::{
     EquivalenceProperties, Partitioning, PhysicalExpr, PhysicalSortExpr, conjunction,
 };
+use datatypes::arrow::array::{Array, BooleanArray};
+use datatypes::arrow::compute::filter_record_batch;
 use datatypes::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use datatypes::compute::SortOptions;
 use futures::{Stream, StreamExt};
@@ -533,11 +536,7 @@ impl ExecutionPlan for RegionScanExec {
 
         // Do not hold the exact-filter lock while calling into the scanner. Scanner
         // implementations may do arbitrary work while installing pruning predicates.
-        let scanner_supported = if scanner_filters.is_empty() {
-            vec![]
-        } else {
-            self.add_dyn_filters_to_predicate(scanner_filters)
-        };
+        let scanner_supported = self.add_dyn_filters_to_predicate(scanner_filters);
         for (index, is_supported) in scanner_filter_indices.into_iter().zip(scanner_supported) {
             if parent_filters[index]
                 .as_any()
@@ -580,6 +579,49 @@ pub struct StreamWithMetricWrapper {
     dyn_filter: Option<Arc<dyn PhysicalExpr>>,
 }
 
+/// Applies a dynamic predicate conservatively: only rows whose result is definitely false
+/// are removed. Unlike a SQL WHERE filter, NULL results must remain in the scan output because
+/// the predicate is an optimization filter and may be updated while the stream is running.
+fn conservative_dynamic_filter(
+    batch: &DfRecordBatch,
+    predicate: &Arc<dyn PhysicalExpr>,
+) -> DfResult<Option<DfRecordBatch>> {
+    match predicate.evaluate(batch)? {
+        ColumnarValue::Scalar(ScalarValue::Boolean(Some(true)))
+        | ColumnarValue::Scalar(ScalarValue::Boolean(None))
+        | ColumnarValue::Scalar(ScalarValue::Null) => Ok(None),
+        ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))) => Ok(Some(batch.slice(0, 0))),
+        ColumnarValue::Scalar(_) => {
+            internal_err!("Cannot create filter_array from non-boolean predicates")
+        }
+        ColumnarValue::Array(array) => {
+            let boolean_array = match as_boolean_array(&array) {
+                Ok(boolean_array) => boolean_array,
+                Err(_) if array.data_type() == &datatypes::arrow::datatypes::DataType::Null => {
+                    return Ok(None);
+                }
+                Err(_) => {
+                    return internal_err!("Cannot create filter_array from non-boolean predicates");
+                }
+            };
+
+            // Avoid constructing a mask and copying the batch when there is no definite FALSE.
+            if (0..boolean_array.len())
+                .all(|index| boolean_array.is_null(index) || boolean_array.value(index))
+            {
+                return Ok(None);
+            }
+
+            let mask = BooleanArray::from(
+                (0..boolean_array.len())
+                    .map(|index| boolean_array.is_null(index) || boolean_array.value(index))
+                    .collect::<Vec<_>>(),
+            );
+            Ok(Some(filter_record_batch(batch, &mask)?))
+        }
+    }
+}
+
 impl Stream for StreamWithMetricWrapper {
     type Item = DfResult<DfRecordBatch>;
 
@@ -602,12 +644,14 @@ impl Stream for StreamWithMetricWrapper {
                         // since it's calling storage api involving I/O ops
                         let record_batch = if let Some(predicate) = &this.dyn_filter {
                             let schema = record_batch.schema.clone();
-                            let batch =
-                                match batch_filter(record_batch.df_record_batch(), predicate) {
-                                    Ok(batch) => batch,
-                                    Err(error) => return Poll::Ready(Some(Err(error))),
-                                };
-                            RecordBatch::from_df_record_batch(schema, batch)
+                            match conservative_dynamic_filter(
+                                record_batch.df_record_batch(),
+                                predicate,
+                            ) {
+                                Ok(Some(batch)) => RecordBatch::from_df_record_batch(schema, batch),
+                                Ok(None) => record_batch,
+                                Err(error) => return Poll::Ready(Some(Err(error))),
+                            }
                         } else {
                             record_batch
                         };
@@ -648,9 +692,11 @@ mod test {
     use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
     use datafusion::physical_plan::metrics::MetricValue;
     use datafusion::prelude::SessionContext;
+    use datatypes::arrow::array::{BooleanArray, Int32Array, NullArray};
+    use datatypes::arrow::datatypes::{DataType, Field, Schema as DfSchema};
     use datatypes::data_type::ConcreteDataType;
     use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
-    use datatypes::vectors::{Int32Vector, TimestampMillisecondVector};
+    use datatypes::vectors::{Int32Vector, TimestampMillisecondVector, VectorRef};
     use futures::TryStreamExt;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::region_engine::SinglePartitionScanner;
@@ -658,19 +704,96 @@ mod test {
 
     use super::*;
 
+    #[test]
+    fn test_conservative_dynamic_filter_branch_discrimination() {
+        let schema = Arc::new(DfSchema::new(vec![
+            Field::new("predicate", DataType::Boolean, true),
+            Field::new("nulls", DataType::Null, true),
+            Field::new("integer", DataType::Int32, false),
+        ]));
+        let batch = DfRecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(BooleanArray::from(vec![Some(true), None])),
+                Arc::new(NullArray::new(2)),
+                Arc::new(Int32Array::from(vec![1, 2])),
+            ],
+        )
+        .unwrap();
+
+        for predicate in [
+            lit(true),
+            lit(ScalarValue::Boolean(None)),
+            lit(ScalarValue::Null),
+        ] {
+            assert!(
+                conservative_dynamic_filter(&batch, &predicate)
+                    .unwrap()
+                    .is_none()
+            );
+        }
+        assert!(matches!(
+            conservative_dynamic_filter(&batch, &lit(false)).unwrap(),
+            Some(batch) if batch.num_rows() == 0
+        ));
+        let predicate: Arc<dyn PhysicalExpr> = Arc::new(Column::new("predicate", 0));
+        assert!(
+            conservative_dynamic_filter(&batch, &predicate)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            conservative_dynamic_filter(
+                &batch,
+                &conjunction(vec![lit(true), lit(ScalarValue::Boolean(None))]),
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(matches!(
+            conservative_dynamic_filter(
+                &batch,
+                &conjunction(vec![lit(false), lit(ScalarValue::Boolean(None))]),
+            )
+            .unwrap(),
+            Some(batch) if batch.num_rows() == 0
+        ));
+        let nulls: Arc<dyn PhysicalExpr> = Arc::new(Column::new("nulls", 1));
+        assert!(
+            conservative_dynamic_filter(&batch, &nulls)
+                .unwrap()
+                .is_none()
+        );
+        assert!(conservative_dynamic_filter(&batch, &lit(1_i32)).is_err());
+        let integer: Arc<dyn PhysicalExpr> = Arc::new(Column::new("integer", 2));
+        assert!(conservative_dynamic_filter(&batch, &integer).is_err());
+    }
+
     fn dynamic_filter_fixture(region_number: u32) -> (SchemaRef, RegionScanExec) {
+        dynamic_filter_fixture_with_nulls(region_number, false)
+    }
+
+    fn dynamic_filter_fixture_with_nulls(
+        region_number: u32,
+        nullable: bool,
+    ) -> (SchemaRef, RegionScanExec) {
         let schema = Arc::new(Schema::new(vec![
-            ColumnSchema::new("a", ConcreteDataType::int32_datatype(), false),
+            ColumnSchema::new("a", ConcreteDataType::int32_datatype(), nullable),
             ColumnSchema::new(
                 "ts",
                 ConcreteDataType::timestamp_millisecond_datatype(),
                 false,
             ),
         ]));
+        let a: VectorRef = if nullable {
+            Arc::new(Int32Vector::from(vec![Some(1), None, Some(3), Some(4)]))
+        } else {
+            Arc::new(Int32Vector::from_slice([1, 2, 3, 4]))
+        };
         let batch = RecordBatch::new(
             schema.clone(),
             vec![
-                Arc::new(Int32Vector::from_slice([1, 2, 3, 4])) as _,
+                a,
                 Arc::new(TimestampMillisecondVector::from_slice([1, 2, 3, 4])) as _,
             ],
         )
@@ -679,7 +802,7 @@ mod test {
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1234, region_number));
         builder
             .push_column_metadata(ColumnMetadata {
-                column_schema: ColumnSchema::new("a", ConcreteDataType::int32_datatype(), false),
+                column_schema: ColumnSchema::new("a", ConcreteDataType::int32_datatype(), nullable),
                 semantic_type: SemanticType::Field,
                 column_id: 1,
             })
@@ -795,6 +918,86 @@ mod test {
                     .logical_slice_memory_size(),
             )
         );
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_filter_keeps_null_rows() {
+        let ctx = SessionContext::new();
+        let (_, plan) = dynamic_filter_fixture_with_nulls(5681, true);
+        let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        plan.handle_child_pushdown_result(
+            FilterPushdownPhase::Post,
+            ChildPushdownResult {
+                parent_filters: vec![ChildFilterPushdownResult {
+                    filter: filter.clone(),
+                    child_results: vec![PushedDown::No],
+                }],
+                self_filters: vec![],
+            },
+            &datafusion::config::ConfigOptions::default(),
+        )
+        .unwrap();
+        filter
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::Gt,
+                lit(2_i32),
+            )))
+            .unwrap();
+
+        let batches = plan
+            .execute(0, ctx.task_ctx())
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let values = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<datatypes::arrow::array::Int32Array>()
+            .unwrap();
+        assert_eq!(values.len(), 3);
+        assert!(values.is_null(0));
+        assert_eq!(values.value(1), 3);
+        assert_eq!(values.value(2), 4);
+    }
+
+    #[tokio::test]
+    async fn test_scalar_dynamic_filter_fast_paths() {
+        for (value, expected_rows) in [(true, 4), (false, 0)] {
+            let ctx = SessionContext::new();
+            let (_, plan) = dynamic_filter_fixture(5682 + expected_rows as u32);
+            let filter = Arc::new(DynamicFilterPhysicalExpr::new(
+                vec![Arc::new(Column::new("a", 0))],
+                lit(true),
+            ));
+            plan.handle_child_pushdown_result(
+                FilterPushdownPhase::Post,
+                ChildPushdownResult {
+                    parent_filters: vec![ChildFilterPushdownResult {
+                        filter: filter.clone(),
+                        child_results: vec![PushedDown::No],
+                    }],
+                    self_filters: vec![],
+                },
+                &datafusion::config::ConfigOptions::default(),
+            )
+            .unwrap();
+            filter.update(lit(value)).unwrap();
+
+            let batches = plan
+                .execute(0, ctx.task_ctx())
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            assert_eq!(batches.len(), 1);
+            assert_eq!(batches[0].num_rows(), expected_rows);
+        }
     }
 
     #[tokio::test]

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -475,6 +475,12 @@ impl ExecutionPlan for RegionScanExec {
         Some(self.metric.clone_inner())
     }
 
+    fn reset_state(self: Arc<Self>) -> DfResult<Arc<dyn ExecutionPlan>> {
+        self.scanner.lock().unwrap().reset_state();
+        self.pushed_dyn_filters.lock().unwrap().clear();
+        Ok(self)
+    }
+
     fn partition_statistics(&self, partition: Option<usize>) -> DfResult<Statistics> {
         if partition.is_some() {
             return Ok(Statistics::new_unknown(self.schema().as_ref()));
@@ -650,15 +656,21 @@ impl DfRecordBatchStream for StreamWithMetricWrapper {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
+    use std::any::Any;
+    use std::fmt;
+    use std::sync::{Arc, Mutex};
 
     use api::v1::SemanticType;
-    use common_recordbatch::{RecordBatch, RecordBatches};
+    use common_error::ext::BoxedError;
+    use common_recordbatch::{RecordBatch, RecordBatches, SendableRecordBatchStream};
     use datafusion::logical_expr::Operator;
     use datafusion::physical_expr::expressions::{
         BinaryExpr, Column, DynamicFilterPhysicalExpr, lit,
     };
-    use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
+    use datafusion::physical_plan::execution_plan::reset_plan_states;
+    use datafusion::physical_plan::filter_pushdown::{
+        ChildFilterPushdownResult, ChildPushdownResult,
+    };
     use datafusion::physical_plan::metrics::MetricValue;
     use datafusion::prelude::SessionContext;
     use datatypes::arrow::array::Array;
@@ -667,19 +679,113 @@ mod test {
     use datatypes::vectors::{Int32Vector, TimestampMillisecondVector, VectorRef};
     use futures::TryStreamExt;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
-    use store_api::region_engine::SinglePartitionScanner;
+    use store_api::region_engine::{
+        PrepareRequest, QueryScanContext, RegionScanner, ScannerProperties, SinglePartitionScanner,
+    };
     use store_api::storage::RegionId;
 
     use super::*;
+
+    #[derive(Debug)]
+    struct RepeatableScanner {
+        batches: RecordBatches,
+        properties: ScannerProperties,
+        metadata: store_api::metadata::RegionMetadataRef,
+        dynamic_filters: Arc<Mutex<Vec<Arc<DynamicFilterPhysicalExpr>>>>,
+    }
+
+    impl fmt::Display for RepeatableScanner {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "RepeatableScanner")
+        }
+    }
+
+    impl DisplayAs for RepeatableScanner {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{self}")
+        }
+    }
+
+    impl RegionScanner for RepeatableScanner {
+        fn name(&self) -> &str {
+            "RepeatableScanner"
+        }
+
+        fn properties(&self) -> &ScannerProperties {
+            &self.properties
+        }
+
+        fn schema(&self) -> SchemaRef {
+            self.batches.schema()
+        }
+
+        fn metadata(&self) -> store_api::metadata::RegionMetadataRef {
+            self.metadata.clone()
+        }
+
+        fn prepare(&mut self, request: PrepareRequest) -> Result<(), BoxedError> {
+            self.properties.prepare(request);
+            Ok(())
+        }
+
+        fn scan_partition(
+            &self,
+            _ctx: &QueryScanContext,
+            _metrics_set: &ExecutionPlanMetricsSet,
+            _partition: usize,
+        ) -> Result<SendableRecordBatchStream, BoxedError> {
+            Ok(self.batches.as_stream())
+        }
+
+        fn reset_state(&mut self) {
+            self.dynamic_filters.lock().unwrap().clear();
+        }
+
+        fn has_predicate_without_region(&self) -> bool {
+            false
+        }
+
+        fn add_dyn_filter_to_predicate(
+            &mut self,
+            filters: Vec<Arc<dyn PhysicalExpr>>,
+        ) -> Vec<bool> {
+            let mut dynamic_filters = self.dynamic_filters.lock().unwrap();
+            filters
+                .into_iter()
+                .map(|filter| {
+                    if let Ok(filter) = (filter as Arc<dyn Any + Send + Sync>)
+                        .downcast::<DynamicFilterPhysicalExpr>()
+                    {
+                        dynamic_filters.push(filter);
+                        true
+                    } else {
+                        false
+                    }
+                })
+                .collect()
+        }
+
+        fn set_logical_region(&mut self, logical_region: bool) {
+            self.properties.set_logical_region(logical_region);
+        }
+
+        fn set_query_load_region_id(&mut self, region_id: RegionId) {
+            self.properties.set_query_load_region_id(region_id);
+        }
+    }
 
     fn dynamic_filter_fixture(region_number: u32) -> (SchemaRef, RegionScanExec) {
         dynamic_filter_fixture_with_nulls(region_number, false)
     }
 
-    fn dynamic_filter_fixture_with_nulls(
+    fn dynamic_filter_test_data(
         region_number: u32,
         nullable: bool,
-    ) -> (SchemaRef, RegionScanExec) {
+    ) -> (
+        SchemaRef,
+        RecordBatch,
+        store_api::metadata::RegionMetadataRef,
+    ) {
         let schema = Arc::new(Schema::new(vec![
             ColumnSchema::new("a", ConcreteDataType::int32_datatype(), nullable),
             ColumnSchema::new(
@@ -701,7 +807,6 @@ mod test {
             ],
         )
         .unwrap();
-        let recordbatches = RecordBatches::try_new(schema.clone(), vec![batch]).unwrap();
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1234, region_number));
         builder
             .push_column_metadata(ColumnMetadata {
@@ -719,7 +824,15 @@ mod test {
                 column_id: 2,
             })
             .primary_key(vec![]);
-        let metadata = Arc::new(builder.build().unwrap());
+        (schema, batch, Arc::new(builder.build().unwrap()))
+    }
+
+    fn dynamic_filter_fixture_with_nulls(
+        region_number: u32,
+        nullable: bool,
+    ) -> (SchemaRef, RegionScanExec) {
+        let (schema, batch, metadata) = dynamic_filter_test_data(region_number, nullable);
+        let recordbatches = RecordBatches::try_new(schema.clone(), vec![batch]).unwrap();
         let scanner = Box::new(SinglePartitionScanner::new(
             recordbatches.as_stream(),
             false,
@@ -730,6 +843,116 @@ mod test {
             schema,
             RegionScanExec::new(scanner, ScanRequest::default(), None).unwrap(),
         )
+    }
+
+    #[tokio::test]
+    async fn test_reset_state_clears_dynamic_filters_for_repeatable_scanner() {
+        let ctx = SessionContext::new();
+        let (schema, batch, metadata) = dynamic_filter_test_data(5684, false);
+        let scanner_dynamic_filters = Arc::new(Mutex::new(Vec::new()));
+        let scanner = RepeatableScanner {
+            batches: RecordBatches::try_new(schema.clone(), vec![batch.clone()]).unwrap(),
+            properties: ScannerProperties::default(),
+            metadata,
+            dynamic_filters: scanner_dynamic_filters.clone(),
+        };
+        let plan =
+            Arc::new(RegionScanExec::new(Box::new(scanner), ScanRequest::default(), None).unwrap());
+        let dynamic_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        plan.handle_child_pushdown_result(
+            FilterPushdownPhase::Post,
+            ChildPushdownResult {
+                parent_filters: vec![ChildFilterPushdownResult {
+                    filter: dynamic_filter.clone(),
+                    child_results: vec![PushedDown::No],
+                }],
+                self_filters: vec![],
+            },
+            &datafusion::config::ConfigOptions::default(),
+        )
+        .unwrap();
+        dynamic_filter
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::Gt,
+                lit(2_i32),
+            )))
+            .unwrap();
+
+        assert_eq!(
+            plan.execute(0, ctx.task_ctx())
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap()[0]
+                .num_rows(),
+            2
+        );
+        assert_eq!(
+            batch_filter(
+                batch.df_record_batch(),
+                &(scanner_dynamic_filters.lock().unwrap()[0].clone() as Arc<dyn PhysicalExpr>)
+            )
+            .unwrap()
+            .num_rows(),
+            2
+        );
+
+        let reset_plan = reset_plan_states(plan).unwrap();
+        assert!(scanner_dynamic_filters.lock().unwrap().is_empty());
+        assert_eq!(
+            batch_filter(
+                batch.df_record_batch(),
+                &(dynamic_filter.clone() as Arc<dyn PhysicalExpr>),
+            )
+            .unwrap()
+            .num_rows(),
+            2
+        );
+        dynamic_filter.update(lit(false)).unwrap();
+        assert_eq!(
+            reset_plan
+                .execute(0, ctx.task_ctx())
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap()[0]
+                .num_rows(),
+            4
+        );
+
+        let fresh_filter = Arc::new(DynamicFilterPhysicalExpr::new(
+            vec![Arc::new(Column::new("a", 0))],
+            lit(true),
+        ));
+        reset_plan
+            .handle_child_pushdown_result(
+                FilterPushdownPhase::Post,
+                ChildPushdownResult {
+                    parent_filters: vec![ChildFilterPushdownResult {
+                        filter: fresh_filter.clone(),
+                        child_results: vec![PushedDown::No],
+                    }],
+                    self_filters: vec![],
+                },
+                &datafusion::config::ConfigOptions::default(),
+            )
+            .unwrap();
+        let stream = reset_plan.execute(0, ctx.task_ctx()).unwrap();
+        fresh_filter
+            .update(Arc::new(BinaryExpr::new(
+                Arc::new(Column::new("a", 0)),
+                Operator::Gt,
+                lit(3_i32),
+            )))
+            .unwrap();
+        assert_eq!(
+            stream.try_collect::<Vec<_>>().await.unwrap()[0].num_rows(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -519,10 +519,10 @@ impl ExecutionPlan for RegionScanExec {
             .map(|f| f.filter)
             .collect::<Vec<_>>();
 
-        // Keep live wrappers for exact filtering, while also giving the scanner their expressions
-        // for statistics pruning. Exact acceptance is independent of scanner pruning support.
-        // Avoid registering an already accepted wrapper when pushdown is revisited.
+        // `supported` holds the final per-parent `PushedDown` answers. Dynamic filters are accepted
+        // because this scan filters decoded rows; scanner support only determines statistics pruning.
         let mut scanner_filters = Vec::with_capacity(parent_filters.len());
+        // Maps compact scanner callback positions back to their original parent-filter positions.
         let mut scanner_filter_indices = Vec::with_capacity(parent_filters.len());
         let mut supported = vec![false; parent_filters.len()];
         {
@@ -548,8 +548,7 @@ impl ExecutionPlan for RegionScanExec {
             }
         }
 
-        // Do not hold the exact-filter lock while calling into the scanner. Scanner
-        // implementations may do arbitrary work while installing pruning predicates.
+        // Release the exact-filter lock before calling into the scanner.
         let scanner_supported = self.add_dyn_filters_to_predicate(scanner_filters);
         for (index, is_supported) in scanner_filter_indices.into_iter().zip(scanner_supported) {
             if parent_filters[index]
@@ -561,8 +560,7 @@ impl ExecutionPlan for RegionScanExec {
             }
         }
 
-        // DataFusion requires an updated node after this mutation; the scan consumes dynamic
-        // filters itself.
+        // DataFusion requires an updated node after installing the filters.
         let new_self = Arc::new(self.clone());
 
         Ok(FilterPushdownPropagation {
@@ -611,10 +609,12 @@ impl Stream for StreamWithMetricWrapper {
                 }
                 match result {
                     Ok(record_batch) => {
-                        // we don't record elapsed time here
-                        // since it's calling storage api involving I/O ops
                         let record_batch = if let Some(predicate) = &this.dyn_filter {
-                            match batch_filter(record_batch.df_record_batch(), predicate) {
+                            let result = {
+                                let _timer = this.metric.dynamic_filter_timer();
+                                batch_filter(record_batch.df_record_batch(), predicate)
+                            };
+                            match result {
                                 Ok(batch) => RecordBatch::from_df_record_batch(
                                     record_batch.schema.clone(),
                                     batch,
@@ -810,6 +810,11 @@ mod test {
         assert_eq!(values.values(), &[3, 4]);
         let metrics = plan.metrics().unwrap();
         assert_eq!(metrics.output_rows(), Some(2));
+        let filter_cost = metrics.iter().find_map(|metric| match metric.value() {
+            MetricValue::Time { name, time } if name == "dynamic_filter_cost" => Some(time.value()),
+            _ => None,
+        });
+        assert!(filter_cost.is_some_and(|cost| cost > 0));
         let output_bytes = metrics.iter().find_map(|metric| match metric.value() {
             MetricValue::OutputBytes(count) => Some(count.value()),
             _ => None,

--- a/tests/perf/query_cases/sql_topk_order_by/case.toml
+++ b/tests/perf/query_cases/sql_topk_order_by/case.toml
@@ -61,3 +61,15 @@ iterations = 3
 
 [scenario.queries.thresholds]
 max_candidate_latency_regression_pct = 50
+
+# The VALUES join keeps the join and final TopK on the frontend. Its runtime
+# membership filter can reach the datanode scan before rows cross MergeScan.
+[[scenario.queries]]
+name = "topk_frontend_join"
+kind = "sql"
+query = "SELECT t.host, t.instance, t.value, t.ts FROM sql_topk_order_by t JOIN (VALUES ('host1'), ('host3'), ('host5')) AS h(host) ON t.host = h.host WHERE t.ts >= '2024-01-01 00:10:00+0000'::TIMESTAMP AND t.ts < '2024-01-01 02:00:00+0000'::TIMESTAMP ORDER BY t.value DESC LIMIT 20"
+warmup = 1
+iterations = 3
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 50


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

None.

## What's changed and what's your intention?

This change first fixes the semantic contract of dynamic-filter pushdown at `RegionScanExec`, and then reduces the amount of rejected data that crosses the scan boundary.

Previously, `RegionScanExec` passed dynamic predicates to region scanners for best-effort statistics pruning, but did not apply them to decoded batches. Statistics pruning can skip files or row groups, but it does not guarantee that every surviving decoded row satisfies the predicate. Reporting such a predicate as `PushedDown::Yes` would therefore be unsound: DataFusion may remove the upstream `FilterExec` after the scan claims to have consumed the filter completely.

This change makes `RegionScanExec` an exact consumer of accepted dynamic predicates:

- retain the live `DynamicFilterPhysicalExpr` wrappers in `RegionScanExec`;
- continue passing the original wrappers to the storage scanner for best-effort statistics pruning;
- apply the accepted predicates to every decoded output batch using DataFusion's standard `batch_filter`;
- report dynamic predicates as fully pushed down independently of scanner statistics-pruning support;
- deduplicate registrations across repeated optimizer callbacks; and
- record output row and byte metrics from the filtered batches using the existing logical-slice byte convention.

Dynamic predicates are optimization predicates rather than ordinary SQL `WHERE` predicates. For each accepted wrapper `D`, the decoded-output expression is guarded using its declared input expressions:

```text
D OR is_null(D.child1) OR is_null(D.child2) ...
```

Each wrapper is guarded independently before multiple wrappers are combined with `AND`. This preserves nullable inputs that may still be required by null-safe joins, TopK, or aggregate producers, while standard filter semantics continue to remove predicate `NULL` results for fully non-null inputs. The guard uses each wrapper's actual child expression, including computed and multi-column inputs.

The retained wrappers remain live, so predicate updates made after stream construction are observed during batch evaluation. The storage scanner still receives the original unguarded wrappers because its role remains statistics pruning; exact decoded-row filtering is enforced by `RegionScanExec`. The scan consumes the predicates directly and does not create a replacement `FilterExec`.

With this correctness contract established, rows rejected after decoding no longer flow to downstream operators. In distributed execution this can reduce datanode-to-frontend and exchange traffic; in both distributed and standalone execution it can also reduce downstream join, TopK, and aggregate work.

Added regression coverage for live updates after stream creation, mixed static/dynamic pushdown results, repeated registration, post-filter metrics, independently guarded multiple predicates, nullable rows, and multi-child/computed child expressions.

Verification:

```text
cargo fmt --all -- --check
# passed

cargo nextest run -p table
# 74 passed, 0 failed

cargo nextest run -p query -E \
  'test(test_topk_dynamic_filter_pushdown_reaches_region_scan) or test(test_join_dynamic_filter_pushdown_reaches_region_scan)'
# 2 passed, 0 failed

cargo clippy -p table --all-targets -- -D warnings
# passed

git diff --check
# passed

sqlness: standalone/common/join/join_with_nulls
sqlness: distributed/common/join/join_with_nulls
# both passed
```

A local paired/interleaved TopK `LIMIT 20` query-regression run kept the parent and candidate clusters live simultaneously and alternated request order across 20 pairs. All canonical query results matched. The candidate/parent latency ratio was `1.01285`, with a paired 95% t interval of `[0.95059, 1.07918]`; this run found no measurable regression and excluded the configured `1.5x` regression boundary.

This change does not alter public APIs, persisted schemas, or wire formats.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
