### PR TITLE
feat(json2): support empty and null JSON2 value

### DIFF
--- a/src/datatypes/src/json/value.rs
+++ b/src/datatypes/src/json/value.rs
@@ -723,12 +723,7 @@ where
     I: IntoIterator<Item = (K, JsonNativeType)>,
     K: Into<String>,
 {
-    let mut fields = fields.into_iter().peekable();
-    if fields.peek().is_none() {
-        JsonNativeType::Null
-    } else {
-        JsonNativeType::Object(fields.map(|(k, v)| (k.into(), v)).collect())
-    }
+    JsonNativeType::Object(fields.into_iter().map(|(k, v)| (k.into(), v)).collect())
 }
 
 impl From<()> for JsonVariantRef<'_> {
@@ -974,11 +969,10 @@ mod tests {
             ])))
         );
 
-        // Empty objects have native type Null, but the value still needs alignment
-        // before converting into a typed struct value.
+        // Empty objects have an empty Object type and remain distinct from Null.
         let expected = JsonNativeType::Object(JsonObjectType::from([(
             "empty".to_string(),
-            JsonNativeType::Null,
+            JsonNativeType::Object(JsonObjectType::default()),
         )]));
         let mut value = parse_json_value(r#"{"empty":{}}"#);
         assert_eq!(value.json_type(), &expected);
@@ -987,7 +981,7 @@ mod tests {
             value,
             JsonValue::from(JsonVariant::Object(BTreeMap::from([(
                 "empty".to_string(),
-                JsonVariant::Null,
+                JsonVariant::Object(BTreeMap::default()),
             )])))
         );
 

--- a/src/datatypes/src/types/json_type.rs
+++ b/src/datatypes/src/types/json_type.rs
@@ -50,6 +50,11 @@ pub enum JsonNumberType {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default)]
 pub enum JsonNativeType {
+    /// JSON null value type.
+    ///
+    /// This variant may also appear as the initial state while merging inferred
+    /// types, but it does not represent an empty object. Empty objects are
+    /// represented as `Object({})`.
     #[default]
     Null,
     Bool,

--- a/src/datatypes/src/vectors/json/builder.rs
+++ b/src/datatypes/src/vectors/json/builder.rs
@@ -155,6 +155,10 @@ impl JsonVectorBuilderState {
     }
 
     fn try_push_value_ref(&mut self, value: &ValueRef) -> Result<()> {
+        if matches!(value, ValueRef::Null) {
+            self.push_null();
+            return Ok(());
+        }
         let ValueRef::Json(value) = value else {
             return TryFromValueSnafu {
                 reason: format!("expected JSON value, got {value:?}"),
@@ -1268,6 +1272,23 @@ mod tests {
         assert_eq!(
             values[2],
             decode_json_variant(reconstructed.value(2)).unwrap()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_v2_builder_accepts_sql_null() -> Result<()> {
+        let settings = JsonSettings::try_new(vec![], Some(1))?;
+        let mut builder = JsonVectorBuilder::with_settings(&settings, 2);
+        builder.try_push_value_ref(&ValueRef::Null)?;
+        let value = settings.encode(json!({}))?;
+        builder.try_push_value_ref(&value.as_value_ref())?;
+
+        let array = builder.to_vector().to_arrow_array();
+        let structs = array.as_struct();
+        assert_eq!(
+            vec![None, Some(json!({}))],
+            variant_to_json_values(structs.column_by_name(JSON2_REMAINDER_FIELD_NAME).unwrap())?
         );
         Ok(())
     }

--- a/src/operator/src/req_convert/insert/stmt_to_region.rs
+++ b/src/operator/src/req_convert/insert/stmt_to_region.rs
@@ -31,7 +31,7 @@ use table::metadata::TableInfoRef;
 
 use crate::error::{
     CatalogSnafu, ColumnDataTypeSnafu, ColumnDefaultValueSnafu, ColumnNoneDefaultValueSnafu,
-    ColumnNotFoundSnafu, InvalidInsertRequestSnafu, InvalidSqlSnafu, MissingInsertBodySnafu,
+    ColumnNotFoundSnafu, InvalidSqlSnafu, MissingInsertBodySnafu,
     ParseSqlSnafu, Result, SchemaReadOnlySnafu, TableNotFoundSnafu, TableReadOnlySnafu,
 };
 use crate::insert::InstantAndNormalInsertRequests;
@@ -286,25 +286,7 @@ fn sql_value_to_value(
         )
         .context(crate::error::SqlCommonSnafu)?
     };
-    validate(&value)?;
     Ok(value)
-}
-
-fn validate(value: &Value) -> Result<()> {
-    match value {
-        Value::Json(value) => {
-            // Json object will be stored as Arrow struct in parquet, and it has the restriction:
-            // "Parquet does not support writing empty structs".
-            ensure!(
-                !value.is_empty_object(),
-                InvalidInsertRequestSnafu {
-                    reason: "empty json object is not supported, consider adding a dummy field"
-                }
-            );
-            Ok(())
-        }
-        _ => Ok(()),
-    }
 }
 
 fn replace_default(sql_val: &SqlValue) -> bool {

--- a/src/operator/src/req_convert/insert/stmt_to_region.rs
+++ b/src/operator/src/req_convert/insert/stmt_to_region.rs
@@ -31,8 +31,8 @@ use table::metadata::TableInfoRef;
 
 use crate::error::{
     CatalogSnafu, ColumnDataTypeSnafu, ColumnDefaultValueSnafu, ColumnNoneDefaultValueSnafu,
-    ColumnNotFoundSnafu, InvalidSqlSnafu, MissingInsertBodySnafu,
-    ParseSqlSnafu, Result, SchemaReadOnlySnafu, TableNotFoundSnafu, TableReadOnlySnafu,
+    ColumnNotFoundSnafu, InvalidSqlSnafu, MissingInsertBodySnafu, ParseSqlSnafu, Result,
+    SchemaReadOnlySnafu, TableNotFoundSnafu, TableReadOnlySnafu,
 };
 use crate::insert::InstantAndNormalInsertRequests;
 use crate::req_convert::common::partitioner::Partitioner;

--- a/tests/cases/standalone/common/types/json/json2_empty.result
+++ b/tests/cases/standalone/common/types/json/json2_empty.result
@@ -289,3 +289,67 @@ drop table json_empty_null_mixed;
 
 Affected Rows: 0
 
+-- Explicit SQL NULL and omitted-column inserts must be accepted and round trip
+-- as NULL (not panic), remaining distinct from empty objects.
+create table json_empty_null_forms (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+insert into json_empty_null_forms (ts, j) values (1, NULL);
+
+Affected Rows: 1
+
+insert into json_empty_null_forms (ts) values (2);
+
+Affected Rows: 1
+
+insert into json_empty_null_forms (ts, j) values (3, '{}');
+
+Affected Rows: 1
+
+select ts, j, j is null from json_empty_null_forms order by ts;
+
++-------------------------+----+---------------------------------+
+| ts                      | j  | json_empty_null_forms.j IS NULL |
++-------------------------+----+---------------------------------+
+| 1970-01-01T00:00:00.001 |    | true                            |
+| 1970-01-01T00:00:00.002 |    | true                            |
+| 1970-01-01T00:00:00.003 | {} | false                           |
++-------------------------+----+---------------------------------+
+
+admin flush_table('json_empty_null_forms');
+
++--------------------------------------------+
+| ADMIN flush_table('json_empty_null_forms') |
++--------------------------------------------+
+| 0                                          |
++--------------------------------------------+
+
+admin compact_table('json_empty_null_forms');
+
++----------------------------------------------+
+| ADMIN compact_table('json_empty_null_forms') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
+
+select ts, j, j is null from json_empty_null_forms order by ts;
+
++-------------------------+----+---------------------------------+
+| ts                      | j  | json_empty_null_forms.j IS NULL |
++-------------------------+----+---------------------------------+
+| 1970-01-01T00:00:00.001 |    | true                            |
+| 1970-01-01T00:00:00.002 |    | true                            |
+| 1970-01-01T00:00:00.003 | {} | false                           |
++-------------------------+----+---------------------------------+
+
+drop table json_empty_null_forms;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/types/json/json2_empty.result
+++ b/tests/cases/standalone/common/types/json/json2_empty.result
@@ -1,0 +1,291 @@
+-- Empty-object JSON2 values are stored in the JSONB remainder column and must
+-- survive memtable flush and compaction unchanged, both as whole values and
+-- through path access.
+-- Whole-value empty objects: insert, flush, then mix with expanded documents
+-- before compacting.
+create table json_empty (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+insert into json_empty values (1, '{}');
+
+Affected Rows: 1
+
+select ts, j from json_empty order by ts;
+
++-------------------------+----+
+| ts                      | j  |
++-------------------------+----+
+| 1970-01-01T00:00:00.001 | {} |
++-------------------------+----+
+
+select ts, j.a from json_empty order by ts;
+
++-------------------------+----------------------------------+
+| ts                      | json_get(json_empty.j,Utf8("a")) |
++-------------------------+----------------------------------+
+| 1970-01-01T00:00:00.001 |                                  |
++-------------------------+----------------------------------+
+
+admin flush_table('json_empty');
+
++---------------------------------+
+| ADMIN flush_table('json_empty') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+select ts, j from json_empty order by ts;
+
++-------------------------+----+
+| ts                      | j  |
++-------------------------+----+
+| 1970-01-01T00:00:00.001 | {} |
++-------------------------+----+
+
+insert into json_empty values (2, '{}'), (3, '{"a": 1}');
+
+Affected Rows: 2
+
+select ts, j, j.a from json_empty order by ts;
+
++-------------------------+---------+----------------------------------+
+| ts                      | j       | json_get(json_empty.j,Utf8("a")) |
++-------------------------+---------+----------------------------------+
+| 1970-01-01T00:00:00.001 | {}      |                                  |
+| 1970-01-01T00:00:00.002 | {}      |                                  |
+| 1970-01-01T00:00:00.003 | {"a":1} | 1                                |
++-------------------------+---------+----------------------------------+
+
+admin flush_table('json_empty');
+
++---------------------------------+
+| ADMIN flush_table('json_empty') |
++---------------------------------+
+| 0                               |
++---------------------------------+
+
+admin compact_table('json_empty');
+
++-----------------------------------+
+| ADMIN compact_table('json_empty') |
++-----------------------------------+
+| 0                                 |
++-----------------------------------+
+
+select ts, j, j.a from json_empty order by ts;
+
++-------------------------+---------+----------------------------------+
+| ts                      | j       | json_get(json_empty.j,Utf8("a")) |
++-------------------------+---------+----------------------------------+
+| 1970-01-01T00:00:00.001 | {}      |                                  |
+| 1970-01-01T00:00:00.002 | {}      |                                  |
+| 1970-01-01T00:00:00.003 | {"a":1} | 1                                |
++-------------------------+---------+----------------------------------+
+
+select count(*) from json_empty;
+
++----------+
+| count(*) |
++----------+
+| 3        |
++----------+
+
+drop table json_empty;
+
+Affected Rows: 0
+
+-- Nested empty objects and arrays, which also produce only remainder content,
+-- must round trip through flush and compaction as whole values.
+create table json_empty_nested (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+insert into json_empty_nested values
+    (1, '{"a": {}}'),
+    (2, '{"a": {"b": {}}}');
+
+Affected Rows: 2
+
+select ts, j from json_empty_nested order by ts;
+
++-------------------------+----------------+
+| ts                      | j              |
++-------------------------+----------------+
+| 1970-01-01T00:00:00.001 | {"a":{}}       |
+| 1970-01-01T00:00:00.002 | {"a":{"b":{}}} |
++-------------------------+----------------+
+
+admin flush_table('json_empty_nested');
+
++----------------------------------------+
+| ADMIN flush_table('json_empty_nested') |
++----------------------------------------+
+| 0                                      |
++----------------------------------------+
+
+select ts, j from json_empty_nested order by ts;
+
++-------------------------+----------------+
+| ts                      | j              |
++-------------------------+----------------+
+| 1970-01-01T00:00:00.001 | {"a":{}}       |
+| 1970-01-01T00:00:00.002 | {"a":{"b":{}}} |
++-------------------------+----------------+
+
+insert into json_empty_nested values (3, '{"x": []}');
+
+Affected Rows: 1
+
+admin flush_table('json_empty_nested');
+
++----------------------------------------+
+| ADMIN flush_table('json_empty_nested') |
++----------------------------------------+
+| 0                                      |
++----------------------------------------+
+
+admin compact_table('json_empty_nested');
+
++------------------------------------------+
+| ADMIN compact_table('json_empty_nested') |
++------------------------------------------+
+| 0                                        |
++------------------------------------------+
+
+select ts, j from json_empty_nested order by ts;
+
++-------------------------+----------------+
+| ts                      | j              |
++-------------------------+----------------+
+| 1970-01-01T00:00:00.001 | {"a":{}}       |
+| 1970-01-01T00:00:00.002 | {"a":{"b":{}}} |
+| 1970-01-01T00:00:00.003 | {"x":[]}       |
++-------------------------+----------------+
+
+drop table json_empty_nested;
+
+Affected Rows: 0
+
+-- Empty objects, SQL NULL values, and JSON null values must remain distinct
+-- through memtable flush and compaction.
+create table json_empty_null_mixed (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+insert into json_empty_null_mixed values
+    (1, '{}'),
+    (2, NULL),
+    (3, '{"a": {}}'),
+    (4, '{"a": null}');
+
+Affected Rows: 4
+
+select ts, j, j is null from json_empty_null_mixed order by ts;
+
++-------------------------+------------+---------------------------------+
+| ts                      | j          | json_empty_null_mixed.j IS NULL |
++-------------------------+------------+---------------------------------+
+| 1970-01-01T00:00:00.001 | {}         | false                           |
+| 1970-01-01T00:00:00.002 |            | true                            |
+| 1970-01-01T00:00:00.003 | {"a":{}}   | false                           |
+| 1970-01-01T00:00:00.004 | {"a":null} | false                           |
++-------------------------+------------+---------------------------------+
+
+admin flush_table('json_empty_null_mixed');
+
++--------------------------------------------+
+| ADMIN flush_table('json_empty_null_mixed') |
++--------------------------------------------+
+| 0                                          |
++--------------------------------------------+
+
+select ts, j, j is null from json_empty_null_mixed order by ts;
+
++-------------------------+------------+---------------------------------+
+| ts                      | j          | json_empty_null_mixed.j IS NULL |
++-------------------------+------------+---------------------------------+
+| 1970-01-01T00:00:00.001 | {}         | false                           |
+| 1970-01-01T00:00:00.002 |            | true                            |
+| 1970-01-01T00:00:00.003 | {"a":{}}   | false                           |
+| 1970-01-01T00:00:00.004 | {"a":null} | false                           |
++-------------------------+------------+---------------------------------+
+
+insert into json_empty_null_mixed values
+    (5, '{"a": 1}'),
+    (6, NULL);
+
+Affected Rows: 2
+
+select ts, j, j.a, j is null from json_empty_null_mixed order by ts;
+
++-------------------------+------------+---------------------------------------------+---------------------------------+
+| ts                      | j          | json_get(json_empty_null_mixed.j,Utf8("a")) | json_empty_null_mixed.j IS NULL |
++-------------------------+------------+---------------------------------------------+---------------------------------+
+| 1970-01-01T00:00:00.001 | {}         |                                             | false                           |
+| 1970-01-01T00:00:00.002 |            |                                             | true                            |
+| 1970-01-01T00:00:00.003 | {"a":{}}   | {}                                          | false                           |
+| 1970-01-01T00:00:00.004 | {"a":null} |                                             | false                           |
+| 1970-01-01T00:00:00.005 | {"a":1}    | 1                                           | false                           |
+| 1970-01-01T00:00:00.006 |            |                                             | true                            |
++-------------------------+------------+---------------------------------------------+---------------------------------+
+
+admin flush_table('json_empty_null_mixed');
+
++--------------------------------------------+
+| ADMIN flush_table('json_empty_null_mixed') |
++--------------------------------------------+
+| 0                                          |
++--------------------------------------------+
+
+admin compact_table('json_empty_null_mixed');
+
++----------------------------------------------+
+| ADMIN compact_table('json_empty_null_mixed') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
+
+select ts, j, j.a, j is null from json_empty_null_mixed order by ts;
+
++-------------------------+------------+---------------------------------------------+---------------------------------+
+| ts                      | j          | json_get(json_empty_null_mixed.j,Utf8("a")) | json_empty_null_mixed.j IS NULL |
++-------------------------+------------+---------------------------------------------+---------------------------------+
+| 1970-01-01T00:00:00.001 | {}         |                                             | false                           |
+| 1970-01-01T00:00:00.002 |            |                                             | true                            |
+| 1970-01-01T00:00:00.003 | {"a":{}}   | {}                                          | false                           |
+| 1970-01-01T00:00:00.004 | {"a":null} |                                             | false                           |
+| 1970-01-01T00:00:00.005 | {"a":1}    | 1                                           | false                           |
+| 1970-01-01T00:00:00.006 |            |                                             | true                            |
++-------------------------+------------+---------------------------------------------+---------------------------------+
+
+select count(*) from json_empty_null_mixed;
+
++----------+
+| count(*) |
++----------+
+| 6        |
++----------+
+
+drop table json_empty_null_mixed;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/types/json/json2_empty.sql
+++ b/tests/cases/standalone/common/types/json/json2_empty.sql
@@ -103,3 +103,29 @@ select ts, j, j.a, j is null from json_empty_null_mixed order by ts;
 select count(*) from json_empty_null_mixed;
 
 drop table json_empty_null_mixed;
+
+-- Explicit SQL NULL and omitted-column inserts must be accepted and round trip
+-- as NULL (not panic), remaining distinct from empty objects.
+create table json_empty_null_forms (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+insert into json_empty_null_forms (ts, j) values (1, NULL);
+
+insert into json_empty_null_forms (ts) values (2);
+
+insert into json_empty_null_forms (ts, j) values (3, '{}');
+
+select ts, j, j is null from json_empty_null_forms order by ts;
+
+admin flush_table('json_empty_null_forms');
+
+admin compact_table('json_empty_null_forms');
+
+select ts, j, j is null from json_empty_null_forms order by ts;
+
+drop table json_empty_null_forms;

--- a/tests/cases/standalone/common/types/json/json2_empty.sql
+++ b/tests/cases/standalone/common/types/json/json2_empty.sql
@@ -1,0 +1,105 @@
+-- Empty-object JSON2 values are stored in the JSONB remainder column and must
+-- survive memtable flush and compaction unchanged, both as whole values and
+-- through path access.
+
+-- Whole-value empty objects: insert, flush, then mix with expanded documents
+-- before compacting.
+create table json_empty (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+insert into json_empty values (1, '{}');
+
+select ts, j from json_empty order by ts;
+
+select ts, j.a from json_empty order by ts;
+
+admin flush_table('json_empty');
+
+select ts, j from json_empty order by ts;
+
+insert into json_empty values (2, '{}'), (3, '{"a": 1}');
+
+select ts, j, j.a from json_empty order by ts;
+
+admin flush_table('json_empty');
+
+admin compact_table('json_empty');
+
+select ts, j, j.a from json_empty order by ts;
+
+select count(*) from json_empty;
+
+drop table json_empty;
+
+-- Nested empty objects and arrays, which also produce only remainder content,
+-- must round trip through flush and compaction as whole values.
+create table json_empty_nested (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+insert into json_empty_nested values
+    (1, '{"a": {}}'),
+    (2, '{"a": {"b": {}}}');
+
+select ts, j from json_empty_nested order by ts;
+
+admin flush_table('json_empty_nested');
+
+select ts, j from json_empty_nested order by ts;
+
+insert into json_empty_nested values (3, '{"x": []}');
+
+admin flush_table('json_empty_nested');
+
+admin compact_table('json_empty_nested');
+
+select ts, j from json_empty_nested order by ts;
+
+drop table json_empty_nested;
+
+-- Empty objects, SQL NULL values, and JSON null values must remain distinct
+-- through memtable flush and compaction.
+create table json_empty_null_mixed (
+    ts timestamp time index,
+    j json2
+) with (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+insert into json_empty_null_mixed values
+    (1, '{}'),
+    (2, NULL),
+    (3, '{"a": {}}'),
+    (4, '{"a": null}');
+
+select ts, j, j is null from json_empty_null_mixed order by ts;
+
+admin flush_table('json_empty_null_mixed');
+
+select ts, j, j is null from json_empty_null_mixed order by ts;
+
+insert into json_empty_null_mixed values
+    (5, '{"a": 1}'),
+    (6, NULL);
+
+select ts, j, j.a, j is null from json_empty_null_mixed order by ts;
+
+admin flush_table('json_empty_null_mixed');
+
+admin compact_table('json_empty_null_mixed');
+
+select ts, j, j.a, j is null from json_empty_null_mixed order by ts;
+
+select count(*) from json_empty_null_mixed;
+
+drop table json_empty_null_mixed;

--- a/tests/cases/standalone/common/types/json/json2_limit.result
+++ b/tests/cases/standalone/common/types/json/json2_limit.result
@@ -28,10 +28,6 @@ insert into json2_disable_non_object_insert values (5, 'null');
 
 Error: 1001(Unsupported), Non-object json is not supported currently
 
-insert into json2_disable_non_object_insert values (6, '{}');
-
-Error: 1004(InvalidArguments), Invalid InsertRequest, reason: empty json object is not supported, consider adding a dummy field
-
 drop table json2_disable_non_object_insert;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/types/json/json2_limit.sql
+++ b/tests/cases/standalone/common/types/json/json2_limit.sql
@@ -16,8 +16,6 @@ insert into json2_disable_non_object_insert values (4, 'true');
 
 insert into json2_disable_non_object_insert values (5, 'null');
 
-insert into json2_disable_non_object_insert values (6, '{}');
-
 drop table json2_disable_non_object_insert;
 
 create table json2_whole_and_path_read (


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

Support empty-object and SQL `NULL` values for `json2`.

- Remove the insert-side rejection for empty JSON objects (`{}`).
- Let `JsonVectorBuilder` append `ValueRef::Null` as a null JSON2 row.
- Add sqlness coverage for `{}`, nested empty objects, SQL `NULL`, JSON `null`, flush, and compaction.

This relaxes insert behavior and is backward compatible. SQL `NULL`, JSON `null`, and `{}` remain distinguishable.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
