### PR TITLE
chore: bump version to 1.3.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -942,7 +942,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "catalog",
  "common-error",
@@ -1658,7 +1658,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -2001,7 +2001,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -2093,7 +2093,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.6",
  "store-api",
- "substrait 1.3.0",
+ "substrait 1.3.0-alpha.1",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "common-base"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "anymap2",
@@ -2318,14 +2318,14 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "const_format",
 ]
 
 [[package]]
 name = "common-config"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-macro",
  "http 1.3.1",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "common-base",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "greptime-proto",
  "once_cell",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "common-memory-manager"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2633,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anymap2",
  "api",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-base",
  "common-grpc",
@@ -2717,11 +2717,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 
 [[package]]
 name = "common-pprof"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-stream",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-trait",
  "catio",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "serde",
  "strum 0.27.1",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "common-sql"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "common-stat"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-base",
  "common-runtime",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "backtrace",
  "common-base",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-grpc",
  "common-query",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "cargo-manifest",
  "const_format",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "common-telemetry",
  "serde",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -4550,7 +4550,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "datatypes"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "arrow 58.3.0",
  "arrow-array 58.3.0",
@@ -5303,7 +5303,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-engine"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -5439,7 +5439,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -5509,7 +5509,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 1.3.0",
+ "substrait 1.3.0-alpha.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -5592,7 +5592,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -8017,7 +8017,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-query"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -8029,7 +8029,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8355,7 +8355,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8388,7 +8388,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -8588,7 +8588,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "bytes",
@@ -8613,7 +8613,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -9451,7 +9451,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9969,7 +9969,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10031,7 +10031,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.3.0",
+ "substrait 1.3.0-alpha.1",
  "table",
  "tokio",
  "tokio-util",
@@ -10366,7 +10366,7 @@ checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
 
 [[package]]
 name = "partition"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -10751,7 +10751,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10914,7 +10914,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "auth",
  "catalog",
@@ -11254,7 +11254,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -11671,7 +11671,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -11733,7 +11733,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -11804,7 +11804,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.3.0",
+ "substrait 1.3.0-alpha.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -13434,7 +13434,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13575,7 +13575,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13929,7 +13929,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arrow-buffer 58.3.0",
@@ -13990,7 +13990,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -14272,7 +14272,7 @@ dependencies = [
 
 [[package]]
 name = "standalone"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "async-trait",
@@ -14320,7 +14320,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-api"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -14513,7 +14513,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -14635,7 +14635,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -14918,7 +14918,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests-fuzz"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -14966,7 +14966,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -15048,7 +15048,7 @@ dependencies = [
  "sqlx",
  "standalone",
  "store-api",
- "substrait 1.3.0",
+ "substrait 1.3.0-alpha.1",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.3.0"
+version = "1.3.0-alpha.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Bump the workspace version on `main` from `1.3.0` to `1.3.0-alpha.1`.
- This places the Alpha version declaration on the development branch after removing the accidental release-branch tag.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
