### PR TITLE
fix(datatypes): reject JSON numbers beyond u64::MAX instead of silently losing precision

### DIFF
--- a/src/common/function/src/scalars/json/parse_json.rs
+++ b/src/common/function/src/scalars/json/parse_json.rs
@@ -20,6 +20,7 @@ use datafusion_common::arrow::array::{Array, AsArray, BinaryViewBuilder};
 use datafusion_common::arrow::compute;
 use datafusion_common::arrow::datatypes::DataType;
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, Signature, Volatility};
+use datatypes::types::validate_json_integer_range;
 
 use crate::function::{Function, extract_args};
 
@@ -67,6 +68,9 @@ impl Function for ParseJsonFunction {
             let s = json_strings.is_valid(i).then(|| json_strings.value(i));
             let result = s
                 .map(|s| {
+                    validate_json_integer_range(s).map_err(|e| {
+                        DataFusionError::Execution(format!("cannot parse '{s}': {e}"))
+                    })?;
                     jsonb::parse_value(s.as_bytes())
                         .map(|x| x.to_vec())
                         .map_err(|e| DataFusionError::Execution(format!("cannot parse '{s}': {e}")))

--- a/src/common/sql/src/convert.rs
+++ b/src/common/sql/src/convert.rs
@@ -20,7 +20,10 @@ use common_time::timezone::Timezone;
 use datatypes::extension::json::{Json2ExtensionType, parse_legacy_json2_settings};
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema};
-use datatypes::types::{JsonFormat, parse_string_to_jsonb, parse_string_to_vector_type_value};
+use datatypes::types::{
+    JsonFormat, parse_string_to_jsonb, parse_string_to_vector_type_value,
+    validate_json_integer_range,
+};
 use datatypes::value::{OrderedF32, OrderedF64, Value};
 use snafu::{OptionExt, ResultExt, ensure};
 pub use sqlparser::ast::{
@@ -307,6 +310,8 @@ pub(crate) fn parse_string_to_value(
                 Ok(Value::Binary(v.into()))
             }
             JsonFormat::Json2(_) => {
+                validate_json_integer_range(&s).context(DatatypeSnafu)?;
+
                 let v = serde_json::from_str(&s).context(DeserializeSnafu { json: s })?;
 
                 if let Some(extension) = column_schema

--- a/src/datatypes/src/error.rs
+++ b/src/datatypes/src/error.rs
@@ -218,6 +218,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("JSON number out of supported range: {}", value))]
+    JsonNumberOutOfRange {
+        value: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Invalid JSON2 layout: {reason}"))]
     InvalidJson2Layout {
         reason: String,
@@ -355,6 +362,7 @@ impl ErrorExt for Error {
             | InvalidTimestampPrecision { .. }
             | InvalidPrecisionOrScale { .. }
             | InvalidJson { .. }
+            | JsonNumberOutOfRange { .. }
             | InvalidJson2Layout { .. }
             | InvalidJson2Settings { .. }
             | InvalidJsonb { .. }

--- a/src/datatypes/src/types.rs
+++ b/src/datatypes/src/types.rs
@@ -45,7 +45,7 @@ pub use interval_type::{
 };
 pub use json_type::{
     JSON_TYPE_NAME, JsonFormat, JsonType, jsonb_to_serde_json, jsonb_to_string,
-    parse_string_to_jsonb,
+    parse_string_to_jsonb, validate_json_integer_range,
 };
 pub use list_type::ListType;
 pub use null_type::NullType;

--- a/src/datatypes/src/types/json_type.rs
+++ b/src/datatypes/src/types/json_type.rs
@@ -27,7 +27,8 @@ use snafu::ResultExt;
 use crate::Error;
 use crate::data_type::DataType;
 use crate::error::{
-    DeserializeSnafu, InvalidJsonSnafu, InvalidJsonbSnafu, Result, UnsupportedArrowTypeSnafu,
+    DeserializeSnafu, InvalidJsonSnafu, InvalidJsonbSnafu, JsonNumberOutOfRangeSnafu, Result,
+    UnsupportedArrowTypeSnafu,
 };
 use crate::prelude::ConcreteDataType;
 use crate::scalars::ScalarVectorBuilder;
@@ -467,14 +468,151 @@ fn fix_unicode_point(json: &str) -> Result<String> {
 
 /// Parses a string to a json type value
 pub fn parse_string_to_jsonb(s: &str) -> Result<Vec<u8>> {
+    validate_json_integer_range(s)?;
     jsonb::parse_value(s.as_bytes())
         .map_err(|_| InvalidJsonSnafu { value: s }.build())
         .map(|json| json.to_vec())
 }
 
+/// Rejects JSON texts that contain an integer literal outside the exact
+/// range representable by `u64` or `i64`.
+///
+/// `jsonb::parse_value` (and its underlying fast-float fallback) silently
+/// coerces such integers to `f64`, losing precision forever. Instead of
+/// storing a corrupted value, we fail the write with an explicit error,
+/// matching the behavior of PostgreSQL `jsonb` and of our own `BIGINT`
+/// columns on overflow.
+pub fn validate_json_integer_range(s: &str) -> Result<()> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' if !in_string => {
+                in_string = true;
+                i += 1;
+            }
+            b'"' if in_string && !escaped => {
+                in_string = false;
+                i += 1;
+            }
+            b'\\' if in_string && !escaped => {
+                escaped = true;
+                i += 1;
+            }
+            b'-' if !in_string && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() => {
+                // Negative number token.
+                let start = i;
+                i += 1;
+                while i < bytes.len()
+                    && (bytes[i].is_ascii_digit()
+                        || bytes[i] == b'.'
+                        || bytes[i] == b'e'
+                        || bytes[i] == b'E'
+                        || (i > start + 1 && (bytes[i] == b'+' || bytes[i] == b'-')))
+                {
+                    i += 1;
+                }
+                let token = &s[start..i];
+                if is_bare_integer(token) && !fits_exact_integer(token) {
+                    return JsonNumberOutOfRangeSnafu { value: token }.fail();
+                }
+            }
+            b'0'..=b'9' if !in_string => {
+                // Collect a full number token: digits, '.', exponent 'e/E',
+                // exponent sign. Digits are the leading part here.
+                let start = i;
+                while i < bytes.len()
+                    && (bytes[i].is_ascii_digit()
+                        || bytes[i] == b'.'
+                        || bytes[i] == b'e'
+                        || bytes[i] == b'E'
+                        || (i > start && (bytes[i] == b'+' || bytes[i] == b'-')))
+                {
+                    i += 1;
+                }
+                let token = &s[start..i];
+                if is_bare_integer(token) && !fits_exact_integer(token) {
+                    return JsonNumberOutOfRangeSnafu { value: token }.fail();
+                }
+            }
+            _ => {
+                if in_string && escaped {
+                    escaped = false;
+                }
+                i += 1;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// A number token is a "bare integer" when it contains no fractional part
+/// and no exponent: e.g. `18446744073709551616` but not `1.5` or `1e3`.
+fn is_bare_integer(token: &str) -> bool {
+    !token.contains(['.', 'e', 'E'])
+}
+
+/// Whether a bare integer token fits exactly in `i64` (negative) or `u64`.
+///
+/// Parses the full token: for a negative number this correctly accepts
+/// `i64::MIN` (`-9223372036854775808`), whose magnitude exceeds `i64::MAX`
+/// and would fail if the sign were stripped before parsing.
+fn fits_exact_integer(token: &str) -> bool {
+    if token.starts_with('-') {
+        token.parse::<i64>().is_ok()
+    } else {
+        token.parse::<u64>().is_ok()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_json_integer_range() {
+        // Valid: integers within u64 / i64 range are accepted.
+        for json in [
+            r#"{"n": 18446744073709551615}"#, // u64::MAX
+            r#"{"n": -9223372036854775808}"#, // i64::MIN
+            r#"{"n": 42}"#,
+            r#"{"n": 1.5}"#,                                // float
+            r#"{"n": 1e3}"#,                                // exponent
+            r#"{"n": -1e400}"#,                             // negative exponent
+            r#"{"s": "18446744073709551616 in a string"}"#, // inside string
+        ] {
+            let r = validate_json_integer_range(json);
+            assert!(r.is_ok(), "expected ok for {json}, got {r:?}");
+        }
+
+        // Invalid: bare integers beyond u64 / i64 range are rejected.
+        for json in [
+            r#"{"n": 18446744073709551616}"#, // u64::MAX + 1
+            r#"{"n": 123456789012345678901234567890}"#,
+            r#"{"n": -9223372036854775809}"#, // i64::MIN - 1
+            r#"[18446744073709551616, 1]"#,   // inside array
+            r#"{"nested": {"a": {"b": 999999999999999999999999999999}}}"#,
+        ] {
+            let r = validate_json_integer_range(json);
+            assert!(r.is_err(), "expected err for {json}, got {r:?}");
+        }
+    }
+
+    #[test]
+    fn test_parse_string_to_jsonb_rejects_out_of_range_integer() {
+        let err = parse_string_to_jsonb(r#"{"n": 18446744073709551616}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("out of supported range"),
+            "unexpected error: {err}"
+        );
+
+        // Control: u64::MAX still parses fine.
+        assert!(parse_string_to_jsonb(r#"{"n": 18446744073709551615}"#).is_ok());
+    }
 
     #[test]
     fn test_fix_unicode_point() -> Result<()> {

--- a/tests/cases/standalone/common/types/json/json_precision_loss.result
+++ b/tests/cases/standalone/common/types/json/json_precision_loss.result
@@ -1,9 +1,7 @@
--- Reproduction for JSON integer precision loss beyond u64::MAX.
--- See issue: TBD (link once published)
---
--- Case 1 (control): integer within u64 range is stored exactly.
--- Case 2 (bug): u64::MAX + 1 is silently coerced to f64.
--- Case 3 (bug): 30-digit integer is severely distorted.
+-- Regression test for JSON integer precision loss beyond u64::MAX.
+-- Integers outside i64/u64 range must be rejected with an explicit
+-- error instead of being silently coerced to f64.
+-- See PR: fix(datatypes): reject JSON numbers beyond u64::MAX
 create table t_json_precision (
     ts timestamp time index,
     j  json
@@ -16,15 +14,30 @@ insert into t_json_precision values (1, '{"n": 18446744073709551615}');
 
 Affected Rows: 1
 
--- Beyond u64::MAX: currently accepted with Affected Rows: 1 and
--- silently stored as a f64 approximation (precision lost forever).
+-- i64::MIN also accepted exactly
+insert into t_json_precision values (4, '{"n": -9223372036854775808}');
+
+Affected Rows: 1
+
+-- Floats and exponents are unaffected
+insert into t_json_precision values (5, '{"n": 1.5}');
+
+Affected Rows: 1
+
+-- Beyond u64::MAX: rejected with an explicit error
 insert into t_json_precision values (2, '{"n": 18446744073709551616}');
 
-Affected Rows: 1
+Error: 1004(InvalidArguments), JSON number out of supported range: 18446744073709551616
 
+-- 30-digit integer: rejected
 insert into t_json_precision values (3, '{"n": 123456789012345678901234567890}');
 
-Affected Rows: 1
+Error: 1004(InvalidArguments), JSON number out of supported range: 123456789012345678901234567890
+
+-- Negative beyond i64::MIN: rejected
+insert into t_json_precision values (6, '{"n": -9223372036854775809}');
+
+Error: 1004(InvalidArguments), JSON number out of supported range: -9223372036854775809
 
 select
     ts,
@@ -32,13 +45,13 @@ select
 from t_json_precision
 order by ts;
 
-+-------------------------+-----------------------+
-| ts                      | n                     |
-+-------------------------+-----------------------+
-| 1970-01-01T00:00:00.001 | 18446744073709551615  |
-| 1970-01-01T00:00:00.002 | 1.8446744073709552e19 |
-| 1970-01-01T00:00:00.003 | 1.2345678901234568e29 |
-+-------------------------+-----------------------+
++-------------------------+----------------------+
+| ts                      | n                    |
++-------------------------+----------------------+
+| 1970-01-01T00:00:00.001 | 18446744073709551615 |
+| 1970-01-01T00:00:00.004 | -9223372036854775808 |
+| 1970-01-01T00:00:00.005 | 1.5                  |
++-------------------------+----------------------+
 
 drop table t_json_precision;
 

--- a/tests/cases/standalone/common/types/json/json_precision_loss.result
+++ b/tests/cases/standalone/common/types/json/json_precision_loss.result
@@ -1,0 +1,46 @@
+-- Reproduction for JSON integer precision loss beyond u64::MAX.
+-- See issue: TBD (link once published)
+--
+-- Case 1 (control): integer within u64 range is stored exactly.
+-- Case 2 (bug): u64::MAX + 1 is silently coerced to f64.
+-- Case 3 (bug): 30-digit integer is severely distorted.
+create table t_json_precision (
+    ts timestamp time index,
+    j  json
+);
+
+Affected Rows: 0
+
+-- Within u64 range: exact round-trip
+insert into t_json_precision values (1, '{"n": 18446744073709551615}');
+
+Affected Rows: 1
+
+-- Beyond u64::MAX: currently accepted with Affected Rows: 1 and
+-- silently stored as a f64 approximation (precision lost forever).
+insert into t_json_precision values (2, '{"n": 18446744073709551616}');
+
+Affected Rows: 1
+
+insert into t_json_precision values (3, '{"n": 123456789012345678901234567890}');
+
+Affected Rows: 1
+
+select
+    ts,
+    json_get(j, '$.n') as n
+from t_json_precision
+order by ts;
+
++-------------------------+-----------------------+
+| ts                      | n                     |
++-------------------------+-----------------------+
+| 1970-01-01T00:00:00.001 | 18446744073709551615  |
+| 1970-01-01T00:00:00.002 | 1.8446744073709552e19 |
+| 1970-01-01T00:00:00.003 | 1.2345678901234568e29 |
++-------------------------+-----------------------+
+
+drop table t_json_precision;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/types/json/json_precision_loss.sql
+++ b/tests/cases/standalone/common/types/json/json_precision_loss.sql
@@ -1,0 +1,27 @@
+-- Reproduction for JSON integer precision loss beyond u64::MAX.
+-- See issue: TBD (link once published)
+--
+-- Case 1 (control): integer within u64 range is stored exactly.
+-- Case 2 (bug): u64::MAX + 1 is silently coerced to f64.
+-- Case 3 (bug): 30-digit integer is severely distorted.
+
+create table t_json_precision (
+    ts timestamp time index,
+    j  json
+);
+
+-- Within u64 range: exact round-trip
+insert into t_json_precision values (1, '{"n": 18446744073709551615}');
+
+-- Beyond u64::MAX: currently accepted with Affected Rows: 1 and
+-- silently stored as a f64 approximation (precision lost forever).
+insert into t_json_precision values (2, '{"n": 18446744073709551616}');
+insert into t_json_precision values (3, '{"n": 123456789012345678901234567890}');
+
+select
+    ts,
+    json_get(j, '$.n') as n
+from t_json_precision
+order by ts;
+
+drop table t_json_precision;

--- a/tests/cases/standalone/common/types/json/json_precision_loss.sql
+++ b/tests/cases/standalone/common/types/json/json_precision_loss.sql
@@ -1,9 +1,7 @@
--- Reproduction for JSON integer precision loss beyond u64::MAX.
--- See issue: TBD (link once published)
---
--- Case 1 (control): integer within u64 range is stored exactly.
--- Case 2 (bug): u64::MAX + 1 is silently coerced to f64.
--- Case 3 (bug): 30-digit integer is severely distorted.
+-- Regression test for JSON integer precision loss beyond u64::MAX.
+-- Integers outside i64/u64 range must be rejected with an explicit
+-- error instead of being silently coerced to f64.
+-- See PR: fix(datatypes): reject JSON numbers beyond u64::MAX
 
 create table t_json_precision (
     ts timestamp time index,
@@ -13,10 +11,20 @@ create table t_json_precision (
 -- Within u64 range: exact round-trip
 insert into t_json_precision values (1, '{"n": 18446744073709551615}');
 
--- Beyond u64::MAX: currently accepted with Affected Rows: 1 and
--- silently stored as a f64 approximation (precision lost forever).
+-- i64::MIN also accepted exactly
+insert into t_json_precision values (4, '{"n": -9223372036854775808}');
+
+-- Floats and exponents are unaffected
+insert into t_json_precision values (5, '{"n": 1.5}');
+
+-- Beyond u64::MAX: rejected with an explicit error
 insert into t_json_precision values (2, '{"n": 18446744073709551616}');
+
+-- 30-digit integer: rejected
 insert into t_json_precision values (3, '{"n": 123456789012345678901234567890}');
+
+-- Negative beyond i64::MIN: rejected
+insert into t_json_precision values (6, '{"n": -9223372036854775809}');
 
 select
     ts,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

fix #9020

## What's changed and what's your intention?

Fix silent precision loss when a JSON number exceeds `u64::MAX`.

### Problem

JSON integers beyond `u64::MAX` were silently coerced to `f64` at parse
time in two places:

1. `jsonb::parse_value` (the third-party `jsonb` crate used for the
   JSONB storage format) falls back to `fast_float2::parse` when
   `u64`/`i64` parsing fails (parser.rs:264-277).
2. `JsonNumber::from(Number)` in `src/datatypes/src/json/value.rs` falls
   back to `n.as_f64()` when `as_i64()`/`as_u64()` both return `None`.

The INSERT reported success (`Affected Rows: 1`) while the stored value
was permanently corrupted, e.g.:

- `18446744073709551616` -> `1.8446744073709552e19`
- `123456789012345678901234567890` -> `1.2345678901234568e29`

### Fix

Added `validate_json_integer_range` in `src/datatypes/src/types/json_type.rs`,
a lightweight scanner that walks the JSON text (skipping string
literals) and rejects bare integer literals that do not fit exactly in
`i64` (negative) or `u64` (positive) with an explicit
`JSON number out of supported range` error.

The validation runs at all JSON text entry points:
- `parse_string_to_jsonb` (SQL INSERT of `JSON` columns)
- `ParseJsonFunction` (the `parse_json()` SQL function)
- JSON2 string conversion in `src/common/sql/src/convert.rs`

This matches the behavior of PostgreSQL `jsonb` (which rejects
out-of-range numbers) and is consistent with our own `BIGINT` columns,
which already error on overflow. Floats, exponents and integers within
range are unaffected.

### Verification

- Unit tests: `test_validate_json_integer_range`,
  `test_parse_string_to_jsonb_rejects_out_of_range_integer` (5/5 pass)
- Manual verification against a running standalone:
  - `18446744073709551616` -> error `JSON number out of supported range`
  - `18446744073709551615` (u64::MAX) -> stored exactly
  - `-9223372036854775808` (i64::MIN) -> stored exactly
  - `1.5`, `1e100` -> unaffected
- sqlness regression test `json_precision_loss` passes

## PR Checklist

Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
