### PR TITLE
fix(wal): bound Kafka requests and extend latency buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12671,7 +12671,7 @@ dependencies = [
 [[package]]
 name = "rskafka"
 version = "0.6.0"
-source = "git+https://github.com/GreptimeTeam/rskafka.git?rev=f5688f83e7da591cda3f2674c2408b4c0ed4ed50#f5688f83e7da591cda3f2674c2408b4c0ed4ed50"
+source = "git+https://github.com/GreptimeTeam/rskafka.git?rev=ba4db85a69312a231a22e8d96e67d8a4207862a3#ba4db85a69312a231a22e8d96e67d8a4207862a3"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12671,7 +12671,7 @@ dependencies = [
 [[package]]
 name = "rskafka"
 version = "0.6.0"
-source = "git+https://github.com/GreptimeTeam/rskafka.git?rev=ba4db85a69312a231a22e8d96e67d8a4207862a3#ba4db85a69312a231a22e8d96e67d8a4207862a3"
+source = "git+https://github.com/GreptimeTeam/rskafka.git?rev=5f9494104f7b43a619d6c42e2a2082e39a7b72aa#5f9494104f7b43a619d6c42e2a2082e39a7b72aa"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 url = "2.3"
 # Branch: feat/request-timeout
 hostname = "0.4.0"
-rskafka = { git = "https://github.com/GreptimeTeam/rskafka.git", rev = "ba4db85a69312a231a22e8d96e67d8a4207862a3", features = [
+rskafka = { git = "https://github.com/GreptimeTeam/rskafka.git", rev = "5f9494104f7b43a619d6c42e2a2082e39a7b72aa", features = [
     "transport-tls",
 ] }
 rstest = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,7 +223,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 url = "2.3"
 # Branch: feat/request-timeout
 hostname = "0.4.0"
-rskafka = { git = "https://github.com/GreptimeTeam/rskafka.git", rev = "f5688f83e7da591cda3f2674c2408b4c0ed4ed50", features = [
+rskafka = { git = "https://github.com/GreptimeTeam/rskafka.git", rev = "ba4db85a69312a231a22e8d96e67d8a4207862a3", features = [
     "transport-tls",
 ] }
 rstest = "0.25"

--- a/config/config.md
+++ b/config/config.md
@@ -106,7 +106,7 @@
 | `wal.recovery_parallelism` | Integer | `2` | Parallelism during WAL recovery. |
 | `wal.broker_endpoints` | Array | -- | The Kafka broker endpoints.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.connect_timeout` | String | `3s` | The connect timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
-| `wal.timeout` | String | `3s` | The timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
+| `wal.timeout` | String | `5s` | The total request timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.auto_create_topics` | Bool | `true` | Automatically create topics for WAL.<br/>Set to `true` to automatically create topics for WAL.<br/>Otherwise, use topics named `topic_name_prefix_[0..num_topics)` |
 | `wal.num_topics` | Integer | `64` | Number of topics.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.selector_type` | String | `round_robin` | Topic selector type.<br/>Available selector types:<br/>- `round_robin` (default)<br/>**It's only used when the provider is `kafka`**. |
@@ -561,7 +561,7 @@
 | `wal.recovery_parallelism` | Integer | `2` | Parallelism during WAL recovery. |
 | `wal.broker_endpoints` | Array | -- | The Kafka broker endpoints.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.connect_timeout` | String | `3s` | The connect timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
-| `wal.timeout` | String | `3s` | The timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
+| `wal.timeout` | String | `5s` | The total request timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.max_batch_bytes` | String | `1MB` | The max size of a single producer batch.<br/>Warning: Kafka has a default limit of 1MB per message in a topic.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.consumer_wait_timeout` | String | `100ms` | The consumer wait timeout.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.create_index` | Bool | `false` | Whether to enable WAL index creation.<br/>**It's only used when the provider is `kafka`**. |

--- a/config/config.md
+++ b/config/config.md
@@ -460,6 +460,8 @@
 | `wal` | -- | -- | -- |
 | `wal.provider` | String | `raft_engine` | -- |
 | `wal.broker_endpoints` | Array | -- | The broker endpoints of the Kafka cluster.<br/><br/>**It's only used when the provider is `kafka`**. |
+| `wal.connect_timeout` | String | `3s` | The connect timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
+| `wal.timeout` | String | `5s` | The total request timeout for kafka client.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.auto_create_topics` | Bool | `true` | Automatically create topics for WAL.<br/>Set to `true` to automatically create topics for WAL.<br/>Otherwise, use topics named `topic_name_prefix_[0..num_topics)`<br/>**It's only used when the provider is `kafka`**. |
 | `wal.auto_prune_interval` | String | `30m` | Interval of automatically WAL pruning.<br/>Set to `0s` to disable automatically WAL pruning which delete unused remote WAL entries periodically.<br/>**It's only used when the provider is `kafka`**. |
 | `wal.auto_prune_logical_delete` | Bool | `false` | Whether automatically WAL pruning only updates the metadata marker and skips Kafka DeleteRecords.<br/>Set to `true` for Kafka deployments that do not support DeleteRecords.<br/>**It's only used when the provider is `kafka`**. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -186,9 +186,9 @@ broker_endpoints = ["127.0.0.1:9092"]
 ## **It's only used when the provider is `kafka`**.
 #+ connect_timeout = "3s"
 
-## The timeout for kafka client.
+## The total request timeout for kafka client.
 ## **It's only used when the provider is `kafka`**.
-#+ timeout = "3s"
+#+ timeout = "5s"
 
 ## The max size of a single producer batch.
 ## Warning: Kafka has a default limit of 1MB per message in a topic.

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -229,6 +229,14 @@ provider = "raft_engine"
 ## **It's only used when the provider is `kafka`**.
 broker_endpoints = ["127.0.0.1:9092"]
 
+## The connect timeout for kafka client.
+## **It's only used when the provider is `kafka`**.
+#+ connect_timeout = "3s"
+
+## The total request timeout for kafka client.
+## **It's only used when the provider is `kafka`**.
+#+ timeout = "5s"
+
 ## Automatically create topics for WAL.
 ## Set to `true` to automatically create topics for WAL.
 ## Otherwise, use topics named `topic_name_prefix_[0..num_topics)`

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -305,9 +305,9 @@ broker_endpoints = ["127.0.0.1:9092"]
 ## **It's only used when the provider is `kafka`**.
 #+ connect_timeout = "3s"
 
-## The timeout for kafka client.
+## The total request timeout for kafka client.
 ## **It's only used when the provider is `kafka`**.
-#+ timeout = "3s"
+#+ timeout = "5s"
 
 ## Automatically create topics for WAL.
 ## Set to `true` to automatically create topics for WAL.

--- a/src/common/wal/Cargo.toml
+++ b/src/common/wal/Cargo.toml
@@ -30,3 +30,4 @@ tokio.workspace = true
 [dev-dependencies]
 serde_json.workspace = true
 toml.workspace = true
+rskafka = { workspace = true, features = ["unstable-fuzzing"] }

--- a/src/common/wal/Cargo.toml
+++ b/src/common/wal/Cargo.toml
@@ -28,6 +28,6 @@ snafu.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+rskafka = { workspace = true, features = ["unstable-fuzzing"] }
 serde_json.workspace = true
 toml.workspace = true
-rskafka = { workspace = true, features = ["unstable-fuzzing"] }

--- a/src/common/wal/src/config.rs
+++ b/src/common/wal/src/config.rs
@@ -214,7 +214,7 @@ mod tests {
                     client_key_path: None,
                 }),
                 connect_timeout: Duration::from_secs(3),
-                timeout: Duration::from_secs(3),
+                timeout: Duration::from_secs(5),
             },
             kafka_topic: KafkaTopicConfig {
                 num_topics: 32,
@@ -252,7 +252,7 @@ mod tests {
                     client_key_path: None,
                 }),
                 connect_timeout: Duration::from_secs(3),
-                timeout: Duration::from_secs(3),
+                timeout: Duration::from_secs(5),
             },
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),
@@ -289,5 +289,35 @@ mod tests {
         assert!(debug.contains("greptime"));
         assert!(debug.contains("<REDACTED>"));
         assert!(!debug.contains("kafka-secret"));
+    }
+}
+
+#[cfg(test)]
+mod rskafka_contract_tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rskafka::build_info::DEFAULT_CLIENT_ID;
+    use rskafka::messenger::{Messenger, RequestError, SyncVersionsError};
+
+    #[tokio::test]
+    async fn test_send_timeout_poisoned_messenger() {
+        let (_peer, stream) = tokio::io::duplex(1);
+        let mut messenger = Messenger::new(
+            stream,
+            1_000,
+            Arc::from(DEFAULT_CLIENT_ID),
+            Some(Duration::from_millis(50)),
+        );
+
+        let error = messenger.sync_versions().await.unwrap_err();
+        assert!(matches!(
+            error,
+            SyncVersionsError::RequestError(RequestError::Poisoned(error))
+                if matches!(
+                    error.as_ref(),
+                    RequestError::IO(error) if error.kind() == std::io::ErrorKind::TimedOut
+                )
+        ));
     }
 }

--- a/src/common/wal/src/config/kafka/common.rs
+++ b/src/common/wal/src/config/kafka/common.rs
@@ -198,7 +198,7 @@ pub struct KafkaConnectionConfig {
     /// The connect timeout for kafka client.
     #[serde(with = "humantime_serde")]
     pub connect_timeout: Duration,
-    /// The timeout for kafka client.
+    /// The total request timeout for kafka client.
     #[serde(with = "humantime_serde")]
     pub timeout: Duration,
 }
@@ -210,7 +210,7 @@ impl Default for KafkaConnectionConfig {
             sasl: None,
             tls: None,
             connect_timeout: Duration::from_secs(3),
-            timeout: Duration::from_secs(3),
+            timeout: Duration::from_secs(5),
         }
     }
 }

--- a/src/log-store/src/metrics.rs
+++ b/src/log-store/src/metrics.rs
@@ -90,23 +90,3 @@ lazy_static! {
     )
     .unwrap();
 }
-
-#[cfg(test)]
-mod tests {
-    use prometheus::core::Collector;
-
-    use super::*;
-
-    #[test]
-    fn test_logstore_op_elapsed_buckets() {
-        for metric in METRIC_LOGSTORE_OP_ELAPSED.collect()[0].get_metric() {
-            let upper_bounds = metric
-                .get_histogram()
-                .get_bucket()
-                .iter()
-                .map(|bucket| bucket.get_upper_bound())
-                .collect::<Vec<_>>();
-            assert_eq!(LOGSTORE_OP_ELAPSED_BUCKETS, upper_bounds.as_slice());
-        }
-    }
-}

--- a/src/log-store/src/metrics.rs
+++ b/src/log-store/src/metrics.rs
@@ -54,6 +54,10 @@ lazy_static! {
         "greptime_logstore_op_elapsed",
         "logstore operation elapsed",
         &[LOGSTORE_LABEL, OPTYPE_LABEL],
+        vec![
+            0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
+            45.0, 60.0,
+        ],
     )
     .unwrap();
     /// Timer of the append_batch operation on the kafka logstore.
@@ -85,4 +89,24 @@ lazy_static! {
         &[LOGSTORE_LABEL, PARTITION_LABEL],
     )
     .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::core::Collector;
+
+    use super::*;
+
+    #[test]
+    fn test_logstore_op_elapsed_buckets() {
+        for metric in METRIC_LOGSTORE_OP_ELAPSED.collect()[0].get_metric() {
+            let upper_bounds = metric
+                .get_histogram()
+                .get_bucket()
+                .iter()
+                .map(|bucket| bucket.get_upper_bound())
+                .collect::<Vec<_>>();
+            assert_eq!(LOGSTORE_OP_ELAPSED_BUCKETS, upper_bounds.as_slice());
+        }
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #9017

## What's changed and what's your intention?

- Pin rskafka to `5f9494104f7b43a619d6c42e2a2082e39a7b72aa`, the merged head of `feat/request-timeout`, where the configured request timeout covers sending the Kafka frame as well as waiting for the response.
- Set the default Kafka remote WAL total request timeout to 5s. Existing explicit `timeout` settings remain unchanged.
- Add a mock transport contract test using `tokio::io::duplex(1)`. A peer that never reads blocks the ApiVersions frame and verifies that the pinned rskafka version returns `Poisoned(IO(TimedOut))` instead of waiting indefinitely.
- Extend the finite buckets of `greptime_logstore_op_elapsed` from 10s to 60s. The existing buckets remain and 15s, 20s, 30s, 45s, and 60s are added. `greptime_logstore_op_bytes_total` is a counter and has no buckets.
- Update Kafka remote WAL configuration examples and regenerate `config/config.md`.

This PR does not change persisted data, wire schemas, or public APIs.

Validation:

- `cargo nextest run -p common-wal -p log-store` — 64 passed
- `cargo fmt --all -- --check`
- `git diff --check`

## PR Checklist
- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
