### PR TITLE
fix(client): complete transport lane isolation

### DIFF
--- a/src/client/src/client.rs
+++ b/src/client/src/client.rs
@@ -105,6 +105,7 @@ struct Peers {
 }
 
 impl Inner {
+    // The legacy single-manager path intentionally shares its pool between lanes.
     fn with_manager_and_peers(
         channel_manager: ChannelManager,
         peers: Vec<String>,
@@ -113,6 +114,7 @@ impl Inner {
         Self::with_managers_and_peers(channel_manager.clone(), channel_manager, peers, options)
     }
 
+    // The explicit dual-manager path keeps query and control pools independent.
     fn with_managers_and_peers(
         query_channel_manager: ChannelManager,
         control_channel_manager: ChannelManager,
@@ -222,10 +224,18 @@ fn random_initial_delay(max_delay: Duration) -> Duration {
 }
 
 impl Client {
+    /// Creates a client whose query and control lanes intentionally share the default manager.
+    ///
+    /// Use [`Self::with_query_and_control_managers`] with independently constructed
+    /// managers when the lanes must be isolated.
     pub fn new() -> Self {
         Default::default()
     }
 
+    /// Creates a client whose query and control lanes intentionally share one manager.
+    ///
+    /// Use [`Self::with_query_and_control_managers`] with independently constructed
+    /// managers when the lanes must be isolated.
     pub fn with_urls<U, A>(urls: A) -> Self
     where
         U: AsRef<str>,
@@ -235,6 +245,8 @@ impl Client {
     }
 
     /// Creates a client with URLs and custom options.
+    ///
+    /// The query and control lanes intentionally share one manager.
     pub fn with_urls_and_options<U, A>(urls: A, options: ClientOptions) -> Self
     where
         U: AsRef<str>,
@@ -243,6 +255,7 @@ impl Client {
         Self::with_manager_and_urls_and_options(ChannelManager::new(), urls, options)
     }
 
+    /// Creates a TLS client whose query and control lanes intentionally share one manager.
     pub fn with_tls_and_urls<U, A>(urls: A, client_tls: ClientTlsOption) -> Result<Self>
     where
         U: AsRef<str>,
@@ -252,6 +265,8 @@ impl Client {
     }
 
     /// Creates a client with TLS URLs and custom options.
+    ///
+    /// The query and control lanes intentionally share one manager.
     pub fn with_tls_and_urls_and_options<U, A>(
         urls: A,
         client_tls: ClientTlsOption,
@@ -272,6 +287,10 @@ impl Client {
         ))
     }
 
+    /// Creates a client with one manager shared intentionally by query and control lanes.
+    ///
+    /// Use [`Self::with_query_and_control_managers`] with independently constructed
+    /// managers when the lanes must be isolated.
     pub fn with_manager_and_urls<U, A>(channel_manager: ChannelManager, urls: A) -> Self
     where
         U: AsRef<str>,
@@ -280,7 +299,11 @@ impl Client {
         Self::with_manager_and_urls_and_options(channel_manager, urls, ClientOptions::default())
     }
 
-    pub(crate) fn with_managers_and_urls<U, A>(
+    /// Creates a client with query and control lanes backed by the supplied managers.
+    ///
+    /// The lanes are isolated only when the supplied managers are independently constructed;
+    /// this constructor does not enforce that they are distinct.
+    pub fn with_query_and_control_managers<U, A>(
         query_channel_manager: ChannelManager,
         control_channel_manager: ChannelManager,
         urls: A,
@@ -289,7 +312,7 @@ impl Client {
         U: AsRef<str>,
         A: AsRef<[U]>,
     {
-        Self::with_managers_and_urls_and_options(
+        Self::with_query_and_control_managers_and_options(
             query_channel_manager,
             control_channel_manager,
             urls,
@@ -297,7 +320,7 @@ impl Client {
         )
     }
 
-    fn with_managers_and_urls_and_options<U, A>(
+    fn with_query_and_control_managers_and_options<U, A>(
         query_channel_manager: ChannelManager,
         control_channel_manager: ChannelManager,
         urls: A,
@@ -323,6 +346,8 @@ impl Client {
     }
 
     /// Creates a client with a channel manager, URLs, and custom options.
+    ///
+    /// The query and control lanes intentionally share this manager and its pool.
     pub fn with_manager_and_urls_and_options<U, A>(
         channel_manager: ChannelManager,
         urls: A,
@@ -333,7 +358,8 @@ impl Client {
         A: AsRef<[U]>,
     {
         let channel_manager_for_query = channel_manager.clone();
-        Self::with_managers_and_urls_and_options(
+        // Legacy constructors intentionally share the manager and therefore its pool.
+        Self::with_query_and_control_managers_and_options(
             channel_manager_for_query,
             channel_manager,
             urls,
@@ -541,6 +567,23 @@ impl Client {
         Ok(())
     }
 
+    /// Returns the number of cached channels in the query and control pools for tests.
+    #[cfg(feature = "testing")]
+    pub fn channel_pool_sizes(&self) -> (usize, usize) {
+        let pool_size = |channel_manager: &ChannelManager| {
+            let mut size = 0;
+            channel_manager.retain_channel(|_, _| {
+                size += 1;
+                true
+            });
+            size
+        };
+        (
+            pool_size(&self.inner.query_channel_manager),
+            pool_size(&self.inner.control_channel_manager),
+        )
+    }
+
     /// Returns peer addresses grouped by active and inactive state for tests.
     #[cfg(feature = "testing")]
     pub fn peer_addresses_by_state(&self) -> (Vec<String>, Vec<String>) {
@@ -664,6 +707,36 @@ mod tests {
             "127.0.0.1:3002".to_string(),
             "127.0.0.1:3003".to_string(),
         ]
+    }
+
+    #[tokio::test]
+    async fn test_explicit_dual_manager_constructor_uses_isolated_reused_channel_pools() {
+        let query_channel_manager = ChannelManager::new();
+        let control_channel_manager = ChannelManager::new();
+        let client = Client::with_query_and_control_managers(
+            query_channel_manager.clone(),
+            control_channel_manager.clone(),
+            ["127.0.0.1:3001"],
+        );
+
+        client.make_flight_client(false, false).unwrap();
+        client.make_flight_client(false, false).unwrap();
+        assert_eq!(1, channel_pool_size(&query_channel_manager));
+        assert_eq!(0, channel_pool_size(&control_channel_manager));
+
+        client.make_control_flight_client(false, false).unwrap();
+        client.make_control_flight_client(false, false).unwrap();
+        assert_eq!(1, channel_pool_size(&query_channel_manager));
+        assert_eq!(1, channel_pool_size(&control_channel_manager));
+    }
+
+    fn channel_pool_size(manager: &ChannelManager) -> usize {
+        let mut size = 0;
+        manager.retain_channel(|_, _| {
+            size += 1;
+            true
+        });
+        size
     }
 
     #[test]

--- a/src/client/src/client_manager.rs
+++ b/src/client/src/client_manager.rs
@@ -77,6 +77,7 @@ impl FlownodeManager for NodeClients {
 }
 
 impl NodeClients {
+    /// Creates node clients with independent query and control channel pools.
     pub fn new(config: ChannelConfig) -> Self {
         Self {
             query_channel_manager: ChannelManager::with_config(config.clone(), None),
@@ -91,7 +92,7 @@ impl NodeClients {
     pub async fn get_client(&self, datanode: &Peer) -> Client {
         self.clients
             .get_with_by_ref(datanode, async move {
-                Client::with_managers_and_urls(
+                Client::with_query_and_control_managers(
                     self.query_channel_manager.clone(),
                     self.control_channel_manager.clone(),
                     vec![datanode.addr.clone()],

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -467,8 +467,6 @@ impl StartCommand {
         // Some queries are expected to take long time.
         let mut channel_config = opts.datanode.client.channel_config();
         channel_config.timeout = None;
-        // Source Flight streams and sink unary responses share pooled connections.
-        channel_config.http2_adaptive_window = Some(true);
         if opts.grpc.flight_compression.transport_compression() {
             channel_config.accept_compression = true;
             channel_config.send_compression = true;

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -91,7 +91,8 @@ impl HandlerMutable {
 pub enum FrontendClient {
     Distributed {
         meta_client: Arc<MetaClient>,
-        chnl_mgr: ChannelManager,
+        query_channel_manager: ChannelManager,
+        control_channel_manager: ChannelManager,
         query: QueryOptions,
         batch_opts: BatchingModeOptions,
     },
@@ -136,17 +137,19 @@ impl FrontendClient {
         batch_opts: BatchingModeOptions,
     ) -> Result<Self, Error> {
         common_telemetry::info!("Frontend client build without auth");
+        let cfg = ChannelConfig::new()
+            .connect_timeout(batch_opts.grpc_conn_timeout)
+            .timeout(Some(batch_opts.query_timeout));
+        let tls_config = load_client_tls_config(batch_opts.frontend_tls.clone())
+            .context(InvalidClientConfigSnafu)?;
+        // Keep separate TLS config handles and pools for query and control traffic.
+        let query_channel_manager = ChannelManager::with_config(cfg.clone(), tls_config.clone());
+        let control_channel_manager = ChannelManager::with_config(cfg, tls_config);
+
         Ok(Self::Distributed {
             meta_client,
-            chnl_mgr: {
-                let cfg = ChannelConfig::new()
-                    .connect_timeout(batch_opts.grpc_conn_timeout)
-                    .timeout(Some(batch_opts.query_timeout));
-
-                let tls_config = load_client_tls_config(batch_opts.frontend_tls.clone())
-                    .context(InvalidClientConfigSnafu)?;
-                ChannelManager::with_config(cfg, tls_config)
-            },
+            query_channel_manager,
+            control_channel_manager,
             query,
             batch_opts,
         })
@@ -219,7 +222,8 @@ impl FrontendClient {
         frontends: &[Peer],
     ) -> Result<Vec<String>, Error> {
         let Self::Distributed {
-            chnl_mgr,
+            query_channel_manager,
+            control_channel_manager,
             batch_opts,
             ..
         } = self
@@ -232,10 +236,15 @@ impl FrontendClient {
             .iter()
             .map(|peer| {
                 let addr = peer.addr.clone();
-                let chnl_mgr = chnl_mgr.clone();
+                let query_channel_manager = query_channel_manager.clone();
+                let control_channel_manager = control_channel_manager.clone();
 
                 async move {
-                    let client = Client::with_manager_and_urls(chnl_mgr, vec![addr.clone()]);
+                    let client = Client::with_query_and_control_managers(
+                        query_channel_manager,
+                        control_channel_manager,
+                        vec![addr.clone()],
+                    );
                     let database = Database::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, client);
 
                     match tokio::time::timeout(probe_timeout, database.sql("SELECT 1")).await {
@@ -274,7 +283,8 @@ impl FrontendClient {
     ) -> Result<DatabaseWithPeer, Error> {
         let Self::Distributed {
             meta_client: _,
-            chnl_mgr,
+            query_channel_manager,
+            control_channel_manager,
             query: _,
             batch_opts,
         } = self
@@ -294,7 +304,11 @@ impl FrontendClient {
 
             for peer in frontends {
                 let addr = peer.addr.clone();
-                let client = Client::with_manager_and_urls(chnl_mgr.clone(), vec![addr.clone()]);
+                let client = Client::with_query_and_control_managers(
+                    query_channel_manager.clone(),
+                    control_channel_manager.clone(),
+                    vec![addr.clone()],
+                );
                 let database = Database::new(catalog, schema, client);
                 let db = DatabaseWithPeer::new(database, peer);
                 match db.try_select_one().await {

--- a/src/meta-srv/src/utils/database.rs
+++ b/src/meta-srv/src/utils/database.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use client::error::{ExternalSnafu, Result as ClientResult};
 use client::{Client, Database, Output};
 use common_error::ext::BoxedError;
+use common_grpc::channel_manager::ChannelManager;
 use common_meta::peer::PeerDiscoveryRef;
 use common_telemetry::{debug, warn};
 use snafu::{ResultExt, ensure};
@@ -43,6 +44,9 @@ impl<'a> DatabaseContext<'a> {
 }
 
 /// A cached frontend database operator used by metasrv.
+///
+/// Its cached clients use independent query and control channel-manager pools;
+/// the legacy single-manager client constructors intentionally remain shared.
 pub struct DatabaseOperator {
     peer_discovery: PeerDiscoveryRef,
     client: RwLock<Option<Client>>,
@@ -110,7 +114,11 @@ impl DatabaseOperator {
 
         debug!("Available frontend addresses: {:?}", urls);
 
-        Ok(Client::with_urls(urls))
+        Ok(Client::with_query_and_control_managers(
+            ChannelManager::new(),
+            ChannelManager::new(),
+            urls,
+        ))
     }
 
     async fn maybe_init_client(&self) -> ClientResult<Client> {
@@ -146,4 +154,63 @@ fn should_reset_client<T>(result: &client::error::Result<T>) -> bool {
         .err()
         .map(|err| err.is_connection_error())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use api::v1::meta::heartbeat_request::NodeWorkloads;
+    use common_meta::cluster::{FrontendStatus, NodeInfo, NodeStatus};
+    use common_meta::peer::{Peer, PeerDiscovery};
+
+    use super::*;
+
+    struct TestPeerDiscovery;
+
+    #[async_trait::async_trait]
+    impl PeerDiscovery for TestPeerDiscovery {
+        async fn active_frontends(&self) -> common_meta::error::Result<Vec<NodeInfo>> {
+            Ok(vec![NodeInfo {
+                peer: Peer::new(1, "127.0.0.1:3001".to_string()),
+                last_activity_ts: 0,
+                status: NodeStatus::Frontend(FrontendStatus::default()),
+                version: String::new(),
+                git_commit: String::new(),
+                start_time_ms: 0,
+                total_cpu_millicores: 0,
+                total_memory_bytes: 0,
+                cpu_usage_millicores: 0,
+                memory_usage_bytes: 0,
+                hostname: String::new(),
+                env_vars: Default::default(),
+            }])
+        }
+
+        async fn active_datanodes(
+            &self,
+            _filter: Option<for<'a> fn(&'a NodeWorkloads) -> bool>,
+        ) -> common_meta::error::Result<Vec<NodeInfo>> {
+            unreachable!()
+        }
+
+        async fn active_flownodes(
+            &self,
+            _filter: Option<for<'a> fn(&'a NodeWorkloads) -> bool>,
+        ) -> common_meta::error::Result<Vec<NodeInfo>> {
+            unreachable!()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_client_uses_isolated_reused_channel_pools() {
+        let operator = DatabaseOperator::new(Arc::new(TestPeerDiscovery));
+        let client = operator.build_client().await.unwrap();
+
+        client.make_flight_client(false, false).unwrap();
+        client.make_flight_client(false, false).unwrap();
+        assert_eq!((1, 0), client.channel_pool_sizes());
+
+        client.find_channel().unwrap();
+        client.find_channel().unwrap();
+        assert_eq!((1, 1), client.channel_pool_sizes());
+    }
 }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -30,7 +30,7 @@ use common_function::function::FunctionContext;
 use common_function::function_factory::ScalarFunctionFactory;
 use common_query::{Output, OutputData, OutputMeta};
 use common_recordbatch::adapter::{RecordBatchStreamAdapter, RegionQueryStatCounters};
-use common_recordbatch::{EmptyRecordBatchStream, RecordBatch, SendableRecordBatchStream};
+use common_recordbatch::{EmptyRecordBatchStream, SendableRecordBatchStream};
 use common_telemetry::tracing;
 use datafusion::catalog::TableFunction;
 use datafusion::dataframe::DataFrame;
@@ -44,7 +44,6 @@ use datafusion_expr::{
 use datatypes::prelude::VectorRef;
 use datatypes::schema::Schema;
 use futures_util::StreamExt;
-use futures_util::future::try_join;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt, ensure};
 use sqlparser::ast::AnalyzeFormat;
@@ -80,29 +79,6 @@ pub const QUERY_PARALLELISM_HINT: &str = "query_parallelism";
 
 /// Whether to fallback to the original plan when failed to push down.
 pub const QUERY_FALLBACK_HINT: &str = "query_fallback";
-
-// An unbounded queue keeps draining source RPCs while mutation RPCs on a shared
-// HTTP/2 connection are pending, trading bounded memory for request liveness.
-async fn forward_record_batches(
-    mut stream: SendableRecordBatchStream,
-    batch_tx: tokio::sync::mpsc::UnboundedSender<Result<RecordBatch>>,
-) -> Result<()> {
-    while let Some(batch) = stream.next().await {
-        match batch.context(CreateRecordBatchSnafu) {
-            Ok(batch) => {
-                if batch_tx.send(Ok(batch)).is_err() {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-            Err(error) => {
-                let _ = batch_tx.send(Err(error));
-                break;
-            }
-        }
-    }
-    Ok(())
-}
 
 fn query_load_region_id(plan: &Arc<dyn ExecutionPlan>) -> Option<u64> {
     let mut region_id = None;
@@ -229,7 +205,7 @@ impl DatafusionQueryEngine {
         let Output { data, meta } = self
             .exec_query_plan((*dml.input).clone(), query_ctx.clone())
             .await?;
-        let stream = match data {
+        let mut stream = match data {
             OutputData::RecordBatches(batches) => batches.as_stream(),
             OutputData::Stream(stream) => stream,
             _ => unreachable!(),
@@ -240,31 +216,32 @@ impl DatafusionQueryEngine {
 
         match dml.op {
             WriteOp::Insert(_) => {
-                let (batch_tx, batch_rx) = tokio::sync::mpsc::unbounded_channel();
-                let producer = forward_record_batches(stream, batch_tx);
-                let consumer = self.consume_insert_record_batches(
-                    batch_rx,
-                    &table_name,
-                    table.schema(),
-                    query_ctx.clone(),
-                );
-                let ((), (rows, cost)) = try_join(producer, consumer).await?;
-                affected_rows += rows;
-                insert_cost += cost;
+                while let Some(batch) = stream.next().await {
+                    let batch = batch.context(CreateRecordBatchSnafu)?;
+                    let column_vectors = batch
+                        .column_vectors(&table_name.to_string(), table.schema())
+                        .map_err(BoxedError::new)
+                        .context(QueryExecutionSnafu)?;
+                    // We ignore the insert op.
+                    let output = self
+                        .insert(&table_name, column_vectors, query_ctx.clone())
+                        .await?;
+                    let (rows, cost) = output.extract_rows_and_cost();
+                    affected_rows += rows;
+                    insert_cost += cost;
+                }
             }
             WriteOp::Delete => {
-                // Keep DELETE on the same producer/consumer schedule as INSERT so the source
-                // stream can continue draining while mutation RPCs are pending.
-                let (batch_tx, batch_rx) = tokio::sync::mpsc::unbounded_channel();
-                let producer = forward_record_batches(stream, batch_tx);
-                let consumer = self.consume_delete_record_batches(
-                    batch_rx,
-                    &table_name,
-                    &table,
-                    query_ctx.clone(),
-                );
-                let (rows, ()) = try_join(consumer, producer).await?;
-                affected_rows += rows;
+                while let Some(batch) = stream.next().await {
+                    let batch = batch.context(CreateRecordBatchSnafu)?;
+                    let column_vectors = batch
+                        .column_vectors(&table_name.to_string(), table.schema())
+                        .map_err(BoxedError::new)
+                        .context(QueryExecutionSnafu)?;
+                    affected_rows += self
+                        .delete(&table_name, &table, column_vectors, query_ctx.clone())
+                        .await?;
+                }
             }
             _ => unreachable!("guarded by the 'ensure!' at the beginning"),
         }
@@ -272,53 +249,6 @@ impl DatafusionQueryEngine {
             OutputData::AffectedRows(affected_rows),
             OutputMeta::new(meta.plan, insert_cost),
         ))
-    }
-
-    async fn consume_insert_record_batches(
-        &self,
-        mut batch_rx: tokio::sync::mpsc::UnboundedReceiver<Result<RecordBatch>>,
-        table_name: &ResolvedTableReference,
-        table_schema: Arc<Schema>,
-        query_ctx: QueryContextRef,
-    ) -> Result<(usize, usize)> {
-        let mut affected_rows = 0;
-        let mut insert_cost = 0;
-        while let Some(batch) = batch_rx.recv().await {
-            let batch = batch?;
-            let column_vectors = batch
-                .column_vectors(&table_name.to_string(), table_schema.clone())
-                .map_err(BoxedError::new)
-                .context(QueryExecutionSnafu)?;
-            // We ignore the insert op.
-            let output = self
-                .insert(table_name, column_vectors, query_ctx.clone())
-                .await?;
-            let (rows, cost) = output.extract_rows_and_cost();
-            affected_rows += rows;
-            insert_cost += cost;
-        }
-        Ok((affected_rows, insert_cost))
-    }
-
-    async fn consume_delete_record_batches(
-        &self,
-        mut batch_rx: tokio::sync::mpsc::UnboundedReceiver<Result<RecordBatch>>,
-        table_name: &ResolvedTableReference,
-        table: &TableRef,
-        query_ctx: QueryContextRef,
-    ) -> Result<usize> {
-        let mut affected_rows = 0;
-        while let Some(batch) = batch_rx.recv().await {
-            let batch = batch?;
-            let column_vectors = batch
-                .column_vectors(&table_name.to_string(), table.schema())
-                .map_err(BoxedError::new)
-                .context(QueryExecutionSnafu)?;
-            affected_rows += self
-                .delete(table_name, table, column_vectors, query_ctx.clone())
-                .await?;
-        }
-        Ok(affected_rows)
     }
 
     #[tracing::instrument(skip_all)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8990.

## What's changed and what's your intention?

This completes the query/control transport separation introduced by #8990 and removes the temporary mitigations that are no longer needed once those lanes use independent channel pools.

- Adds an explicit `Client` constructor that accepts separate query and control `ChannelManager`s. Existing constructors remain backward compatible and continue to share one manager.
- Migrates Flow batching frontend clients and metasrv's cached `DatabaseOperator` client to independently constructed query/control managers, preserving their existing timeout, TLS state, discovery, and cache behavior.
- Restores direct per-batch INSERT/DELETE processing instead of forwarding batches through an unbounded queue. Physical lane isolation removes the shared-connection liveness dependency, so normal bounded backpressure can be retained without an OOM-prone queue.
- Removes the frontend-wide HTTP/2 adaptive-window override that was added as a mitigation for the shared-connection condition.
- Adds focused tests for independent pools and per-lane reuse.

The scope is the `NodeClients`, Flow batching, and metasrv client construction paths. This is not a generic HTTP/2 deadlock-prevention mechanism; legacy single-manager constructors intentionally remain shared.

Verification:

- `cargo fmt --all -- --check`
- `cargo check -p query --locked`
- `cargo check -p client --features testing --locked`
- `cargo check -p flow --tests --locked`
- `cargo check -p meta-srv --tests --locked`
- focused client dual-manager constructor test
- focused `NodeClients` pool isolation/reuse test
- focused metasrv builder pool isolation/reuse test
- retained Flight stream physical-connection integration test
- independent Oracle correctness and anti-over-design review: approved

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
