### PR TITLE
ci: skip bumping helm charts and homebrew and downstream repository for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,7 +715,7 @@ jobs:
 
   bump-downstream-repo-versions:
     name: Bump downstream repo versions
-    if: ${{ github.event_name == 'schedule' || ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_type == 'tag' && !contains(github.ref_name, 'nightly')) }}
+    if: ${{ github.event_name == 'schedule' || ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_type == 'tag' && !contains(github.ref_name, 'nightly')) && (needs.allocate-runners.outputs.is-current-version-stable == 'true' && needs.allocate-runners.outputs.is-current-version-latest == 'true') }}
     needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -741,7 +741,7 @@ jobs:
 
   bump-helm-charts-version:
     name: Bump helm charts version
-    if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'nightly') && github.event_name != 'schedule' && (needs.allocate-runners.outputs.is-current-version-stable != 'true' || needs.allocate-runners.outputs.is-current-version-latest == 'true') }}
+    if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'nightly') && github.event_name != 'schedule' && (needs.allocate-runners.outputs.is-current-version-stable == 'true' && needs.allocate-runners.outputs.is-current-version-latest == 'true') }}
     needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     permissions:
@@ -762,7 +762,7 @@ jobs:
 
   bump-homebrew-greptime-version:
     name: Bump homebrew greptime version
-    if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'nightly') && github.event_name != 'schedule' && (needs.allocate-runners.outputs.is-current-version-stable != 'true' || needs.allocate-runners.outputs.is-current-version-latest == 'true') }}
+    if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'nightly') && github.event_name != 'schedule' && (needs.allocate-runners.outputs.is-current-version-stable == 'true' && needs.allocate-runners.outputs.is-current-version-latest == 'true') }}
     needs: [allocate-runners, publish-github-release]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Follow-up to #9008.

## What's changed and what's your intention?

### Summary                                                                                                                                             
                                                                                                                                                           
   Stop triggering the Helm Chart and Homebrew and downstream repository version bumps for pre-release                                                                               
   versions (alpha/beta/rc). Only the latest stable release should update those                                                                            
   downstream repositories.                                                                                                                                
                                                                                                                                                           
   ### How it works                                                                                                                                        
                                                                                                                                                           
   `bump-helm-charts-version` and `bump-homebrew-greptime-version` previously and `bump-downstream-repo-versions` ran                                                                          
   when a tag version was either **not stable** (pre-release) **or** the latest                                                                            
   release:                                                                                                                                                
                                                                                                                                                           
   ```yaml                                                                                                                                                 
   if: ... && (needs.allocate-runners.outputs.is-current-version-stable != 'true' || needs.allocate-runners.outputs.is-current-version-latest == 'true')   
 ```                                                                                                                                                       
                                                                                                                                                           
 This PR restores the condition to require the version to be both stable and                                                                               
 the latest release:                                                                                                                                       
                                                                                                                                                           
 ```yaml                                                                                                                                                   
   if: ... && (needs.allocate-runners.outputs.is-current-version-stable == 'true' && needs.allocate-runners.outputs.is-current-version-latest == 'true')   
 ```                                                                                                                                                       
                                                                                                                                                           
 Helm Chart and Homebrew and downstream repository formulae only track the latest stable release, so                                                                                 
 pre-releases should not push version bumps to them. Nightly builds are already                                                                            
 excluded by the !contains(github.ref_name, 'nightly') guard.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
