### PR TITLE
fix(mito-codec): safely decode mutations without panicking on missing time index

### DIFF
--- a/src/mito-codec/src/key_values.rs
+++ b/src/mito-codec/src/key_values.rs
@@ -46,7 +46,7 @@ impl KeyValues {
         let rows = mutation.rows.as_ref()?;
         let primary_key_encoding =
             infer_primary_key_encoding_from_hint(mutation.write_hint.as_ref());
-        let helper = SparseReadRowHelper::new(metadata, rows, primary_key_encoding);
+        let helper = SparseReadRowHelper::new(metadata, rows, primary_key_encoding)?;
 
         Some(KeyValues {
             mutation,
@@ -120,7 +120,7 @@ impl<'a> KeyValuesRef<'a> {
         let rows = mutation.rows.as_ref()?;
         let primary_key_encoding =
             infer_primary_key_encoding_from_hint(mutation.write_hint.as_ref());
-        let helper = SparseReadRowHelper::new(metadata, rows, primary_key_encoding);
+        let helper = SparseReadRowHelper::new(metadata, rows, primary_key_encoding)?;
 
         Some(KeyValuesRef {
             mutation,
@@ -276,7 +276,7 @@ impl SparseReadRowHelper {
         metadata: &RegionMetadata,
         rows: &Rows,
         primary_key_encoding: PrimaryKeyEncoding,
-    ) -> SparseReadRowHelper {
+    ) -> Option<SparseReadRowHelper> {
         if primary_key_encoding == PrimaryKeyEncoding::Sparse {
             // Optimized case: when schema has exactly 3 columns (primary key, timestamp, and one field),
             // we can directly use their indices in order without building an explicit mapping.
@@ -288,10 +288,10 @@ impl SparseReadRowHelper {
                     .enumerate()
                     .map(|(index, _)| Some(index))
                     .collect();
-                return SparseReadRowHelper {
+                return Some(SparseReadRowHelper {
                     indices,
                     num_primary_key_column: 1,
-                };
+                });
             };
 
             let mut indices = Vec::with_capacity(rows.schema.len());
@@ -313,10 +313,10 @@ impl SparseReadRowHelper {
                 let index = name_to_index.get(&column.column_schema.name);
                 indices.push(index.copied());
             }
-            return SparseReadRowHelper {
+            return Some(SparseReadRowHelper {
                 indices,
                 num_primary_key_column: 1,
-            };
+            });
         }
         // Build a name to index mapping for rows.
         let name_to_index: HashMap<_, _> = rows
@@ -335,10 +335,8 @@ impl SparseReadRowHelper {
             indices.push(index.copied());
         }
         // Get timestamp index.
-        // Safety: time index must exist
         let ts_index = name_to_index
-            .get(&metadata.time_index_column().column_schema.name)
-            .unwrap();
+            .get(&metadata.time_index_column().column_schema.name)?;
         indices.push(Some(*ts_index));
 
         // Iterate columns and find field columns.
@@ -348,10 +346,10 @@ impl SparseReadRowHelper {
             indices.push(index.copied());
         }
 
-        SparseReadRowHelper {
+        Some(SparseReadRowHelper {
             indices,
             num_primary_key_column: metadata.primary_key.len(),
-        }
+        })
     }
 }
 
@@ -535,5 +533,14 @@ mod tests {
         // ts: 2,
         // fields: [v0=1, v1=null]
         check_key_values(&kvs, 3, &[Some(0), None], 2, &[Some(1), None]);
+    }
+
+    #[test]
+    fn test_missing_time_index() {
+        let meta = new_region_metadata(2, 2);
+        // Mutation contains tags and fields, but lacks the time index column "ts"
+        let mutation = new_mutation(&["k0", "v0", "k1", "v1"], 3);
+        let kvs = KeyValues::new(&meta, mutation);
+        assert!(kvs.is_none());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #7999

## What's changed and what's your intention?

### Problem & Invariant
During region opening and replay, the engine consumes WAL entries and writes them into the mutable memtable (`RegionWriteCtx::write_memtable`). In `write_memtable`, mutation entries are decoded into `KeyValues` views using `KeyValues::new`.

Previously, `SparseReadRowHelper::new` unconditionally called `.unwrap()` when looking up the time index column in the row schema:
```rust
let ts_index = name_to_index
    .get(&metadata.time_index_column().column_schema.name)
    .unwrap();
```
When replaying a WAL entry or mutation where the time index column is missing from the row schema (for example during cross-version recovery or unexpected malformed entries), this `.unwrap()` panicked the region opener worker thread, preventing region recovery and taking down the region.

### Root Cause
`SparseReadRowHelper::new` assumed the time index column was unconditionally present in every input row schema and called `.unwrap()`, breaking the fallible `Option` return contract already established by `KeyValues::new` and `KeyValuesRef::new`.

### Architecture & Design
1. **Fallible Helper Initialization**: Changed `SparseReadRowHelper::new` to return `Option<SparseReadRowHelper>`. If `name_to_index.get(&metadata.time_index_column().column_schema.name)` returns `None`, it safely returns `None` via `?`.
2. **Propagate Option Upstream**: Updated `KeyValues::new` and `KeyValuesRef::new` to propagate the `None` return via `SparseReadRowHelper::new(...)?`.
3. **Graceful Replay**: In `RegionWriteCtx::write_memtable`, the caller already handles `KeyValues::new` with `filter_map(|(i, mutation)| { let kvs = KeyValues::new(...)?; Some((i, kvs)) })`, so missing-time-index mutations are safely handled without panicking the region replay loop.

### Verification
- Added unit test `test_missing_time_index` in `src/mito-codec/src/key_values.rs` verifying that mutations with missing time index columns return `None` from `KeyValues::new` instead of panicking.

## PR Checklist
- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
