### PR TITLE
perf(promql): push down last row for instant queries

### DIFF
--- a/.github/scripts/query-regression-run.py
+++ b/.github/scripts/query-regression-run.py
@@ -38,6 +38,7 @@ DEFAULT_CASES = [
     "tests/perf/query_cases/prom_remote_write_mixed_every/case.toml",
     "tests/perf/query_cases/prom_remote_write_integer_counter/case.toml",
     "tests/perf/query_cases/promql_range_boundary/case.toml",
+    "tests/perf/query_cases/promql_instant_last_row_9034/case.toml",
 ]
 
 HEAVY_CASES = [

--- a/src/cmd/src/bin/query_perf_fixture/direct_sst.rs
+++ b/src/cmd/src/bin/query_perf_fixture/direct_sst.rs
@@ -32,6 +32,7 @@ use mito_codec::row_converter::{DensePrimaryKeyCodec, PrimaryKeyCodecExt, SortFi
 use mito2::access_layer::{FilePathProvider, Metrics, WriteType};
 use mito2::config::IndexConfig;
 use mito2::manifest::action::{RegionCheckpoint, RegionManifest, RemovedFilesRecord};
+use mito2::memtable::sort_primary_key_record_batch;
 use mito2::read::FlatSource;
 use mito2::sst::file::{FileMeta, RegionFileId};
 use mito2::sst::index::{Indexer, IndexerBuilder};
@@ -282,8 +283,10 @@ fn generate_record_batch(
     columns.push(Arc::new(pk_builder.finish()));
     columns.push(Arc::new(UInt64Array::from_value(sequence, rows)));
     columns.push(Arc::new(UInt8Array::from_value(OpType::Put as u8, rows)));
-    RecordBatch::try_new(flat_schema, columns)
-        .expect("generated fixture columns should match flat SST Arrow schema")
+    let batch = RecordBatch::try_new(flat_schema, columns)
+        .expect("generated fixture columns should match flat SST Arrow schema");
+    sort_primary_key_record_batch(&batch)
+        .expect("generated fixture batch should sort by primary key, timestamp, and sequence")
 }
 
 fn file_meta_from_sst_info(
@@ -531,4 +534,205 @@ pub(super) async fn run_direct_sst(args: DirectArgs) {
     jsonl.flush().expect("failed to flush fixture files.jsonl");
     fs::write(out_dir.join("summary.json"), serde_json::to_vec_pretty(&serde_json::json!({ "case": case_name, "seed": seed, "table_index": table_index, "table": table.name, "database": table.database, "region_id": region_id.as_u64(), "table_dir": table_dir, "region_dir": region_dir, "sst_format": format!("{format:?}"), "sst_count": scenario.layout.sst_count, "rows_per_sst": scenario.layout.rows_per_sst, "row_group_size": scenario.layout.row_group_size, "total_rows": scenario.layout.sst_count * scenario.layout.rows_per_sst, "checkpoint_path": checkpoint_path, "files_jsonl_path": files_jsonl_path, "readback_validated": false, "metadata_source": "synthetic" })).expect("failed to serialize fixture summary")).expect("failed to write fixture summary.json");
     println!("Done. wrote {} SST file entries", manifest.files.len());
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use datatypes::arrow::array::{BinaryArray, DictionaryArray, StringArray};
+
+    use super::*;
+
+    type LogicalRow = (Vec<u8>, i64, u64, String, String, f64);
+
+    fn string_values(batch: &RecordBatch, column: usize) -> Vec<String> {
+        let dictionary = batch
+            .column(column)
+            .as_any()
+            .downcast_ref::<DictionaryArray<UInt32Type>>()
+            .expect("fixture tag column should be a string dictionary");
+        let values = dictionary
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("fixture tag dictionary should contain strings");
+        dictionary
+            .keys()
+            .values()
+            .iter()
+            .map(|key| values.value(*key as usize).to_string())
+            .collect()
+    }
+
+    fn encoded_primary_keys(batch: &RecordBatch) -> Vec<Vec<u8>> {
+        let dictionary = batch
+            .column(batch.num_columns() - 3)
+            .as_any()
+            .downcast_ref::<DictionaryArray<UInt32Type>>()
+            .expect("fixture primary key should be a binary dictionary");
+        let values = dictionary
+            .values()
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("fixture primary key dictionary should contain binary keys");
+        dictionary
+            .keys()
+            .values()
+            .iter()
+            .map(|key| values.value(*key as usize).to_vec())
+            .collect()
+    }
+
+    #[test]
+    fn direct_sst_generator_sorts_all_layouts_and_timestamp_units() {
+        for (series_layout, timestamp_type) in [
+            ("timestamp_major", "TIMESTAMP(9)"),
+            ("timestamp_major", "TIMESTAMP(3)"),
+            ("round_robin", "TIMESTAMP(9)"),
+            ("round_robin", "TIMESTAMP(3)"),
+            ("per_sst", "TIMESTAMP(9)"),
+            ("per_sst", "TIMESTAMP(3)"),
+        ] {
+            let mut case: CaseFile = toml::from_str(include_str!(
+                "../../../../../tests/perf/query_cases/promql_instant_last_row_9034/case.toml"
+            ))
+            .expect("existing query perf case should parse");
+            let scenario = match &mut case.scenario {
+                Scenario::DirectReadableSst(scenario) => scenario,
+                _ => unreachable!("included case is a direct SST case"),
+            };
+            scenario.layout.series_layout = series_layout.to_string();
+            scenario.layout.series_count = NonZeroUsize::new(12).expect("12 is nonzero");
+            scenario.layout.rows_per_sst = 36;
+            scenario.layout.sst_count = 1;
+            scenario.layout.row_group_size = 12;
+            let table = &mut scenario.tables[0];
+            let time_index = table.time_index.clone();
+            table
+                .columns
+                .iter_mut()
+                .find(|column| column.name == time_index)
+                .expect("fixture case has time index column")
+                .ty = timestamp_type.to_string();
+
+            let sst_idx = 10;
+            let sequence = 1010;
+            let metadata = Arc::new(build_region_metadata(table, RegionId::from(42)));
+            let batch =
+                generate_record_batch(table, &metadata, &scenario.layout, sst_idx, sequence);
+            assert_eq!(36, batch.num_rows(), "{series_layout}/{timestamp_type}");
+
+            let base_row = sst_idx * scenario.layout.rows_per_sst;
+            let host = table
+                .columns
+                .iter()
+                .find(|column| column.name == "host")
+                .expect("fixture case has host tag");
+            let instance = table
+                .columns
+                .iter()
+                .find(|column| column.name == "instance")
+                .expect("fixture case has instance tag");
+            let value = table
+                .columns
+                .iter()
+                .find(|column| column.name == "value")
+                .expect("fixture case has value field");
+            let (min, max) = match value.distribution.as_ref() {
+                Some(Distribution::DeterministicWave { min, max }) => (*min, *max),
+                _ => unreachable!("included case has deterministic wave values"),
+            };
+            let mut expected = (0..scenario.layout.rows_per_sst)
+                .map(|row| {
+                    let series = series_for_row(&scenario.layout, sst_idx, base_row, row);
+                    let mut tags = HashMap::new();
+                    tags.insert(host.name.clone(), tag_value(host, series));
+                    tags.insert(instance.name.clone(), tag_value(instance, series));
+                    let timestamp = timestamp_for_row(&scenario.layout, base_row, row);
+                    (
+                        encode_dense_primary_key(table, &tags),
+                        if timestamp_type == "TIMESTAMP(3)" {
+                            timestamp / 1_000_000
+                        } else {
+                            timestamp
+                        },
+                        sequence,
+                        tag_value(host, series),
+                        tag_value(instance, series),
+                        wave_value(min, max, base_row + row),
+                    )
+                })
+                .collect::<Vec<LogicalRow>>();
+            expected.sort_by(|left, right| {
+                left.0
+                    .cmp(&right.0)
+                    .then_with(|| left.1.cmp(&right.1))
+                    .then_with(|| right.2.cmp(&left.2))
+            });
+
+            let timestamps = if timestamp_type == "TIMESTAMP(9)" {
+                batch
+                    .column(batch.num_columns() - 4)
+                    .as_any()
+                    .downcast_ref::<TimestampNanosecondArray>()
+                    .expect("nanosecond fixture timestamp")
+                    .values()
+                    .to_vec()
+            } else {
+                batch
+                    .column(batch.num_columns() - 4)
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .expect("millisecond fixture timestamp")
+                    .values()
+                    .to_vec()
+            };
+            let sequences = batch
+                .column(batch.num_columns() - 2)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("fixture sequence column")
+                .values()
+                .to_vec();
+            let hosts = string_values(&batch, 0);
+            let instances = string_values(&batch, 1);
+            let values = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("fixture value column")
+                .values()
+                .to_vec();
+            let actual = encoded_primary_keys(&batch)
+                .into_iter()
+                .zip(timestamps)
+                .zip(sequences)
+                .zip(hosts)
+                .zip(instances)
+                .zip(values)
+                .map(
+                    |(((((primary_key, timestamp), sequence), host), instance), value)| {
+                        (primary_key, timestamp, sequence, host, instance, value)
+                    },
+                )
+                .collect::<Vec<LogicalRow>>();
+
+            assert_eq!(expected, actual, "{series_layout}/{timestamp_type}");
+            for pair in actual.windows(2) {
+                assert!(
+                    pair[0].0 < pair[1].0
+                        || (pair[0].0 == pair[1].0 && pair[0].1 < pair[1].1)
+                        || (pair[0].0 == pair[1].0
+                            && pair[0].1 == pair[1].1
+                            && pair[0].2 >= pair[1].2),
+                    "rows must be encoded-PK ascending, timestamp ascending, sequence descending: {series_layout}/{timestamp_type}"
+                );
+            }
+            if series_layout != "per_sst" {
+                assert!(actual.iter().any(|row| row.3 == "host2"));
+                assert!(actual.iter().any(|row| row.3 == "host10"));
+            }
+        }
+    }
 }

--- a/src/cmd/src/datanode/scanbench.rs
+++ b/src/cmd/src/datanode/scanbench.rs
@@ -389,7 +389,7 @@ fn resolve_series_row_selector(
     scan_config: &ScanConfig,
 ) -> error::Result<Option<TimeSeriesRowSelector>> {
     match scan_config.series_row_selector.as_deref() {
-        Some("last_row") => Ok(Some(TimeSeriesRowSelector::LastRow)),
+        Some("last_row") => Ok(Some(TimeSeriesRowSelector::LastRow { after_merge: false })),
         Some(other) => Err(error::IllegalConfigSnafu {
             msg: format!("Unknown series_row_selector '{other}'"),
         }

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -429,8 +429,7 @@ mod test {
         let scan_req = ScanRequest {
             projection,
             filters: vec![],
-            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
-            series_row_selector_after_merge: true,
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: true }),
             ..Default::default()
         };
 
@@ -448,9 +447,8 @@ mod test {
         assert_eq!(scan_req.filters.len(), 1);
         assert_eq!(
             scan_req.series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
-        assert!(scan_req.series_row_selector_after_merge);
         assert_eq!(
             scan_req.filters[0],
             logical_expr::col(DATA_SCHEMA_TABLE_ID_COLUMN_NAME)

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -318,7 +318,7 @@ mod test {
     use mito2::config::MitoConfig;
     use store_api::region_engine::{PrepareRequest, QueryScanContext};
     use store_api::region_request::{RegionFlushRequest, RegionPutRequest, RegionRequest};
-    use store_api::storage::TimeSeriesDistribution;
+    use store_api::storage::{TimeSeriesDistribution, TimeSeriesRowSelector};
 
     use super::*;
     use crate::config::EngineConfig;
@@ -429,6 +429,8 @@ mod test {
         let scan_req = ScanRequest {
             projection,
             filters: vec![],
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+            series_row_selector_after_merge: true,
             ..Default::default()
         };
 
@@ -444,6 +446,11 @@ mod test {
             &[11, 10, 9, 8, 0, 1, 4]
         );
         assert_eq!(scan_req.filters.len(), 1);
+        assert_eq!(
+            scan_req.series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+        assert!(scan_req.series_row_selector_after_merge);
         assert_eq!(
             scan_req.filters[0],
             logical_expr::col(DATA_SCHEMA_TABLE_ID_COLUMN_NAME)

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -2621,7 +2621,7 @@ mod tests {
         let key = SelectorResultKey {
             file_id,
             row_group_idx: 0,
-            selector: TimeSeriesRowSelector::LastRow,
+            selector: TimeSeriesRowSelector::LastRow { after_merge: false },
         };
         assert!(cache.get_selector_result(&key).is_none());
         let result = Arc::new(SelectorResultValue::new(
@@ -2770,7 +2770,6 @@ mod tests {
                 filters: vec!["tag_0 = 1".to_string()],
                 time_filters: vec![],
                 series_row_selector: None,
-                series_row_selector_after_merge: false,
                 append_mode: false,
                 filter_deleted: true,
                 merge_mode: crate::region::options::MergeMode::LastRow,

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -2770,6 +2770,7 @@ mod tests {
                 filters: vec!["tag_0 = 1".to_string()],
                 time_filters: vec![],
                 series_row_selector: None,
+                series_row_selector_after_merge: false,
                 append_mode: false,
                 filter_deleted: true,
                 merge_mode: crate::region::options::MergeMode::LastRow,

--- a/src/mito2/src/engine/row_selector_test.rs
+++ b/src/mito2/src/engine/row_selector_test.rs
@@ -103,7 +103,7 @@ async fn test_last_row(append_mode: bool, flat_format: bool) {
         .scanner(
             region_id,
             ScanRequest {
-                series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+                series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: false }),
                 ..Default::default()
             },
         )
@@ -126,7 +126,7 @@ async fn scan_last_row(
             region_id,
             ScanRequest {
                 filters,
-                series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+                series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: false }),
                 ..Default::default()
             },
         )
@@ -254,7 +254,7 @@ async fn last_row_scanner(engine: &MitoEngine, region_id: RegionId) -> Scanner {
         .scanner(
             region_id,
             ScanRequest {
-                series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+                series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: false }),
                 ..Default::default()
             },
         )
@@ -446,8 +446,7 @@ async fn test_last_row_returns_older_put_after_newest_delete_across_ssts() {
             .scanner(
                 region_id,
                 ScanRequest {
-                    series_row_selector: Some(TimeSeriesRowSelector::LastRow),
-                    series_row_selector_after_merge: true,
+                    series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: true }),
                     ..Default::default()
                 },
             )

--- a/src/mito2/src/engine/row_selector_test.rs
+++ b/src/mito2/src/engine/row_selector_test.rs
@@ -442,7 +442,17 @@ async fn test_last_row_returns_older_put_after_newest_delete_across_ssts() {
         .await;
         flush_region(&engine, region_id, None).await;
 
-        let scanner = last_row_scanner(&engine, region_id).await;
+        let scanner = engine
+            .scanner(
+                region_id,
+                ScanRequest {
+                    series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+                    series_row_selector_after_merge: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
         assert_eq!(2, scanner.num_files());
         assert_eq!(0, scanner.num_memtables());
         assert_eq!(

--- a/src/mito2/src/engine/row_selector_test.rs
+++ b/src/mito2/src/engine/row_selector_test.rs
@@ -12,20 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use api::v1::Rows;
+use api::v1::value::ValueData;
+use api::v1::{Rows, Value};
 use common_base::readable_size::ReadableSize;
+use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
 use common_recordbatch::RecordBatches;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{col, lit};
+use datatypes::arrow::array::{Float64Array, StringArray, TimestampMillisecondArray};
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::RegionRequest;
 use store_api::storage::{RegionId, ScanRequest, TimeSeriesRowSelector};
 
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
+use crate::read::scan_region::Scanner;
 use crate::test_util::batch_util::sort_batches_and_print;
 use crate::test_util::{
-    CreateRequestBuilder, TestEnv, build_rows_for_key, flush_region, put_rows, rows_schema,
+    CreateRequestBuilder, TestEnv, build_delete_rows_for_key, build_rows_for_key, delete_rows,
+    flush_region, put_rows, rows_schema,
 };
 
 async fn test_last_row(append_mode: bool, flat_format: bool) {
@@ -192,6 +197,231 @@ const LAST_ROW_AT_TEN: &str = "\
 +-------+---------+---------------------+
 | a     | 10.0    | 1970-01-01T00:00:10 |
 +-------+---------+---------------------+";
+
+async fn new_merge_last_row_engine(
+    flat_format: bool,
+) -> (
+    TestEnv,
+    MitoEngine,
+    RegionId,
+    Vec<api::v1::ColumnSchema>,
+    Vec<api::v1::ColumnSchema>,
+) {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    env.get_schema_metadata_manager()
+        .register_region_table_info(
+            region_id.table_id(),
+            "test_table",
+            "test_catalog",
+            "test_schema",
+            None,
+            env.get_kv_backend(),
+        )
+        .await;
+    let sst_format = if flat_format { "flat" } else { "primary_key" };
+    let request = CreateRequestBuilder::new()
+        .insert_option("sst_format", sst_format)
+        .build();
+    let schema = rows_schema(&request);
+    let delete_schema = crate::test_util::delete_rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    (env, engine, region_id, schema, delete_schema)
+}
+
+fn value_row(key: &str, value: f64, timestamp: i64) -> api::v1::Row {
+    api::v1::Row {
+        values: vec![
+            Value {
+                value_data: Some(ValueData::StringValue(key.to_string())),
+            },
+            Value {
+                value_data: Some(ValueData::F64Value(value)),
+            },
+            Value {
+                value_data: Some(ValueData::TimestampMillisecondValue(timestamp)),
+            },
+        ],
+    }
+}
+
+async fn last_row_scanner(engine: &MitoEngine, region_id: RegionId) -> Scanner {
+    engine
+        .scanner(
+            region_id,
+            ScanRequest {
+                series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+}
+
+async fn scan_last_row_batches(scanner: &Scanner) -> RecordBatches {
+    RecordBatches::try_collect(scanner.scan().await.unwrap())
+        .await
+        .unwrap()
+}
+
+fn last_row_values(batches: &RecordBatches) -> Vec<(String, f64, i64)> {
+    let mut rows = Vec::new();
+    for batch in batches.iter() {
+        let batch = batch.df_record_batch();
+        let tags = batch
+            .column_by_name("tag_0")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let fields = batch
+            .column_by_name("field_0")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        let timestamps = batch
+            .column_by_name("ts")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .unwrap();
+        for index in 0..batch.num_rows() {
+            rows.push((
+                tags.value(index).to_string(),
+                fields.value(index),
+                timestamps.value(index),
+            ));
+        }
+    }
+    rows.sort_by(|left, right| left.0.cmp(&right.0));
+    rows
+}
+
+#[tokio::test]
+async fn test_last_row_merge_deduplicates_same_timestamp_across_ssts() {
+    for flat_format in [false, true] {
+        let (_env, engine, region_id, schema, _delete_schema) =
+            new_merge_last_row_engine(flat_format).await;
+
+        put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: schema.clone(),
+                rows: vec![value_row("a", 1.0, 1000)],
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+        put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema,
+                rows: vec![value_row("a", 2.0, 1000)],
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+
+        let scanner = last_row_scanner(&engine, region_id).await;
+        assert_eq!(2, scanner.num_files());
+        assert_eq!(0, scanner.num_memtables());
+        assert_eq!(
+            vec![("a".to_string(), 2.0, 1000)],
+            last_row_values(&scan_last_row_batches(&scanner).await)
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_last_row_returns_stale_marker_and_preserves_ordinary_nan() {
+    for flat_format in [false, true] {
+        let (_env, engine, region_id, schema, _delete_schema) =
+            new_merge_last_row_engine(flat_format).await;
+        put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: schema.clone(),
+                rows: vec![value_row("a", 1.0, 1000), value_row("b", f64::NAN, 1000)],
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+        put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema,
+                rows: vec![value_row(
+                    "a",
+                    f64::from_bits(PROMETHEUS_STALE_NAN_BITS),
+                    1000,
+                )],
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+
+        let scanner = last_row_scanner(&engine, region_id).await;
+        assert_eq!(2, scanner.num_files());
+        assert_eq!(0, scanner.num_memtables());
+        let values = last_row_values(&scan_last_row_batches(&scanner).await);
+        assert_eq!(2, values.len(), "unexpected LastRow values: {values:?}");
+        assert_eq!("a", values[0].0);
+        assert_eq!(PROMETHEUS_STALE_NAN_BITS, values[0].1.to_bits());
+        assert_eq!(1000, values[0].2);
+        assert_eq!("b", values[1].0);
+        assert!(values[1].1.is_nan());
+        assert_ne!(PROMETHEUS_STALE_NAN_BITS, values[1].1.to_bits());
+    }
+}
+
+#[tokio::test]
+async fn test_last_row_delete_wins_across_ssts() {
+    for flat_format in [false, true] {
+        let (_env, engine, region_id, schema, delete_schema) =
+            new_merge_last_row_engine(flat_format).await;
+        put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema,
+                rows: vec![value_row("a", 1.0, 1000)],
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+        delete_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: delete_schema,
+                rows: build_delete_rows_for_key("a", 1, 2),
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+
+        let scanner = last_row_scanner(&engine, region_id).await;
+        assert_eq!(2, scanner.num_files());
+        assert_eq!(0, scanner.num_memtables());
+        assert!(last_row_values(&scan_last_row_batches(&scanner).await).is_empty());
+    }
+}
+
+#[tokio::test]
+async fn test_last_row_empty_region_returns_empty() {
+    let (_env, engine, region_id, _schema, _delete_schema) = new_merge_last_row_engine(false).await;
+    let scanner = last_row_scanner(&engine, region_id).await;
+    assert!(last_row_values(&scan_last_row_batches(&scanner).await).is_empty());
+}
 
 #[tokio::test]
 async fn test_last_row_append_mode_disabled() {

--- a/src/mito2/src/engine/row_selector_test.rs
+++ b/src/mito2/src/engine/row_selector_test.rs
@@ -417,6 +417,42 @@ async fn test_last_row_delete_wins_across_ssts() {
 }
 
 #[tokio::test]
+async fn test_last_row_returns_older_put_after_newest_delete_across_ssts() {
+    for flat_format in [false, true] {
+        let (_env, engine, region_id, schema, delete_schema) =
+            new_merge_last_row_engine(flat_format).await;
+        put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema,
+                rows: vec![value_row("a", 1.0, 1000), value_row("a", 2.0, 2000)],
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+        delete_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: delete_schema,
+                rows: build_delete_rows_for_key("a", 2, 3),
+            },
+        )
+        .await;
+        flush_region(&engine, region_id, None).await;
+
+        let scanner = last_row_scanner(&engine, region_id).await;
+        assert_eq!(2, scanner.num_files());
+        assert_eq!(0, scanner.num_memtables());
+        assert_eq!(
+            vec![("a".to_string(), 1.0, 1000)],
+            last_row_values(&scan_last_row_batches(&scanner).await)
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_last_row_empty_region_returns_empty() {
     let (_env, engine, region_id, _schema, _delete_schema) = new_merge_last_row_engine(false).await;
     let scanner = last_row_scanner(&engine, region_id).await;

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -2197,7 +2197,7 @@ async fn test_exact_sequence_read_with_last_row_selector_keeps_in_range_rows() {
             memtable_min_sequence: Some(0),
             memtable_max_sequence: Some(1),
             exact_sequence_range: true,
-            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: false }),
             ..Default::default()
         })
         .await
@@ -2213,7 +2213,7 @@ async fn test_exact_sequence_read_with_last_row_selector_keeps_in_range_rows() {
 | series | 2.0     | 1970-01-01T00:00:02 |
 +--------+---------+---------------------+",
         scan(ScanRequest {
-            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: false }),
             ..Default::default()
         })
         .await
@@ -2583,7 +2583,9 @@ async fn test_non_preserve_compaction_sequence_collision_with_format(flat_format
             .scan_to_stream(
                 region_id,
                 ScanRequest {
-                    series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+                    series_row_selector: Some(TimeSeriesRowSelector::LastRow {
+                        after_merge: false,
+                    }),
                     ..Default::default()
                 },
             )

--- a/src/mito2/src/read/last_row.rs
+++ b/src/mito2/src/read/last_row.rs
@@ -144,7 +144,7 @@ impl FlatRowGroupLastRowCachedReader {
         let key = SelectorResultKey {
             file_id,
             row_group_idx,
-            selector: TimeSeriesRowSelector::LastRow,
+            selector: TimeSeriesRowSelector::LastRow { after_merge: false },
         };
 
         if let Some(value) = cache_strategy.get_selector_result(&key) {

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -60,7 +60,6 @@ pub(crate) struct ScanRequestFingerprint {
     /// Filters with the time index column.
     time_filters: Option<Arc<Vec<String>>>,
     series_row_selector: Option<TimeSeriesRowSelector>,
-    series_row_selector_after_merge: bool,
     append_mode: bool,
     filter_deleted: bool,
     merge_mode: MergeMode,
@@ -88,7 +87,6 @@ pub(crate) struct ScanRequestFingerprintBuilder {
     pub(crate) filters: Vec<String>,
     pub(crate) time_filters: Vec<String>,
     pub(crate) series_row_selector: Option<TimeSeriesRowSelector>,
-    pub(crate) series_row_selector_after_merge: bool,
     pub(crate) append_mode: bool,
     pub(crate) filter_deleted: bool,
     pub(crate) merge_mode: MergeMode,
@@ -104,7 +102,6 @@ impl ScanRequestFingerprintBuilder {
             filters,
             time_filters,
             series_row_selector,
-            series_row_selector_after_merge,
             append_mode,
             filter_deleted,
             merge_mode,
@@ -120,7 +117,6 @@ impl ScanRequestFingerprintBuilder {
             }),
             time_filters: (!time_filters.is_empty()).then(|| Arc::new(time_filters)),
             series_row_selector,
-            series_row_selector_after_merge,
             append_mode,
             filter_deleted,
             merge_mode,
@@ -172,7 +168,6 @@ impl ScanRequestFingerprint {
             inner: Arc::clone(&self.inner),
             time_filters: None,
             series_row_selector: self.series_row_selector,
-            series_row_selector_after_merge: self.series_row_selector_after_merge,
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
@@ -187,7 +182,6 @@ impl ScanRequestFingerprint {
             inner: Arc::clone(&self.inner),
             time_filters: self.time_filters.clone(),
             series_row_selector: self.series_row_selector,
-            series_row_selector_after_merge: self.series_row_selector_after_merge,
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
@@ -202,7 +196,6 @@ impl ScanRequestFingerprint {
             inner: Arc::clone(&self.inner),
             time_filters: self.time_filters.clone(),
             series_row_selector: self.series_row_selector,
-            series_row_selector_after_merge: self.series_row_selector_after_merge,
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
@@ -875,7 +868,6 @@ pub fn bench_cache_flat_range_stream(
         filters: vec![],
         time_filters: vec![],
         series_row_selector: None,
-        series_row_selector_after_merge: false,
         append_mode: false,
         filter_deleted: false,
         merge_mode: MergeMode::LastRow,
@@ -933,7 +925,6 @@ mod tests {
         filters: Vec<String>,
         time_filters: Vec<String>,
         series_row_selector: Option<TimeSeriesRowSelector>,
-        series_row_selector_after_merge: bool,
         filter_deleted: bool,
         partition_expr_version: u64,
     ) -> ScanRequestFingerprint {
@@ -944,7 +935,6 @@ mod tests {
             filters,
             time_filters,
             series_row_selector,
-            series_row_selector_after_merge,
             append_mode: false,
             filter_deleted,
             merge_mode: MergeMode::LastRow,
@@ -959,7 +949,7 @@ mod tests {
         let key = RangeScanCacheKey {
             region_id,
             row_groups: vec![],
-            scan: test_scan_fingerprint(vec![], vec![], None, false, false, 0),
+            scan: test_scan_fingerprint(vec![], vec![], None, false, 0),
         };
 
         let metrics_set = ExecutionPlanMetricsSet::new();
@@ -1455,16 +1445,14 @@ mod tests {
         let ordinary = test_scan_fingerprint(
             vec!["k0 = 'foo'".to_string()],
             vec![],
-            Some(TimeSeriesRowSelector::LastRow),
-            false,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: false }),
             true,
             0,
         );
         let after_merge = test_scan_fingerprint(
             vec!["k0 = 'foo'".to_string()],
             vec![],
-            Some(TimeSeriesRowSelector::LastRow),
-            true,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true }),
             true,
             0,
         );
@@ -1475,15 +1463,14 @@ mod tests {
     #[test]
     fn true_selector_after_merge_is_preserved_by_fingerprint_transforms() {
         let normalized =
-            test_scan_fingerprint(vec!["k0 = 'foo'".to_string()], vec![], None, false, true, 0);
+            test_scan_fingerprint(vec!["k0 = 'foo'".to_string()], vec![], None, true, 0);
 
         assert!(normalized.time_filters().is_empty());
 
         let fingerprint = test_scan_fingerprint(
             vec!["k0 = 'foo'".to_string()],
             vec!["ts >= 1000".to_string()],
-            Some(TimeSeriesRowSelector::LastRow),
-            true,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true }),
             true,
             7,
         );
@@ -1497,10 +1484,18 @@ mod tests {
         assert_eq!(reset.filters(), fingerprint.filters());
         assert!(reset.time_filters().is_empty());
         assert_eq!(reset.series_row_selector, fingerprint.series_row_selector);
-        assert!(fingerprint.series_row_selector_after_merge);
-        assert!(reset.series_row_selector_after_merge);
-        assert!(candidate.series_row_selector_after_merge);
-        assert!(series_data.series_row_selector_after_merge);
+        assert_eq!(
+            fingerprint.series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+        );
+        assert_eq!(
+            candidate.series_row_selector,
+            fingerprint.series_row_selector
+        );
+        assert_eq!(
+            series_data.series_row_selector,
+            fingerprint.series_row_selector
+        );
         assert_eq!(reset.append_mode, fingerprint.append_mode);
         assert_eq!(reset.filter_deleted, fingerprint.filter_deleted);
         assert_eq!(reset.merge_mode, fingerprint.merge_mode);

--- a/src/mito2/src/read/range_cache.rs
+++ b/src/mito2/src/read/range_cache.rs
@@ -60,6 +60,7 @@ pub(crate) struct ScanRequestFingerprint {
     /// Filters with the time index column.
     time_filters: Option<Arc<Vec<String>>>,
     series_row_selector: Option<TimeSeriesRowSelector>,
+    series_row_selector_after_merge: bool,
     append_mode: bool,
     filter_deleted: bool,
     merge_mode: MergeMode,
@@ -87,6 +88,7 @@ pub(crate) struct ScanRequestFingerprintBuilder {
     pub(crate) filters: Vec<String>,
     pub(crate) time_filters: Vec<String>,
     pub(crate) series_row_selector: Option<TimeSeriesRowSelector>,
+    pub(crate) series_row_selector_after_merge: bool,
     pub(crate) append_mode: bool,
     pub(crate) filter_deleted: bool,
     pub(crate) merge_mode: MergeMode,
@@ -102,6 +104,7 @@ impl ScanRequestFingerprintBuilder {
             filters,
             time_filters,
             series_row_selector,
+            series_row_selector_after_merge,
             append_mode,
             filter_deleted,
             merge_mode,
@@ -117,6 +120,7 @@ impl ScanRequestFingerprintBuilder {
             }),
             time_filters: (!time_filters.is_empty()).then(|| Arc::new(time_filters)),
             series_row_selector,
+            series_row_selector_after_merge,
             append_mode,
             filter_deleted,
             merge_mode,
@@ -168,6 +172,7 @@ impl ScanRequestFingerprint {
             inner: Arc::clone(&self.inner),
             time_filters: None,
             series_row_selector: self.series_row_selector,
+            series_row_selector_after_merge: self.series_row_selector_after_merge,
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
@@ -182,6 +187,7 @@ impl ScanRequestFingerprint {
             inner: Arc::clone(&self.inner),
             time_filters: self.time_filters.clone(),
             series_row_selector: self.series_row_selector,
+            series_row_selector_after_merge: self.series_row_selector_after_merge,
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
@@ -196,6 +202,7 @@ impl ScanRequestFingerprint {
             inner: Arc::clone(&self.inner),
             time_filters: self.time_filters.clone(),
             series_row_selector: self.series_row_selector,
+            series_row_selector_after_merge: self.series_row_selector_after_merge,
             append_mode: self.append_mode,
             filter_deleted: self.filter_deleted,
             merge_mode: self.merge_mode,
@@ -868,6 +875,7 @@ pub fn bench_cache_flat_range_stream(
         filters: vec![],
         time_filters: vec![],
         series_row_selector: None,
+        series_row_selector_after_merge: false,
         append_mode: false,
         filter_deleted: false,
         merge_mode: MergeMode::LastRow,
@@ -925,6 +933,7 @@ mod tests {
         filters: Vec<String>,
         time_filters: Vec<String>,
         series_row_selector: Option<TimeSeriesRowSelector>,
+        series_row_selector_after_merge: bool,
         filter_deleted: bool,
         partition_expr_version: u64,
     ) -> ScanRequestFingerprint {
@@ -935,6 +944,7 @@ mod tests {
             filters,
             time_filters,
             series_row_selector,
+            series_row_selector_after_merge,
             append_mode: false,
             filter_deleted,
             merge_mode: MergeMode::LastRow,
@@ -949,7 +959,7 @@ mod tests {
         let key = RangeScanCacheKey {
             region_id,
             row_groups: vec![],
-            scan: test_scan_fingerprint(vec![], vec![], None, false, 0),
+            scan: test_scan_fingerprint(vec![], vec![], None, false, false, 0),
         };
 
         let metrics_set = ExecutionPlanMetricsSet::new();
@@ -1441,9 +1451,31 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_and_clears_time_filters() {
+    fn selector_after_merge_changes_fingerprint() {
+        let ordinary = test_scan_fingerprint(
+            vec!["k0 = 'foo'".to_string()],
+            vec![],
+            Some(TimeSeriesRowSelector::LastRow),
+            false,
+            true,
+            0,
+        );
+        let after_merge = test_scan_fingerprint(
+            vec!["k0 = 'foo'".to_string()],
+            vec![],
+            Some(TimeSeriesRowSelector::LastRow),
+            true,
+            true,
+            0,
+        );
+
+        assert_ne!(ordinary, after_merge);
+    }
+
+    #[test]
+    fn true_selector_after_merge_is_preserved_by_fingerprint_transforms() {
         let normalized =
-            test_scan_fingerprint(vec!["k0 = 'foo'".to_string()], vec![], None, true, 0);
+            test_scan_fingerprint(vec!["k0 = 'foo'".to_string()], vec![], None, false, true, 0);
 
         assert!(normalized.time_filters().is_empty());
 
@@ -1452,16 +1484,23 @@ mod tests {
             vec!["ts >= 1000".to_string()],
             Some(TimeSeriesRowSelector::LastRow),
             true,
+            true,
             7,
         );
 
         let reset = fingerprint.without_time_filters();
+        let candidate = fingerprint.for_candidate_series();
+        let series_data = fingerprint.for_series_data(SeriesRange::new(0, 1).unwrap());
 
         assert_eq!(reset.read_columns(), fingerprint.read_columns());
         assert_eq!(reset.read_column_types(), fingerprint.read_column_types());
         assert_eq!(reset.filters(), fingerprint.filters());
         assert!(reset.time_filters().is_empty());
         assert_eq!(reset.series_row_selector, fingerprint.series_row_selector);
+        assert!(fingerprint.series_row_selector_after_merge);
+        assert!(reset.series_row_selector_after_merge);
+        assert!(candidate.series_row_selector_after_merge);
+        assert!(series_data.series_row_selector_after_merge);
         assert_eq!(reset.append_mode, fingerprint.append_mode);
         assert_eq!(reset.filter_deleted, fingerprint.filter_deleted);
         assert_eq!(reset.merge_mode, fingerprint.merge_mode);

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -574,6 +574,7 @@ impl ScanRegion {
             .with_filter_deleted(self.filter_deleted)
             .with_merge_mode(self.version.options.merge_mode())
             .with_series_row_selector(self.request.series_row_selector)
+            .with_series_row_selector_after_merge(self.request.series_row_selector_after_merge)
             .with_distribution(self.request.distribution)
             .with_explain_flat_format(
                 self.version.options.sst_format == Some(crate::sst::FormatType::Flat),
@@ -977,6 +978,8 @@ pub struct ScanInput {
     pub(crate) merge_mode: MergeMode,
     /// Hint to select rows from time series.
     pub(crate) series_row_selector: Option<TimeSeriesRowSelector>,
+    /// Whether the selector must run after cross-source merge and deduplication.
+    pub(crate) series_row_selector_after_merge: bool,
     /// Hint for the required distribution of the scanner.
     pub(crate) distribution: Option<TimeSeriesDistribution>,
     /// Whether the region's configured SST format is flat.
@@ -1051,6 +1054,7 @@ impl ScanInput {
                 filter_deleted: true,
                 merge_mode: MergeMode::default(),
                 series_row_selector: None,
+                series_row_selector_after_merge: false,
                 distribution: None,
                 explain_flat_format: false,
                 snapshot_sequence: None,
@@ -1199,6 +1203,7 @@ impl ScanInputBuilder {
                 filters,
                 time_filters,
                 series_row_selector: input.series_row_selector,
+                series_row_selector_after_merge: input.series_row_selector_after_merge,
                 append_mode: input.append_mode,
                 filter_deleted: input.filter_deleted,
                 merge_mode: input.merge_mode,
@@ -1378,6 +1383,13 @@ impl ScanInputBuilder {
         series_row_selector: Option<TimeSeriesRowSelector>,
     ) -> Self {
         self.input.series_row_selector = series_row_selector;
+        self
+    }
+
+    /// Sets whether the row selector must run after merge and deduplication.
+    #[must_use]
+    pub(crate) fn with_series_row_selector_after_merge(mut self, after_merge: bool) -> Self {
+        self.input.series_row_selector_after_merge = after_merge;
         self
     }
 
@@ -2504,6 +2516,7 @@ mod tests {
         .await
         .with_distribution(Some(TimeSeriesDistribution::PerSeries))
         .with_series_row_selector(Some(TimeSeriesRowSelector::LastRow))
+        .with_series_row_selector_after_merge(true)
         .with_merge_mode(MergeMode::LastNonNull)
         .with_filter_deleted(false)
         .build();
@@ -2529,6 +2542,7 @@ mod tests {
             ],
             time_filters: vec![col("ts").gt_eq(ts_lit(1000)).to_string()],
             series_row_selector: Some(TimeSeriesRowSelector::LastRow),
+            series_row_selector_after_merge: true,
             append_mode: false,
             filter_deleted: false,
             merge_mode: MergeMode::LastNonNull,
@@ -2537,6 +2551,7 @@ mod tests {
         }
         .build();
         assert_eq!(&expected, fingerprint);
+        assert!(input.series_row_selector_after_merge);
     }
 
     #[tokio::test]
@@ -2611,6 +2626,7 @@ mod tests {
             filters: vec![col("k0").eq(lit("foo")).to_string()],
             time_filters: vec![],
             series_row_selector: None,
+            series_row_selector_after_merge: false,
             append_mode: false,
             filter_deleted: true,
             merge_mode: MergeMode::LastRow,

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -574,7 +574,6 @@ impl ScanRegion {
             .with_filter_deleted(self.filter_deleted)
             .with_merge_mode(self.version.options.merge_mode())
             .with_series_row_selector(self.request.series_row_selector)
-            .with_series_row_selector_after_merge(self.request.series_row_selector_after_merge)
             .with_distribution(self.request.distribution)
             .with_explain_flat_format(
                 self.version.options.sst_format == Some(crate::sst::FormatType::Flat),
@@ -978,8 +977,6 @@ pub struct ScanInput {
     pub(crate) merge_mode: MergeMode,
     /// Hint to select rows from time series.
     pub(crate) series_row_selector: Option<TimeSeriesRowSelector>,
-    /// Whether the selector must run after cross-source merge and deduplication.
-    pub(crate) series_row_selector_after_merge: bool,
     /// Hint for the required distribution of the scanner.
     pub(crate) distribution: Option<TimeSeriesDistribution>,
     /// Whether the region's configured SST format is flat.
@@ -1054,7 +1051,6 @@ impl ScanInput {
                 filter_deleted: true,
                 merge_mode: MergeMode::default(),
                 series_row_selector: None,
-                series_row_selector_after_merge: false,
                 distribution: None,
                 explain_flat_format: false,
                 snapshot_sequence: None,
@@ -1203,7 +1199,6 @@ impl ScanInputBuilder {
                 filters,
                 time_filters,
                 series_row_selector: input.series_row_selector,
-                series_row_selector_after_merge: input.series_row_selector_after_merge,
                 append_mode: input.append_mode,
                 filter_deleted: input.filter_deleted,
                 merge_mode: input.merge_mode,
@@ -1383,13 +1378,6 @@ impl ScanInputBuilder {
         series_row_selector: Option<TimeSeriesRowSelector>,
     ) -> Self {
         self.input.series_row_selector = series_row_selector;
-        self
-    }
-
-    /// Sets whether the row selector must run after merge and deduplication.
-    #[must_use]
-    pub(crate) fn with_series_row_selector_after_merge(mut self, after_merge: bool) -> Self {
-        self.input.series_row_selector_after_merge = after_merge;
         self
     }
 
@@ -2515,8 +2503,7 @@ mod tests {
         )
         .await
         .with_distribution(Some(TimeSeriesDistribution::PerSeries))
-        .with_series_row_selector(Some(TimeSeriesRowSelector::LastRow))
-        .with_series_row_selector_after_merge(true)
+        .with_series_row_selector(Some(TimeSeriesRowSelector::LastRow { after_merge: true }))
         .with_merge_mode(MergeMode::LastNonNull)
         .with_filter_deleted(false)
         .build();
@@ -2541,8 +2528,7 @@ mod tests {
                 col("v0").gt(lit(1)).to_string(),
             ],
             time_filters: vec![col("ts").gt_eq(ts_lit(1000)).to_string()],
-            series_row_selector: Some(TimeSeriesRowSelector::LastRow),
-            series_row_selector_after_merge: true,
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: true }),
             append_mode: false,
             filter_deleted: false,
             merge_mode: MergeMode::LastNonNull,
@@ -2551,7 +2537,10 @@ mod tests {
         }
         .build();
         assert_eq!(&expected, fingerprint);
-        assert!(input.series_row_selector_after_merge);
+        assert_eq!(
+            input.series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+        );
     }
 
     #[tokio::test]
@@ -2626,7 +2615,6 @@ mod tests {
             filters: vec![col("k0").eq(lit("foo")).to_string()],
             time_filters: vec![],
             series_row_selector: None,
-            series_row_selector_after_merge: false,
             append_mode: false,
             filter_deleted: true,
             merge_mode: MergeMode::LastRow,

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1571,19 +1571,8 @@ pub fn build_flat_file_range_scan_stream(
             let build_reader_start = Instant::now();
             let Some(mut reader) = range
                 .flat_reader(
-                    // In exact `sequence_range` mode the row-group-level LastRow
-                    // shortcut would reduce each row group to its last-timestamp
-                    // row *before* the row-level sequence filter runs, silently
-                    // dropping in-range rows (a series with seq 1 at t1 and seq 2
-                    // at t2 under `(0, 1]` keeps only seq 2 and then filters it
-                    // out). Bypass the shortcut so the final per-row selector
-                    // (`FlatLastRowReader`, applied after source merging and the
-                    // sequence filter) selects on the filtered rows instead.
-                    if stream_ctx.input.sequence_range.is_some() {
-                        None
-                    } else {
-                        stream_ctx.input.series_row_selector
-                    },
+                    // LastRow must run after cross-source merge and deduplication.
+                    None,
                     fetch_metrics.as_deref(),
                 )
                 .await?

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -30,7 +30,7 @@ use futures::Stream;
 use prometheus::IntGauge;
 use smallvec::SmallVec;
 use snafu::ResultExt;
-use store_api::storage::{RegionId, SequenceRange};
+use store_api::storage::{RegionId, SequenceRange, TimeSeriesRowSelector};
 
 use crate::error::{ComputeArrowSnafu, Result};
 use crate::memtable::MemScanMetrics;
@@ -1571,12 +1571,13 @@ pub fn build_flat_file_range_scan_stream(
             let build_reader_start = Instant::now();
             let Some(mut reader) = range
                 .flat_reader(
-                    if stream_ctx.input.sequence_range.is_none()
-                        && !stream_ctx.input.series_row_selector_after_merge
-                    {
-                        stream_ctx.input.series_row_selector
-                    } else {
-                        None
+                    match stream_ctx.input.series_row_selector {
+                        Some(TimeSeriesRowSelector::LastRow { after_merge: false })
+                            if stream_ctx.input.sequence_range.is_none() =>
+                        {
+                            stream_ctx.input.series_row_selector
+                        }
+                        _ => None,
                     },
                     fetch_metrics.as_deref(),
                 )

--- a/src/mito2/src/read/scan_util.rs
+++ b/src/mito2/src/read/scan_util.rs
@@ -1571,8 +1571,13 @@ pub fn build_flat_file_range_scan_stream(
             let build_reader_start = Instant::now();
             let Some(mut reader) = range
                 .flat_reader(
-                    // LastRow must run after cross-source merge and deduplication.
-                    None,
+                    if stream_ctx.input.sequence_range.is_none()
+                        && !stream_ctx.input.series_row_selector_after_merge
+                    {
+                        stream_ctx.input.series_row_selector
+                    } else {
+                        None
+                    },
                     fetch_metrics.as_deref(),
                 )
                 .await?

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -263,7 +263,7 @@ impl SeqScan {
         };
 
         let reader = match &stream_ctx.input.series_row_selector {
-            Some(TimeSeriesRowSelector::LastRow) => {
+            Some(TimeSeriesRowSelector::LastRow { .. }) => {
                 Box::pin(FlatLastRowReader::new(reader).into_stream()) as _
             }
             None => reader,

--- a/src/mito2/src/read/series_scan.rs
+++ b/src/mito2/src/read/series_scan.rs
@@ -180,7 +180,7 @@ impl SeriesScan {
     }
 
     fn supports_two_phase(input: &ScanInput) -> bool {
-        if !is_sparse_metric_metadata(input.region_metadata()) {
+        if input.sequence_range.is_some() || !is_sparse_metric_metadata(input.region_metadata()) {
             return false;
         }
         #[cfg(feature = "enterprise")]
@@ -1214,6 +1214,39 @@ mod tests {
     use datatypes::arrow::record_batch::RecordBatch;
 
     use super::*;
+    use crate::read::flat_projection::FlatProjectionMapper;
+    use crate::read::scan_region::PredicateGroup;
+    use crate::test_util::scheduler_util::SchedulerEnv;
+    use crate::test_util::sst_util::sst_region_metadata_with_encoding;
+
+    #[tokio::test]
+    async fn two_phase_eligibility_rejects_exact_sequence_range() {
+        let env = SchedulerEnv::new().await;
+        let metadata = Arc::new(sst_region_metadata_with_encoding(
+            store_api::codec::PrimaryKeyEncoding::Sparse,
+        ));
+        let predicate = PredicateGroup::default();
+
+        let eligible = ScanInput::builder(
+            env.access_layer.clone(),
+            FlatProjectionMapper::new(&metadata, [0]).unwrap(),
+        )
+        .with_predicate(predicate.clone())
+        .build();
+        assert!(SeriesScan::supports_two_phase(&eligible));
+
+        let exact_sequence = ScanInput::builder(
+            env.access_layer.clone(),
+            FlatProjectionMapper::new(&metadata, [0]).unwrap(),
+        )
+        .with_predicate(predicate)
+        .with_sequence_range(Some(store_api::storage::SequenceRange::GtLtEq {
+            min: 1,
+            max: 2,
+        }))
+        .build();
+        assert!(!SeriesScan::supports_two_phase(&exact_sequence));
+    }
 
     #[test]
     fn candidate_distributor_stops_after_all_receivers_close() {

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -202,10 +202,10 @@ impl FileRange {
             ))
             .await?;
 
-        let use_last_row_reader = if selector
-            .map(|s| s == TimeSeriesRowSelector::LastRow)
-            .unwrap_or(false)
-        {
+        let use_last_row_reader = if matches!(
+            selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: false })
+        ) {
             // Only use LastRowReader if row group does not contain DELETE, all
             // rows are selected, and filters that still run after this reader
             // cannot change which row is last. Tag filters are safe because a

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -231,6 +231,11 @@ impl InstantManipulate {
         "InstantManipulate"
     }
 
+    /// Returns whether this node evaluates a single timestamp rather than a range.
+    pub fn is_single_evaluation(&self) -> bool {
+        self.start == self.end
+    }
+
     fn staleness_field_columns(&self) -> impl Iterator<Item = &str> {
         let [field, companion] = mixed_sample_fields(self.field_column.as_deref());
         [

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -200,6 +200,11 @@ impl SeriesNormalize {
         "SeriesNormalize"
     }
 
+    /// Returns whether this plan removes Prometheus stale markers.
+    pub const fn filter_stale_markers(&self) -> bool {
+        self.filter_stale_markers
+    }
+
     pub fn to_execution_plan(&self, exec_input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
         Arc::new(SeriesNormalizeExec {
             offset: self.offset,

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -286,6 +286,17 @@ impl DummyTableProvider {
         self.scan_request.lock().unwrap().series_row_selector = Some(selector);
     }
 
+    /// Clones this provider for one logical table-scan use-site.
+    ///
+    /// The optimizer may attach different hints to scans that share the same
+    /// catalog provider, so the per-scan request must not share its mutex.
+    pub fn clone_for_scan(&self) -> Self {
+        Self {
+            scan_request: Arc::new(Mutex::new(self.scan_request.lock().unwrap().clone())),
+            ..self.clone()
+        }
+    }
+
     pub fn with_vector_search_hint(&self, hint: VectorSearchRequest) {
         self.scan_request.lock().unwrap().vector_search = Some(hint);
     }

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -286,13 +286,6 @@ impl DummyTableProvider {
         self.scan_request.lock().unwrap().series_row_selector = Some(selector);
     }
 
-    /// Sets the instant-derived LastRow hint, which must run after merge and deduplication.
-    pub fn with_last_row_selector_after_merge_hint(&self) {
-        let mut request = self.scan_request.lock().unwrap();
-        request.series_row_selector = Some(TimeSeriesRowSelector::LastRow);
-        request.series_row_selector_after_merge = true;
-    }
-
     /// Clones this provider for one logical table-scan use-site.
     ///
     /// The optimizer may attach different hints to scans that share the same

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -286,6 +286,13 @@ impl DummyTableProvider {
         self.scan_request.lock().unwrap().series_row_selector = Some(selector);
     }
 
+    /// Sets the instant-derived LastRow hint, which must run after merge and deduplication.
+    pub fn with_last_row_selector_after_merge_hint(&self) {
+        let mut request = self.scan_request.lock().unwrap();
+        request.series_row_selector = Some(TimeSeriesRowSelector::LastRow);
+        request.series_row_selector_after_merge = true;
+    }
+
     /// Clones this provider for one logical table-scan use-site.
     ///
     /// The optimizer may attach different hints to scans that share the same

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -19,11 +19,12 @@ use arrow_schema::SortOptions;
 use common_function::aggrs::aggr_wrapper::aggr_state_func_name;
 use common_recordbatch::OrderOption;
 use datafusion::datasource::DefaultTableSource;
-use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion, TreeNodeVisitor};
+use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
 use datafusion_common::{Column, Result};
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{Expr, LogicalPlan, utils};
 use datafusion_optimizer::{OptimizerConfig, OptimizerRule};
+use promql::extension_plan::InstantManipulate;
 use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
 use store_api::storage::{TimeSeriesDistribution, TimeSeriesRowSelector};
 
@@ -59,65 +60,89 @@ impl OptimizerRule for ScanHintRule {
 
 impl ScanHintRule {
     fn optimize(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
-        let mut visitor = ScanHintVisitor::default();
-        let _ = plan.visit(&mut visitor)?;
-
-        if visitor.need_rewrite() {
-            plan.transform_down(&mut |plan| Self::set_hints(plan, &mut visitor))
-        } else {
-            Ok(Transformed::no(plan))
-        }
+        let mut rewriter = ScanHintRewriter::default();
+        // The extension's input is included by DataFusion's normal TreeNode
+        // rewrite, so this is one scoped recursive walk (subquery expressions
+        // are included by the dedicated API as well).
+        plan.rewrite_with_subqueries(&mut rewriter)
     }
 
     fn set_hints(
         plan: LogicalPlan,
-        visitor: &mut ScanHintVisitor,
+        rewriter: &mut ScanHintRewriter,
     ) -> Result<Transformed<LogicalPlan>> {
-        match &plan {
-            LogicalPlan::TableScan(table_scan) => {
-                let mut transformed = false;
-                if let Some(source) = table_scan
-                    .source
-                    .as_any()
-                    .downcast_ref::<DefaultTableSource>()
-                {
-                    // The provider in the region server is [DummyTableProvider].
-                    if let Some(adapter) = source
-                        .table_provider
-                        .as_any()
-                        .downcast_ref::<DummyTableProvider>()
-                    {
-                        // set order_hint
-                        if let Some(order_expr) = &visitor.order_expr {
-                            Self::set_order_hint(adapter, order_expr);
-                        }
+        let LogicalPlan::TableScan(mut table_scan) = plan else {
+            return Ok(Transformed::no(plan));
+        };
+        let Some(source) = table_scan
+            .source
+            .as_any()
+            .downcast_ref::<DefaultTableSource>()
+        else {
+            return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
+        };
+        // The provider in the region server is [DummyTableProvider].
+        let Some(original) = source
+            .table_provider
+            .as_any()
+            .downcast_ref::<DummyTableProvider>()
+        else {
+            return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
+        };
 
-                        // set time series selector hint
-                        if let Some((group_by_cols, order_by_col)) = &visitor.ts_row_selector {
-                            Self::set_time_series_row_selector_hint(
-                                adapter,
-                                group_by_cols,
-                                order_by_col,
-                            );
-                        }
+        #[cfg(feature = "vector_index")]
+        let has_vector_hint = rewriter.vector_search.need_rewrite();
+        #[cfg(not(feature = "vector_index"))]
+        let has_vector_hint = false;
+        let has_hint = rewriter.order_expr.is_some()
+            || rewriter.ts_row_selector.is_some()
+            || rewriter.inside_single_evaluation
+            || has_vector_hint;
+        if !has_hint {
+            return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
+        }
 
-                        #[cfg(feature = "vector_index")]
-                        if let Some(vector_request) = visitor
-                            .vector_search
-                            .take_vector_request_from_dummy(adapter, &table_scan.table_name)
-                        {
-                            adapter.with_vector_search_hint(vector_request);
-                        }
-                        transformed = true;
-                    }
-                }
-                if transformed {
-                    Ok(Transformed::yes(plan))
-                } else {
-                    Ok(Transformed::no(plan))
-                }
-            }
-            _ => Ok(Transformed::no(plan)),
+        // A provider can be used by several TableScan nodes. Fork its request
+        // for every hinted use-site before applying hints, rather than mutating
+        // the shared catalog provider. This keeps order/vector/legacy hints
+        // local as well as the new LastRow hint.
+        let adapter = original.clone_for_scan();
+        Self::apply_hints(&adapter, rewriter, &table_scan);
+        if rewriter.inside_single_evaluation {
+            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
+        }
+        table_scan.source =
+            std::sync::Arc::new(DefaultTableSource::new(std::sync::Arc::new(adapter)));
+        Ok(Transformed::yes(LogicalPlan::TableScan(table_scan)))
+    }
+
+    fn apply_hints(
+        adapter: &DummyTableProvider,
+        rewriter: &mut ScanHintRewriter,
+        table_scan: &datafusion_expr::logical_plan::TableScan,
+    ) {
+        #[cfg(not(feature = "vector_index"))]
+        let _ = table_scan;
+        if let Some(order_expr) = &rewriter.order_expr {
+            Self::set_order_hint(adapter, order_expr);
+        }
+        if let Some((group_by_cols, order_by_col)) = &rewriter.ts_row_selector {
+            Self::set_time_series_row_selector_hint(adapter, group_by_cols, order_by_col);
+        }
+        #[cfg(feature = "vector_index")]
+        if rewriter.inside_single_evaluation {
+            // LastRow and vector search are mutually exclusive for one scan:
+            // vector search would bypass the ordinary sort/limit path needed by
+            // the single-evaluation semantics. Still consume the queued hint so
+            // it cannot be applied to a later scan of the same table.
+            let _ = rewriter
+                .vector_search
+                .take_vector_request_from_dummy(adapter, &table_scan.table_name);
+        } else if let Some(vector_request) = rewriter
+            .vector_search
+            .take_vector_request_from_dummy(adapter, &table_scan.table_name)
+        {
+            adapter.with_vector_search_hint(vector_request);
         }
     }
 
@@ -226,181 +251,161 @@ impl ScanHintRule {
     }
 }
 
-/// Traverse and fetch hints.
+/// Traverse and apply hints with state scoped to the current logical-plan path.
+///
+/// Rewriting the scan while walking down the tree is important: the state then
+/// describes the actual parent path of that scan, and a shared provider is forked
+/// at that exact use-site. No traversal-order identity is involved.
 #[derive(Default)]
-struct ScanHintVisitor {
-    /// The closest order requirement to the leaf node.
+struct ScanHintRewriter {
     order_expr: Option<Vec<Sort>>,
-    /// Row selection on time series distribution.
-    /// This field stores saved `group_by` columns when all aggregate functions are `last_value`
-    /// and the `order_by` column which should be time index.
+    order_stack: Vec<Option<Vec<Sort>>>,
     ts_row_selector: Option<(HashSet<Column>, Column)>,
+    ts_stack: Vec<Option<(HashSet<Column>, Column)>>,
+    inside_single_evaluation: bool,
+    single_evaluation_stack: Vec<bool>,
     #[cfg(feature = "vector_index")]
     vector_search: VectorSearchState,
 }
 
-impl TreeNodeVisitor<'_> for ScanHintVisitor {
+impl TreeNodeRewriter for ScanHintRewriter {
     type Node = LogicalPlan;
 
-    fn f_down(&mut self, node: &Self::Node) -> Result<TreeNodeRecursion> {
-        #[cfg(feature = "vector_index")]
-        if let LogicalPlan::Limit(limit) = node {
-            // Track LIMIT so vector hint k can be derived within the same input chain.
-            self.vector_search.on_limit_enter(limit);
-        }
+    fn f_down(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+        self.order_stack.push(self.order_expr.clone());
+        self.ts_stack.push(self.ts_row_selector.clone());
+        self.single_evaluation_stack
+            .push(self.inside_single_evaluation);
 
-        // Get order requirement from sort plan
-        if let LogicalPlan::Sort(sort) = node {
+        if let LogicalPlan::Sort(sort) = &node {
             self.order_expr = Some(sort.expr.clone());
-
-            #[cfg(feature = "vector_index")]
-            {
-                // Capture vector ORDER BY and TopK hints from sort nodes.
-                self.vector_search.on_sort_enter(sort);
-            }
+        }
+        if let LogicalPlan::Extension(extension) = &node
+            && let Some(instant) = extension.node.as_any().downcast_ref::<InstantManipulate>()
+        {
+            self.inside_single_evaluation = instant.is_single_evaluation();
+        }
+        // DataFusion uses a synthetic Subquery plan node for expression
+        // subqueries. It is an evaluation boundary: an outer instant query
+        // must not make the subquery's scan use LastRow. SubqueryAlias is not
+        // a boundary here because it can still be part of the direct data flow.
+        if matches!(node, LogicalPlan::Subquery(_)) {
+            self.inside_single_evaluation = false;
+        }
+        if let LogicalPlan::Aggregate(aggregate) = &node {
+            self.ts_row_selector = Self::extract_last_value_selector(aggregate);
         }
 
-        // Get time series row selector from aggr plan
-        if let LogicalPlan::Aggregate(aggregate) = node {
-            let mut is_all_last_value = !aggregate.aggr_expr.is_empty();
-            let mut order_by_expr = None;
-            for expr in &aggregate.aggr_expr {
-                // check function name
-                let Expr::AggregateFunction(func) = expr else {
-                    is_all_last_value = false;
-                    break;
-                };
-                if (func.func.name() != "last_value"
-                    && func.func.name() != aggr_state_func_name("last_value"))
-                    || func.params.filter.is_some()
-                    || func.params.distinct
-                {
-                    is_all_last_value = false;
-                    break;
-                }
-                // check order by requirement
-                let order_by = &func.params.order_by;
-                if let Some(first_order_by) = order_by.first()
-                    && order_by.len() == 1
-                {
-                    if let Some(existing_order_by) = &order_by_expr {
-                        if existing_order_by != first_order_by {
-                            is_all_last_value = false;
-                            break;
-                        }
-                    } else {
-                        // only allow `order by xxx [ASC]`, xxx is a bare column reference so `last_value()` is the max
-                        // value of the column.
-                        if !first_order_by.asc || !matches!(&first_order_by.expr, Expr::Column(_)) {
-                            is_all_last_value = false;
-                            break;
-                        }
-                        order_by_expr = Some(first_order_by.clone());
-                    }
-                }
-            }
-            is_all_last_value &= order_by_expr.is_some();
-            if is_all_last_value {
-                // make sure all the exprs are DIRECT `col` and collect them
-                let mut group_by_cols = HashSet::with_capacity(aggregate.group_expr.len());
-                for expr in &aggregate.group_expr {
-                    if let Expr::Column(col) = expr {
-                        group_by_cols.insert(col.clone());
-                    } else {
-                        is_all_last_value = false;
-                        break;
-                    }
-                }
-                // Safety: checked in the above loop
-                let order_by_expr = order_by_expr.unwrap();
-                let Expr::Column(order_by_col) = order_by_expr.expr else {
-                    unreachable!()
-                };
-                if is_all_last_value {
-                    self.ts_row_selector = Some((group_by_cols, order_by_col));
-                }
-            }
-        }
-
-        // Avoid carrying vector hints across branching inputs (join/subquery) to prevent
-        // pruning results before global ordering is applied. Only treat a subquery as a
-        // barrier when it contains non-inlineable operators.
-        let is_branching_for_ts = matches!(
+        let is_branching = matches!(
             node,
             LogicalPlan::Subquery(_) | LogicalPlan::SubqueryAlias(_)
         ) || node.inputs().len() > 1;
-        if is_branching_for_ts && self.ts_row_selector.is_some() {
-            // clean previous time series selector hint when encounter subqueries or join
+        if is_branching {
             self.ts_row_selector = None;
         }
-        #[cfg(feature = "vector_index")]
-        if is_branching_for_vector(node) {
-            self.vector_search.on_branching_enter();
-        }
-
-        if let LogicalPlan::Filter(filter) = node
+        if let LogicalPlan::Filter(filter) = &node
             && let Some(group_by_exprs) = &self.ts_row_selector
         {
-            let mut filter_referenced_cols = HashSet::default();
-            utils::expr_to_columns(&filter.predicate, &mut filter_referenced_cols)?;
-            // ensure only group_by columns are used in filter
-            if !filter_referenced_cols.is_subset(&group_by_exprs.0) {
+            let mut referenced = HashSet::default();
+            utils::expr_to_columns(&filter.predicate, &mut referenced)?;
+            if !referenced.is_subset(&group_by_exprs.0) {
                 self.ts_row_selector = None;
             }
         }
 
         #[cfg(feature = "vector_index")]
-        if let LogicalPlan::Filter(filter) = node {
-            self.vector_search.on_filter_enter(&filter.predicate);
+        {
+            if let LogicalPlan::Limit(limit) = &node {
+                self.vector_search.on_limit_enter(limit);
+            }
+            if let LogicalPlan::Sort(sort) = &node {
+                self.vector_search.on_sort_enter(sort);
+            }
+            if is_branching_for_vector(&node) {
+                self.vector_search.on_branching_enter();
+            }
+            if let LogicalPlan::Filter(filter) = &node {
+                self.vector_search.on_filter_enter(&filter.predicate);
+            }
+            if let LogicalPlan::TableScan(table_scan) = &node {
+                self.vector_search.on_table_scan(table_scan);
+            }
         }
 
-        #[cfg(feature = "vector_index")]
-        if let LogicalPlan::TableScan(table_scan) = node {
-            // Record vector hints at leaf scans after scope checks.
-            self.vector_search.on_table_scan(table_scan);
-        }
-
-        Ok(TreeNodeRecursion::Continue)
+        ScanHintRule::set_hints(node, self)
     }
 
-    fn f_up(&mut self, _node: &Self::Node) -> Result<TreeNodeRecursion> {
+    fn f_up(&mut self, node: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
         #[cfg(feature = "vector_index")]
-        match _node {
-            LogicalPlan::Limit(_) => {
-                self.vector_search.on_limit_exit();
+        {
+            match &node {
+                LogicalPlan::Limit(_) => self.vector_search.on_limit_exit(),
+                LogicalPlan::Sort(_) => self.vector_search.on_sort_exit(),
+                LogicalPlan::Filter(_) => self.vector_search.on_filter_exit(),
+                LogicalPlan::Subquery(_) | LogicalPlan::SubqueryAlias(_)
+                    if is_branching_for_vector(&node) =>
+                {
+                    self.vector_search.on_branching_exit()
+                }
+                _ if node.inputs().len() > 1 => self.vector_search.on_branching_exit(),
+                _ => {}
             }
-            LogicalPlan::Sort(_) => {
-                self.vector_search.on_sort_exit();
-            }
-            LogicalPlan::Filter(_) => {
-                self.vector_search.on_filter_exit();
-            }
-            LogicalPlan::Subquery(_) | LogicalPlan::SubqueryAlias(_)
-                if is_branching_for_vector(_node) =>
-            {
-                self.vector_search.on_branching_exit();
-            }
-            _ if _node.inputs().len() > 1 => {
-                self.vector_search.on_branching_exit();
-            }
-            _ => {}
         }
-
-        Ok(TreeNodeRecursion::Continue)
+        if let Some(previous) = self.order_stack.pop() {
+            self.order_expr = previous;
+        }
+        if let Some(previous) = self.ts_stack.pop() {
+            self.ts_row_selector = previous;
+        }
+        if let Some(previous) = self.single_evaluation_stack.pop() {
+            self.inside_single_evaluation = previous;
+        }
+        Ok(Transformed::no(node))
     }
 }
 
-impl ScanHintVisitor {
-    fn need_rewrite(&self) -> bool {
-        let base = self.order_expr.is_some() || self.ts_row_selector.is_some();
-        #[cfg(feature = "vector_index")]
-        {
-            base || self.vector_search.need_rewrite()
+impl ScanHintRewriter {
+    fn extract_last_value_selector(
+        aggregate: &datafusion_expr::logical_plan::Aggregate,
+    ) -> Option<(HashSet<Column>, Column)> {
+        let mut order_by_expr = None;
+        if aggregate.aggr_expr.is_empty() {
+            return None;
         }
-        #[cfg(not(feature = "vector_index"))]
-        {
-            base
+        for expr in &aggregate.aggr_expr {
+            let Expr::AggregateFunction(func) = expr else {
+                return None;
+            };
+            if (func.func.name() != "last_value"
+                && func.func.name() != aggr_state_func_name("last_value"))
+                || func.params.filter.is_some()
+                || func.params.distinct
+            {
+                return None;
+            }
+            let order_by = &func.params.order_by;
+            if order_by.len() != 1 || !order_by[0].asc {
+                return None;
+            }
+            if let Some(existing) = &order_by_expr {
+                if existing != &order_by[0] {
+                    return None;
+                }
+            } else {
+                order_by_expr = Some(order_by[0].clone());
+            }
         }
+        let Expr::Column(order_by_col) = order_by_expr?.expr else {
+            return None;
+        };
+        let mut group_by_cols = HashSet::with_capacity(aggregate.group_expr.len());
+        for expr in &aggregate.group_expr {
+            let Expr::Column(col) = expr else {
+                return None;
+            };
+            group_by_cols.insert(col.clone());
+        }
+        Some((group_by_cols, order_by_col))
     }
 }
 
@@ -443,17 +448,271 @@ fn has_non_inlineable_ops(plan: &LogicalPlan) -> bool {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use datafusion::functions_aggregate::first_last::last_value_udaf;
+    use datafusion_common::tree_node::TreeNodeRecursion;
     use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams};
-    use datafusion_expr::{LogicalPlanBuilder, col};
+    use datafusion_expr::expr_fn::scalar_subquery;
+    use datafusion_expr::{Extension, LogicalPlan, LogicalPlanBuilder, col};
     use datafusion_optimizer::OptimizerContext;
     use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
-    use store_api::storage::RegionId;
+    use store_api::storage::{RegionId, TimeSeriesRowSelector};
 
     use super::*;
+
+    fn scan_requests(plan: &LogicalPlan) -> Vec<store_api::storage::ScanRequest> {
+        scan_requests_with_names(plan)
+            .into_iter()
+            .map(|(_, request)| request)
+            .collect()
+    }
+
+    fn scan_requests_with_names(
+        plan: &LogicalPlan,
+    ) -> Vec<(String, store_api::storage::ScanRequest)> {
+        let mut requests = Vec::new();
+        plan.apply_with_subqueries(|node| {
+            if let LogicalPlan::TableScan(scan) = node
+                && let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>()
+                && let Some(provider) = source
+                    .table_provider
+                    .as_any()
+                    .downcast_ref::<DummyTableProvider>()
+            {
+                requests.push((scan.table_name.to_string(), provider.scan_request()));
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        requests
+    }
+
+    fn instant_plan(provider: Arc<DummyTableProvider>, end: i64) -> LogicalPlan {
+        instant_plan_named(provider, "t", end)
+    }
+
+    fn scan_plan(provider: Arc<DummyTableProvider>, table_name: &str) -> LogicalPlan {
+        LogicalPlanBuilder::scan(
+            table_name,
+            Arc::new(DefaultTableSource::new(provider)),
+            None,
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+    }
+
+    fn instant_with_expression_subquery(
+        outer_provider: Arc<DummyTableProvider>,
+        inner_plan: LogicalPlan,
+        outer_end: i64,
+    ) -> LogicalPlan {
+        let outer_scan = scan_plan(outer_provider, "outer");
+        let input = LogicalPlanBuilder::from(outer_scan)
+            .project(vec![
+                col("ts"),
+                col("v0"),
+                scalar_subquery(Arc::new(inner_plan)),
+            ])
+            .unwrap()
+            .build()
+            .unwrap();
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                outer_end,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v0".to_string()),
+                input,
+            )),
+        })
+    }
+
+    fn instant_plan_named(
+        provider: Arc<DummyTableProvider>,
+        table_name: &str,
+        end: i64,
+    ) -> LogicalPlan {
+        let input = LogicalPlanBuilder::scan(
+            table_name,
+            Arc::new(DefaultTableSource::new(provider)),
+            None,
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                end,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v0".to_string()),
+                input,
+            )),
+        })
+    }
     use crate::optimizer::test_util::{mock_table_provider, mock_table_provider_with_tsid};
+
+    #[test]
+    fn single_evaluation_sets_last_row_on_the_rewritten_scan() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan(provider.clone(), 1000);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+        assert_eq!(provider.scan_request().series_row_selector, None);
+    }
+
+    #[test]
+    fn range_evaluation_does_not_set_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan(provider.clone(), 2000);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        assert_eq!(provider.scan_request().series_row_selector, None);
+    }
+
+    #[test]
+    fn expression_subquery_isolated_from_outer_single_evaluation() {
+        let outer_provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let inner_provider = Arc::new(mock_table_provider(RegionId::new(2, 1)));
+        let plan = instant_with_expression_subquery(
+            outer_provider.clone(),
+            instant_plan_named(inner_provider, "inner", 2000),
+            1000,
+        );
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        let requests = scan_requests_with_names(&rewritten)
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            requests["outer"].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+        assert_eq!(requests["inner"].series_row_selector, None);
+    }
+
+    #[test]
+    fn expression_subquery_can_start_its_own_single_evaluation() {
+        let outer_provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let inner_provider = Arc::new(mock_table_provider(RegionId::new(2, 1)));
+        let plan = instant_with_expression_subquery(
+            outer_provider,
+            instant_plan_named(inner_provider, "inner", 1000),
+            1000,
+        );
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        let requests = scan_requests_with_names(&rewritten)
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            requests["outer"].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+        assert_eq!(
+            requests["inner"].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+    }
+
+    #[test]
+    fn nested_single_outer_range_inner_does_not_set_inner_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan_named(provider.clone(), "nested", 2000);
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                1000,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v0".to_string()),
+                plan,
+            )),
+        });
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        assert_eq!(provider.scan_request().series_row_selector, None);
+    }
+
+    #[test]
+    fn nested_range_outer_single_inner_sets_inner_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan_named(provider.clone(), "nested", 1000);
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                2000,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v0".to_string()),
+                plan,
+            )),
+        });
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+    }
+
+    #[test]
+    fn shared_provider_isolated_between_single_and_range_scans() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = LogicalPlanBuilder::from(instant_plan(provider.clone(), 1000))
+            .union(instant_plan(provider.clone(), 2000))
+            .unwrap()
+            .build()
+            .unwrap();
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+        let requests = scan_requests(&rewritten);
+
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+        assert_eq!(requests[1].series_row_selector, None);
+        assert_eq!(provider.scan_request().series_row_selector, None);
+    }
 
     #[test]
     fn set_order_hint() {
@@ -469,10 +728,10 @@ mod test {
             .unwrap();
 
         let context = OptimizerContext::default();
-        ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
         // should read the first (with `.sort(true, false)`) sort option
-        let scan_req = provider.scan_request();
+        let scan_req = scan_requests(&rewritten)[0].clone();
         assert_eq!(
             OrderOption {
                 name: "ts".to_string(),
@@ -513,9 +772,9 @@ mod test {
             .unwrap();
 
         let context = OptimizerContext::default();
-        ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
-        let scan_req = provider.scan_request();
+        let scan_req = scan_requests(&rewritten)[0].clone();
         let _ = scan_req.series_row_selector.unwrap();
     }
 
@@ -534,9 +793,9 @@ mod test {
             .unwrap();
 
         let context = OptimizerContext::default();
-        ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
-        let scan_req = provider.scan_request();
+        let scan_req = scan_requests(&rewritten)[0].clone();
         assert_eq!(
             scan_req.distribution,
             Some(TimeSeriesDistribution::PerSeries)

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -124,7 +124,7 @@ impl ScanHintRule {
             // Apply the instant-derived hint after the aggregate hint. Both
             // select LastRow today, and this ordering preserves the existing
             // aggregate selector when the instant guard rejects a scan.
-            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
+            adapter.with_last_row_selector_after_merge_hint();
         }
         table_scan.source =
             std::sync::Arc::new(DefaultTableSource::new(std::sync::Arc::new(adapter)));
@@ -636,6 +636,8 @@ mod test {
             scan_requests(&rewritten)[0].series_row_selector,
             Some(TimeSeriesRowSelector::LastRow)
         );
+        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
+        assert!(!provider.scan_request().series_row_selector_after_merge);
         assert_eq!(provider.scan_request().series_row_selector, None);
     }
 
@@ -649,7 +651,9 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
         assert_eq!(provider.scan_request().series_row_selector, None);
+        assert!(!provider.scan_request().series_row_selector_after_merge);
     }
 
     #[test]
@@ -665,6 +669,7 @@ mod test {
             scan_requests(&rewritten)[0].series_row_selector,
             Some(TimeSeriesRowSelector::LastRow)
         );
+        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -680,6 +685,7 @@ mod test {
             scan_requests(&rewritten)[0].series_row_selector,
             Some(TimeSeriesRowSelector::LastRow)
         );
+        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -693,6 +699,7 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -705,6 +712,7 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -717,6 +725,7 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -729,6 +738,7 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -830,6 +840,7 @@ mod test {
             scan_requests(&rewritten)[0].series_row_selector,
             Some(TimeSeriesRowSelector::LastRow)
         );
+        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -852,7 +863,10 @@ mod test {
             Some(TimeSeriesRowSelector::LastRow)
         );
         assert_eq!(requests[1].series_row_selector, None);
+        assert!(requests[0].series_row_selector_after_merge);
+        assert!(!requests[1].series_row_selector_after_merge);
         assert_eq!(provider.scan_request().series_row_selector, None);
+        assert!(!provider.scan_request().series_row_selector_after_merge);
     }
 
     #[test]
@@ -916,7 +930,11 @@ mod test {
         let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
         let scan_req = scan_requests(&rewritten)[0].clone();
-        let _ = scan_req.series_row_selector.unwrap();
+        assert_eq!(
+            scan_req.series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+        assert!(!scan_req.series_row_selector_after_merge);
     }
 
     #[test]

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -132,6 +132,17 @@ impl ScanHintRule {
         Ok(Transformed::yes(LogicalPlan::TableScan(table_scan)))
     }
 
+    /// Checks whether attached scan predicates permit instant-derived LastRow selection.
+    ///
+    /// Selecting the newest row too early can discard an older matching sample if a
+    /// predicate later rejects that row. Only recognized tag/time predicates are
+    /// allowed: tags select whole series, and supported time predicates constrain
+    /// the scan window before row selection. Field or unrecognized predicates are
+    /// conservatively rejected. Finer-than-millisecond timestamps are also excluded
+    /// because instant evaluation can conflate distinct samples at that precision.
+    ///
+    /// This checks only attached predicates; the rewriter separately rejects residual
+    /// Filter nodes between InstantManipulate and the scan.
     fn filters_preserve_last_row(
         table_scan: &datafusion_expr::logical_plan::TableScan,
         provider: &DummyTableProvider,

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -18,6 +18,7 @@ use api::v1::SemanticType;
 use arrow_schema::SortOptions;
 use common_function::aggrs::aggr_wrapper::aggr_state_func_name;
 use common_recordbatch::OrderOption;
+use common_recordbatch::filter::SimpleFilterEvaluator;
 use datafusion::datasource::DefaultTableSource;
 use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
 use datafusion_common::{Column, Result};
@@ -90,13 +91,24 @@ impl ScanHintRule {
             return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
         };
 
+        // LastRow is only sound when every predicate already attached to this
+        // scan is restricted to columns that preserve the series' last row.
+        // In particular, do not infer this from a Filter node above the scan:
+        // only the filters that DataFusion actually pushed to this scan matter.
+        let filters_preserve_last_row = if rewriter.inside_single_evaluation {
+            Self::filters_preserve_last_row(&table_scan, original)
+        } else {
+            true
+        };
+        let use_last_row = rewriter.inside_single_evaluation && filters_preserve_last_row;
+
         #[cfg(feature = "vector_index")]
         let has_vector_hint = rewriter.vector_search.need_rewrite();
         #[cfg(not(feature = "vector_index"))]
         let has_vector_hint = false;
         let has_hint = rewriter.order_expr.is_some()
             || rewriter.ts_row_selector.is_some()
-            || rewriter.inside_single_evaluation
+            || use_last_row
             || has_vector_hint;
         if !has_hint {
             return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
@@ -107,8 +119,11 @@ impl ScanHintRule {
         // the shared catalog provider. This keeps order/vector/legacy hints
         // local as well as the new LastRow hint.
         let adapter = original.clone_for_scan();
-        Self::apply_hints(&adapter, rewriter, &table_scan);
-        if rewriter.inside_single_evaluation {
+        Self::apply_hints(&adapter, rewriter, &table_scan, use_last_row);
+        if use_last_row {
+            // Apply the instant-derived hint after the aggregate hint. Both
+            // select LastRow today, and this ordering preserves the existing
+            // aggregate selector when the instant guard rejects a scan.
             adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
         }
         table_scan.source =
@@ -116,13 +131,36 @@ impl ScanHintRule {
         Ok(Transformed::yes(LogicalPlan::TableScan(table_scan)))
     }
 
+    fn filters_preserve_last_row(
+        table_scan: &datafusion_expr::logical_plan::TableScan,
+        provider: &DummyTableProvider,
+    ) -> bool {
+        let metadata = provider.region_metadata();
+        for filter in &table_scan.filters {
+            let Some(filter) = SimpleFilterEvaluator::try_new(filter) else {
+                return false;
+            };
+            let Some(column_metadata) = metadata.column_by_name(filter.column_name()) else {
+                return false;
+            };
+            if !matches!(
+                column_metadata.semantic_type,
+                SemanticType::Tag | SemanticType::Timestamp
+            ) {
+                return false;
+            }
+        }
+        true
+    }
+
     fn apply_hints(
         adapter: &DummyTableProvider,
         rewriter: &mut ScanHintRewriter,
         table_scan: &datafusion_expr::logical_plan::TableScan,
+        use_last_row: bool,
     ) {
         #[cfg(not(feature = "vector_index"))]
-        let _ = table_scan;
+        let _ = (table_scan, use_last_row);
         if let Some(order_expr) = &rewriter.order_expr {
             Self::set_order_hint(adapter, order_expr);
         }
@@ -130,7 +168,7 @@ impl ScanHintRule {
             Self::set_time_series_row_selector_hint(adapter, group_by_cols, order_by_col);
         }
         #[cfg(feature = "vector_index")]
-        if rewriter.inside_single_evaluation {
+        if use_last_row {
             // LastRow and vector search are mutually exclusive for one scan:
             // vector search would bypass the ordinary sort/limit path needed by
             // the single-evaluation semantics. Still consume the queued hint so
@@ -453,10 +491,11 @@ mod test {
 
     use datafusion::functions_aggregate::first_last::last_value_udaf;
     use datafusion_common::tree_node::TreeNodeRecursion;
-    use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams};
+    use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams, Cast};
     use datafusion_expr::expr_fn::scalar_subquery;
-    use datafusion_expr::{Extension, LogicalPlan, LogicalPlanBuilder, col};
+    use datafusion_expr::{Extension, LogicalPlan, LogicalPlanBuilder, col, lit};
     use datafusion_optimizer::OptimizerContext;
+    use datatypes::arrow::datatypes::DataType;
     use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
     use store_api::storage::{RegionId, TimeSeriesRowSelector};
 
@@ -491,6 +530,29 @@ mod test {
 
     fn instant_plan(provider: Arc<DummyTableProvider>, end: i64) -> LogicalPlan {
         instant_plan_named(provider, "t", end)
+    }
+
+    fn instant_plan_with_filters(
+        provider: Arc<DummyTableProvider>,
+        filters: Vec<Expr>,
+    ) -> LogicalPlan {
+        let scan = scan_plan(provider, "t");
+        let LogicalPlan::TableScan(mut scan) = scan else {
+            unreachable!();
+        };
+        scan.filters = filters;
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                1000,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v0".to_string()),
+                LogicalPlan::TableScan(scan),
+            )),
+        })
     }
 
     fn scan_plan(provider: Arc<DummyTableProvider>, table_name: &str) -> LogicalPlan {
@@ -588,6 +650,85 @@ mod test {
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
         assert_eq!(provider.scan_request().series_row_selector, None);
+    }
+
+    #[test]
+    fn single_evaluation_with_tag_filter_sets_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan_with_filters(provider, vec![col("k0").eq(lit("tag"))]);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+    }
+
+    #[test]
+    fn single_evaluation_with_timestamp_filter_sets_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan_with_filters(provider, vec![col("ts").gt_eq(lit(1_i64))]);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow)
+        );
+    }
+
+    #[test]
+    fn single_evaluation_with_cast_timestamp_filter_does_not_set_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let filter = Expr::Cast(Cast::new(Box::new(col("ts")), DataType::Int64)).gt(lit(1_i64));
+        let plan = instant_plan_with_filters(provider, vec![filter]);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+    }
+
+    #[test]
+    fn single_evaluation_with_multi_column_timestamp_filter_does_not_set_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan_with_filters(provider, vec![col("ts").gt(col("k0"))]);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+    }
+
+    #[test]
+    fn single_evaluation_with_field_filter_does_not_set_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan_with_filters(provider, vec![col("v0").gt(lit(1.0_f64))]);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+    }
+
+    #[test]
+    fn single_evaluation_with_unknown_filter_does_not_set_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = instant_plan_with_filters(provider, vec![col("unknown").eq(lit(1_i64))]);
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
     }
 
     #[test]

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -125,7 +125,9 @@ impl ScanHintRule {
             // Apply the instant-derived hint after the aggregate hint. Both
             // select LastRow today, and this ordering preserves the existing
             // aggregate selector when the instant guard rejects a scan.
-            adapter.with_last_row_selector_after_merge_hint();
+            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow {
+                after_merge: true,
+            });
         }
         table_scan.source =
             std::sync::Arc::new(DefaultTableSource::new(std::sync::Arc::new(adapter)));
@@ -293,7 +295,9 @@ impl ScanHintRule {
         }
 
         if should_set_selector_hint {
-            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow);
+            adapter.with_time_series_selector_hint(TimeSeriesRowSelector::LastRow {
+                after_merge: false,
+            });
         }
     }
 }
@@ -643,10 +647,9 @@ mod test {
 
         assert_eq!(
             scan_requests(&rewritten)[0].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
-        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
-        assert!(!provider.scan_request().series_row_selector_after_merge);
+
         assert_eq!(provider.scan_request().series_row_selector, None);
     }
 
@@ -660,9 +663,8 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
-        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
+
         assert_eq!(provider.scan_request().series_row_selector, None);
-        assert!(!provider.scan_request().series_row_selector_after_merge);
     }
 
     #[test]
@@ -676,9 +678,8 @@ mod test {
 
         assert_eq!(
             scan_requests(&rewritten)[0].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
-        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -692,9 +693,8 @@ mod test {
 
         assert_eq!(
             scan_requests(&rewritten)[0].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
-        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -708,7 +708,6 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
-        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -721,7 +720,6 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
-        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -734,7 +732,6 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
-        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -747,7 +744,6 @@ mod test {
             .data;
 
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
-        assert!(!scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -769,7 +765,7 @@ mod test {
             .collect::<HashMap<_, _>>();
         assert_eq!(
             requests["outer"].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
         assert_eq!(requests["inner"].series_row_selector, None);
     }
@@ -793,11 +789,11 @@ mod test {
             .collect::<HashMap<_, _>>();
         assert_eq!(
             requests["outer"].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
         assert_eq!(
             requests["inner"].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
     }
 
@@ -847,9 +843,8 @@ mod test {
             .data;
         assert_eq!(
             scan_requests(&rewritten)[0].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
-        assert!(scan_requests(&rewritten)[0].series_row_selector_after_merge);
     }
 
     #[test]
@@ -869,13 +864,10 @@ mod test {
         assert_eq!(requests.len(), 2);
         assert_eq!(
             requests[0].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
         );
         assert_eq!(requests[1].series_row_selector, None);
-        assert!(requests[0].series_row_selector_after_merge);
-        assert!(!requests[1].series_row_selector_after_merge);
         assert_eq!(provider.scan_request().series_row_selector, None);
-        assert!(!provider.scan_request().series_row_selector_after_merge);
     }
 
     #[test]
@@ -941,9 +933,8 @@ mod test {
         let scan_req = scan_requests(&rewritten)[0].clone();
         assert_eq!(
             scan_req.series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow)
+            Some(TimeSeriesRowSelector::LastRow { after_merge: false })
         );
-        assert!(!scan_req.series_row_selector_after_merge);
     }
 
     #[test]

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -92,10 +92,8 @@ impl ScanHintRule {
             return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
         };
 
-        // LastRow is only sound when every predicate already attached to this
-        // scan is restricted to columns that preserve the series' last row.
-        // In particular, do not infer this from a Filter node above the scan:
-        // only the filters that DataFusion actually pushed to this scan matter.
+        // Attached scan filters are checked below; the intervening Filter guard
+        // disables LastRow for residual predicates.
         let filters_preserve_last_row = if rewriter.inside_single_evaluation {
             Self::filters_preserve_last_row(&table_scan, original)
         } else {
@@ -343,6 +341,10 @@ impl TreeNodeRewriter for ScanHintRewriter {
         if matches!(node, LogicalPlan::Subquery(_)) {
             self.inside_single_evaluation = false;
         }
+        // A residual predicate can change which row is last for a series.
+        if matches!(&node, LogicalPlan::Filter(_)) {
+            self.inside_single_evaluation = false;
+        }
         if let LogicalPlan::Aggregate(aggregate) = &node {
             self.ts_row_selector = Self::extract_last_value_selector(aggregate);
         }
@@ -579,6 +581,21 @@ mod test {
         .unwrap()
     }
 
+    fn single_evaluation(input: LogicalPlan) -> LogicalPlan {
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                1000,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v0".to_string()),
+                input,
+            )),
+        })
+    }
+
     fn instant_with_expression_subquery(
         outer_provider: Arc<DummyTableProvider>,
         inner_plan: LogicalPlan,
@@ -665,6 +682,121 @@ mod test {
         assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
 
         assert_eq!(provider.scan_request().series_row_selector, None);
+    }
+
+    #[test]
+    fn residual_field_filter_does_not_set_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let input = LogicalPlanBuilder::from(scan_plan(provider, "t"))
+            .filter(col("v0").gt(lit(1.0_f64)))
+            .unwrap()
+            .build()
+            .unwrap();
+        let rewritten = ScanHintRule
+            .rewrite(single_evaluation(input), &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+    }
+
+    #[test]
+    fn outer_residual_filter_does_not_block_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let plan = LogicalPlanBuilder::from(single_evaluation(scan_plan(provider, "t")))
+            .filter(col("v0").gt(lit(1.0_f64)))
+            .unwrap()
+            .build()
+            .unwrap();
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+        );
+    }
+
+    #[test]
+    fn residual_filter_only_blocks_its_union_branch() {
+        for filtered_first in [true, false] {
+            let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+            let filtered = LogicalPlanBuilder::from(scan_plan(provider.clone(), "filtered"))
+                .filter(col("v0").gt(lit(1.0_f64)))
+                .unwrap()
+                .build()
+                .unwrap();
+            let plain = scan_plan(provider.clone(), "plain");
+            let union = if filtered_first {
+                LogicalPlanBuilder::from(filtered)
+                    .union(plain)
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            } else {
+                LogicalPlanBuilder::from(plain)
+                    .union(filtered)
+                    .unwrap()
+                    .build()
+                    .unwrap()
+            };
+            let rewritten = ScanHintRule
+                .rewrite(single_evaluation(union), &OptimizerContext::default())
+                .unwrap()
+                .data;
+            let requests = scan_requests_with_names(&rewritten)
+                .into_iter()
+                .collect::<HashMap<_, _>>();
+
+            assert_eq!(requests["filtered"].series_row_selector, None);
+            assert_eq!(
+                requests["plain"].series_row_selector,
+                Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+            );
+            assert_eq!(provider.scan_request().series_row_selector, None);
+        }
+    }
+
+    #[test]
+    fn residual_time_filters_do_not_set_last_row() {
+        for predicate in [
+            col("ts").lt(lit(1_i64)),
+            Expr::Cast(Cast::new(Box::new(col("ts")), DataType::Int64)).gt(lit(1_i64)),
+        ] {
+            let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+            let input = LogicalPlanBuilder::from(scan_plan(provider, "t"))
+                .filter(predicate)
+                .unwrap()
+                .build()
+                .unwrap();
+            let rewritten = ScanHintRule
+                .rewrite(single_evaluation(input), &OptimizerContext::default())
+                .unwrap()
+                .data;
+
+            assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        }
+    }
+
+    #[test]
+    fn inner_single_evaluation_resets_residual_filter() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let filtered = LogicalPlanBuilder::from(single_evaluation(scan_plan(provider, "t")))
+            .filter(col("v0").gt(lit(1.0_f64)))
+            .unwrap()
+            .build()
+            .unwrap();
+        let rewritten = ScanHintRule
+            .rewrite(single_evaluation(filtered), &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+        );
     }
 
     #[test]

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -26,7 +26,8 @@ use datafusion_common::{Column, Result};
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{Expr, LogicalPlan, utils};
 use datafusion_optimizer::{OptimizerConfig, OptimizerRule};
-use promql::extension_plan::InstantManipulate;
+use datatypes::arrow::datatypes::{DataType, TimeUnit as ArrowTimeUnit};
+use promql::extension_plan::{InstantManipulate, SeriesDivide, SeriesNormalize};
 use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
 use store_api::storage::{TimeSeriesDistribution, TimeSeriesRowSelector};
 
@@ -92,8 +93,8 @@ impl ScanHintRule {
             return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
         };
 
-        // Attached scan filters are checked below; the intervening Filter guard
-        // disables LastRow for residual predicates.
+        // Attached scan filters are checked below; residual Filter nodes are
+        // rejected by the single-evaluation path allowlist.
         let filters_preserve_last_row = if rewriter.inside_single_evaluation {
             Self::filters_preserve_last_row(&table_scan, original)
         } else {
@@ -141,8 +142,8 @@ impl ScanHintRule {
     /// conservatively rejected. Finer-than-millisecond timestamps are also excluded
     /// because instant evaluation can conflate distinct samples at that precision.
     ///
-    /// This checks only attached predicates; the rewriter separately rejects residual
-    /// Filter nodes between InstantManipulate and the scan.
+    /// This checks only attached predicates; the path allowlist separately rejects
+    /// residual Filter nodes between InstantManipulate and the scan.
     fn filters_preserve_last_row(
         table_scan: &datafusion_expr::logical_plan::TableScan,
         provider: &DummyTableProvider,
@@ -344,17 +345,12 @@ impl TreeNodeRewriter for ScanHintRewriter {
             && let Some(instant) = extension.node.as_any().downcast_ref::<InstantManipulate>()
         {
             self.inside_single_evaluation = instant.is_single_evaluation();
-        }
-        // DataFusion uses a synthetic Subquery plan node for expression
-        // subqueries. It is an evaluation boundary: an outer instant query
-        // must not make the subquery's scan use LastRow. SubqueryAlias is not
-        // a boundary here because it can still be part of the direct data flow.
-        if matches!(node, LogicalPlan::Subquery(_)) {
-            self.inside_single_evaluation = false;
-        }
-        // A residual predicate can change which row is last for a series.
-        if matches!(&node, LogicalPlan::Filter(_)) {
-            self.inside_single_evaluation = false;
+        } else if self.inside_single_evaluation {
+            // This allowlist is coupled to the controlled PromQL planner. It
+            // permits only nodes known to preserve the newest row per series;
+            // every other node is a sticky boundary until a nested instant
+            // extension establishes a new evaluation scope.
+            self.inside_single_evaluation = single_evaluation_node_allowed(&node);
         }
         if let LogicalPlan::Aggregate(aggregate) = &node {
             self.ts_row_selector = Self::extract_last_value_selector(aggregate);
@@ -425,6 +421,61 @@ impl TreeNodeRewriter for ScanHintRewriter {
             self.inside_single_evaluation = previous;
         }
         Ok(Transformed::no(node))
+    }
+}
+
+/// Returns whether a plan node can occur on the scan path of a controlled
+/// PromQL single evaluation without changing which row is newest per series.
+fn single_evaluation_node_allowed(node: &LogicalPlan) -> bool {
+    match node {
+        LogicalPlan::TableScan(_) | LogicalPlan::SubqueryAlias(_) => true,
+        LogicalPlan::Sort(sort) => sort.fetch.is_none(),
+        LogicalPlan::Projection(projection) => projection
+            .expr
+            .iter()
+            .all(|expr| single_evaluation_projection_expr_allowed(expr, projection)),
+        LogicalPlan::Extension(extension) => {
+            let extension = extension.node.as_any();
+            extension.is::<SeriesDivide>()
+                || extension
+                    .downcast_ref::<SeriesNormalize>()
+                    .is_some_and(|normalize| !normalize.filter_stale_markers())
+        }
+        _ => false,
+    }
+}
+
+/// This whitelist assumes the planner preserves time-index and series identity;
+/// it is not a proof that an arbitrary plan does so.
+fn single_evaluation_projection_expr_allowed(
+    expr: &Expr,
+    projection: &datafusion_expr::logical_plan::Projection,
+) -> bool {
+    match expr {
+        Expr::Column(_) => true,
+        Expr::Alias(alias) => match alias.expr.as_ref() {
+            Expr::Column(column) => alias.name == column.name,
+            Expr::Cast(cast) => {
+                let Expr::Column(column) = cast.expr.as_ref() else {
+                    return false;
+                };
+                alias.name == column.name
+                    && matches!(
+                        cast.data_type,
+                        DataType::Timestamp(ArrowTimeUnit::Millisecond, None)
+                    )
+                    && matches!(
+                        projection
+                            .input
+                            .schema()
+                            .qualified_field_from_column(column),
+                        Ok((_, field))
+                            if matches!(field.data_type(), DataType::Timestamp(ArrowTimeUnit::Second | ArrowTimeUnit::Millisecond, None))
+                    )
+            }
+            _ => false,
+        },
+        _ => false,
     }
 }
 
@@ -516,12 +567,23 @@ mod test {
     use std::sync::Arc;
 
     use datafusion::functions_aggregate::first_last::last_value_udaf;
+    use datafusion::functions_aggregate::min_max::max_udaf;
+    use datafusion::functions_window::row_number::RowNumber;
+    use datafusion::logical_expr::expr::WindowFunction;
+    use datafusion::logical_expr::{WindowFrame, WindowFunctionDefinition};
+    use datafusion::prelude::JoinType;
     use datafusion_common::tree_node::TreeNodeRecursion;
-    use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams, Cast};
+    use datafusion_expr::expr::{
+        AggregateFunction, AggregateFunctionParams, Cast, WindowFunctionParams,
+    };
     use datafusion_expr::expr_fn::scalar_subquery;
     use datafusion_expr::{Extension, LogicalPlan, LogicalPlanBuilder, col, lit};
     use datafusion_optimizer::OptimizerContext;
     use datatypes::arrow::datatypes::DataType;
+    use datatypes::data_type::ConcreteDataType;
+    use datatypes::schema::ColumnSchema;
+    use promql::extension_plan::RangeManipulate;
+    use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::metric_engine_consts::DATA_SCHEMA_TSID_COLUMN_NAME;
     use store_api::storage::{RegionId, TimeSeriesRowSelector};
 
@@ -590,6 +652,57 @@ mod test {
         .unwrap()
         .build()
         .unwrap()
+    }
+
+    fn mock_table_provider_with_timestamp(
+        region_id: RegionId,
+        timestamp_type: ConcreteDataType,
+    ) -> DummyTableProvider {
+        let mut builder = RegionMetadataBuilder::new(region_id);
+        builder
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new("k0", ConcreteDataType::string_datatype(), true),
+                semantic_type: SemanticType::Tag,
+                column_id: 1,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new("ts", timestamp_type, false),
+                semantic_type: SemanticType::Timestamp,
+                column_id: 2,
+            })
+            .push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new("v0", ConcreteDataType::float64_datatype(), false),
+                semantic_type: SemanticType::Field,
+                column_id: 3,
+            })
+            .primary_key(vec![1]);
+        let metadata = Arc::new(builder.build().unwrap());
+        let engine = Arc::new(MetaRegionEngine::with_metadata(metadata.clone()));
+        DummyTableProvider::new(region_id, engine, metadata)
+    }
+
+    fn last_value_aggregate(input: LogicalPlan) -> LogicalPlan {
+        LogicalPlanBuilder::from(input)
+            .aggregate(
+                vec![col("k0")],
+                vec![Expr::AggregateFunction(AggregateFunction {
+                    func: last_value_udaf(),
+                    params: AggregateFunctionParams {
+                        args: vec![col("v0")],
+                        distinct: false,
+                        filter: None,
+                        order_by: vec![Sort {
+                            expr: col("ts"),
+                            asc: true,
+                            nulls_first: true,
+                        }],
+                        null_treatment: None,
+                    },
+                })],
+            )
+            .unwrap()
+            .build()
+            .unwrap()
     }
 
     fn single_evaluation(input: LogicalPlan) -> LogicalPlan {
@@ -662,7 +775,9 @@ mod test {
             )),
         })
     }
-    use crate::optimizer::test_util::{mock_table_provider, mock_table_provider_with_tsid};
+    use crate::optimizer::test_util::{
+        MetaRegionEngine, mock_table_provider, mock_table_provider_with_tsid,
+    };
 
     #[test]
     fn single_evaluation_sets_last_row_on_the_rewritten_scan() {
@@ -679,6 +794,340 @@ mod test {
         );
 
         assert_eq!(provider.scan_request().series_row_selector, None);
+    }
+
+    #[test]
+    fn single_evaluation_limit_sort_does_not_set_last_row_below_limit() {
+        let mut selectors = Vec::new();
+        for input in [
+            // Instant(1000, lookback=1000) -> Limit(0, 1) -> Sort(ts ASC) -> Scan.
+            LogicalPlanBuilder::from(scan_plan(
+                Arc::new(mock_table_provider(RegionId::new(1, 1))),
+                "t",
+            ))
+            .sort(vec![col("ts").sort(true, false)])
+            .unwrap()
+            .limit(0, Some(1))
+            .unwrap()
+            .build()
+            .unwrap(),
+            // Sort.fetch is a limit embedded in the Sort node and has the same boundary.
+            LogicalPlanBuilder::from(scan_plan(
+                Arc::new(mock_table_provider(RegionId::new(1, 1))),
+                "t",
+            ))
+            .sort_with_limit(vec![col("ts").sort(true, false)], Some(1))
+            .unwrap()
+            .build()
+            .unwrap(),
+        ] {
+            let rewritten = ScanHintRule
+                .rewrite(single_evaluation(input), &OptimizerContext::default())
+                .unwrap()
+                .data;
+            selectors.push(scan_requests(&rewritten)[0].series_row_selector);
+        }
+
+        // With samples (ts=100, v=10) and (ts=900, v=1), an unhinted ascending
+        // sort/limit pipeline returns 10. LastRow at the scan instead leaves only
+        // (900, 1) before the limit. A LastRow scan hint cannot cross either limit.
+        assert_eq!(selectors, vec![None, None]);
+    }
+
+    #[test]
+    fn single_evaluation_allows_controlled_promql_selector_chain() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let projection = LogicalPlanBuilder::from(scan_plan(provider, "t"))
+            .project(vec![
+                col("k0").alias("k0"),
+                Expr::Cast(Cast::new(
+                    Box::new(col("ts")),
+                    DataType::Timestamp(ArrowTimeUnit::Millisecond, None),
+                ))
+                .alias("ts"),
+                col("v0"),
+            ])
+            .unwrap()
+            .sort(vec![col("ts").sort(true, false)])
+            .unwrap()
+            .build()
+            .unwrap();
+        let divide = LogicalPlan::Extension(Extension {
+            node: Arc::new(SeriesDivide::new(
+                vec!["k0".to_string()],
+                "ts".to_string(),
+                projection,
+            )),
+        });
+        let normalize = LogicalPlan::Extension(Extension {
+            node: Arc::new(SeriesNormalize::new(
+                42,
+                "ts",
+                false,
+                vec!["k0".to_string()],
+                divide,
+            )),
+        });
+        let rewritten = ScanHintRule
+            .rewrite(single_evaluation(normalize), &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+        );
+    }
+
+    #[test]
+    fn single_evaluation_filtering_normalize_does_not_set_last_row() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let normalize = LogicalPlan::Extension(Extension {
+            node: Arc::new(SeriesNormalize::new(
+                42,
+                "ts",
+                true,
+                vec!["k0".to_string()],
+                scan_plan(provider, "t"),
+            )),
+        });
+        let rewritten = ScanHintRule
+            .rewrite(single_evaluation(normalize), &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        // An older finite sample can precede a newest stale marker. LastRow
+        // would discard that sample before SeriesNormalize filters the marker.
+        assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+    }
+
+    #[test]
+    fn single_evaluation_rejects_row_changing_nodes() {
+        let provider = || Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let window = LogicalPlanBuilder::from(scan_plan(provider(), "window"))
+            .window(vec![Expr::WindowFunction(Box::new(WindowFunction {
+                fun: WindowFunctionDefinition::WindowUDF(Arc::new(RowNumber::new().into())),
+                params: WindowFunctionParams {
+                    args: vec![],
+                    partition_by: vec![col("k0")],
+                    order_by: vec![col("ts").sort(true, true)],
+                    window_frame: WindowFrame::new(Some(true)),
+                    filter: None,
+                    null_treatment: None,
+                    distinct: false,
+                },
+            }))])
+            .unwrap()
+            .build()
+            .unwrap();
+        let join = LogicalPlanBuilder::from(scan_plan(provider(), "left"))
+            .join(
+                scan_plan(provider(), "right"),
+                JoinType::Inner,
+                (Vec::<Column>::new(), Vec::<Column>::new()),
+                None,
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        let nonlast_aggregate = LogicalPlanBuilder::from(scan_plan(provider(), "aggregate"))
+            .aggregate(
+                vec![col("k0")],
+                vec![Expr::AggregateFunction(AggregateFunction {
+                    func: max_udaf(),
+                    params: AggregateFunctionParams {
+                        args: vec![col("v0")],
+                        distinct: false,
+                        filter: None,
+                        order_by: vec![],
+                        null_treatment: None,
+                    },
+                })],
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        let range = LogicalPlan::Extension(Extension {
+            node: Arc::new(
+                RangeManipulate::new(
+                    1000,
+                    1000,
+                    1000,
+                    1000,
+                    "ts".to_string(),
+                    vec!["v0".to_string()],
+                    scan_plan(provider(), "range"),
+                )
+                .unwrap(),
+            ),
+        });
+
+        for (plan, scan_count) in [(window, 1), (join, 2), (nonlast_aggregate, 1), (range, 1)] {
+            let rewritten = ScanHintRule
+                .rewrite(single_evaluation(plan), &OptimizerContext::default())
+                .unwrap()
+                .data;
+            assert_eq!(
+                scan_requests(&rewritten)
+                    .into_iter()
+                    .map(|request| request.series_row_selector)
+                    .collect::<Vec<_>>(),
+                vec![None; scan_count]
+            );
+        }
+    }
+
+    #[test]
+    fn single_evaluation_last_value_aggregate_keeps_legacy_selector() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let rewritten = ScanHintRule
+            .rewrite(
+                single_evaluation(last_value_aggregate(scan_plan(provider, "t"))),
+                &OptimizerContext::default(),
+            )
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: false })
+        );
+    }
+
+    #[test]
+    fn single_evaluation_allows_second_to_millisecond_time_index_cast() {
+        let provider = Arc::new(mock_table_provider_with_timestamp(
+            RegionId::new(1, 1),
+            ConcreteDataType::timestamp_second_datatype(),
+        ));
+        let input = LogicalPlanBuilder::from(scan_plan(provider, "t"))
+            .project(vec![
+                Expr::Cast(Cast::new(
+                    Box::new(Expr::Column(Column::new(Some("t"), "ts"))),
+                    DataType::Timestamp(ArrowTimeUnit::Millisecond, None),
+                ))
+                .alias("ts"),
+            ])
+            .unwrap()
+            .build()
+            .unwrap();
+        let rewritten = ScanHintRule
+            .rewrite(single_evaluation(input), &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)[0].series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+        );
+    }
+
+    #[test]
+    fn single_evaluation_rejects_microsecond_and_nanosecond_time_index_casts() {
+        for timestamp_type in [
+            ConcreteDataType::timestamp_microsecond_datatype(),
+            ConcreteDataType::timestamp_nanosecond_datatype(),
+        ] {
+            let provider = Arc::new(mock_table_provider_with_timestamp(
+                RegionId::new(1, 1),
+                timestamp_type,
+            ));
+            let input = LogicalPlanBuilder::from(scan_plan(provider, "t"))
+                .project(vec![
+                    Expr::Cast(Cast::new(
+                        Box::new(Expr::Column(Column::new(Some("t"), "ts"))),
+                        DataType::Timestamp(ArrowTimeUnit::Millisecond, None),
+                    ))
+                    .alias("ts"),
+                ])
+                .unwrap()
+                .build()
+                .unwrap();
+            let rewritten = ScanHintRule
+                .rewrite(single_evaluation(input), &OptimizerContext::default())
+                .unwrap()
+                .data;
+
+            assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        }
+    }
+
+    #[test]
+    fn single_evaluation_rejects_unresolved_time_index_cast_qualifier() {
+        let provider = Arc::new(mock_table_provider_with_timestamp(
+            RegionId::new(1, 1),
+            ConcreteDataType::timestamp_second_datatype(),
+        ));
+        let input = LogicalPlanBuilder::from(scan_plan(provider, "t"))
+            .project(vec![col("ts")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let LogicalPlan::Projection(projection) = input else {
+            unreachable!();
+        };
+        let unresolved_cast = Expr::Cast(Cast::new(
+            Box::new(Expr::Column(Column::new(Some("missing"), "ts"))),
+            DataType::Timestamp(ArrowTimeUnit::Millisecond, None),
+        ))
+        .alias("ts");
+
+        assert!(!single_evaluation_projection_expr_allowed(
+            &unresolved_cast,
+            &projection
+        ));
+    }
+
+    #[test]
+    fn single_evaluation_rejects_projection_expressions_that_change_rows() {
+        let invalid_projections = [
+            vec![col("ts").alias("renamed")],
+            vec![
+                Expr::BinaryExpr(datafusion_expr::expr::BinaryExpr::new(
+                    Box::new(col("v0")),
+                    datafusion_expr::Operator::Plus,
+                    Box::new(lit(1.0_f64)),
+                ))
+                .alias("v0"),
+            ],
+            vec![
+                Expr::Cast(Cast::new(
+                    Box::new(col("ts")),
+                    DataType::Timestamp(ArrowTimeUnit::Second, None),
+                ))
+                .alias("ts"),
+            ],
+            vec![Expr::Cast(Cast::new(Box::new(col("v0")), DataType::Int64)).alias("v0")],
+            vec![
+                Expr::Cast(Cast::new(
+                    Box::new(col("ts")),
+                    DataType::Timestamp(ArrowTimeUnit::Microsecond, None),
+                ))
+                .alias("ts"),
+            ],
+            vec![
+                Expr::Cast(Cast::new(
+                    Box::new(col("ts")),
+                    DataType::Timestamp(ArrowTimeUnit::Nanosecond, None),
+                ))
+                .alias("ts"),
+            ],
+        ];
+
+        for expressions in invalid_projections {
+            let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+            let input = LogicalPlanBuilder::from(scan_plan(provider, "t"))
+                .project(expressions)
+                .unwrap()
+                .build()
+                .unwrap();
+            let rewritten = ScanHintRule
+                .rewrite(single_evaluation(input), &OptimizerContext::default())
+                .unwrap()
+                .data;
+
+            assert_eq!(scan_requests(&rewritten)[0].series_row_selector, None);
+        }
     }
 
     #[test]
@@ -731,15 +1180,17 @@ mod test {
     }
 
     #[test]
-    fn residual_filter_only_blocks_its_union_branch() {
+    fn branch_local_residual_filter_isolation_in_both_orders() {
         for filtered_first in [true, false] {
             let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
-            let filtered = LogicalPlanBuilder::from(scan_plan(provider.clone(), "filtered"))
-                .filter(col("v0").gt(lit(1.0_f64)))
-                .unwrap()
-                .build()
-                .unwrap();
-            let plain = scan_plan(provider.clone(), "plain");
+            let filtered = single_evaluation(
+                LogicalPlanBuilder::from(scan_plan(provider.clone(), "filtered"))
+                    .filter(col("v0").gt(lit(1.0_f64)))
+                    .unwrap()
+                    .build()
+                    .unwrap(),
+            );
+            let plain = single_evaluation(scan_plan(provider.clone(), "plain"));
             let union = if filtered_first {
                 LogicalPlanBuilder::from(filtered)
                     .union(plain)
@@ -754,7 +1205,7 @@ mod test {
                     .unwrap()
             };
             let rewritten = ScanHintRule
-                .rewrite(single_evaluation(union), &OptimizerContext::default())
+                .rewrite(union, &OptimizerContext::default())
                 .unwrap()
                 .data;
             let requests = scan_requests_with_names(&rewritten)
@@ -768,6 +1219,28 @@ mod test {
             );
             assert_eq!(provider.scan_request().series_row_selector, None);
         }
+    }
+
+    #[test]
+    fn union_inside_single_evaluation_blocks_both_branches() {
+        let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
+        let union = LogicalPlanBuilder::from(scan_plan(provider.clone(), "left"))
+            .union(scan_plan(provider, "right"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let rewritten = ScanHintRule
+            .rewrite(single_evaluation(union), &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        assert_eq!(
+            scan_requests(&rewritten)
+                .into_iter()
+                .map(|request| request.series_row_selector)
+                .collect::<Vec<_>>(),
+            vec![None, None]
+        );
     }
 
     #[test]
@@ -906,10 +1379,7 @@ mod test {
         let requests = scan_requests_with_names(&rewritten)
             .into_iter()
             .collect::<HashMap<_, _>>();
-        assert_eq!(
-            requests["outer"].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
-        );
+        assert_eq!(requests["outer"].series_row_selector, None);
         assert_eq!(requests["inner"].series_row_selector, None);
     }
 
@@ -930,10 +1400,7 @@ mod test {
         let requests = scan_requests_with_names(&rewritten)
             .into_iter()
             .collect::<HashMap<_, _>>();
-        assert_eq!(
-            requests["outer"].series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
-        );
+        assert_eq!(requests["outer"].series_row_selector, None);
         assert_eq!(
             requests["inner"].series_row_selector,
             Some(TimeSeriesRowSelector::LastRow { after_merge: true })
@@ -1046,29 +1513,7 @@ mod test {
     #[test]
     fn set_time_series_row_selector_hint() {
         let provider = Arc::new(mock_table_provider(RegionId::new(1, 1)));
-        let table_source = Arc::new(DefaultTableSource::new(provider.clone()));
-        let plan = LogicalPlanBuilder::scan("t", table_source, None)
-            .unwrap()
-            .aggregate(
-                vec![col("k0")],
-                vec![Expr::AggregateFunction(AggregateFunction {
-                    func: last_value_udaf(),
-                    params: AggregateFunctionParams {
-                        args: vec![col("v0")],
-                        distinct: false,
-                        filter: None,
-                        order_by: vec![Sort {
-                            expr: col("ts"),
-                            asc: true,
-                            nulls_first: true,
-                        }],
-                        null_treatment: None,
-                    },
-                })],
-            )
-            .unwrap()
-            .build()
-            .unwrap();
+        let plan = last_value_aggregate(scan_plan(provider.clone(), "t"));
 
         let context = OptimizerContext::default();
         let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;

--- a/src/query/src/optimizer/scan_hint.rs
+++ b/src/query/src/optimizer/scan_hint.rs
@@ -19,6 +19,7 @@ use arrow_schema::SortOptions;
 use common_function::aggrs::aggr_wrapper::aggr_state_func_name;
 use common_recordbatch::OrderOption;
 use common_recordbatch::filter::SimpleFilterEvaluator;
+use common_time::timestamp::TimeUnit;
 use datafusion::datasource::DefaultTableSource;
 use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
 use datafusion_common::{Column, Result};
@@ -136,6 +137,14 @@ impl ScanHintRule {
         provider: &DummyTableProvider,
     ) -> bool {
         let metadata = provider.region_metadata();
+        // Instant evaluation is millisecond-based, so finer time units can
+        // conflate timestamps and must not use the LastRow hint.
+        if !matches!(
+            metadata.time_index_type().unit(),
+            TimeUnit::Second | TimeUnit::Millisecond
+        ) {
+            return false;
+        }
         for filter in &table_scan.filters {
             let Some(filter) = SimpleFilterEvaluator::try_new(filter) else {
                 return false;

--- a/src/query/src/optimizer/scan_hint/vector_search.rs
+++ b/src/query/src/optimizer/scan_hint/vector_search.rs
@@ -410,12 +410,13 @@ mod tests {
     use datafusion_expr::expr::ScalarFunction;
     use datafusion_expr::logical_plan::JoinType;
     use datafusion_expr::{
-        Expr, LogicalPlan, LogicalPlanBuilder, Signature, Subquery, Volatility, col, lit,
+        Expr, Extension, LogicalPlan, LogicalPlanBuilder, Signature, Subquery, Volatility, col, lit,
     };
     use datafusion_optimizer::{OptimizerContext, OptimizerRule};
     use datatypes::schema::ColumnSchema;
+    use promql::extension_plan::InstantManipulate;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
-    use store_api::storage::{ConcreteDataType, VectorDistanceMetric};
+    use store_api::storage::{ConcreteDataType, VectorDistanceMetric, VectorSearchRequest};
 
     use super::VectorSearchState;
     use crate::dummy_catalog::DummyTableProvider;
@@ -469,14 +470,40 @@ mod tests {
     }
 
     fn vec_distance_expr(function_name: &'static str) -> Expr {
+        vec_distance_expr_with_query(function_name, "[1.0, 2.0]")
+    }
+
+    fn vec_distance_expr_with_query(function_name: &'static str, query_vector: &str) -> Expr {
         let udf = create_udf(Arc::new(TestVectorFunction::new(function_name)));
         Expr::ScalarFunction(ScalarFunction::new_udf(
             Arc::new(udf),
             vec![
                 col("v"),
-                lit(ScalarValue::Utf8(Some("[1.0, 2.0]".to_string()))),
+                lit(ScalarValue::Utf8(Some(query_vector.to_string()))),
             ],
         ))
+    }
+
+    fn scan_request_from_plan(plan: &LogicalPlan) -> store_api::storage::ScanRequest {
+        let mut request = None;
+        plan.apply_with_subqueries(|node| {
+            if let LogicalPlan::TableScan(scan) = node
+                && let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>()
+                && let Some(provider) = source
+                    .table_provider
+                    .as_any()
+                    .downcast_ref::<DummyTableProvider>()
+            {
+                request = Some(provider.scan_request());
+            }
+            Ok(datafusion_common::tree_node::TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        request.unwrap()
+    }
+
+    fn vector_hint_from_plan(plan: &LogicalPlan) -> Option<VectorSearchRequest> {
+        scan_request_from_plan(plan).vector_search
     }
 
     fn build_dummy_provider(column_id: u32) -> Arc<DummyTableProvider> {
@@ -565,13 +592,135 @@ mod tests {
             .unwrap();
 
         let context = OptimizerContext::default();
-        let _ = ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
-        let hint = dummy_provider.get_vector_search_hint().unwrap();
+        let hint = vector_hint_from_plan(&rewritten).unwrap();
         assert_eq!(hint.column_id, 10);
         assert_eq!(hint.k, 5);
         assert_eq!(hint.metric, VectorDistanceMetric::L2sq);
         assert_eq!(hint.query_vector, vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_vector_hint_is_skipped_for_single_evaluation() {
+        let provider = build_dummy_provider(10);
+        let source = Arc::new(DefaultTableSource::new(provider));
+        let distance = vec_distance_expr(VEC_L2SQ_DISTANCE);
+        let scan = LogicalPlanBuilder::scan_with_filters("t", source, None, vec![])
+            .unwrap()
+            .sort(vec![distance.sort(true, false)])
+            .unwrap()
+            .limit(0, Some(5))
+            .unwrap()
+            .build()
+            .unwrap();
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                1000,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v".to_string()),
+                scan,
+            )),
+        });
+
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+        let request = scan_request_from_plan(&rewritten);
+        assert_eq!(
+            request.series_row_selector,
+            Some(store_api::storage::TimeSeriesRowSelector::LastRow)
+        );
+        assert!(request.vector_search.is_none());
+    }
+
+    #[test]
+    fn test_single_evaluation_consumes_only_its_vector_hint() {
+        let provider_a = build_dummy_provider(10);
+        let provider_b = build_dummy_provider(20);
+        let distance_a = vec_distance_expr_with_query(VEC_L2SQ_DISTANCE, "[1.0, 2.0]");
+        let distance_b = vec_distance_expr_with_query(VEC_L2SQ_DISTANCE, "[3.0, 4.0]");
+
+        let branch_a = LogicalPlanBuilder::scan_with_filters(
+            "t",
+            Arc::new(DefaultTableSource::new(provider_a)),
+            None,
+            vec![],
+        )
+        .unwrap()
+        .sort(vec![distance_a.sort(true, false)])
+        .unwrap()
+        .limit(0, Some(5))
+        .unwrap()
+        .build()
+        .unwrap();
+        let branch_a = LogicalPlan::Extension(Extension {
+            node: Arc::new(InstantManipulate::new(
+                1000,
+                1000,
+                1000,
+                1000,
+                "ts".to_string(),
+                vec![],
+                Some("v".to_string()),
+                branch_a,
+            )),
+        });
+
+        let branch_b = LogicalPlanBuilder::scan_with_filters(
+            "t",
+            Arc::new(DefaultTableSource::new(provider_b)),
+            None,
+            vec![],
+        )
+        .unwrap()
+        .sort(vec![distance_b.sort(true, false)])
+        .unwrap()
+        .limit(0, Some(9))
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let plan = LogicalPlanBuilder::from(branch_a)
+            .union(branch_b)
+            .unwrap()
+            .build()
+            .unwrap();
+        let rewritten = ScanHintRule
+            .rewrite(plan, &OptimizerContext::default())
+            .unwrap()
+            .data;
+
+        let LogicalPlan::Union(union) = rewritten else {
+            panic!("expected union plan")
+        };
+        let request_a = scan_request_from_plan(&union.inputs[0]);
+        let request_b = scan_request_from_plan(&union.inputs[1]);
+
+        assert_eq!(
+            request_a.series_row_selector,
+            Some(store_api::storage::TimeSeriesRowSelector::LastRow)
+        );
+        assert!(request_a.vector_search.is_none());
+        assert_eq!(request_b.series_row_selector, None);
+        assert_eq!(
+            request_b.vector_search,
+            Some(VectorSearchRequest {
+                column_id: 20,
+                query_vector: vec![3.0, 4.0],
+                k: 9,
+                metric: VectorDistanceMetric::L2sq,
+            })
+        );
+
+        // The catalog providers are not mutated; the requests above belong to
+        // the two rewritten scan use-sites.
+        assert!(request_b.vector_search != request_a.vector_search);
     }
 
     #[test]
@@ -589,9 +738,9 @@ mod tests {
             .unwrap();
 
         let context = OptimizerContext::default();
-        let _ = ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
-        let hint = dummy_provider.get_vector_search_hint().unwrap();
+        let hint = vector_hint_from_plan(&rewritten).unwrap();
         assert_eq!(hint.k, 15);
     }
 
@@ -621,8 +770,8 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        let _ = ScanHintRule.rewrite(plan, &context).unwrap();
-        let hint = dummy_provider.get_vector_search_hint().unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
+        let hint = vector_hint_from_plan(&rewritten).unwrap();
         assert_eq!(hint.metric, VectorDistanceMetric::InnerProduct);
     }
 
@@ -681,9 +830,9 @@ mod tests {
             .unwrap();
 
         let context = OptimizerContext::default();
-        let _ = ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
-        let hint = dummy_provider.get_vector_search_hint().unwrap();
+        let hint = vector_hint_from_plan(&rewritten).unwrap();
         assert_eq!(hint.column_id, 10);
         assert_eq!(hint.k, 5);
     }
@@ -701,9 +850,9 @@ mod tests {
             .unwrap();
 
         let context = OptimizerContext::default();
-        let _ = ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
-        let hint = dummy_provider.get_vector_search_hint().unwrap();
+        let hint = vector_hint_from_plan(&rewritten).unwrap();
         assert_eq!(hint.k, 4);
     }
 
@@ -828,10 +977,10 @@ mod tests {
             .unwrap();
 
         let context = OptimizerContext::default();
-        let _ = ScanHintRule.rewrite(plan, &context).unwrap();
+        let rewritten = ScanHintRule.rewrite(plan, &context).unwrap().data;
 
         // Hint propagates through simple subquery
-        let hint = provider.get_vector_search_hint().unwrap();
+        let hint = vector_hint_from_plan(&rewritten).unwrap();
         assert_eq!(hint.k, 5);
     }
 
@@ -901,8 +1050,8 @@ mod tests {
         let _ = ScanHintRule.rewrite(t1_plan, &context).unwrap();
         assert!(t1_provider.get_vector_search_hint().is_none());
 
-        let _ = ScanHintRule.rewrite(t2_plan, &context).unwrap();
-        let hint = t2_provider.get_vector_search_hint().unwrap();
+        let rewritten = ScanHintRule.rewrite(t2_plan, &context).unwrap().data;
+        let hint = vector_hint_from_plan(&rewritten).unwrap();
         assert_eq!(hint.column_id, 20);
         assert_eq!(hint.k, 5);
     }

--- a/src/query/src/optimizer/scan_hint/vector_search.rs
+++ b/src/query/src/optimizer/scan_hint/vector_search.rs
@@ -602,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vector_hint_is_skipped_for_single_evaluation() {
+    fn test_vector_hint_is_applied_when_single_evaluation_limit_blocks_last_row() {
         let provider = build_dummy_provider(10);
         let source = Arc::new(DefaultTableSource::new(provider));
         let distance = vec_distance_expr(VEC_L2SQ_DISTANCE);
@@ -632,15 +632,20 @@ mod tests {
             .unwrap()
             .data;
         let request = scan_request_from_plan(&rewritten);
+        assert_eq!(request.series_row_selector, None);
         assert_eq!(
-            request.series_row_selector,
-            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: true })
+            request.vector_search,
+            Some(VectorSearchRequest {
+                column_id: 10,
+                query_vector: vec![1.0, 2.0],
+                k: 5,
+                metric: VectorDistanceMetric::L2sq,
+            })
         );
-        assert!(request.vector_search.is_none());
     }
 
     #[test]
-    fn test_single_evaluation_consumes_only_its_vector_hint() {
+    fn test_single_evaluation_limit_keeps_vector_hints_on_both_branches() {
         let provider_a = build_dummy_provider(10);
         let provider_b = build_dummy_provider(20);
         let distance_a = vec_distance_expr_with_query(VEC_L2SQ_DISTANCE, "[1.0, 2.0]");
@@ -702,11 +707,16 @@ mod tests {
         let request_a = scan_request_from_plan(&union.inputs[0]);
         let request_b = scan_request_from_plan(&union.inputs[1]);
 
+        assert_eq!(request_a.series_row_selector, None);
         assert_eq!(
-            request_a.series_row_selector,
-            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: true })
+            request_a.vector_search,
+            Some(VectorSearchRequest {
+                column_id: 10,
+                query_vector: vec![1.0, 2.0],
+                k: 5,
+                metric: VectorDistanceMetric::L2sq,
+            })
         );
-        assert!(request_a.vector_search.is_none());
         assert_eq!(request_b.series_row_selector, None);
         assert_eq!(
             request_b.vector_search,
@@ -720,7 +730,7 @@ mod tests {
 
         // The catalog providers are not mutated; the requests above belong to
         // the two rewritten scan use-sites.
-        assert!(request_b.vector_search != request_a.vector_search);
+        assert_ne!(request_a.vector_search, request_b.vector_search);
     }
 
     #[test]

--- a/src/query/src/optimizer/scan_hint/vector_search.rs
+++ b/src/query/src/optimizer/scan_hint/vector_search.rs
@@ -634,7 +634,7 @@ mod tests {
         let request = scan_request_from_plan(&rewritten);
         assert_eq!(
             request.series_row_selector,
-            Some(store_api::storage::TimeSeriesRowSelector::LastRow)
+            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: false })
         );
         assert!(request.vector_search.is_none());
     }
@@ -704,7 +704,7 @@ mod tests {
 
         assert_eq!(
             request_a.series_row_selector,
-            Some(store_api::storage::TimeSeriesRowSelector::LastRow)
+            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: false })
         );
         assert!(request_a.vector_search.is_none());
         assert_eq!(request_b.series_row_selector, None);

--- a/src/query/src/optimizer/scan_hint/vector_search.rs
+++ b/src/query/src/optimizer/scan_hint/vector_search.rs
@@ -634,7 +634,7 @@ mod tests {
         let request = scan_request_from_plan(&rewritten);
         assert_eq!(
             request.series_row_selector,
-            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: false })
+            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: true })
         );
         assert!(request.vector_search.is_none());
     }
@@ -704,7 +704,7 @@ mod tests {
 
         assert_eq!(
             request_a.series_row_selector,
-            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: false })
+            Some(store_api::storage::TimeSeriesRowSelector::LastRow { after_merge: true })
         );
         assert!(request_a.vector_search.is_none());
         assert_eq!(request_b.series_row_selector, None);

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -82,7 +82,11 @@ pub trait VectorIndexEngine: Send + Sync {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
 pub enum TimeSeriesRowSelector {
     /// Only keep the last row of each time-series.
-    LastRow,
+    #[strum(to_string = "LastRow")]
+    LastRow {
+        /// Whether selection runs after cross-source merge and deduplication.
+        after_merge: bool,
+    },
 }
 
 /// A hint on how to distribute time-series data on the scan output.
@@ -112,11 +116,6 @@ pub struct ScanRequest {
     pub limit: Option<usize>,
     /// Optional hint to select rows from time-series.
     pub series_row_selector: Option<TimeSeriesRowSelector>,
-    /// Whether the row selector must run only after cross-source merge and deduplication.
-    ///
-    /// This is required by instant-derived LastRow scans. Ordinary selector users
-    /// keep the default `false` and may use source-local selector optimization.
-    pub series_row_selector_after_merge: bool,
     /// Optional constraint on the sequence number of the rows to read.
     /// If set, only rows with a sequence number **lesser or equal** to this value
     /// will be returned.
@@ -210,7 +209,10 @@ impl Display for ScanRequest {
                 series_row_selector
             )?;
         }
-        if self.series_row_selector_after_merge {
+        if matches!(
+            self.series_row_selector,
+            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
+        ) {
             write!(
                 f,
                 "{}series_row_selector_after_merge: true",
@@ -335,14 +337,14 @@ mod tests {
         );
 
         let request = ScanRequest {
+            series_row_selector: Some(TimeSeriesRowSelector::LastRow { after_merge: true }),
             snapshot_on_scan: true,
-            series_row_selector_after_merge: true,
             exact_sequence_range: true,
             ..Default::default()
         };
         assert_eq!(
             request.to_string(),
-            "ScanRequest { series_row_selector_after_merge: true, snapshot_on_scan: true, exact_sequence_range: true }"
+            "ScanRequest { series_row_selector: LastRow, series_row_selector_after_merge: true, snapshot_on_scan: true, exact_sequence_range: true }"
         );
 
         let request = ScanRequest {

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -82,7 +82,7 @@ pub trait VectorIndexEngine: Send + Sync {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
 pub enum TimeSeriesRowSelector {
     /// Only keep the last row of each time-series.
-    #[strum(to_string = "LastRow")]
+    #[strum(to_string = "LastRow {{ after_merge: {after_merge} }}")]
     LastRow {
         /// Whether selection runs after cross-source merge and deduplication.
         after_merge: bool,
@@ -207,16 +207,6 @@ impl Display for ScanRequest {
                 "{}series_row_selector: {}",
                 delimiter.as_str(),
                 series_row_selector
-            )?;
-        }
-        if matches!(
-            self.series_row_selector,
-            Some(TimeSeriesRowSelector::LastRow { after_merge: true })
-        ) {
-            write!(
-                f,
-                "{}series_row_selector_after_merge: true",
-                delimiter.as_str()
             )?;
         }
         if let Some(sequence) = &self.memtable_max_sequence {
@@ -344,7 +334,12 @@ mod tests {
         };
         assert_eq!(
             request.to_string(),
-            "ScanRequest { series_row_selector: LastRow, series_row_selector_after_merge: true, snapshot_on_scan: true, exact_sequence_range: true }"
+            "ScanRequest { series_row_selector: LastRow { after_merge: true }, snapshot_on_scan: true, exact_sequence_range: true }"
+        );
+
+        assert_eq!(
+            TimeSeriesRowSelector::LastRow { after_merge: false }.to_string(),
+            "LastRow { after_merge: false }"
         );
 
         let request = ScanRequest {

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -112,6 +112,11 @@ pub struct ScanRequest {
     pub limit: Option<usize>,
     /// Optional hint to select rows from time-series.
     pub series_row_selector: Option<TimeSeriesRowSelector>,
+    /// Whether the row selector must run only after cross-source merge and deduplication.
+    ///
+    /// This is required by instant-derived LastRow scans. Ordinary selector users
+    /// keep the default `false` and may use source-local selector optimization.
+    pub series_row_selector_after_merge: bool,
     /// Optional constraint on the sequence number of the rows to read.
     /// If set, only rows with a sequence number **lesser or equal** to this value
     /// will be returned.
@@ -203,6 +208,13 @@ impl Display for ScanRequest {
                 "{}series_row_selector: {}",
                 delimiter.as_str(),
                 series_row_selector
+            )?;
+        }
+        if self.series_row_selector_after_merge {
+            write!(
+                f,
+                "{}series_row_selector_after_merge: true",
+                delimiter.as_str()
             )?;
         }
         if let Some(sequence) = &self.memtable_max_sequence {
@@ -324,12 +336,13 @@ mod tests {
 
         let request = ScanRequest {
             snapshot_on_scan: true,
+            series_row_selector_after_merge: true,
             exact_sequence_range: true,
             ..Default::default()
         };
         assert_eq!(
             request.to_string(),
-            "ScanRequest { snapshot_on_scan: true, exact_sequence_range: true }"
+            "ScanRequest { series_row_selector_after_merge: true, snapshot_on_scan: true, exact_sequence_range: true }"
         );
 
         let request = ScanRequest {

--- a/tests-integration/src/tests/promql_test.rs
+++ b/tests-integration/src/tests/promql_test.rs
@@ -15,9 +15,14 @@
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use api::v1::value::ValueData;
+use api::v1::{
+    ColumnDataType, ColumnSchema, Row, RowInsertRequest, RowInsertRequests, Rows, SemanticType,
+};
+use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
 use common_query::{Output, OutputData};
 use common_recordbatch::util::collect_batches;
-use datatypes::arrow::array::{Float64Array, Int64Array};
+use datatypes::arrow::array::{Float64Array, Int64Array, StringArray, TimestampMillisecondArray};
 use frontend::instance::Instance;
 use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
 use rstest::rstest;
@@ -944,4 +949,199 @@ async fn anon_promql_ratio_repro(instance: Arc<dyn MockInstance>) {
         "{}",
         whole[0].pretty_print()
     );
+}
+
+#[apply(both_instances_cases)]
+async fn promql_stale_marker_excludes_series_across_flushes(instance: Arc<dyn MockInstance>) {
+    let ins = instance.frontend();
+    let table = "promql_stale_marker";
+    execute_all(
+        &ins,
+        &format!(
+            "CREATE TABLE {table} (\
+                series STRING, \
+                ts TIMESTAMP TIME INDEX, \
+                value DOUBLE, \
+                PRIMARY KEY (series)\
+            ) WITH (sst_format = 'flat')"
+        ),
+        QueryContext::arc(),
+    )
+    .await;
+
+    let rows = |samples: &[(&str, f64, i64)]| Rows {
+        schema: vec![
+            ColumnSchema {
+                column_name: "series".to_string(),
+                datatype: ColumnDataType::String as i32,
+                semantic_type: SemanticType::Tag as i32,
+                ..Default::default()
+            },
+            ColumnSchema {
+                column_name: "ts".to_string(),
+                datatype: ColumnDataType::TimestampMillisecond as i32,
+                semantic_type: SemanticType::Timestamp as i32,
+                ..Default::default()
+            },
+            ColumnSchema {
+                column_name: "value".to_string(),
+                datatype: ColumnDataType::Float64 as i32,
+                semantic_type: SemanticType::Field as i32,
+                ..Default::default()
+            },
+        ],
+        rows: samples
+            .iter()
+            .map(|(series, value, timestamp)| Row {
+                values: vec![
+                    ValueData::StringValue((*series).to_string()).into(),
+                    ValueData::TimestampMillisecondValue(*timestamp).into(),
+                    ValueData::F64Value(*value).into(),
+                ],
+            })
+            .collect(),
+    };
+    let insert = |samples: &[(&str, f64, i64)]| RowInsertRequests {
+        inserts: vec![RowInsertRequest {
+            table_name: table.to_string(),
+            rows: Some(rows(samples)),
+        }],
+    };
+
+    ins.handle_row_inserts(
+        insert(&[("stale", 10.0, 1_000), ("ordinary", 20.0, 1_000)]),
+        QueryContext::arc(),
+        false,
+        false,
+    )
+    .await
+    .unwrap();
+    execute_all(
+        &ins,
+        &format!("ADMIN FLUSH_TABLE('{table}')"),
+        QueryContext::arc(),
+    )
+    .await;
+
+    let ordinary_nan = f64::from_bits(0x7ff8_0000_0000_0000);
+    ins.handle_row_inserts(
+        insert(&[
+            ("stale", f64::from_bits(PROMETHEUS_STALE_NAN_BITS), 2_000),
+            ("ordinary", ordinary_nan, 2_000),
+        ]),
+        QueryContext::arc(),
+        false,
+        false,
+    )
+    .await
+    .unwrap();
+
+    let extract_samples = |batches: common_recordbatch::RecordBatches| {
+        let mut samples = batches
+            .iter()
+            .flat_map(|batch| {
+                let series = batch
+                    .column_by_name("series")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .unwrap();
+                let values = batch
+                    .column_by_name("value")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Float64Array>()
+                    .unwrap();
+                let timestamps = batch
+                    .column_by_name("ts")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .unwrap();
+                (0..batch.num_rows())
+                    .map(|row| {
+                        (
+                            series.value(row).to_string(),
+                            values.value(row),
+                            timestamps.value(row),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        samples.sort_by(|left, right| left.0.cmp(&right.0));
+        samples
+    };
+
+    let raw_output = ins
+        .do_query(
+            &format!("SELECT series, value, ts FROM {table} WHERE ts = 2000"),
+            QueryContext::arc(),
+        )
+        .await
+        .remove(0)
+        .unwrap();
+    let raw_batches = match raw_output.data {
+        OutputData::Stream(stream) => collect_batches(stream).await.unwrap(),
+        OutputData::RecordBatches(recordbatches) => recordbatches,
+        _ => unreachable!(),
+    };
+    let raw_samples = extract_samples(raw_batches);
+    assert_eq!(raw_samples.len(), 2, "{raw_samples:?}");
+    let stale_marker = raw_samples
+        .iter()
+        .find(|(series, _, _)| series == "stale")
+        .unwrap();
+    assert_eq!(stale_marker.1.to_bits(), PROMETHEUS_STALE_NAN_BITS);
+    let ordinary_marker = raw_samples
+        .iter()
+        .find(|(series, _, _)| series == "ordinary")
+        .unwrap();
+    assert_eq!(ordinary_marker.1.to_bits(), ordinary_nan.to_bits());
+
+    // Keep the finite 1000ms sample eligible so a stale marker cannot fall back to it.
+    let query_at = |at| {
+        let time = UNIX_EPOCH.checked_add(Duration::from_millis(at)).unwrap();
+        promql_query_as_batches(
+            ins.clone(),
+            table,
+            None,
+            QueryContext::arc(),
+            time,
+            time,
+            Duration::from_secs(1),
+            Duration::from_secs(3),
+        )
+    };
+    let assert_nan_series = |samples: Vec<(String, f64, i64)>, at| {
+        assert_eq!(samples.len(), 1, "{samples:?}");
+        assert_eq!(samples[0].0, "ordinary", "{samples:?}");
+        assert_eq!(samples[0].2, at, "{samples:?}");
+        assert_eq!(
+            samples[0].1.to_bits(),
+            ordinary_nan.to_bits(),
+            "{samples:?}"
+        );
+    };
+
+    for flush_markers in [false, true] {
+        if flush_markers {
+            execute_all(
+                &ins,
+                &format!("ADMIN FLUSH_TABLE('{table}')"),
+                QueryContext::arc(),
+            )
+            .await;
+        }
+
+        assert_eq!(
+            extract_samples(query_at(1_500).await),
+            vec![
+                ("ordinary".to_string(), 20.0, 1_500),
+                ("stale".to_string(), 10.0, 1_500)
+            ]
+        );
+        assert_nan_series(extract_samples(query_at(2_000).await), 2_000);
+        assert_nan_series(extract_samples(query_at(2_500).await), 2_500);
+    }
 }

--- a/tests-integration/src/tests/promql_test.rs
+++ b/tests-integration/src/tests/promql_test.rs
@@ -963,7 +963,7 @@ async fn promql_stale_marker_excludes_series_across_flushes(instance: Arc<dyn Mo
             "CREATE TABLE {table} (\
                 series STRING, \
                 ts TIMESTAMP TIME INDEX, \
-                value DOUBLE, \
+                val DOUBLE, \
                 PRIMARY KEY (series)\
             ) WITH (sst_format = 'flat')"
         ),
@@ -986,7 +986,7 @@ async fn promql_stale_marker_excludes_series_across_flushes(instance: Arc<dyn Mo
                 ..Default::default()
             },
             ColumnSchema {
-                column_name: "value".to_string(),
+                column_name: "val".to_string(),
                 datatype: ColumnDataType::Float64 as i32,
                 semantic_type: SemanticType::Field as i32,
                 ..Default::default()
@@ -1049,7 +1049,7 @@ async fn promql_stale_marker_excludes_series_across_flushes(instance: Arc<dyn Mo
                 .unwrap();
                 let series = series.as_any().downcast_ref::<StringArray>().unwrap();
                 let values = batch
-                    .column_by_name("value")
+                    .column_by_name("val")
                     .unwrap()
                     .as_any()
                     .downcast_ref::<Float64Array>()
@@ -1077,7 +1077,7 @@ async fn promql_stale_marker_excludes_series_across_flushes(instance: Arc<dyn Mo
 
     let raw_output = ins
         .do_query(
-            &format!("SELECT series, value, ts FROM {table} WHERE ts = 2000"),
+            &format!("SELECT series, val, ts FROM {table} WHERE ts = 2000"),
             QueryContext::arc(),
         )
         .await

--- a/tests-integration/src/tests/promql_test.rs
+++ b/tests-integration/src/tests/promql_test.rs
@@ -23,6 +23,8 @@ use common_query::prometheus::PROMETHEUS_STALE_NAN_BITS;
 use common_query::{Output, OutputData};
 use common_recordbatch::util::collect_batches;
 use datatypes::arrow::array::{Float64Array, Int64Array, StringArray, TimestampMillisecondArray};
+use datatypes::arrow::compute::cast;
+use datatypes::arrow::datatypes::DataType;
 use frontend::instance::Instance;
 use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
 use rstest::rstest;
@@ -1040,12 +1042,12 @@ async fn promql_stale_marker_excludes_series_across_flushes(instance: Arc<dyn Mo
         let mut samples = batches
             .iter()
             .flat_map(|batch| {
-                let series = batch
-                    .column_by_name("series")
-                    .unwrap()
-                    .as_any()
-                    .downcast_ref::<StringArray>()
-                    .unwrap();
+                let series = cast(
+                    batch.column_by_name("series").unwrap().as_ref(),
+                    &DataType::Utf8,
+                )
+                .unwrap();
+                let series = series.as_any().downcast_ref::<StringArray>().unwrap();
                 let values = batch
                     .column_by_name("value")
                     .unwrap()

--- a/tests/cases/distributed/explain/step_aggr_advance.result
+++ b/tests/cases/distributed/explain/step_aggr_advance.result
@@ -429,7 +429,7 @@ tql analyze sum(aggr_optimize_not);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@4 as greptime_timestamp, greptime_value@5 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a", "b", "c", "d"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: true }", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=FinalPartitioned, gby=[greptime_timestamp@0 as greptime_timestamp], aggr=[__sum_state(aggr_optimize_not.greptime_value)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
@@ -437,7 +437,7 @@ tql analyze sum(aggr_optimize_not);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@4 as greptime_timestamp, greptime_value@5 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a", "b", "c", "d"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: true }", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/distributed/explain/step_aggr_advance.result
+++ b/tests/cases/distributed/explain/step_aggr_advance.result
@@ -429,7 +429,7 @@ tql analyze sum(aggr_optimize_not);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@4 as greptime_timestamp, greptime_value@5 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a", "b", "c", "d"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=FinalPartitioned, gby=[greptime_timestamp@0 as greptime_timestamp], aggr=[__sum_state(aggr_optimize_not.greptime_value)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
@@ -437,7 +437,7 @@ tql analyze sum(aggr_optimize_not);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@4 as greptime_timestamp, greptime_value@5 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["a", "b", "c", "d"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/distributed/optimizer/last_value_advance.result
+++ b/tests/cases/distributed/optimizer/last_value_advance.result
@@ -113,7 +113,7 @@ explain analyze
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -165,7 +165,7 @@ explain analyze
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[last_value(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[last_value(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -277,7 +277,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_ProjectionExec: expr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST]@0 as ordered_host, last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST]@1 as last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]@2 as last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_SortPreservingMergeExec: [last_value(t.host) ORDER BY [t.ts ASC NULLS LAST]@0 ASC NULLS LAST] REDACTED
@@ -286,7 +286,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_ProjectionExec: expr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST]@0 as ordered_host, last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST]@1 as last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]@2 as last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_SortPreservingMergeExec: [last_value(t.host) ORDER BY [t.ts ASC NULLS LAST]@0 ASC NULLS LAST] REDACTED
@@ -295,7 +295,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -355,17 +355,17 @@ explain analyze
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -559,17 +559,17 @@ explain analyze
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -648,7 +648,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_ProjectionExec: expr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST]@0 as ordered_host, last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]@1 as last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_SortPreservingMergeExec: [last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST]@0 ASC NULLS LAST] REDACTED
@@ -657,7 +657,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_ProjectionExec: expr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST]@0 as ordered_host, last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]@1 as last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_SortPreservingMergeExec: [last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST]@0 ASC NULLS LAST] REDACTED
@@ -666,7 +666,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+

--- a/tests/cases/standalone/common/promql/instant_last_row.result
+++ b/tests/cases/standalone/common/promql/instant_last_row.result
@@ -1,0 +1,485 @@
+-- Correctness coverage for the instant-selector last-row optimization.
+-- Each TQL EVAL below has distinct values so its chosen physical sample is visible.
+-- The default instant lookback is (T - 300s, T]: exclude its lower bound,
+-- include a sample just inside it and at T, and exclude a future sample.
+CREATE TABLE instant_last_lookback (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_lookback VALUES
+    (700000, 10, 'lower_excluded'),
+    (700001, 11, 'just_inside'),
+    (1000000, 12, 'upper_included'),
+    (1000000, 14, 'future_has_prior'),
+    (1000001, 13, 'future_has_prior');
+
+Affected Rows: 5
+
+ADMIN FLUSH_TABLE('instant_last_lookback');
+
++--------------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_lookback') |
++--------------------------------------------+
+| 0                                          |
++--------------------------------------------+
+
+-- Expected pairs: just_inside=11, upper_included=12, future_has_prior=14.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_lookback;
+
++---------------------+------+------------------+
+| ts                  | val  | series           |
++---------------------+------+------------------+
+| 1970-01-01T00:16:40 | 11.0 | just_inside      |
+| 1970-01-01T00:16:40 | 12.0 | upper_included   |
+| 1970-01-01T00:16:40 | 14.0 | future_has_prior |
++---------------------+------+------------------+
+
+-- An empty table must remain an empty instant vector.
+CREATE TABLE instant_last_empty (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+-- Expected: no rows.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_empty;
+
+++
+++
+
+DROP TABLE instant_last_empty;
+
+Affected Rows: 0
+
+DROP TABLE instant_last_lookback;
+
+Affected Rows: 0
+
+-- Positive offset reads earlier data; negative offset reads later data.  Repeat
+-- the earlier evaluation after a later one to catch a cached instant window.
+CREATE TABLE instant_last_offset (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_offset VALUES
+    (940000, 21, 'offset'),
+    (1000000, 22, 'offset'),
+    (1060000, 23, 'offset');
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('instant_last_offset');
+
++------------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_offset') |
++------------------------------------------+
+| 0                                        |
++------------------------------------------+
+
+-- Expected value: 22.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 22.0 | offset |
++---------------------+------+--------+
+
+-- Expected value: 21 (evaluation time shifted back 60s).
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset offset 60s;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 21.0 | offset |
++---------------------+------+--------+
+
+-- Expected value: 23 (evaluation time shifted forward 60s).
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset offset -60s;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 23.0 | offset |
++---------------------+------+--------+
+
+-- Expected value: 23.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1060, 1060, '1s') instant_last_offset;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:17:40 | 23.0 | offset |
++---------------------+------+--------+
+
+-- Expected value: 22 again, not the later evaluation's value.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 22.0 | offset |
++---------------------+------+--------+
+
+DROP TABLE instant_last_offset;
+
+Affected Rows: 0
+
+-- Put t1 and t2 in one SST. Deleting newest t2 must reveal t1 whether the
+-- Delete is still in the memtable or has been flushed to a newer SST.
+CREATE TABLE instant_last_delete (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_delete VALUES
+    (900000, 31, 'delete'),
+    (1000000, 32, 'delete');
+
+Affected Rows: 2
+
+ADMIN FLUSH_TABLE('instant_last_delete');
+
++------------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_delete') |
++------------------------------------------+
+| 0                                        |
++------------------------------------------+
+
+DELETE FROM instant_last_delete WHERE series = 'delete' AND ts = 1000000;
+
+Affected Rows: 1
+
+-- Expected value: 31; the newest point is a memtable Delete.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 31.0 | delete |
++---------------------+------+--------+
+
+ADMIN FLUSH_TABLE('instant_last_delete');
+
++------------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_delete') |
++------------------------------------------+
+| 0                                        |
++------------------------------------------+
+
+-- Expected value: 31; the Delete is now in an SST.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 31.0 | delete |
++---------------------+------+--------+
+
+-- A same-timestamp memtable overwrite of t1 must win over the old SST value.
+INSERT INTO instant_last_delete VALUES (900000, 33, 'delete');
+
+Affected Rows: 1
+
+-- Expected value: 33.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 33.0 | delete |
++---------------------+------+--------+
+
+-- A newer memtable point must win, and retain that identity after its flush.
+INSERT INTO instant_last_delete VALUES (1010000, 34, 'delete');
+
+Affected Rows: 1
+
+-- Expected value: 34.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1010, 1010, '1s') instant_last_delete;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:50 | 34.0 | delete |
++---------------------+------+--------+
+
+ADMIN FLUSH_TABLE('instant_last_delete');
+
++------------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_delete') |
++------------------------------------------+
+| 0                                        |
++------------------------------------------+
+
+-- Expected value: 33 after flush; it overwrites t1 in an older SST.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:40 | 33.0 | delete |
++---------------------+------+--------+
+
+-- Expected value: 34 after flush.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1010, 1010, '1s') instant_last_delete;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:16:50 | 34.0 | delete |
++---------------------+------+--------+
+
+DROP TABLE instant_last_delete;
+
+Affected Rows: 0
+
+-- Ordinary IEEE NaN is a valid PromQL sample and must not be suppressed.
+CREATE TABLE instant_last_nan (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_nan VALUES (1000000, 'NaN'::DOUBLE, 'ordinary_nan');
+
+Affected Rows: 1
+
+ADMIN FLUSH_TABLE('instant_last_nan');
+
++---------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_nan') |
++---------------------------------------+
+| 0                                     |
++---------------------------------------+
+
+-- Expected value: NaN, with the ordinary_nan series present.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_nan;
+
++---------------------+-----+--------------+
+| ts                  | val | series       |
++---------------------+-----+--------------+
+| 1970-01-01T00:16:40 | NaN | ordinary_nan |
++---------------------+-----+--------------+
+
+DROP TABLE instant_last_nan;
+
+Affected Rows: 0
+
+-- PromQL normalizes to milliseconds; these distinct raw timestamps collide at
+-- 1s. LastRow must preserve the unhinted path's selected samples: 42 and 52.
+CREATE TABLE instant_last_sec (
+    ts TIMESTAMP(0) TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_sec VALUES
+    (0, 61, 'sec'),
+    (1, 62, 'sec'),
+    (2, 63, 'sec');
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('instant_last_sec');
+
++---------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_sec') |
++---------------------------------------+
+| 0                                     |
++---------------------------------------+
+
+-- Expected value: 62 at the native seconds boundary.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_sec;
+
++------+--------+---------------------+
+| val  | series | ts                  |
++------+--------+---------------------+
+| 62.0 | sec    | 1970-01-01T00:00:01 |
++------+--------+---------------------+
+
+CREATE TABLE instant_last_micro (
+    ts TIMESTAMP(6) TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_micro VALUES
+    (999999, 41, 'micro'),
+    (1000000, 42, 'micro'),
+    (1000001, 43, 'micro');
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('instant_last_micro');
+
++-----------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_micro') |
++-----------------------------------------+
+| 0                                       |
++-----------------------------------------+
+
+-- Expected value: 42, matching the unhinted millisecond-normalized path.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_micro;
+
++------+--------+---------------------+
+| val  | series | ts                  |
++------+--------+---------------------+
+| 42.0 | micro  | 1970-01-01T00:00:01 |
++------+--------+---------------------+
+
+CREATE TABLE instant_last_nano (
+    ts TIMESTAMP(9) TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_nano VALUES
+    (999999999, 51, 'nano'),
+    (1000000000, 52, 'nano'),
+    (1000000001, 53, 'nano');
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('instant_last_nano');
+
++----------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_nano') |
++----------------------------------------+
+| 0                                      |
++----------------------------------------+
+
+-- Expected value: 52, matching the unhinted millisecond-normalized path.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_nano;
+
++------+--------+---------------------+
+| val  | series | ts                  |
++------+--------+---------------------+
+| 52.0 | nano   | 1970-01-01T00:00:01 |
++------+--------+---------------------+
+
+DROP TABLE instant_last_sec;
+
+Affected Rows: 0
+
+DROP TABLE instant_last_micro;
+
+Affected Rows: 0
+
+DROP TABLE instant_last_nano;
+
+Affected Rows: 0
+
+-- Range evaluation is a control: range functions need their complete windows,
+-- not a single last row.  At 10s and 20s, [11s] contains two samples.
+CREATE TABLE instant_last_range_control (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+Affected Rows: 0
+
+INSERT INTO instant_last_range_control VALUES
+    (0, 0, 'range'),
+    (10000, 10, 'range'),
+    (20000, 20, 'range');
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('instant_last_range_control');
+
++-------------------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_range_control') |
++-------------------------------------------------+
+| 0                                               |
++-------------------------------------------------+
+
+-- Expected instant values at 0s, 10s, and 20s: 0, 10, and 20.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 20, '10s') instant_last_range_control;
+
++---------------------+------+--------+
+| ts                  | val  | series |
++---------------------+------+--------+
+| 1970-01-01T00:00:00 | 0.0  | range  |
+| 1970-01-01T00:00:10 | 10.0 | range  |
+| 1970-01-01T00:00:20 | 20.0 | range  |
++---------------------+------+--------+
+
+-- Expected last values at 0s, 10s, and 20s: 0, 10, and 20.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 20, '10s') last_over_time(instant_last_range_control[11s]);
+
++---------------------+-----------------------------------+--------+
+| ts                  | prom_last_over_time(ts_range,val) | series |
++---------------------+-----------------------------------+--------+
+| 1970-01-01T00:00:00 | 0.0                               | range  |
+| 1970-01-01T00:00:10 | 10.0                              | range  |
+| 1970-01-01T00:00:20 | 20.0                              | range  |
++---------------------+-----------------------------------+--------+
+
+-- At 10s, rate is 10/11 because counter-zero extrapolation stops at 0s;
+-- at 20s it is 1. The 0s window has only one sample.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 20, '10s') rate(instant_last_range_control[11s]);
+
++---------------------+-----------------------------------------+--------+
+| ts                  | prom_rate(ts_range,val,ts,Int64(11000)) | series |
++---------------------+-----------------------------------------+--------+
+| 1970-01-01T00:00:10 | 0.9090909090909092                      | range  |
+| 1970-01-01T00:00:20 | 1.0                                     | range  |
++---------------------+-----------------------------------------+--------+
+
+-- Expected rate at 20s: 1 from both points in the [11s] window.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (20, 20, '1s') rate(instant_last_range_control[11s]);
+
++---------------------+-----------------------------------------+--------+
+| ts                  | prom_rate(ts_range,val,ts,Int64(11000)) | series |
++---------------------+-----------------------------------------+--------+
+| 1970-01-01T00:00:20 | 1.0                                     | range  |
++---------------------+-----------------------------------------+--------+
+
+DROP TABLE instant_last_range_control;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/instant_last_row.result
+++ b/tests/cases/standalone/common/promql/instant_last_row.result
@@ -408,6 +408,69 @@ DROP TABLE instant_last_nano;
 
 Affected Rows: 0
 
+-- A field selector chooses the val column; it does not filter val. PromQL must
+-- apply the comparison after selecting the latest eligible sample, rather than
+-- falling back to an older sample that satisfies the comparison.
+CREATE TABLE instant_last_field_filter (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    host STRING,
+    instance STRING,
+    PRIMARY KEY (host, instance)
+) ENGINE=mito;
+
+Affected Rows: 0
+
+-- Keep the older matching sample in an SST and the latest non-matching sample
+-- in the memtable. Both timestamps are eligible at 1s.
+INSERT INTO instant_last_field_filter VALUES (900, 10, 'host-a', 'instance-a');
+
+Affected Rows: 1
+
+ADMIN FLUSH_TABLE('instant_last_field_filter');
+
++------------------------------------------------+
+| ADMIN FLUSH_TABLE('instant_last_field_filter') |
++------------------------------------------------+
+| 0                                              |
++------------------------------------------------+
+
+INSERT INTO instant_last_field_filter VALUES (1000, 1, 'host-a', 'instance-a');
+
+Affected Rows: 1
+
+-- Expected: no rows. The selected latest value is 1, so it must not fall back
+-- to the older value 10 merely because that value is greater than 5.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_field_filter{__field__="val"} > 5;
+
+++
+++
+
+-- A value matcher filters the scan before selecting a sample: the older 10
+-- remains eligible, unlike the post-selection comparison above.
+TQL EVAL (1, 1, '1s') instant_last_field_filter{val="10.0"};
+
++---------------------+------+--------+------------+
+| ts                  | val  | host   | instance   |
++---------------------+------+--------+------------+
+| 1970-01-01T00:00:01 | 10.0 | host-a | instance-a |
++---------------------+------+--------+------------+
+
+-- SQL filters rows before aggregation, so the older matching value remains.
+-- Expected value: 10.
+SELECT last_value(val ORDER BY ts) FROM instant_last_field_filter WHERE val > 5;
+
++--------------------------------------------------------------------------------------------------+
+| last_value(instant_last_field_filter.val) ORDER BY [instant_last_field_filter.ts ASC NULLS LAST] |
++--------------------------------------------------------------------------------------------------+
+| 10.0                                                                                             |
++--------------------------------------------------------------------------------------------------+
+
+DROP TABLE instant_last_field_filter;
+
+Affected Rows: 0
+
 -- Range evaluation is a control: range functions need their complete windows,
 -- not a single last row.  At 10s and 20s, [11s] contains two samples.
 CREATE TABLE instant_last_range_control (

--- a/tests/cases/standalone/common/promql/instant_last_row.sql
+++ b/tests/cases/standalone/common/promql/instant_last_row.sql
@@ -1,0 +1,226 @@
+-- Correctness coverage for the instant-selector last-row optimization.
+-- Each TQL EVAL below has distinct values so its chosen physical sample is visible.
+
+-- The default instant lookback is (T - 300s, T]: exclude its lower bound,
+-- include a sample just inside it and at T, and exclude a future sample.
+CREATE TABLE instant_last_lookback (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_lookback VALUES
+    (700000, 10, 'lower_excluded'),
+    (700001, 11, 'just_inside'),
+    (1000000, 12, 'upper_included'),
+    (1000000, 14, 'future_has_prior'),
+    (1000001, 13, 'future_has_prior');
+ADMIN FLUSH_TABLE('instant_last_lookback');
+
+-- Expected pairs: just_inside=11, upper_included=12, future_has_prior=14.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_lookback;
+
+-- An empty table must remain an empty instant vector.
+CREATE TABLE instant_last_empty (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+-- Expected: no rows.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_empty;
+
+DROP TABLE instant_last_empty;
+DROP TABLE instant_last_lookback;
+
+-- Positive offset reads earlier data; negative offset reads later data.  Repeat
+-- the earlier evaluation after a later one to catch a cached instant window.
+CREATE TABLE instant_last_offset (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_offset VALUES
+    (940000, 21, 'offset'),
+    (1000000, 22, 'offset'),
+    (1060000, 23, 'offset');
+ADMIN FLUSH_TABLE('instant_last_offset');
+
+-- Expected value: 22.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset;
+
+-- Expected value: 21 (evaluation time shifted back 60s).
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset offset 60s;
+
+-- Expected value: 23 (evaluation time shifted forward 60s).
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset offset -60s;
+
+-- Expected value: 23.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1060, 1060, '1s') instant_last_offset;
+
+-- Expected value: 22 again, not the later evaluation's value.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_offset;
+
+DROP TABLE instant_last_offset;
+
+-- Put t1 and t2 in one SST. Deleting newest t2 must reveal t1 whether the
+-- Delete is still in the memtable or has been flushed to a newer SST.
+CREATE TABLE instant_last_delete (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_delete VALUES
+    (900000, 31, 'delete'),
+    (1000000, 32, 'delete');
+ADMIN FLUSH_TABLE('instant_last_delete');
+
+DELETE FROM instant_last_delete WHERE series = 'delete' AND ts = 1000000;
+
+-- Expected value: 31; the newest point is a memtable Delete.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
+ADMIN FLUSH_TABLE('instant_last_delete');
+
+-- Expected value: 31; the Delete is now in an SST.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
+-- A same-timestamp memtable overwrite of t1 must win over the old SST value.
+INSERT INTO instant_last_delete VALUES (900000, 33, 'delete');
+
+-- Expected value: 33.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
+-- A newer memtable point must win, and retain that identity after its flush.
+INSERT INTO instant_last_delete VALUES (1010000, 34, 'delete');
+
+-- Expected value: 34.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1010, 1010, '1s') instant_last_delete;
+
+ADMIN FLUSH_TABLE('instant_last_delete');
+
+-- Expected value: 33 after flush; it overwrites t1 in an older SST.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_delete;
+
+-- Expected value: 34 after flush.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1010, 1010, '1s') instant_last_delete;
+
+DROP TABLE instant_last_delete;
+
+-- Ordinary IEEE NaN is a valid PromQL sample and must not be suppressed.
+CREATE TABLE instant_last_nan (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_nan VALUES (1000000, 'NaN'::DOUBLE, 'ordinary_nan');
+ADMIN FLUSH_TABLE('instant_last_nan');
+
+-- Expected value: NaN, with the ordinary_nan series present.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1000, 1000, '1s') instant_last_nan;
+
+DROP TABLE instant_last_nan;
+
+-- PromQL normalizes to milliseconds; these distinct raw timestamps collide at
+-- 1s. LastRow must preserve the unhinted path's selected samples: 42 and 52.
+CREATE TABLE instant_last_sec (
+    ts TIMESTAMP(0) TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_sec VALUES
+    (0, 61, 'sec'),
+    (1, 62, 'sec'),
+    (2, 63, 'sec');
+ADMIN FLUSH_TABLE('instant_last_sec');
+
+-- Expected value: 62 at the native seconds boundary.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_sec;
+
+CREATE TABLE instant_last_micro (
+    ts TIMESTAMP(6) TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_micro VALUES
+    (999999, 41, 'micro'),
+    (1000000, 42, 'micro'),
+    (1000001, 43, 'micro');
+ADMIN FLUSH_TABLE('instant_last_micro');
+
+-- Expected value: 42, matching the unhinted millisecond-normalized path.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_micro;
+
+CREATE TABLE instant_last_nano (
+    ts TIMESTAMP(9) TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_nano VALUES
+    (999999999, 51, 'nano'),
+    (1000000000, 52, 'nano'),
+    (1000000001, 53, 'nano');
+ADMIN FLUSH_TABLE('instant_last_nano');
+
+-- Expected value: 52, matching the unhinted millisecond-normalized path.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_nano;
+
+DROP TABLE instant_last_sec;
+DROP TABLE instant_last_micro;
+DROP TABLE instant_last_nano;
+
+-- Range evaluation is a control: range functions need their complete windows,
+-- not a single last row.  At 10s and 20s, [11s] contains two samples.
+CREATE TABLE instant_last_range_control (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    series STRING PRIMARY KEY
+) ENGINE=mito;
+
+INSERT INTO instant_last_range_control VALUES
+    (0, 0, 'range'),
+    (10000, 10, 'range'),
+    (20000, 20, 'range');
+ADMIN FLUSH_TABLE('instant_last_range_control');
+
+-- Expected instant values at 0s, 10s, and 20s: 0, 10, and 20.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 20, '10s') instant_last_range_control;
+
+-- Expected last values at 0s, 10s, and 20s: 0, 10, and 20.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 20, '10s') last_over_time(instant_last_range_control[11s]);
+
+-- At 10s, rate is 10/11 because counter-zero extrapolation stops at 0s;
+-- at 20s it is 1. The 0s window has only one sample.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (0, 20, '10s') rate(instant_last_range_control[11s]);
+
+-- Expected rate at 20s: 1 from both points in the [11s] window.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (20, 20, '1s') rate(instant_last_range_control[11s]);
+
+DROP TABLE instant_last_range_control;

--- a/tests/cases/standalone/common/promql/instant_last_row.sql
+++ b/tests/cases/standalone/common/promql/instant_last_row.sql
@@ -192,6 +192,38 @@ DROP TABLE instant_last_sec;
 DROP TABLE instant_last_micro;
 DROP TABLE instant_last_nano;
 
+-- A field selector chooses the val column; it does not filter val. PromQL must
+-- apply the comparison after selecting the latest eligible sample, rather than
+-- falling back to an older sample that satisfies the comparison.
+CREATE TABLE instant_last_field_filter (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE,
+    host STRING,
+    instance STRING,
+    PRIMARY KEY (host, instance)
+) ENGINE=mito;
+
+-- Keep the older matching sample in an SST and the latest non-matching sample
+-- in the memtable. Both timestamps are eligible at 1s.
+INSERT INTO instant_last_field_filter VALUES (900, 10, 'host-a', 'instance-a');
+ADMIN FLUSH_TABLE('instant_last_field_filter');
+INSERT INTO instant_last_field_filter VALUES (1000, 1, 'host-a', 'instance-a');
+
+-- Expected: no rows. The selected latest value is 1, so it must not fall back
+-- to the older value 10 merely because that value is greater than 5.
+-- SQLNESS SORT_RESULT 3 1
+TQL EVAL (1, 1, '1s') instant_last_field_filter{__field__="val"} > 5;
+
+-- A value matcher filters the scan before selecting a sample: the older 10
+-- remains eligible, unlike the post-selection comparison above.
+TQL EVAL (1, 1, '1s') instant_last_field_filter{val="10.0"};
+
+-- SQL filters rows before aggregation, so the older matching value remains.
+-- Expected value: 10.
+SELECT last_value(val ORDER BY ts) FROM instant_last_field_filter WHERE val > 5;
+
+DROP TABLE instant_last_field_filter;
+
 -- Range evaluation is a control: range functions need their complete windows,
 -- not a single last row.  At 10s and 20s, [11s] contains two samples.
 CREATE TABLE instant_last_range_control (

--- a/tests/cases/standalone/common/promql/regex.result
+++ b/tests/cases/standalone/common/promql/regex.result
@@ -75,7 +75,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host=~".*"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+
@@ -99,7 +99,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host=~".+"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host != Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host != Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+
@@ -145,7 +145,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host!~".+"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host = Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host = Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/promql/regex.result
+++ b/tests/cases/standalone/common/promql/regex.result
@@ -75,7 +75,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host=~".*"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: true }", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+
@@ -99,7 +99,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host=~".+"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host != Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: true }", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host != Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+
@@ -145,7 +145,7 @@ TQL ANALYZE VERBOSE (0, 0, '1s') test{host!~".+"};
 | 1_| 0_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[1000], time index=[ts] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["host"] REDACTED
 |_|_|_CooperativeExec REDACTED
-|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host = Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
+|_|_|_SeriesScan: region=REDACTED, {"partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: true }", "distribution":"PerSeries", "projection": ["ts", "host", "val"], "filters": ["host = Dictionary(UInt32, Utf8(\"\"))", "ts >= TimestampMillisecond(-299999, None)", "ts <= TimestampMillisecond(0, None)"], "REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/last_value.result
+++ b/tests/cases/standalone/optimizer/last_value.result
@@ -87,7 +87,7 @@ explain analyze
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -139,7 +139,7 @@ explain analyze
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[last_value(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[last_value(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":1, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/last_value_advance.result
+++ b/tests/cases/standalone/optimizer/last_value_advance.result
@@ -113,7 +113,7 @@ explain analyze
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -165,7 +165,7 @@ explain analyze
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[last_value(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[last_value(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":{"count":1, "mem_ranges":0, "files":1, "file_ranges":1}, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -276,7 +276,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_SortPreservingMergeExec: [ordered_host@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[ordered_host@0 ASC NULLS LAST], preserve_REDACTED
@@ -284,7 +284,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_SortPreservingMergeExec: [ordered_host@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[ordered_host@0 ASC NULLS LAST], preserve_REDACTED
@@ -292,7 +292,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -352,17 +352,17 @@ explain analyze
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t.ts) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -556,17 +556,17 @@ explain analyze
 | 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_AggregateExec: mode=Final, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[__last_value_state(t1.ts) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -644,7 +644,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 1_|_SortPreservingMergeExec: [ordered_host@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[ordered_host@0 ASC NULLS LAST], preserve_REDACTED
@@ -652,7 +652,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 | 1_| 2_|_SortPreservingMergeExec: [ordered_host@0 ASC NULLS LAST] REDACTED
 |_|_|_SortExec: expr=[ordered_host@0 ASC NULLS LAST], preserve_REDACTED
@@ -660,7 +660,7 @@ order by ordered_host;
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@0 as host], aggr=[last_value(t1.host) ORDER BY [t1.ts ASC NULLS LAST], last_value(t1.val) ORDER BY [t1.ts ASC NULLS LAST]] REDACTED
-|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow" REDACTED
+|_|_|_SeqScan: region=REDACTED, "partition_count":REDACTED, "selector":"LastRow { after_merge: false }" REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+

--- a/tests/cases/standalone/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.result
@@ -297,7 +297,7 @@ TQL ANALYZE sum(test2);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@0 as greptime_timestamp, greptime_value@1 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["shard"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: true }", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=FinalPartitioned, gby=[greptime_timestamp@0 as greptime_timestamp], aggr=[__sum_state(test2.greptime_value)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
@@ -305,7 +305,7 @@ TQL ANALYZE sum(test2);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@0 as greptime_timestamp, greptime_value@1 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["shard"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow { after_merge: true }", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/tql-explain-analyze/analyze.result
@@ -297,7 +297,7 @@ TQL ANALYZE sum(test2);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@0 as greptime_timestamp, greptime_value@1 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["shard"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 | 1_| 1_|_AggregateExec: mode=FinalPartitioned, gby=[greptime_timestamp@0 as greptime_timestamp], aggr=[__sum_state(test2.greptime_value)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
@@ -305,7 +305,7 @@ TQL ANALYZE sum(test2);
 |_|_|_ProjectionExec: expr=[greptime_timestamp@0 as greptime_timestamp, greptime_value@1 as greptime_value] REDACTED
 |_|_|_PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[greptime_timestamp] REDACTED
 |_|_|_PromSeriesDivideExec: tags=["shard"] REDACTED
-|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "distribution":"PerSeries", "mode":"legacy" REDACTED
+|_|_|_SeriesScan: region=REDACTED, "partition_count":{"count":0, "mem_ranges":0, "files":0, "file_ranges":0}, "selector":"LastRow", "distribution":"PerSeries", "mode":"legacy" REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -204,7 +204,7 @@ case for issue #7913. It writes 8192 series × 20160 samples through remote-writ
 in 1440-sample daily time chunks, flushing after each chunk before running 1d/7d/14d
 TQL selectors. It is not included in the default `all` case set because ingestion
 cost dominates routine CI validation. Commenting `/query-regression heavy` runs
-only this case; `/query-regression` runs the six routine default cases. Manual
+only this case; `/query-regression` runs the seven routine default cases. Manual
 workflow dispatch accepts the `heavy` token to select this case.
 
 ## OTLP trace load scenario
@@ -393,12 +393,12 @@ parquetbench/scanbench` as the read-bench tool against each target's data direct
 
 The workflow runs when an allowlisted repository admin comments
 `/query-regression` on a non-draft PR. It does not rerun on pushes,
-ready-for-review, or reopen events. `/query-regression` runs the six routine
-default cases; `/query-regression heavy` runs only the high-cardinality
-remote-write #7913 case. PR runs build base/candidate once and
-use `--allow-large-fixture`. Manual `workflow_dispatch` runs can pass `all`,
-`heavy`, one case path, or a comma/whitespace-separated list of case paths, and
-can override refs.
+ready-for-review, or reopen events. `/query-regression` runs the seven routine
+default cases, including `promql_instant_last_row_9034`;
+`/query-regression heavy` runs only the high-cardinality remote-write #7913 case.
+PR runs build base/candidate once and use `--allow-large-fixture`. Manual
+`workflow_dispatch` runs can pass `all`, `heavy`, one case path, or a
+comma/whitespace-separated list of case paths, and can override refs.
 
 Comment admission is two workflows. `slash-command-dispatch.yml` uses
 [peter-evans/slash-command-dispatch](https://github.com/peter-evans/slash-command-dispatch)

--- a/tests/perf/fixture-format.md
+++ b/tests/perf/fixture-format.md
@@ -77,7 +77,12 @@ cycles series labels across rows. `series_layout = "timestamp_major"` writes all
 series for one timestamp before advancing to the next timestamp; use it for
 Prometheus-like high-cardinality scrape fixtures where short query windows should
 still contain many raw samples. `timestamp_major` requires `rows_per_sst` to be
-divisible by `series_count`.
+divisible by `series_count`. `per_sst` uses one series selected from the SST
+index. These describe logical generation order. Before either flat or primary-key
+SST format is written, each completed generated batch is physically sorted by
+encoded primary key ascending, timestamp ascending, and sequence descending, as
+required by the Mito Parquet writer; sorting preserves every generated column and
+row, including deterministic-wave values.
 
 `[scenario]` is required. Other scenario variants are intentionally unsupported
 for now, but `scenario.kind` leaves room for future `write_then_query` and

--- a/tests/perf/query_cases/promql_instant_last_row_9034/case.toml
+++ b/tests/perf/query_cases/promql_instant_last_row_9034/case.toml
@@ -1,7 +1,7 @@
 # PromQL instant-selector latency regression coverage for #9034.
 #
 # Instant, range, and aggregate controls cover LastRow latency behavior. The
-# candidate instant query may enable the existing LastRow selector; the range
+# candidate instant query must exercise the existing LastRow selector; the range
 # query must not. This is latency regression coverage only: optimizer and
 # sqlness tests own plan and correctness coverage. Evaluation is 0.7s after the
 # final generated sample (last timestamp = start + 1023 * 0.1s =
@@ -44,7 +44,7 @@ distribution = { kind = "deterministic_wave", min = 0.0, max = 1000.0 }
 
 [[scenario.tables.columns]]
 name = "ts"
-type = "TIMESTAMP(9)"
+type = "TIMESTAMP(3)"
 semantic = "timestamp"
 
 [scenario.layout]
@@ -58,7 +58,7 @@ step_nanos = 100000000
 time_range_layout = "non_overlapping_per_sst"
 series_layout = "timestamp_major"
 
-# Candidate instant query may enable the existing LastRow selector.
+# Candidate instant query must exercise the existing LastRow selector.
 [[scenario.queries]]
 name = "instant_selector_last_row_candidate"
 kind = "tql"

--- a/tests/perf/query_cases/promql_instant_last_row_9034/case.toml
+++ b/tests/perf/query_cases/promql_instant_last_row_9034/case.toml
@@ -1,0 +1,92 @@
+# PromQL instant-selector latency regression coverage for #9034.
+#
+# Instant, range, and aggregate controls cover LastRow latency behavior. The
+# candidate instant query may enable the existing LastRow selector; the range
+# query must not. This is latency regression coverage only: optimizer and
+# sqlness tests own plan and correctness coverage. Evaluation is 0.7s after the
+# final generated sample (last timestamp = start + 1023 * 0.1s =
+# 1704067302.3) and remains inside the default lookback window.
+
+[case]
+name = "promql_instant_last_row_9034"
+description = "PromQL instant selector LastRow latency regression for #9034"
+
+[scenario]
+kind = "direct_readable_sst"
+seed = 9034
+
+[[scenario.tables]]
+database = "public"
+name = "promql_instant_last_row_9034"
+engine = "mito"
+append_mode = true
+sst_format = "flat"
+primary_key = ["host", "instance"]
+time_index = "ts"
+
+[[scenario.tables.columns]]
+name = "host"
+type = "STRING"
+semantic = "tag"
+distribution = { kind = "cardinality", values = 16, prefix = "host" }
+
+[[scenario.tables.columns]]
+name = "instance"
+type = "STRING"
+semantic = "tag"
+distribution = { kind = "cardinality", values = 256, prefix = "instance" }
+
+[[scenario.tables.columns]]
+name = "value"
+type = "DOUBLE"
+semantic = "field"
+distribution = { kind = "deterministic_wave", min = 0.0, max = 1000.0 }
+
+[[scenario.tables.columns]]
+name = "ts"
+type = "TIMESTAMP(9)"
+semantic = "timestamp"
+
+[scenario.layout]
+regions = 1
+sst_count = 64
+rows_per_sst = 4096
+row_group_size = 1024
+series_count = 256
+start_unix_nanos = 1704067200000000000
+step_nanos = 100000000
+time_range_layout = "non_overlapping_per_sst"
+series_layout = "timestamp_major"
+
+# Candidate instant query may enable the existing LastRow selector.
+[[scenario.queries]]
+name = "instant_selector_last_row_candidate"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704067303, 1704067303, '1s') promql_instant_last_row_9034{host=~'host.*'}"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 25
+
+# True range control: this must not enable the LastRow selector.
+[[scenario.queries]]
+name = "range_selector_last_row_control"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704067293, 1704067303, '1s') promql_instant_last_row_9034{host=~'host.*'}"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 25
+
+# This pre-existing aggregate-hint control should return one row per 256 series; it is latency regression coverage, not a result oracle.
+[[scenario.queries]]
+name = "sql_aggregate_last_row_control"
+kind = "sql"
+query = "SELECT host, instance, last_value(value ORDER BY ts ASC) FROM promql_instant_last_row_9034 GROUP BY host, instance"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 25

--- a/tests/perf/test_query_regression_case_selection.py
+++ b/tests/perf/test_query_regression_case_selection.py
@@ -40,6 +40,7 @@ class QueryRegressionCaseSelectionTest(unittest.TestCase):
                 "tests/perf/query_cases/prom_remote_write_mixed_every/case.toml",
                 "tests/perf/query_cases/prom_remote_write_integer_counter/case.toml",
                 "tests/perf/query_cases/promql_range_boundary/case.toml",
+                "tests/perf/query_cases/promql_instant_last_row_9034/case.toml",
             ],
         )
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Supersedes the query-side portion of #8759 with a smaller implementation based on the current scan path.

## What's changed and what's your intention?

PromQL instant queries evaluate one timestamp but currently read every sample in the lookback window before `InstantManipulate` keeps the latest sample per series. This PR passes the existing `TimeSeriesRowSelector::LastRow` hint to each concrete table-scan use site when `InstantManipulate` has `start == end`.

The optimizer now performs one scoped logical-plan rewrite so the hint follows the actual parent path instead of relying on matching traversal order across two passes. It clones each hinted `DummyTableProvider` scan request, which keeps shared providers isolated when instant and range scans coexist in one plan.

Correctness boundaries:

- The instant LastRow hint currently applies only to second/millisecond time indexes. Microsecond and nanosecond tables, including OTLP metrics stored as `TIMESTAMP(9)`, remain on the unhinted path until native timestamp selection semantics are preserved.

- Range evaluations (`start != end`) do not receive the hint.
- Expression subqueries do not inherit an outer instant-query hint; an instant query inside a subquery can establish its own hint.
- Limit/TopK blocks instant LastRow; existing vector hints remain supported on that path. If an eligible scan has competing LastRow/vector hints, they are not combined.
- Existing ordering, per-series distribution, aggregate `last_value`, and vector-only hints remain supported.

### Safe selector-path allowlist

The rule is deliberately scoped to plans emitted by the PromQL planner, not arbitrary logical plans. Between a single-evaluation `InstantManipulate` and a scan, it permits:

- `Sort` only without `fetch` (not TopK), and `SubqueryAlias`.
- `Projection` only for column references, same-name column aliases, or the planner's same-name seconds/milliseconds-to-milliseconds timestamp cast. The planner must preserve time-index and series identity.
- `SeriesDivide`, and `SeriesNormalize` only when `filter_stale_markers == false` (the instant-offset path).
- `TableScan`, subject to the separate attached-predicate and seconds/milliseconds precision checks. Only recognized tag/time scan predicates qualify; field predicates and unsupported expressions do not.

All other nodes—including residual `Filter`, `Limit`, fetching `Sort`, `Union`, `Join`, `Aggregate`, `Window`, and unknown extensions—block the **instant-derived** hint. A blocker remains effective down that path; a nested `InstantManipulate` establishes its own evaluation scope. Existing aggregate hints are handled separately.

Typical eligible chain after predicate pushdown:

```text
InstantManipulate(start == end)
  → [SeriesNormalize(offset, filter_stale_markers=false)]
  → SeriesDivide → Sort(fetch=None)
  → [restricted Projection / SubqueryAlias] → TableScan
```

Examples:

```text
Instant → Filter → Scan           blocked: filtering precedes sample selection
Filter → Instant → Scan           eligible: filtering follows sample selection
Instant → Limit(1) → Sort → Scan   blocked: LIMIT changes the candidate rows
```

For one series with `(ts=100ms, value=10)` and `(ts=900ms, value=1)`, an ascending sort followed by `LIMIT 1` must keep `10`. Applying LastRow below that limit would incorrectly keep `1`. This is a logical-plan composition regression test, not a claim that ordinary PromQL selectors generate that LIMIT chain.

The instant hint selects LastRow after the existing merge/deduplication path, so SST-local shortcuts cannot discard rows needed for deletion or timestamp correctness. The existing aggregate hint retains its behavior.

Verification of the allowlist (`1283629c2cd`):

- `cargo fmt --check`; `cargo check -p query -p promql --tests`.
- `cargo nextest run -p query --features vector_index scan_hint --retries 0`: 47 passed.
- `cargo nextest run -p query -p promql --retries 0`: 927 passed, 2 skipped.
- Built `greptime`; ran `sqlness-runner bare --bins-dir <fresh-binary-dir> --case-dir tests/cases -t instant_last_row`, with and without `--enable-flat-format`: standalone/distributed passed in both formats; expected results unchanged.
- Actual TQL ANALYZE confirms LastRow remains active for ordinary, tag-filtered, offset, seconds, and metric-engine selectors, and absent for range and field-value matchers. Returned-value checks also pass.

Reviewer follow-up (`4f0d92437f8`):

- The performance regression fixture now uses `TIMESTAMP(3)`. Actual plan validation confirms instant LastRow on the candidate only, with range controls unhinted on both revisions.
- Returned-value regressions cover post-selection comparison, a field-value matcher, and filtered SQL `last_value`. SQLness passes in standalone and distributed modes with both primary and flat SST formats.

### Display review and rebase

Rebased onto main `0d5d97e7cb6b979bbd979ab38976664ab8e62bb4`; current revision: `8ab31ab86e97a38149394b77f2887dff3fa75e98`.

Removed the diagnostic display compatibility handling: `LastRow { after_merge: true/false }` is now shown directly, without a separate `series_row_selector_after_merge` field. Regenerated six EXPLAIN/ANALYZE result files (37 selector-string changes only).

Validation after rebase:
- `cargo fmt --check`.
- `cargo nextest run -p query -p promql -p store-api --retries 0`: 1,003 passed, 2 skipped.
- Performance harness case-selection and slash-command Python tests: 3 + 31 passed.
- Fresh debug `greptime` build; 13 selected SQLness cases in each of Basic and Flat formats, across standalone/distributed (26 executions), with no further expected-output changes.

### Performance regression CI (2026-09-09)

**Ordinary instant-query follow-up:** [CI run 34345776369](https://github.com/GreptimeTeam/greptimedb/actions/runs/34345776369) passed on separate branch `perf/pr9034-eval-ci` (`06cac59017e271700ed24ecb0abd32d706ea9339`). That commit only adds benchmark queries; production code is identical to this PR's `8ab31ab86e9`. Base remains `0d5d97e7cb6`.

| Ordinary query (`TQL EVAL`, no ANALYZE output) | Base median / p95 | Candidate median / p95 | Median change |
| --- | ---: | ---: | ---: |
| Instant selector | 94.89 / 98.89 ms | 25.54 / 26.73 ms | **−73.1%** |
| Range control | 104.55 / 107.29 ms | 104.68 / 121.36 ms | +0.1% |

Each query used 3 warmups and 9 measurements per target. Inspected all measured EVAL responses: instant returns 256 identical rows and range returns 2,816 identical rows across both targets and all repetitions. This measures ordinary query execution and normal result serialization through `/v1/sql`, not the Prometheus `/api/v1/query` endpoint. It confirms the gain in this workload does not depend on ANALYZE metrics/plan transfer. The same run's ANALYZE instant median decreased 66.3%; the earlier diagnostic-only measurement below remains separately labelled. No local timing figures are used.

[Run 34337454470](https://github.com/GreptimeTeam/greptimedb/actions/runs/34337454470) **passed**, comparing base `0d5d97e7cb6b979bbd979ab38976664ab8e62bb4` with final candidate `8ab31ab86e97a38149394b77f2887dff3fa75e98` using the optimized `nightly` profile on the CI ECS runner.

The instant and range queries measure **`TQL ANALYZE VERBOSE` end-to-end request latency, not `TQL EVAL`**; the aggregate control is ordinary SQL. Each query has 3 warmups and 9 measured requests per target. Changes below compare the two medians, not paired samples.

| Query | Base median ms | Base p95 ms | Candidate median ms | Candidate p95 ms | Median latency change |
| --- | ---: | ---: | ---: | ---: | ---: |
| instant_selector_last_row_candidate | 100.24 | 133.01 | 34.26 | 35.30 | -65.8% |
| range_selector_last_row_control | 99.97 | 110.15 | 102.28 | 124.90 | +2.3% |
| sql_aggregate_last_row_control | 23.25 | 23.92 | 22.94 | 23.56 | -1.4% |

- Instant-selector median latency fell **65.8%** (100.24 → 34.26 ms). Both controls stayed within the configured +25% regression limit; all three thresholds passed.
- Fixture: `TIMESTAMP(3)`, one region, flat append-mode, 64 SSTs × 4,096 rows (262,144 rows), 256 series, non-overlapping SST time ranges and timestamp-major generation.
- Inspected all measured instant/range plans in the CI JSON: candidate instant uses `LastRow { after_merge: true }`; base instant and both range controls have no LastRow selector. All 54 measured requests succeeded and both targets report zero validation errors. Returned-value correctness is covered separately by the tests above; ANALYZE output is not a row-by-row result oracle.
- Evidence: this run's `query-regression-report` artifact contains `query-regression-summary.md`, the JSON report with samples/plans, fixture metadata and component logs. These are CI measurements for this workload, not a general latency guarantee. No local timing figures are used here, and existing CI runs were not cancelled.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).




