### PR TITLE
chore(deps): switch rskafka to upstream main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12672,7 +12672,7 @@ dependencies = [
 [[package]]
 name = "rskafka"
 version = "0.6.0"
-source = "git+https://github.com/GreptimeTeam/rskafka.git?rev=5f9494104f7b43a619d6c42e2a2082e39a7b72aa#5f9494104f7b43a619d6c42e2a2082e39a7b72aa"
+source = "git+https://github.com/influxdata/rskafka.git?rev=80f42eb15eb9419579a376bdf4411893a7da2728#80f42eb15eb9419579a376bdf4411893a7da2728"
 dependencies = [
  "bytes",
  "chrono",
@@ -12682,7 +12682,7 @@ dependencies = [
  "integer-encoding 4.0.2",
  "lz4",
  "parking_lot 0.12.4",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rsasl",
  "rustls",
  "snap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ futures = "0.3"
 futures-util = "0.3"
 greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "32f467fa2ba2b3588a58381a24af83de09fbb00a" }
 hex = "0.4"
+hostname = "0.4.0"
 http = "1"
 humantime = "2.1"
 humantime-serde = "1.1"
@@ -220,10 +221,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "stream",
     "multipart",
 ] }
-url = "2.3"
-# Branch: feat/request-timeout
-hostname = "0.4.0"
-rskafka = { git = "https://github.com/GreptimeTeam/rskafka.git", rev = "5f9494104f7b43a619d6c42e2a2082e39a7b72aa", features = [
+rskafka = { git = "https://github.com/influxdata/rskafka.git", rev = "80f42eb15eb9419579a376bdf4411893a7da2728", features = [
     "transport-tls",
 ] }
 rstest = "0.25"
@@ -260,6 +258,7 @@ tokio-rustls = { version = "0.26.2", default-features = false }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 toml = "0.8.8"
+url = "2.3"
 # Pin below 0.14.5 to avoid the `connection_timeout_future` "async fn resumed after
 # completion" panic (greptimedb#8265 / grpc-rust#2522). Remove once tonic ships a fix.
 tonic = { version = "0.14, <0.14.5", features = ["tls-aws-lc", "gzip", "zstd"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- https://github.com/influxdata/rskafka/pull/299
- https://github.com/influxdata/rskafka/pull/300

## What's changed and what's your intention?

Our two rskafka changes have now merged into upstream main: returning encoded Kafka response sizes (#299) and extending request timeouts to cover sending requests as well as waiting for responses (#300). We can therefore switch back from the GreptimeTeam fork to upstream.

Pin influxdata/rskafka to 80f42eb15eb9419579a376bdf4411893a7da2728, the merge commit for #300, and retain the transport-tls feature. Update Cargo.lock, including rskafka's rand dependency from 0.9.4 to 0.10.1, and remove the obsolete fork-branch comment. No application code changes are needed.

Validation:
- Passed cargo check --locked --all-targets for common-wal, log-store, common-meta, mito2, meta-srv, tests-integration, and tests-fuzz.
- Passed git diff --check.
- Tests, full formatting, Clippy, unused-dependency checks, and compatibility tests were not run.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
