### PR TITLE
ci(backport): fix issue creation on cherry-pick conflict

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -68,13 +68,16 @@ jobs:
             git checkout -b "${head_branch}" "origin/${release_branch}"
 
             if ! git cherry-pick -x "${MERGE_COMMIT}"; then
-              echo "ERROR: Cherry-pick failed for ${release_branch}. Creating an issue instead."
+              echo "ERROR: Cherry-pick failed for ${release_branch}. Aborting and creating an issue instead."
+              # Abort and clean up first so the repo is back to a sane state,
+              # even if the issue creation below fails.
+              git cherry-pick --abort
+              git checkout -f "${BASE_BRANCH}"
+              git branch -D "${head_branch}"
               gh issue create \
                 --title "Backport failure: PR #${PR_NUMBER} to ${release_branch}" \
                 --body "Cherry-pick of ${MERGE_COMMIT} (PR #${PR_NUMBER}) failed on ${release_branch}. Manual backport required." \
-              git cherry-pick --abort
-              git checkout "${BASE_BRANCH}"
-              git branch -D "${head_branch}"
+                || true
               continue
             fi
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #9028.

## What's changed and what's your intention?

Fixes the conflict path of the Backport workflow, which was broken:

- The `gh issue create` call had a trailing line-continuation \` after `--body`, so the next line (`git cherry-pick --abort`) was parsed as arguments to `gh issue create` (`unknown flag: --abort`). As a result **no issue was created** on conflict, and the cherry-pick was never aborted, leaving the workspace dirty for subsequent targets.
- Now the failure path aborts the cherry-pick and checks out / deletes the branch **first** (with `-f`), so the repo returns to a clean state regardless of whether issue creation succeeds; then it creates the issue, tolerating failure (`|| true`) so one bad target doesn't kill the remaining backport targets.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.