### PR TITLE
feat: add scanbench query suites and structured results

### DIFF
--- a/docs/scanbench.md
+++ b/docs/scanbench.md
@@ -21,12 +21,14 @@ cargo build -p cmd --bin greptime
   --table-dir <TABLE_DIR> \
   [--scanner <seq|unordered|series>] \
   [--scan-config <SCAN_CONFIG_JSON>] \
+  [--scan-configs <SCAN_CONFIGS_JSON>] \
   [--parallelism <N>] \
   [--iterations <N>] \
   [--path-type <bare|data|metadata>] \
   [--force-flat-format] \
   [--enable-wal] \
   [--pprof-file <FLAMEGRAPH_SVG>] \
+  [--result-file <RESULT_JSON>] \
   [--pprof-after-warmup] \
   [--verbose]
 ```
@@ -46,12 +48,19 @@ cargo build -p cmd --bin greptime
   - `unordered`: time-windowed distribution
   - `series`: per-series distribution
 - `--scan-config`: JSON file to tune scan request.
+- `--scan-configs`: JSON array of named scan requests. Each entry is executed
+  exactly once in file order. This conflicts with `--scan-config`; the array
+  length replaces `--iterations`, which must remain at its default value of `1`.
 - `--parallelism`: Simulated scan parallelism. Default: `1`.
 - `--iterations`: Benchmark iterations. Default: `1`.
 - `--path-type`: Region path type (`bare`, `data`, `metadata`). Default: `bare`.
 - `--force-flat-format`: Force reading the region in flat format. Default: disabled.
 - `--enable-wal`: Enable WAL replay when opening the region. Default: disabled. When enabled, scanbench uses the log store configured in the `[wal]` section of the config TOML (raft-engine or Kafka). When disabled or when no WAL is configured, a `NoopLogStore` is used.
 - `--pprof-file`: Output flamegraph path (Unix only).
+- `--result-file`: Write structured benchmark and scanner analyze results as
+  JSON. Existing files are overwritten after all scans complete successfully.
+  Supplying this option collects verbose scanner metrics even without
+  `--verbose`.
 - `--pprof-after-warmup`: Start profiling after the first iteration, using it as a warmup. Requires `--pprof-file`. Default: disabled.
 - `--verbose` / `-v`: Print scanner metrics plus per-partition row counts,
   first-batch latency, total elapsed time, and partition skew. Parquet scanner
@@ -96,6 +105,46 @@ Notes:
 - `filters` is a list of SQL expressions (not full SQL statements), e.g. `"host = 'web-1'"`.
 - `series_row_selector` currently supports only `"last_row"`.
 
+## Multiple Scan Configs
+
+Use `--scan-configs` to run a sequence of different scan requests:
+
+```json
+[
+  {
+    "name": "cold",
+    "projection_names": ["hostname", "usage_user"],
+    "filters": ["hostname = 'host_1'"]
+  },
+  {
+    "name": "hot-001",
+    "projection_names": ["hostname", "usage_user"],
+    "filters": ["hostname = 'host_2'"]
+  }
+]
+```
+
+The array must contain at least one config. `name` is optional; omitted names
+become `query-001`, `query-002`, and so on. Names must be non-empty and unique.
+Scanbench validates every config before starting the benchmark, executes the
+array once in order, and prints both an overall mean and a per-query summary.
+
+With `--pprof-after-warmup`, the first entry is the warmup query and profiling
+starts before the second entry. The warmup query remains part of the reported
+overall statistics.
+
+## Result JSON
+
+`--result-file` writes a versioned JSON document with benchmark settings,
+ordered run results, and overall and per-query summaries. Each run contains its
+normalized config, row and batch counts, setup/scan/total timing, memory sizes,
+per-partition statistics, and verbose scanner explain output. Normalized
+projections use resolved column indexes.
+
+Timing fields end in `_ns` and use nanoseconds. Size fields end in `_bytes`. If
+config validation or any scan fails, scanbench returns the error without writing
+the result file.
+
 ## Examples
 
 Default sequential scan:
@@ -117,6 +166,20 @@ Unordered scan with parallelism:
   --scanner unordered \
   --parallelism 8 \
   --iterations 5
+```
+
+Run 10 different queries once each by placing 10 entries in the JSON array:
+
+```bash
+./target/debug/greptime datanode scanbench \
+  --config /path/to/config.toml \
+  --region-id 1024:0 \
+  --table-dir greptime/public/1024 \
+  --scanner seq \
+  --parallelism 8 \
+  --scan-configs /path/to/scan-configs.json \
+  --result-file /path/to/scanbench-results.json \
+  --verbose
 ```
 
 Series scan with scan config and flamegraph:

--- a/docs/scanbench.md
+++ b/docs/scanbench.md
@@ -53,7 +53,30 @@ cargo build -p cmd --bin greptime
 - `--enable-wal`: Enable WAL replay when opening the region. Default: disabled. When enabled, scanbench uses the log store configured in the `[wal]` section of the config TOML (raft-engine or Kafka). When disabled or when no WAL is configured, a `NoopLogStore` is used.
 - `--pprof-file`: Output flamegraph path (Unix only).
 - `--pprof-after-warmup`: Start profiling after the first iteration, using it as a warmup. Requires `--pprof-file`. Default: disabled.
-- `--verbose` / `-v`: Enable verbose output.
+- `--verbose` / `-v`: Print scanner metrics plus per-partition row counts,
+  first-batch latency, total elapsed time, and partition skew. Parquet scanner
+  metrics also identify the physical prefilter columns and split fetch metrics
+  into `primary_key_io`, `prefilter_io`, and `projection_io`. Prefilter timing
+  separates column read/decode, predicate evaluation, and selection construction.
+
+### Verbose prefilter diagnostics
+
+The `fetch_metrics` object in scanner explain output includes these additional
+fields when prefiltering runs:
+
+- `prefilter_columns_read`: physical columns decoded for predicate cache misses.
+- `prefilter_candidate_rows`, `prefilter_selected_rows`, and
+  `prefilter_filtered_rows`: prefilter selectivity.
+- `prefilter_rows_read` and `prefilter_batches_read`: work actually decoded;
+  these can be lower than candidate rows when the predicate-result cache hits.
+- `prefilter_column_read_elapsed`, `prefilter_filter_eval_elapsed`, and
+  `prefilter_selection_elapsed`: time spent reading/decoding columns, evaluating
+  predicates, and constructing the row selection.
+- `prefilter_result_cache_hits` and `prefilter_result_cache_misses`: reuse of
+  cached predicate masks.
+- `primary_key_io`, `prefilter_io`, and `projection_io`: cache/store requests,
+  bytes, and fetch elapsed time attributed to the three Parquet read phases. The
+  existing top-level fetch fields remain totals across all phases.
 
 ## Scan Config JSON
 

--- a/docs/scanbench.md
+++ b/docs/scanbench.md
@@ -9,7 +9,7 @@ greptime datanode scanbench ...
 ## Build
 
 ```bash
-cargo build -p cmd --bin greptime
+cargo build -p cmd --bin greptime --features dev-tools
 ```
 
 ## Command
@@ -25,7 +25,6 @@ cargo build -p cmd --bin greptime
   [--parallelism <N>] \
   [--iterations <N>] \
   [--path-type <bare|data|metadata>] \
-  [--force-flat-format] \
   [--enable-wal] \
   [--pprof-file <FLAMEGRAPH_SVG>] \
   [--result-file <RESULT_JSON>] \
@@ -54,7 +53,6 @@ cargo build -p cmd --bin greptime
 - `--parallelism`: Simulated scan parallelism. Default: `1`.
 - `--iterations`: Benchmark iterations. Default: `1`.
 - `--path-type`: Region path type (`bare`, `data`, `metadata`). Default: `bare`.
-- `--force-flat-format`: Force reading the region in flat format. Default: disabled.
 - `--enable-wal`: Enable WAL replay when opening the region. Default: disabled. When enabled, scanbench uses the log store configured in the `[wal]` section of the config TOML (raft-engine or Kafka). When disabled or when no WAL is configured, a `NoopLogStore` is used.
 - `--pprof-file`: Output flamegraph path (Unix only).
 - `--result-file`: Write structured benchmark and scanner analyze results as
@@ -63,29 +61,7 @@ cargo build -p cmd --bin greptime
   `--verbose`.
 - `--pprof-after-warmup`: Start profiling after the first iteration, using it as a warmup. Requires `--pprof-file`. Default: disabled.
 - `--verbose` / `-v`: Print scanner metrics plus per-partition row counts,
-  first-batch latency, total elapsed time, and partition skew. Parquet scanner
-  metrics also identify the physical prefilter columns and split fetch metrics
-  into `primary_key_io`, `prefilter_io`, and `projection_io`. Prefilter timing
-  separates column read/decode, predicate evaluation, and selection construction.
-
-### Verbose prefilter diagnostics
-
-The `fetch_metrics` object in scanner explain output includes these additional
-fields when prefiltering runs:
-
-- `prefilter_columns_read`: physical columns decoded for predicate cache misses.
-- `prefilter_candidate_rows`, `prefilter_selected_rows`, and
-  `prefilter_filtered_rows`: prefilter selectivity.
-- `prefilter_rows_read` and `prefilter_batches_read`: work actually decoded;
-  these can be lower than candidate rows when the predicate-result cache hits.
-- `prefilter_column_read_elapsed`, `prefilter_filter_eval_elapsed`, and
-  `prefilter_selection_elapsed`: time spent reading/decoding columns, evaluating
-  predicates, and constructing the row selection.
-- `prefilter_result_cache_hits` and `prefilter_result_cache_misses`: reuse of
-  cached predicate masks.
-- `primary_key_io`, `prefilter_io`, and `projection_io`: cache/store requests,
-  bytes, and fetch elapsed time attributed to the three Parquet read phases. The
-  existing top-level fetch fields remain totals across all phases.
+  first-batch latency, total elapsed time, and partition skew.
 
 ## Scan Config JSON
 
@@ -192,16 +168,6 @@ Series scan with scan config and flamegraph:
   --scanner series \
   --scan-config /path/to/scan-config.json \
   --pprof-file /tmp/scanbench.svg
-```
-
-Force flat-format read:
-
-```bash
-./target/debug/greptime datanode scanbench \
-  --config /path/to/config.toml \
-  --region-id 1024:0 \
-  --table-dir greptime/public/1024 \
-  --force-flat-format
 ```
 
 Scan with WAL replay enabled (uses `[wal]` config from TOML):

--- a/src/cmd/src/datanode/scanbench.rs
+++ b/src/cmd/src/datanode/scanbench.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
 use colored::Colorize;
@@ -46,7 +46,7 @@ use moka::future::CacheBuilder;
 use object_store::manager::ObjectStoreManager;
 use object_store::util::normalize_dir;
 use query::optimizer::parallelize_scan::ParallelizeScan;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use sqlparser::ast::ExprWithAlias as SqlExprWithAlias;
 use sqlparser::dialect::GenericDialect;
@@ -102,8 +102,12 @@ pub struct ScanbenchCommand {
     scanner: String,
 
     /// Path to scan request JSON config file (optional)
-    #[clap(long, value_name = "FILE")]
+    #[clap(long, value_name = "FILE", conflicts_with = "scan_configs")]
     scan_config: Option<PathBuf>,
+
+    /// Path to a JSON array of scan request configs, each executed once
+    #[clap(long, value_name = "FILE", conflicts_with = "scan_config")]
+    scan_configs: Option<PathBuf>,
 
     /// Number of partitions for parallel scan (simulates parallelism)
     #[clap(long, default_value = "1")]
@@ -125,6 +129,10 @@ pub struct ScanbenchCommand {
     #[clap(long, value_name = "FILE")]
     pprof_file: Option<PathBuf>,
 
+    /// Output structured benchmark and analyze results as JSON
+    #[clap(long, value_name = "FILE")]
+    result_file: Option<PathBuf>,
+
     /// Enable WAL replay when opening the region.
     #[clap(long, default_value_t = false)]
     enable_wal: bool,
@@ -135,12 +143,300 @@ pub struct ScanbenchCommand {
 }
 
 /// JSON config for scan request parameters.
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize, Default)]
 struct ScanConfig {
+    name: Option<String>,
     projection: Option<Vec<usize>>,
     projection_names: Option<Vec<String>>,
     filters: Option<Vec<String>>,
     series_row_selector: Option<String>,
+}
+
+struct ScanConfigSet {
+    configs: Vec<ScanConfig>,
+    is_suite: bool,
+}
+
+impl ScanConfigSet {
+    fn run_count(&self, iterations: usize) -> usize {
+        if self.is_suite {
+            self.configs.len()
+        } else {
+            iterations
+        }
+    }
+
+    fn query_index(&self, iteration: usize) -> usize {
+        if self.is_suite { iteration } else { 0 }
+    }
+}
+
+struct ResolvedScanConfig {
+    name: String,
+    projection: Option<Vec<usize>>,
+    filters: Vec<DfExpr>,
+    series_row_selector: Option<TimeSeriesRowSelector>,
+}
+
+struct QueryRunSummary {
+    name: String,
+    runs: u64,
+    total_rows: u64,
+    total_elapsed: Duration,
+}
+
+impl QueryRunSummary {
+    fn new(name: String) -> Self {
+        Self {
+            name,
+            runs: 0,
+            total_rows: 0,
+            total_elapsed: Duration::ZERO,
+        }
+    }
+
+    fn record(&mut self, rows: u64, elapsed: Duration) {
+        self.runs += 1;
+        self.total_rows += rows;
+        self.total_elapsed += elapsed;
+    }
+
+    fn mean_rows(&self) -> u64 {
+        self.total_rows.checked_div(self.runs).unwrap_or_default()
+    }
+
+    fn mean_elapsed(&self) -> Duration {
+        self.total_elapsed
+            .checked_div(self.runs as u32)
+            .unwrap_or_default()
+    }
+}
+
+const RESULT_FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize)]
+struct ScanbenchResult {
+    format_version: u32,
+    started_at_unix_ms: u64,
+    benchmark: BenchmarkMetadata,
+    runs: Vec<ScanRunResult>,
+    summary: BenchmarkResultSummary,
+}
+
+#[derive(Debug, Serialize)]
+struct BenchmarkMetadata {
+    scanner: String,
+    region_id: String,
+    region_id_u64: u64,
+    table_dir: String,
+    path_type: String,
+    parallelism: usize,
+    enable_wal: bool,
+    config_mode: String,
+    run_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct NormalizedScanConfig {
+    name: String,
+    projection: Option<Vec<usize>>,
+    filters: Vec<String>,
+    series_row_selector: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ScanRunResult {
+    iteration: usize,
+    query_index: usize,
+    name: String,
+    config: NormalizedScanConfig,
+    rows: u64,
+    batches: u64,
+    setup_elapsed_ns: u64,
+    scan_elapsed_ns: u64,
+    elapsed_ns: u64,
+    array_mem_size_bytes: u64,
+    estimated_size_bytes: u64,
+    partitions: Vec<PartitionResult>,
+    scanner_explain: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PartitionResult {
+    partition: usize,
+    rows: u64,
+    batches: u64,
+    array_mem_size_bytes: u64,
+    estimated_size_bytes: u64,
+    first_batch_elapsed_ns: Option<u64>,
+    elapsed_ns: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct BenchmarkResultSummary {
+    runs: u64,
+    total_rows: u64,
+    total_elapsed_ns: u64,
+    mean_rows: u64,
+    mean_elapsed_ns: u64,
+    queries: Vec<QueryResultSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct QueryResultSummary {
+    query_index: usize,
+    name: String,
+    runs: u64,
+    total_rows: u64,
+    total_elapsed_ns: u64,
+    mean_rows: u64,
+    mean_elapsed_ns: u64,
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    duration.as_nanos().try_into().unwrap_or(u64::MAX)
+}
+
+fn started_at_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn result_summary(
+    total_rows: u64,
+    total_elapsed: Duration,
+    summaries: &[QueryRunSummary],
+) -> BenchmarkResultSummary {
+    let runs = summaries.iter().map(|summary| summary.runs).sum::<u64>();
+    BenchmarkResultSummary {
+        runs,
+        total_rows,
+        total_elapsed_ns: duration_ns(total_elapsed),
+        mean_rows: total_rows.checked_div(runs).unwrap_or_default(),
+        mean_elapsed_ns: duration_ns(total_elapsed.checked_div(runs as u32).unwrap_or_default()),
+        queries: summaries
+            .iter()
+            .enumerate()
+            .map(|(index, summary)| QueryResultSummary {
+                query_index: index + 1,
+                name: summary.name.clone(),
+                runs: summary.runs,
+                total_rows: summary.total_rows,
+                total_elapsed_ns: duration_ns(summary.total_elapsed),
+                mean_rows: summary.mean_rows(),
+                mean_elapsed_ns: duration_ns(summary.mean_elapsed()),
+            })
+            .collect(),
+    }
+}
+
+async fn write_result_file(path: &PathBuf, result: &ScanbenchResult) -> error::Result<()> {
+    let content = serde_json::to_vec_pretty(result).context(error::SerdeJsonSnafu)?;
+    fs::write(path, content).await.context(error::FileIoSnafu)
+}
+
+fn validate_scan_config_suite(
+    mut configs: Vec<ScanConfig>,
+    iterations: usize,
+) -> error::Result<Vec<ScanConfig>> {
+    if iterations != 1 {
+        return Err(error::IllegalConfigSnafu {
+            msg: format!(
+                "--iterations cannot be used with --scan-configs (got {iterations}); the array length defines the run count"
+            ),
+        }
+        .build());
+    }
+    if configs.is_empty() {
+        return Err(error::IllegalConfigSnafu {
+            msg: "--scan-configs file must contain at least one scan config".to_string(),
+        }
+        .build());
+    }
+
+    let mut names = HashSet::with_capacity(configs.len());
+    for (index, config) in configs.iter_mut().enumerate() {
+        let name = match config.name.take() {
+            Some(name) => {
+                let name = name.trim();
+                if name.is_empty() {
+                    return Err(error::IllegalConfigSnafu {
+                        msg: format!("scan config at index {index} has an empty name"),
+                    }
+                    .build());
+                }
+                name.to_string()
+            }
+            None => format!("query-{:03}", index + 1),
+        };
+        if !names.insert(name.clone()) {
+            return Err(error::IllegalConfigSnafu {
+                msg: format!("duplicate scan config name '{name}' at index {index}"),
+            }
+            .build());
+        }
+        config.name = Some(name);
+    }
+
+    Ok(configs)
+}
+
+fn resolve_series_row_selector(
+    scan_config: &ScanConfig,
+) -> error::Result<Option<TimeSeriesRowSelector>> {
+    match scan_config.series_row_selector.as_deref() {
+        Some("last_row") => Ok(Some(TimeSeriesRowSelector::LastRow)),
+        Some(other) => Err(error::IllegalConfigSnafu {
+            msg: format!("Unknown series_row_selector '{other}'"),
+        }
+        .build()),
+        None => Ok(None),
+    }
+}
+
+fn resolve_scan_configs(
+    config_set: &ScanConfigSet,
+    metadata: &RegionMetadata,
+) -> error::Result<Vec<ResolvedScanConfig>> {
+    config_set
+        .configs
+        .iter()
+        .enumerate()
+        .map(|(index, config)| {
+            let name = config
+                .name
+                .clone()
+                .unwrap_or_else(|| format!("query-{:03}", index + 1));
+            let projection = resolve_projection(config, Some(metadata)).map_err(|err| {
+                error::IllegalConfigSnafu {
+                    msg: format!("invalid scan config at index {index} ('{name}'): {err}"),
+                }
+                .build()
+            })?;
+            let filters = resolve_filters(config, metadata).map_err(|err| {
+                error::IllegalConfigSnafu {
+                    msg: format!("invalid scan config at index {index} ('{name}'): {err}"),
+                }
+                .build()
+            })?;
+            let series_row_selector = resolve_series_row_selector(config).map_err(|err| {
+                error::IllegalConfigSnafu {
+                    msg: format!("invalid scan config at index {index} ('{name}'): {err}"),
+                }
+                .build()
+            })?;
+            Ok(ResolvedScanConfig {
+                name,
+                projection,
+                filters,
+                series_row_selector,
+            })
+        })
+        .collect()
 }
 
 fn resolve_projection(
@@ -399,12 +695,59 @@ fn mock_schema_metadata_manager() -> Arc<SchemaMetadataManager> {
 }
 
 impl ScanbenchCommand {
+    async fn load_scan_config_set(&self) -> error::Result<ScanConfigSet> {
+        match (&self.scan_config, &self.scan_configs) {
+            (Some(_), Some(_)) => Err(error::IllegalConfigSnafu {
+                msg: "--scan-config and --scan-configs are mutually exclusive".to_string(),
+            }
+            .build()),
+            (Some(path), None) => {
+                let content = tokio::fs::read_to_string(path)
+                    .await
+                    .context(error::FileIoSnafu)?;
+                let config =
+                    serde_json::from_str::<ScanConfig>(&content).context(error::SerdeJsonSnafu)?;
+                Ok(ScanConfigSet {
+                    configs: vec![config],
+                    is_suite: false,
+                })
+            }
+            (None, Some(path)) => {
+                if self.iterations != 1 {
+                    return Err(error::IllegalConfigSnafu {
+                        msg: format!(
+                            "--iterations cannot be used with --scan-configs (got {}); the array length defines the run count",
+                            self.iterations
+                        ),
+                    }
+                    .build());
+                }
+                let content = tokio::fs::read_to_string(path)
+                    .await
+                    .context(error::FileIoSnafu)?;
+                let configs = serde_json::from_str::<Vec<ScanConfig>>(&content)
+                    .context(error::SerdeJsonSnafu)?;
+                Ok(ScanConfigSet {
+                    configs: validate_scan_config_suite(configs, self.iterations)?,
+                    is_suite: true,
+                })
+            }
+            (None, None) => Ok(ScanConfigSet {
+                configs: vec![ScanConfig::default()],
+                is_suite: false,
+            }),
+        }
+    }
+
     pub async fn run(&self) -> error::Result<()> {
         if self.verbose {
             common_telemetry::init_default_ut_logging();
         }
 
         println!("{}", "Starting scanbench...".cyan().bold());
+        let benchmark_started_at_unix_ms = started_at_unix_ms();
+
+        let scan_config_set = self.load_scan_config_set().await?;
 
         let region_id = parse_region_id(&self.region_id)?;
         let path_type = parse_path_type(&self.path_type)?;
@@ -501,22 +844,12 @@ impl ScanbenchCommand {
             .context(error::BuildCliSnafu)?;
         println!("{} Region opened", "✓".green());
 
-        // Load scan config
-        let scan_config = if let Some(path) = &self.scan_config {
-            let content = tokio::fs::read_to_string(path)
-                .await
-                .context(error::FileIoSnafu)?;
-            serde_json::from_str::<ScanConfig>(&content).context(error::SerdeJsonSnafu)?
-        } else {
-            ScanConfig::default()
-        };
         let metadata = engine
             .get_metadata(region_id)
             .await
             .map_err(BoxedError::new)
             .context(error::BuildCliSnafu)?;
-        let projection = resolve_projection(&scan_config, Some(&metadata))?;
-        let filters = resolve_filters(&scan_config, &metadata)?;
+        let scan_configs = resolve_scan_configs(&scan_config_set, &metadata)?;
 
         // Build scan request
         let distribution = match self.scanner.as_str() {
@@ -534,24 +867,24 @@ impl ScanbenchCommand {
             }
         };
 
-        let series_row_selector = match scan_config.series_row_selector.as_deref() {
-            Some("last_row") => Some(TimeSeriesRowSelector::LastRow),
-            Some(other) => {
-                return Err(error::IllegalConfigSnafu {
-                    msg: format!("Unknown series_row_selector '{}'", other),
-                }
-                .build());
-            }
-            None => None,
-        };
-
-        println!(
-            "{} Scanner: {}, Parallelism: {}, Iterations: {}",
-            "ℹ".blue(),
-            self.scanner,
-            self.parallelism,
-            self.iterations,
-        );
+        let run_count = scan_config_set.run_count(self.iterations);
+        if scan_config_set.is_suite {
+            println!(
+                "{} Scanner: {}, Parallelism: {}, Queries: {}",
+                "ℹ".blue(),
+                self.scanner,
+                self.parallelism,
+                run_count,
+            );
+        } else {
+            println!(
+                "{} Scanner: {}, Parallelism: {}, Iterations: {}",
+                "ℹ".blue(),
+                self.scanner,
+                self.parallelism,
+                run_count,
+            );
+        }
 
         // Start profiling if pprof_file is specified (unless pprof_after_warmup is set)
         #[cfg(unix)]
@@ -584,12 +917,24 @@ impl ScanbenchCommand {
 
         let mut total_rows_all = 0u64;
         let mut total_elapsed_all = std::time::Duration::ZERO;
+        let mut run_results = Vec::with_capacity(if self.result_file.is_some() {
+            run_count
+        } else {
+            0
+        });
+        let mut query_summaries = scan_configs
+            .iter()
+            .map(|config| QueryRunSummary::new(config.name.clone()))
+            .collect::<Vec<_>>();
+        let collect_scanner_explain = self.verbose || self.result_file.is_some();
 
-        for iteration in 0..self.iterations {
+        for iteration in 0..run_count {
+            let query_index = scan_config_set.query_index(iteration);
+            let scan_config = &scan_configs[query_index];
             let request = ScanRequest {
-                projection: projection.clone(),
-                filters: filters.clone(),
-                series_row_selector,
+                projection: scan_config.projection.clone(),
+                filters: scan_config.filters.clone(),
+                series_row_selector: scan_config.series_row_selector,
                 distribution,
                 ..Default::default()
             };
@@ -642,7 +987,7 @@ impl ScanbenchCommand {
             // Scan all partitions
             let num_partitions = scanner.properties().partitions.len();
             let ctx = QueryScanContext {
-                explain_verbose: self.verbose,
+                explain_verbose: collect_scanner_explain,
             };
             let metrics_set = ExecutionPlanMetricsSet::new();
 
@@ -694,6 +1039,7 @@ impl ScanbenchCommand {
             }
 
             let mut total_rows = 0u64;
+            let mut total_batches = 0u64;
             let mut total_array_mem_size = 0u64;
             let mut total_estimated_size = 0u64;
             let mut partition_stats = Vec::with_capacity(num_partitions);
@@ -708,6 +1054,7 @@ impl ScanbenchCommand {
                     .context(error::BuildCliSnafu)?;
                 let stats = result.context(error::BuildCliSnafu)?;
                 total_rows += stats.rows;
+                total_batches += stats.batches;
                 total_array_mem_size += stats.array_mem_size;
                 total_estimated_size += stats.estimated_size;
                 partition_stats.push(stats);
@@ -717,10 +1064,23 @@ impl ScanbenchCommand {
             let elapsed = start.elapsed();
             total_rows_all += total_rows;
             total_elapsed_all += elapsed;
+            query_summaries[query_index].record(total_rows, elapsed);
+
+            let query_display = if scan_config_set.is_suite {
+                format!(
+                    " [query {}/{}: {}]",
+                    query_index + 1,
+                    scan_configs.len(),
+                    scan_config.name
+                )
+            } else {
+                String::new()
+            };
 
             println!(
-                "  [iter {}] {} rows in {:?} ({} partitions), array_mem_size: {}, estimated_size: {}",
+                "  [iter {}]{} {} rows in {:?} ({} partitions), array_mem_size: {}, estimated_size: {}",
                 iteration + 1,
+                query_display,
                 total_rows.to_string().cyan(),
                 elapsed,
                 num_partitions,
@@ -728,8 +1088,11 @@ impl ScanbenchCommand {
                 format_bytes(total_estimated_size),
             );
 
-            if self.verbose {
+            if collect_scanner_explain {
                 partition_stats.sort_unstable_by_key(|stats| stats.partition);
+            }
+
+            if self.verbose {
                 for stats in &partition_stats {
                     let first_batch = stats
                         .first_batch_elapsed
@@ -770,11 +1133,50 @@ impl ScanbenchCommand {
                         skew,
                     );
                 }
-                println!(
-                    "  {} Scanner explain: {}",
-                    "ℹ".blue(),
-                    VerboseScannerDisplay(scanner.as_ref())
-                );
+            }
+
+            let scanner_explain = if collect_scanner_explain {
+                format!("{}", VerboseScannerDisplay(scanner.as_ref()))
+            } else {
+                String::new()
+            };
+            if self.verbose {
+                println!("  {} Scanner explain: {}", "ℹ".blue(), scanner_explain);
+            }
+
+            if self.result_file.is_some() {
+                let source_config = &scan_config_set.configs[query_index];
+                run_results.push(ScanRunResult {
+                    iteration: iteration + 1,
+                    query_index: query_index + 1,
+                    name: scan_config.name.clone(),
+                    config: NormalizedScanConfig {
+                        name: scan_config.name.clone(),
+                        projection: scan_config.projection.clone(),
+                        filters: source_config.filters.clone().unwrap_or_default(),
+                        series_row_selector: source_config.series_row_selector.clone(),
+                    },
+                    rows: total_rows,
+                    batches: total_batches,
+                    setup_elapsed_ns: duration_ns(setup_elapsed),
+                    scan_elapsed_ns: duration_ns(scan_elapsed),
+                    elapsed_ns: duration_ns(elapsed),
+                    array_mem_size_bytes: total_array_mem_size,
+                    estimated_size_bytes: total_estimated_size,
+                    partitions: partition_stats
+                        .iter()
+                        .map(|stats| PartitionResult {
+                            partition: stats.partition,
+                            rows: stats.rows,
+                            batches: stats.batches,
+                            array_mem_size_bytes: stats.array_mem_size,
+                            estimated_size_bytes: stats.estimated_size,
+                            first_batch_elapsed_ns: stats.first_batch_elapsed.map(duration_ns),
+                            elapsed_ns: duration_ns(stats.elapsed),
+                        })
+                        .collect(),
+                    scanner_explain,
+                });
             }
 
             // Start profiling after the first iteration (warmup) if pprof_after_warmup is set
@@ -835,15 +1237,66 @@ impl ScanbenchCommand {
         }
 
         // Summary
-        if self.iterations > 1 {
-            let avg_elapsed = total_elapsed_all / self.iterations as u32;
-            let avg_rows = total_rows_all / self.iterations as u64;
+        if scan_config_set.is_suite {
+            let avg_elapsed = total_elapsed_all / run_count as u32;
+            let avg_rows = total_rows_all / run_count as u64;
+            println!(
+                "\n{} Overall average: {} rows in {:?} over {} queries",
+                "Summary".green().bold(),
+                avg_rows.to_string().cyan(),
+                avg_elapsed,
+                run_count,
+            );
+            println!("{} Per-query:", "Summary".green().bold());
+            for (index, summary) in query_summaries.iter().enumerate() {
+                println!(
+                    "  [{}] {}: runs={}, mean_rows={}, mean_elapsed={:?}",
+                    index + 1,
+                    summary.name,
+                    summary.runs,
+                    summary.mean_rows(),
+                    summary.mean_elapsed(),
+                );
+            }
+        } else if run_count > 1 {
+            let avg_elapsed = total_elapsed_all / run_count as u32;
+            let avg_rows = total_rows_all / run_count as u64;
             println!(
                 "\n{} Average: {} rows in {:?} over {} iterations",
                 "Summary".green().bold(),
                 avg_rows.to_string().cyan(),
                 avg_elapsed,
-                self.iterations,
+                run_count,
+            );
+        }
+
+        if let Some(result_file) = &self.result_file {
+            let result = ScanbenchResult {
+                format_version: RESULT_FORMAT_VERSION,
+                started_at_unix_ms: benchmark_started_at_unix_ms,
+                benchmark: BenchmarkMetadata {
+                    scanner: self.scanner.clone(),
+                    region_id: self.region_id.clone(),
+                    region_id_u64: region_id.as_u64(),
+                    table_dir: self.table_dir.clone(),
+                    path_type: self.path_type.clone(),
+                    parallelism: self.parallelism,
+                    enable_wal: self.enable_wal,
+                    config_mode: if scan_config_set.is_suite {
+                        "suite".to_string()
+                    } else {
+                        "single".to_string()
+                    },
+                    run_count,
+                },
+                runs: run_results,
+                summary: result_summary(total_rows_all, total_elapsed_all, &query_summaries),
+            };
+            write_result_file(result_file, &result).await?;
+            println!(
+                "{} Results saved to {}",
+                "✓".green(),
+                result_file.display().to_string().cyan()
             );
         }
 
@@ -862,7 +1315,11 @@ mod tests {
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
 
-    use super::{ScanConfig, resolve_filters, resolve_projection};
+    use super::{
+        BenchmarkMetadata, BenchmarkResultSummary, NormalizedScanConfig, PartitionResult,
+        ScanConfig, ScanRunResult, ScanbenchResult, resolve_filters, resolve_projection,
+        validate_scan_config_suite, write_result_file,
+    };
     use crate::error;
 
     #[test]
@@ -880,6 +1337,7 @@ mod tests {
     #[test]
     fn test_resolve_projection_by_indexes() -> error::Result<()> {
         let config = ScanConfig {
+            name: None,
             projection: Some(vec![0, 2]),
             projection_names: None,
             filters: None,
@@ -894,6 +1352,7 @@ mod tests {
     #[test]
     fn test_resolve_projection_by_names_without_metadata() {
         let config = ScanConfig {
+            name: None,
             projection: None,
             projection_names: Some(vec!["cpu".to_string(), "host".to_string()]),
             filters: None,
@@ -910,6 +1369,7 @@ mod tests {
     #[test]
     fn test_resolve_projection_conflict_fields() {
         let config = ScanConfig {
+            name: None,
             projection: Some(vec![0]),
             projection_names: Some(vec!["host".to_string()]),
             filters: None,
@@ -965,6 +1425,7 @@ mod tests {
         let metadata = builder.build().unwrap();
 
         let config = ScanConfig {
+            name: None,
             projection: None,
             projection_names: None,
             filters: Some(vec!["table_id = 1117".to_string()]),
@@ -990,5 +1451,122 @@ mod tests {
             config.filters,
             Some(vec!["host = 'web-1'".to_string(), "cpu > 80".to_string()])
         );
+    }
+
+    #[test]
+    fn test_parse_and_validate_scan_config_suite() {
+        let json = r#"[
+            {"name":" cold ","filters":["host = 'web-1'"]},
+            {"projection_names":["host","cpu"]}
+        ]"#;
+        let configs: Vec<ScanConfig> = serde_json::from_str(json).unwrap();
+        let configs = validate_scan_config_suite(configs, 1).unwrap();
+
+        assert_eq!(2, configs.len());
+        assert_eq!(Some("cold"), configs[0].name.as_deref());
+        assert_eq!(Some("query-002"), configs[1].name.as_deref());
+        assert_eq!(
+            Some(&vec!["host = 'web-1'".to_string()]),
+            configs[0].filters.as_ref()
+        );
+    }
+
+    #[test]
+    fn test_validate_scan_config_suite_rejects_invalid_input() {
+        let empty = validate_scan_config_suite(Vec::new(), 1)
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("at least one"));
+
+        let iterations = validate_scan_config_suite(vec![ScanConfig::default()], 2)
+            .unwrap_err()
+            .to_string();
+        assert!(iterations.contains("--iterations"));
+
+        let configs: Vec<ScanConfig> =
+            serde_json::from_str(r#"[{"name":"query"},{"name":" query "}]"#).unwrap();
+        let duplicate = validate_scan_config_suite(configs, 1)
+            .unwrap_err()
+            .to_string();
+        assert!(duplicate.contains("duplicate"));
+
+        let configs: Vec<ScanConfig> = serde_json::from_str(r#"[{"name":"  "}]"#).unwrap();
+        let blank = validate_scan_config_suite(configs, 1)
+            .unwrap_err()
+            .to_string();
+        assert!(blank.contains("empty name"));
+    }
+
+    #[tokio::test]
+    async fn test_write_result_file_overwrites_complete_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("scanbench-result.json");
+        tokio::fs::write(&path, b"old result").await.unwrap();
+
+        let result = ScanbenchResult {
+            format_version: 1,
+            started_at_unix_ms: 42,
+            benchmark: BenchmarkMetadata {
+                scanner: "seq".to_string(),
+                region_id: "1024:0".to_string(),
+                region_id_u64: RegionId::new(1024, 0).as_u64(),
+                table_dir: "greptime/public/1024".to_string(),
+                path_type: "bare".to_string(),
+                parallelism: 8,
+                enable_wal: false,
+                config_mode: "suite".to_string(),
+                run_count: 1,
+            },
+            runs: vec![ScanRunResult {
+                iteration: 1,
+                query_index: 1,
+                name: "cpu-host-1".to_string(),
+                config: NormalizedScanConfig {
+                    name: "cpu-host-1".to_string(),
+                    projection: Some(vec![1, 2]),
+                    filters: vec!["hostname = 'host_1'".to_string()],
+                    series_row_selector: None,
+                },
+                rows: 100,
+                batches: 2,
+                setup_elapsed_ns: 10,
+                scan_elapsed_ns: 80,
+                elapsed_ns: 90,
+                array_mem_size_bytes: 1024,
+                estimated_size_bytes: 512,
+                partitions: vec![PartitionResult {
+                    partition: 0,
+                    rows: 100,
+                    batches: 2,
+                    array_mem_size_bytes: 1024,
+                    estimated_size_bytes: 512,
+                    first_batch_elapsed_ns: Some(20),
+                    elapsed_ns: 80,
+                }],
+                scanner_explain: "SeqScanExec: prefilter_columns_read=[hostname]".to_string(),
+            }],
+            summary: BenchmarkResultSummary {
+                runs: 1,
+                total_rows: 100,
+                total_elapsed_ns: 90,
+                mean_rows: 100,
+                mean_elapsed_ns: 90,
+                queries: vec![],
+            },
+        };
+
+        write_result_file(&path, &result).await.unwrap();
+        let content = tokio::fs::read(&path).await.unwrap();
+        let actual: serde_json::Value = serde_json::from_slice(&content).unwrap();
+
+        assert_eq!(1, actual["format_version"]);
+        assert_eq!("suite", actual["benchmark"]["config_mode"]);
+        assert_eq!(2, actual["runs"][0]["config"]["projection"][1]);
+        assert_eq!(100, actual["runs"][0]["partitions"][0]["rows"]);
+        assert_eq!(
+            "SeqScanExec: prefilter_columns_read=[hostname]",
+            actual["runs"][0]["scanner_explain"]
+        );
+        assert_eq!(90, actual["summary"]["mean_elapsed_ns"]);
     }
 }

--- a/src/cmd/src/datanode/scanbench.rs
+++ b/src/cmd/src/datanode/scanbench.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use clap::Parser;
 use colored::Colorize;
@@ -70,6 +70,16 @@ impl<T: DisplayAs + ?Sized> fmt::Display for VerboseScannerDisplay<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt_as(DisplayFormatType::Verbose, f)
     }
+}
+
+struct PartitionScanStats {
+    partition: usize,
+    rows: u64,
+    batches: u64,
+    array_mem_size: u64,
+    estimated_size: u64,
+    first_batch_elapsed: Option<Duration>,
+    elapsed: Duration,
 }
 
 /// Scan benchmark command - benchmarks scanning a region directly from storage.
@@ -637,6 +647,8 @@ impl ScanbenchCommand {
             let metrics_set = ExecutionPlanMetricsSet::new();
 
             let mut scan_futures = FuturesUnordered::new();
+            let setup_elapsed = start.elapsed();
+            let scan_start = Instant::now();
 
             for partition_idx in 0..num_partitions {
                 let mut stream = scanner
@@ -645,12 +657,19 @@ impl ScanbenchCommand {
                     .context(error::BuildCliSnafu)?;
 
                 scan_futures.push(tokio::spawn(async move {
+                    let partition_start = Instant::now();
                     let mut rows = 0u64;
+                    let mut batches = 0u64;
                     let mut array_mem_size = 0u64;
                     let mut estimated_size = 0u64;
+                    let mut first_batch_elapsed = None;
                     while let Some(batch_result) = stream.next().await {
                         match batch_result {
                             Ok(batch) => {
+                                if first_batch_elapsed.is_none() {
+                                    first_batch_elapsed = Some(partition_start.elapsed());
+                                }
+                                batches += 1;
                                 rows += batch.num_rows() as u64;
                                 let df_batch = batch.df_record_batch();
                                 array_mem_size += df_batch.get_array_memory_size() as u64;
@@ -662,13 +681,22 @@ impl ScanbenchCommand {
                             }
                         }
                     }
-                    Ok::<(u64, u64, u64), BoxedError>((rows, array_mem_size, estimated_size))
+                    Ok::<PartitionScanStats, BoxedError>(PartitionScanStats {
+                        partition: partition_idx,
+                        rows,
+                        batches,
+                        array_mem_size,
+                        estimated_size,
+                        first_batch_elapsed,
+                        elapsed: partition_start.elapsed(),
+                    })
                 }));
             }
 
             let mut total_rows = 0u64;
             let mut total_array_mem_size = 0u64;
             let mut total_estimated_size = 0u64;
+            let mut partition_stats = Vec::with_capacity(num_partitions);
             while let Some(task) = scan_futures.next().await {
                 let result = task
                     .map_err(|e| {
@@ -678,12 +706,13 @@ impl ScanbenchCommand {
                         ))
                     })
                     .context(error::BuildCliSnafu)?;
-                let (rows, array_mem_size, estimated_size) =
-                    result.context(error::BuildCliSnafu)?;
-                total_rows += rows;
-                total_array_mem_size += array_mem_size;
-                total_estimated_size += estimated_size;
+                let stats = result.context(error::BuildCliSnafu)?;
+                total_rows += stats.rows;
+                total_array_mem_size += stats.array_mem_size;
+                total_estimated_size += stats.estimated_size;
+                partition_stats.push(stats);
             }
+            let scan_elapsed = scan_start.elapsed();
 
             let elapsed = start.elapsed();
             total_rows_all += total_rows;
@@ -700,6 +729,47 @@ impl ScanbenchCommand {
             );
 
             if self.verbose {
+                partition_stats.sort_unstable_by_key(|stats| stats.partition);
+                for stats in &partition_stats {
+                    let first_batch = stats
+                        .first_batch_elapsed
+                        .map(|elapsed| format!("{elapsed:?}"))
+                        .unwrap_or_else(|| "n/a".to_string());
+                    println!(
+                        "    partition {}: rows={}, batches={}, first_batch={}, elapsed={:?}, array_mem_size={}, estimated_size={}",
+                        stats.partition,
+                        stats.rows,
+                        stats.batches,
+                        first_batch,
+                        stats.elapsed,
+                        format_bytes(stats.array_mem_size),
+                        format_bytes(stats.estimated_size),
+                    );
+                }
+                if !partition_stats.is_empty() {
+                    let total_partition_elapsed = partition_stats
+                        .iter()
+                        .map(|stats| stats.elapsed)
+                        .sum::<Duration>();
+                    let mean_partition_elapsed =
+                        total_partition_elapsed / partition_stats.len() as u32;
+                    let max_partition_elapsed = partition_stats
+                        .iter()
+                        .map(|stats| stats.elapsed)
+                        .max()
+                        .unwrap_or_default();
+                    let skew = max_partition_elapsed.as_secs_f64()
+                        / mean_partition_elapsed.as_secs_f64().max(f64::EPSILON);
+                    println!(
+                        "  {} Timing: setup={:?}, scan={:?}, mean_partition={:?}, max_partition={:?}, partition_skew={:.2}x",
+                        "ℹ".blue(),
+                        setup_elapsed,
+                        scan_elapsed,
+                        mean_partition_elapsed,
+                        max_partition_elapsed,
+                        skew,
+                    );
+                }
                 println!(
                     "  {} Scanner explain: {}",
                     "ℹ".blue(),

--- a/src/cmd/src/datanode/scanbench.rs
+++ b/src/cmd/src/datanode/scanbench.rs
@@ -1543,7 +1543,7 @@ mod tests {
                     first_batch_elapsed_ns: Some(20),
                     elapsed_ns: 80,
                 }],
-                scanner_explain: "SeqScanExec: prefilter_columns_read=[hostname]".to_string(),
+                scanner_explain: "SeqScan: region=1024(0)".to_string(),
             }],
             summary: BenchmarkResultSummary {
                 runs: 1,
@@ -1564,7 +1564,7 @@ mod tests {
         assert_eq!(2, actual["runs"][0]["config"]["projection"][1]);
         assert_eq!(100, actual["runs"][0]["partitions"][0]["rows"]);
         assert_eq!(
-            "SeqScanExec: prefilter_columns_read=[hostname]",
+            "SeqScan: region=1024(0)",
             actual["runs"][0]["scanner_explain"]
         );
         assert_eq!(90, actual["summary"]["mean_elapsed_ns"]);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Ports benchmark tooling from `perf/scanbench-scan-metrics`; the query-suite commit is cherry-picked with source attribution.

## What's changed and what's your intention?

Scanbench currently repeats a single scan request. Add `--scan-configs` to execute a JSON array of named requests once in file order, with configuration validation and overall and per-query summaries. Existing single-config iterations remain supported.

Add `--result-file` for versioned JSON results containing normalized scan configs, row and batch counts, setup and scan timing, memory sizes, partition statistics, and scanner explain output. Verbose output also reports first-batch latency and partition skew. Update the usage documentation and result serialization fixture.

This port changes only the benchmark tool and its documentation. It uses the existing scanner metrics on main and excludes the source branch's Mito instrumentation changes. There are no storage or wire-format changes.

Validation:
- `CARGO_PROFILE_DEV_DEBUG=1 cargo nextest run -p cmd --features dev-tools`: 124 tests passed.
- `CARGO_PROFILE_DEV_DEBUG=1 cargo build -p cmd --bin greptime --features dev-tools`: passed.
- `cargo fmt --all -- --check`: passed.
- `CARGO_PROFILE_DEV_DEBUG=1 cargo clippy -p cmd --all-targets --features dev-tools -- -D warnings`: passed.
- CLI smoke checks passed for help, mutually exclusive config flags, suite iteration restrictions, single-config iteration acceptance, and preserving existing result files on failure.
- Full workspace tests and unused-dependency checks have not been run.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
