### PR TITLE
chore: bump release version to v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -942,7 +942,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1664,7 +1664,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -1999,7 +1999,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -2090,7 +2090,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.6",
  "store-api",
- "substrait 1.2.0-beta.2",
+ "substrait 1.2.0",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "common-base"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "anymap2",
@@ -2312,14 +2312,14 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "const_format",
 ]
 
 [[package]]
 name = "common-config"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "bigdecimal 0.4.8",
  "common-error",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-macro",
  "http 1.3.1",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "common-event-recorder"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "common-base",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "greptime-proto",
  "once_cell",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "common-error",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "common-memory-manager"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "common-options"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-base",
  "common-grpc",
@@ -2709,11 +2709,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 
 [[package]]
 name = "common-pprof"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-stream",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "common-session"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "serde",
  "strum 0.27.1",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "common-sql"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "arrow-schema 58.3.0",
  "common-base",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "common-stat"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-base",
  "common-runtime",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "backtrace",
  "common-base",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "client",
  "common-grpc",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "cargo-manifest",
  "const_format",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "common-workload"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "common-telemetry",
  "serde",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -4533,7 +4533,7 @@ checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
 name = "datatypes"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-array 58.3.0",
@@ -5286,7 +5286,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file-engine"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -5423,7 +5423,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flow"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arrow 58.3.0",
@@ -5493,7 +5493,7 @@ dependencies = [
  "sql",
  "store-api",
  "strum 0.27.1",
- "substrait 1.2.0-beta.2",
+ "substrait 1.2.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -5576,7 +5576,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -8002,7 +8002,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "log-query"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -8014,7 +8014,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8339,7 +8339,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8372,7 +8372,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -8471,7 +8471,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -8572,7 +8572,7 @@ dependencies = [
 
 [[package]]
 name = "mito-codec"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "bytes",
@@ -8597,7 +8597,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -9405,7 +9405,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9976,7 +9976,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10036,7 +10036,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0-beta.2",
+ "substrait 1.2.0",
  "table",
  "tokio",
  "tokio-util",
@@ -10371,7 +10371,7 @@ checksum = "e3c406c9e2aa74554e662d2c2ee11cd3e73756988800be7e6f5eddb16fed4699"
 
 [[package]]
 name = "partition"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "async-trait",
@@ -10756,7 +10756,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -10919,7 +10919,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "auth",
  "catalog",
@@ -11259,7 +11259,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -11612,7 +11612,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -11674,7 +11674,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -11745,7 +11745,7 @@ dependencies = [
  "sql",
  "sqlparser",
  "store-api",
- "substrait 1.2.0-beta.2",
+ "substrait 1.2.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -13374,7 +13374,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13514,7 +13514,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "api",
@@ -13868,7 +13868,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arrow-buffer 58.3.0",
@@ -13929,7 +13929,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -14211,7 +14211,7 @@ dependencies = [
 
 [[package]]
 name = "standalone"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "catalog",
@@ -14257,7 +14257,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store-api"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -14450,7 +14450,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -14572,7 +14572,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -14855,7 +14855,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests-fuzz"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -14903,7 +14903,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "1.2.0-beta.2"
+version = "1.2.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -14985,7 +14985,7 @@ dependencies = [
  "sqlx",
  "standalone",
  "store-api",
- "substrait 1.2.0-beta.2",
+ "substrait 1.2.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0-beta.2"
+version = "1.2.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Release #9015; follows merged backports #9023.

## What’s changed and what’s your intention?
Set the workspace version to 1.2.0 for the Stable release and regenerate Cargo.lock using cargo metadata --offline. The diff consists only of 1.2.0-beta.2 → 1.2.0 replacements, including workspace dependency references; no third-party dependencies or product behavior changed.

Validation: cargo metadata --offline --format-version 1; git diff --check; formal tag validation with GITHUB_REF_NAME=v1.2.0 returned v1.2.0. Backport PR #9023 completed with 48 successful checks and 2 skipped.

## PR Checklist
- [x] API changes are backward compatible (no API changes).
- [x] Schema or data changes are backward compatible (no schema/data changes).
- Rustdoc and new unit/integration tests: not applicable to version metadata only.
- Documentation updates: release notes are tracked separately in #9015.