### PR TITLE
feat(mito2): adapt bulk memtable encode threshold to write buffer size

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -898,18 +898,47 @@ mod tests {
     }
 
     #[test]
-    fn test_provider_uses_adaptive_config_for_implicit_bulk_builder() {
-        let config = MitoConfig {
+    fn test_providers_use_isolated_adaptive_configs_for_implicit_bulk_builders() {
+        let small_config = MitoConfig {
             global_write_buffer_size: ReadableSize::gb(8),
             ..Default::default()
         };
-        let provider = MemtableBuilderProvider::new(None, Arc::new(config));
+        let large_config = MitoConfig {
+            global_write_buffer_size: ReadableSize::gb(64),
+            ..Default::default()
+        };
+        let small_provider = MemtableBuilderProvider::new(None, Arc::new(small_config));
+        let large_provider = MemtableBuilderProvider::new(None, Arc::new(large_config));
         let options = RegionOptions::default();
 
-        let builder =
-            provider.bulk_memtable_builder(options.need_dedup(), options.merge_mode(), &options);
+        let small_builder = small_provider.bulk_memtable_builder(
+            options.need_dedup(),
+            options.merge_mode(),
+            &options,
+        );
+        let large_builder = large_provider.bulk_memtable_builder(
+            options.need_dedup(),
+            options.merge_mode(),
+            &options,
+        );
+        let another_small_builder = small_provider.bulk_memtable_builder(
+            options.need_dedup(),
+            options.merge_mode(),
+            &options,
+        );
 
-        assert_eq!(256 * 1024 * 1024, builder.config().encode_bytes_threshold);
+        assert_eq!(
+            256 * 1024 * 1024,
+            small_builder.config().encode_bytes_threshold
+        );
+        assert_eq!(
+            512 * 1024 * 1024,
+            large_builder.config().encode_bytes_threshold
+        );
+        assert_eq!(
+            256 * 1024 * 1024,
+            another_small_builder.config().encode_bytes_threshold
+        );
     }
 
     #[test]

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -14,7 +14,7 @@
 
 //! Memtables are write buffers for regions.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -31,12 +31,12 @@ use mito_codec::row_converter::{PrimaryKeyCodec, build_primary_key_codec};
 use snafu::ensure;
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
-use store_api::storage::{ColumnId, SequenceNumber, SequenceRange};
+use store_api::storage::{ColumnId, RegionId, SequenceNumber, SequenceRange};
 
 use crate::config::MitoConfig;
 use crate::error::{InvalidRegionOptionsSnafu, Result, UnsupportedOperationSnafu};
 use crate::flush::WriteBufferManagerRef;
-use crate::memtable::bulk::{BulkMemtableBuilder, CompactDispatcher};
+use crate::memtable::bulk::{BulkMemtableBuilder, BulkMemtableConfig, CompactDispatcher};
 use crate::memtable::time_series::TimeSeriesMemtableBuilder;
 use crate::metrics::WRITE_BUFFER_BYTES;
 use crate::read::Batch;
@@ -398,6 +398,7 @@ impl Drop for AllocTracker {
 pub(crate) struct MemtableBuilderProvider {
     write_buffer_manager: Option<WriteBufferManagerRef>,
     config: Arc<MitoConfig>,
+    default_bulk_memtable_config: BulkMemtableConfig,
     compact_dispatcher: Arc<CompactDispatcher>,
 }
 
@@ -428,12 +429,29 @@ impl MemtableBuilderProvider {
     ) -> Self {
         let compact_dispatcher =
             Arc::new(CompactDispatcher::new(config.max_background_compactions));
+        let default_bulk_memtable_config = BulkMemtableConfig::default_for_write_buffer_size(
+            config.global_write_buffer_size.as_bytes() as usize,
+        );
 
         Self {
             write_buffer_manager,
             config,
+            default_bulk_memtable_config,
             compact_dispatcher,
         }
+    }
+
+    /// Parses region options with this provider's default bulk memtable config.
+    pub(crate) fn parse_options(
+        &self,
+        region_id: RegionId,
+        options: &HashMap<String, String>,
+    ) -> Result<RegionOptions> {
+        RegionOptions::try_from_options_with_bulk_config(
+            region_id,
+            options,
+            &self.default_bulk_memtable_config,
+        )
     }
 
     pub(crate) fn builder_for_options(&self, options: &RegionOptions) -> MemtableBuilderRef {
@@ -495,6 +513,7 @@ impl MemtableBuilderProvider {
             !dedup, // append_mode: true if not dedup, false if dedup
             merge_mode,
         )
+        .with_config(self.default_bulk_memtable_config.clone())
         .with_row_group_size(options.row_group_size())
         .with_compact_dispatcher(self.compact_dispatcher.clone());
 
@@ -790,12 +809,15 @@ impl MemtableRange {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
+    use common_base::readable_size::ReadableSize;
     use common_error::ext::WhateverResult;
     use datatypes::prelude::ConcreteDataType;
     use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
     use store_api::metadata::RegionMetadataBuilder;
+    use store_api::storage::RegionId;
 
     use super::*;
     use crate::flush::{WriteBufferManager, WriteBufferManagerImpl};
@@ -873,6 +895,65 @@ mod tests {
             provider.bulk_memtable_builder(options.need_dedup(), options.merge_mode(), &options);
 
         assert_eq!(&config, builder.config());
+    }
+
+    #[test]
+    fn test_provider_uses_adaptive_config_for_implicit_bulk_builder() {
+        let config = MitoConfig {
+            global_write_buffer_size: ReadableSize::gb(8),
+            ..Default::default()
+        };
+        let provider = MemtableBuilderProvider::new(None, Arc::new(config));
+        let options = RegionOptions::default();
+
+        let builder =
+            provider.bulk_memtable_builder(options.need_dedup(), options.merge_mode(), &options);
+
+        assert_eq!(256 * 1024 * 1024, builder.config().encode_bytes_threshold);
+    }
+
+    #[test]
+    fn test_provider_parses_bulk_memtable_with_adaptive_config() {
+        let config = MitoConfig {
+            global_write_buffer_size: ReadableSize::gb(8),
+            ..Default::default()
+        };
+        let provider = MemtableBuilderProvider::new(None, Arc::new(config));
+        let options = HashMap::from([("memtable.type".to_string(), "bulk".to_string())]);
+
+        let options = provider
+            .parse_options(RegionId::new(0, 0), &options)
+            .unwrap();
+
+        let Some(MemtableOptions::Bulk(config)) = options.memtable else {
+            panic!("expected bulk memtable options");
+        };
+        assert_eq!(256 * 1024 * 1024, config.encode_bytes_threshold);
+    }
+
+    #[test]
+    fn test_provider_preserves_explicit_bulk_encode_bytes_threshold() {
+        let config = MitoConfig {
+            global_write_buffer_size: ReadableSize::gb(8),
+            ..Default::default()
+        };
+        let provider = MemtableBuilderProvider::new(None, Arc::new(config));
+        let options = HashMap::from([
+            ("memtable.type".to_string(), "bulk".to_string()),
+            (
+                "memtable.bulk.encode_bytes_threshold".to_string(),
+                "13".to_string(),
+            ),
+        ]);
+
+        let options = provider
+            .parse_options(RegionId::new(0, 0), &options)
+            .unwrap();
+
+        let Some(MemtableOptions::Bulk(config)) = options.memtable else {
+            panic!("expected bulk memtable options");
+        };
+        assert_eq!(13, config.encode_bytes_threshold);
     }
 
     #[test]

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -1654,20 +1654,20 @@ mod tests {
 
     #[test]
     fn test_adaptive_encode_bytes_threshold() {
-        // Below the lower bound: clamped to the default 64MB.
+        // Below the lower bound: clamped to the default 64 MiB.
         assert_eq!(
             DEFAULT_ENCODE_BYTES_THRESHOLD,
-            adaptive_encode_bytes_threshold(1024 * 1024 * 1024) // 1GB / 32 = 32MB
+            adaptive_encode_bytes_threshold(1024 * 1024 * 1024) // 1 GiB / 32 = 32 MiB
         );
         // In range: global_write_buffer_size / 32.
         assert_eq!(
             256 * 1024 * 1024,
-            adaptive_encode_bytes_threshold(8 * 1024 * 1024 * 1024) // 8GB / 32 = 256MB
+            adaptive_encode_bytes_threshold(8 * 1024 * 1024 * 1024) // 8 GiB / 32 = 256 MiB
         );
-        // Above the upper bound: clamped to 512MB.
+        // Above the upper bound: clamped to 512 MiB.
         assert_eq!(
             MAX_ENCODE_BYTES_THRESHOLD,
-            adaptive_encode_bytes_threshold(64 * 1024 * 1024 * 1024) // 64GB / 32 = 2GB
+            adaptive_encode_bytes_threshold(64 * 1024 * 1024 * 1024) // 64 GiB / 32 = 2 GiB
         );
     }
 

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -112,6 +112,13 @@ fn adaptive_encode_bytes_threshold(global_write_buffer_bytes: usize) -> usize {
         .clamp(DEFAULT_ENCODE_BYTES_THRESHOLD, MAX_ENCODE_BYTES_THRESHOLD)
 }
 
+fn resolve_encode_bytes_threshold(
+    global_write_buffer_bytes: usize,
+    override_value: Option<usize>,
+) -> usize {
+    override_value.unwrap_or_else(|| adaptive_encode_bytes_threshold(global_write_buffer_bytes))
+}
+
 /// Returns the default bytes threshold for encoding parts.
 fn default_encode_bytes_threshold() -> usize {
     ENCODE_BYTES_THRESHOLD_OVERRIDE.unwrap_or(DEFAULT_ENCODE_BYTES_THRESHOLD)
@@ -152,8 +159,10 @@ impl BulkMemtableConfig {
     /// Returns the default config adapted to `global_write_buffer_bytes`.
     pub(crate) fn default_for_write_buffer_size(global_write_buffer_bytes: usize) -> Self {
         Self {
-            encode_bytes_threshold: ENCODE_BYTES_THRESHOLD_OVERRIDE
-                .unwrap_or_else(|| adaptive_encode_bytes_threshold(global_write_buffer_bytes)),
+            encode_bytes_threshold: resolve_encode_bytes_threshold(
+                global_write_buffer_bytes,
+                *ENCODE_BYTES_THRESHOLD_OVERRIDE,
+            ),
             ..Default::default()
         }
     }
@@ -1655,6 +1664,14 @@ mod tests {
         assert_eq!(
             MAX_ENCODE_BYTES_THRESHOLD,
             adaptive_encode_bytes_threshold(64 * 1024 * 1024 * 1024) // 64 GiB / 32 = 2 GiB
+        );
+    }
+
+    #[test]
+    fn test_resolve_encode_bytes_threshold_prefers_override() {
+        assert_eq!(
+            13,
+            resolve_encode_bytes_threshold(8 * 1024 * 1024 * 1024, Some(13))
         );
     }
 

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -105,36 +105,16 @@ static ENCODE_BYTES_THRESHOLD_OVERRIDE: LazyLock<Option<usize>> = LazyLock::new(
         .and_then(|v| v.parse().ok())
 });
 
-/// Global write buffer size in bytes used to adapt the default encode bytes
-/// threshold. Set on engine start; 0 means uninitialized (e.g. in tests) and
-/// falls back to [DEFAULT_ENCODE_BYTES_THRESHOLD].
-static GLOBAL_WRITE_BUFFER_BYTES: AtomicUsize = AtomicUsize::new(0);
-
-/// Sets the global write buffer size used to derive the default encode bytes
-/// threshold for bulk memtables.
-pub(crate) fn set_global_write_buffer_bytes(bytes: usize) {
-    GLOBAL_WRITE_BUFFER_BYTES.store(bytes, Ordering::Relaxed);
-}
-
 /// Computes the encode bytes threshold adapted to the global write buffer size:
-/// `max(64MB, min(global_write_buffer_size / 32, 512MB))`.
+/// `max(64 MiB, min(global_write_buffer_size / 32, 512 MiB))`.
 fn adaptive_encode_bytes_threshold(global_write_buffer_bytes: usize) -> usize {
     (global_write_buffer_bytes / ENCODE_BYTES_THRESHOLD_DIVISOR)
         .clamp(DEFAULT_ENCODE_BYTES_THRESHOLD, MAX_ENCODE_BYTES_THRESHOLD)
 }
 
 /// Returns the default bytes threshold for encoding parts.
-/// `GREPTIME_BULK_ENCODE_BYTES_THRESHOLD` takes precedence if set; otherwise the
-/// threshold adapts to the global write buffer size.
 fn default_encode_bytes_threshold() -> usize {
-    if let Some(threshold) = *ENCODE_BYTES_THRESHOLD_OVERRIDE {
-        return threshold;
-    }
-    let buffer_bytes = GLOBAL_WRITE_BUFFER_BYTES.load(Ordering::Relaxed);
-    if buffer_bytes == 0 {
-        return DEFAULT_ENCODE_BYTES_THRESHOLD;
-    }
-    adaptive_encode_bytes_threshold(buffer_bytes)
+    ENCODE_BYTES_THRESHOLD_OVERRIDE.unwrap_or(DEFAULT_ENCODE_BYTES_THRESHOLD)
 }
 
 /// Configuration for bulk memtable.
@@ -148,9 +128,7 @@ pub struct BulkMemtableConfig {
     /// Row threshold for encoding parts.
     #[serde_as(as = "DisplayFromStr")]
     pub encode_row_threshold: usize,
-    /// Bytes threshold for encoding parts. Defaults to an adaptive value derived
-    /// from the global write buffer size; `GREPTIME_BULK_ENCODE_BYTES_THRESHOLD`
-    /// overrides the default.
+    /// Bytes threshold for encoding parts.
     #[serde_as(as = "DisplayFromStr")]
     pub encode_bytes_threshold: usize,
     /// Maximum number of groups for parallel merging.
@@ -171,6 +149,15 @@ impl Default for BulkMemtableConfig {
 }
 
 impl BulkMemtableConfig {
+    /// Returns the default config adapted to `global_write_buffer_bytes`.
+    pub(crate) fn default_for_write_buffer_size(global_write_buffer_bytes: usize) -> Self {
+        Self {
+            encode_bytes_threshold: ENCODE_BYTES_THRESHOLD_OVERRIDE
+                .unwrap_or_else(|| adaptive_encode_bytes_threshold(global_write_buffer_bytes)),
+            ..Default::default()
+        }
+    }
+
     fn sanitize(mut self) -> Self {
         if self.merge_threshold == 0 {
             self.merge_threshold = DEFAULT_MERGE_THRESHOLD;

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -92,14 +92,50 @@ pub(crate) static ENCODE_ROW_THRESHOLD: LazyLock<usize> = LazyLock::new(|| {
 /// Default bytes threshold for encoding.
 const DEFAULT_ENCODE_BYTES_THRESHOLD: usize = 64 * 1024 * 1024;
 
-/// Bytes threshold for encoding parts. Configurable via `GREPTIME_BULK_ENCODE_BYTES_THRESHOLD`.
-/// When estimated bytes exceed this threshold, parts are encoded as EncodedBulkPart.
-static ENCODE_BYTES_THRESHOLD: LazyLock<usize> = LazyLock::new(|| {
-    env_usize(
-        "GREPTIME_BULK_ENCODE_BYTES_THRESHOLD",
-        DEFAULT_ENCODE_BYTES_THRESHOLD,
-    )
+/// Maximum bytes threshold for encoding when adapting to the write buffer size.
+const MAX_ENCODE_BYTES_THRESHOLD: usize = 512 * 1024 * 1024;
+
+/// Divisor to derive the encode bytes threshold from the global write buffer size.
+const ENCODE_BYTES_THRESHOLD_DIVISOR: usize = 32;
+
+/// Optional bytes threshold override from `GREPTIME_BULK_ENCODE_BYTES_THRESHOLD`.
+static ENCODE_BYTES_THRESHOLD_OVERRIDE: LazyLock<Option<usize>> = LazyLock::new(|| {
+    std::env::var("GREPTIME_BULK_ENCODE_BYTES_THRESHOLD")
+        .ok()
+        .and_then(|v| v.parse().ok())
 });
+
+/// Global write buffer size in bytes used to adapt the default encode bytes
+/// threshold. Set on engine start; 0 means uninitialized (e.g. in tests) and
+/// falls back to [DEFAULT_ENCODE_BYTES_THRESHOLD].
+static GLOBAL_WRITE_BUFFER_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Sets the global write buffer size used to derive the default encode bytes
+/// threshold for bulk memtables.
+pub(crate) fn set_global_write_buffer_bytes(bytes: usize) {
+    GLOBAL_WRITE_BUFFER_BYTES.store(bytes, Ordering::Relaxed);
+}
+
+/// Computes the encode bytes threshold adapted to the global write buffer size:
+/// `max(64MB, min(global_write_buffer_size / 32, 512MB))`.
+fn adaptive_encode_bytes_threshold(global_write_buffer_bytes: usize) -> usize {
+    (global_write_buffer_bytes / ENCODE_BYTES_THRESHOLD_DIVISOR)
+        .clamp(DEFAULT_ENCODE_BYTES_THRESHOLD, MAX_ENCODE_BYTES_THRESHOLD)
+}
+
+/// Returns the default bytes threshold for encoding parts.
+/// `GREPTIME_BULK_ENCODE_BYTES_THRESHOLD` takes precedence if set; otherwise the
+/// threshold adapts to the global write buffer size.
+fn default_encode_bytes_threshold() -> usize {
+    if let Some(threshold) = *ENCODE_BYTES_THRESHOLD_OVERRIDE {
+        return threshold;
+    }
+    let buffer_bytes = GLOBAL_WRITE_BUFFER_BYTES.load(Ordering::Relaxed);
+    if buffer_bytes == 0 {
+        return DEFAULT_ENCODE_BYTES_THRESHOLD;
+    }
+    adaptive_encode_bytes_threshold(buffer_bytes)
+}
 
 /// Configuration for bulk memtable.
 #[serde_as]
@@ -112,7 +148,9 @@ pub struct BulkMemtableConfig {
     /// Row threshold for encoding parts.
     #[serde_as(as = "DisplayFromStr")]
     pub encode_row_threshold: usize,
-    /// Bytes threshold for encoding parts.
+    /// Bytes threshold for encoding parts. Defaults to an adaptive value derived
+    /// from the global write buffer size; `GREPTIME_BULK_ENCODE_BYTES_THRESHOLD`
+    /// overrides the default.
     #[serde_as(as = "DisplayFromStr")]
     pub encode_bytes_threshold: usize,
     /// Maximum number of groups for parallel merging.
@@ -125,7 +163,7 @@ impl Default for BulkMemtableConfig {
         Self {
             merge_threshold: *MERGE_THRESHOLD,
             encode_row_threshold: *ENCODE_ROW_THRESHOLD,
-            encode_bytes_threshold: *ENCODE_BYTES_THRESHOLD,
+            encode_bytes_threshold: default_encode_bytes_threshold(),
             max_merge_groups: *MAX_MERGE_GROUPS,
         }
         .sanitize()
@@ -1612,6 +1650,25 @@ mod tests {
 
         converter.append_key_values(&key_values)?;
         converter.convert()
+    }
+
+    #[test]
+    fn test_adaptive_encode_bytes_threshold() {
+        // Below the lower bound: clamped to the default 64MB.
+        assert_eq!(
+            DEFAULT_ENCODE_BYTES_THRESHOLD,
+            adaptive_encode_bytes_threshold(1024 * 1024 * 1024) // 1GB / 32 = 32MB
+        );
+        // In range: global_write_buffer_size / 32.
+        assert_eq!(
+            256 * 1024 * 1024,
+            adaptive_encode_bytes_threshold(8 * 1024 * 1024 * 1024) // 8GB / 32 = 256MB
+        );
+        // Above the upper bound: clamped to 512MB.
+        assert_eq!(
+            MAX_ENCODE_BYTES_THRESHOLD,
+            adaptive_encode_bytes_threshold(64 * 1024 * 1024 * 1024) // 64GB / 32 = 2GB
+        );
     }
 
     #[test]

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -237,7 +237,10 @@ impl RegionOpener {
     /// Parses and sets options for the region.
     pub(crate) fn parse_options(self, options: HashMap<String, String>) -> Result<Self> {
         let region_id = self.region_id;
-        self.options(RegionOptions::try_from_options(region_id, &options)?)
+        let options = self
+            .memtable_builder_provider
+            .parse_options(region_id, &options)?;
+        self.options(options)
     }
 
     /// Sets the replay checkpoint for the region.

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -32,7 +32,9 @@ use store_api::codec::PrimaryKeyEncoding;
 use store_api::metric_engine_consts::{
     MEMTABLE_PARTITION_TREE_PRIMARY_KEY_ENCODING, PRIMARY_KEY_ENCODING,
 };
-use store_api::mito_engine_options::{COMPACTION_OVERRIDE, MAX_ROW_GROUP_ROW_COUNT_LIMIT};
+use store_api::mito_engine_options::{
+    COMPACTION_OVERRIDE, MAX_ROW_GROUP_ROW_COUNT_LIMIT, MEMTABLE_BULK_ENCODE_BYTES_THRESHOLD,
+};
 use store_api::storage::{ColumnId, RegionId};
 use strum::EnumString;
 
@@ -45,7 +47,6 @@ const DEFAULT_INDEX_SEGMENT_ROW_COUNT: usize = 1024;
 const COMPACTION_TWCS_PREFIX: &str = "compaction.twcs.";
 const MEMTABLE_PARTITION_TREE_PREFIX: &str = "memtable.partition_tree.";
 const MEMTABLE_BULK_PREFIX: &str = "memtable.bulk.";
-const MEMTABLE_BULK_ENCODE_BYTES_THRESHOLD: &str = "memtable.bulk.encode_bytes_threshold";
 
 /// Legacy memtable type identifier accepted for backward compatibility.
 /// The partition tree memtable has been removed; parsing this value falls

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -45,6 +45,7 @@ const DEFAULT_INDEX_SEGMENT_ROW_COUNT: usize = 1024;
 const COMPACTION_TWCS_PREFIX: &str = "compaction.twcs.";
 const MEMTABLE_PARTITION_TREE_PREFIX: &str = "memtable.partition_tree.";
 const MEMTABLE_BULK_PREFIX: &str = "memtable.bulk.";
+const MEMTABLE_BULK_ENCODE_BYTES_THRESHOLD: &str = "memtable.bulk.encode_bytes_threshold";
 
 /// Legacy memtable type identifier accepted for backward compatibility.
 /// The partition tree memtable has been removed; parsing this value falls
@@ -312,6 +313,21 @@ impl RegionOptions {
         opts.validate()?;
 
         Ok(opts)
+    }
+
+    /// Parses region options using `default_bulk_config` for an implicit bulk threshold.
+    pub(crate) fn try_from_options_with_bulk_config(
+        region_id: RegionId,
+        options_map: &HashMap<String, String>,
+        default_bulk_config: &BulkMemtableConfig,
+    ) -> Result<Self> {
+        let mut options = Self::try_from_options(region_id, options_map)?;
+        if !options_map.contains_key(MEMTABLE_BULK_ENCODE_BYTES_THRESHOLD)
+            && let Some(MemtableOptions::Bulk(config)) = &mut options.memtable
+        {
+            config.encode_bytes_threshold = default_bulk_config.encode_bytes_threshold;
+        }
+        Ok(options)
     }
 }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -178,10 +178,6 @@ impl WorkerGroup {
             WriteBufferManagerImpl::new(config.global_write_buffer_size.as_bytes() as usize)
                 .with_notifier(flush_sender.clone()),
         );
-        // Adapts the default bulk memtable encode threshold to the write buffer size.
-        crate::memtable::bulk::set_global_write_buffer_bytes(
-            config.global_write_buffer_size.as_bytes() as usize,
-        );
         let puffin_manager_factory = PuffinManagerFactory::new(
             &config.index.aux_path,
             config.index.staging_size.as_bytes(),
@@ -401,10 +397,6 @@ impl WorkerGroup {
                     .with_notifier(flush_sender.clone()),
             )
         });
-        // Adapts the default bulk memtable encode threshold to the write buffer size.
-        crate::memtable::bulk::set_global_write_buffer_bytes(
-            config.global_write_buffer_size.as_bytes() as usize,
-        );
         let index_build_job_pool =
             Arc::new(LocalScheduler::new(config.max_background_index_builds));
         let flush_job_pool = Arc::new(LocalScheduler::new(config.max_background_flushes));

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -178,6 +178,10 @@ impl WorkerGroup {
             WriteBufferManagerImpl::new(config.global_write_buffer_size.as_bytes() as usize)
                 .with_notifier(flush_sender.clone()),
         );
+        // Adapts the default bulk memtable encode threshold to the write buffer size.
+        crate::memtable::bulk::set_global_write_buffer_bytes(
+            config.global_write_buffer_size.as_bytes() as usize,
+        );
         let puffin_manager_factory = PuffinManagerFactory::new(
             &config.index.aux_path,
             config.index.staging_size.as_bytes(),
@@ -397,6 +401,10 @@ impl WorkerGroup {
                     .with_notifier(flush_sender.clone()),
             )
         });
+        // Adapts the default bulk memtable encode threshold to the write buffer size.
+        crate::memtable::bulk::set_global_write_buffer_bytes(
+            config.global_write_buffer_size.as_bytes() as usize,
+        );
         let index_build_job_pool =
             Arc::new(LocalScheduler::new(config.max_background_index_builds));
         let flush_job_pool = Arc::new(LocalScheduler::new(config.max_background_flushes));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

N/A

## What's changed and what's your intention?

The bulk memtable encode-bytes threshold previously defaulted to a fixed 64 MiB regardless of the configured write-buffer budget. This PR makes the default scale with `global_write_buffer_size` so larger memtables do not encode parts too aggressively.

- Derive the default threshold as `max(64 MiB, min(global_write_buffer_size / 32, 512 MiB))`.
- Initialize the adaptive default from the Mito worker group configuration.
- Preserve `GREPTIME_BULK_ENCODE_BYTES_THRESHOLD` and per-region `memtable.bulk.encode_bytes_threshold` as explicit overrides.
- Add unit coverage for the lower bound, proportional range, and upper bound.

This change does not alter APIs, schemas, persisted data, or wire formats.

## Tests

- `cargo nextest run -p mito2` (1263 passed)

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [x] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).