### PR TITLE
fix(operator): apply metric ingest TTL hints to physical tables

### DIFF
--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -940,6 +940,11 @@ impl Inserter {
         create_table_expr
             .table_options
             .insert(PHYSICAL_TABLE_METADATA_KEY.to_string(), "true".to_string());
+        fill_table_options_for_create(
+            &mut create_table_expr.table_options,
+            &AutoCreateTableType::Physical,
+            ctx,
+        );
 
         // create physical table
         let res = statement_executor
@@ -1295,6 +1300,7 @@ pub fn fill_table_options_for_create(
 
     match create_type {
         AutoCreateTableType::Logical(physical_table) => {
+            table_options.remove(TTL_KEY);
             table_options.insert(
                 LOGICAL_TABLE_METADATA_KEY.to_string(),
                 physical_table.clone(),
@@ -1795,6 +1801,22 @@ mod tests {
         );
         assert!(!table_options.contains_key(SEMANTIC_METRIC_TYPE));
         assert!(!table_options.contains_key(SEMANTIC_PER_TABLE_INDEX_KEY));
+    }
+
+    #[test]
+    fn test_logical_create_options_do_not_copy_ttl() {
+        let mut ctx = QueryContext::with(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        ctx.set_extension(TTL_KEY, "1s");
+        let ctx = Arc::new(ctx);
+        let mut table_options = Default::default();
+
+        fill_table_options_for_create(
+            &mut table_options,
+            &AutoCreateTableType::Logical("physical".to_string()),
+            &ctx,
+        );
+
+        assert!(!table_options.contains_key(TTL_KEY));
     }
 
     #[test]

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -93,7 +93,7 @@ use sql::statements::create::{
 use sql::statements::statement::Statement;
 use sqlparser::ast::{Expr, Ident, UnaryOperator, Value as ParserValue};
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, METRIC_ENGINE_NAME};
-use store_api::mito_engine_options::APPEND_MODE_KEY;
+use store_api::mito_engine_options::{APPEND_MODE_KEY, TTL_KEY};
 use substrait::{DFLogicalSubstraitConvertor, SubstraitPlan};
 use table::TableRef;
 use table::dist_table::DistTable;
@@ -447,6 +447,14 @@ impl StatementExecutor {
                 .table_options
                 .contains_key(LOGICAL_TABLE_METADATA_KEY)
         {
+            if create_table.table_options.contains_key(TTL_KEY) {
+                return CreateLogicalTablesSnafu {
+                    reason: format!(
+                        "TTL is not supported on metric logical tables; set `{TTL_KEY}` on the physical table instead"
+                    ),
+                }
+                .fail();
+            }
             if let Some(partitions) = partitions.as_ref()
                 && !partitions.exprs.is_empty()
             {
@@ -1959,6 +1967,24 @@ impl StatementExecutor {
         } else {
             // This is logical table. Annotation alters only rewrite its own
             // metadata; `AlterLogicalTablesProcedure` only handles column adds.
+            let alters_ttl = expr.kind.as_ref().is_some_and(|kind| match kind {
+                Kind::SetTableOptions(options) => options
+                    .table_options
+                    .iter()
+                    .any(|option| option.key == TTL_KEY),
+                Kind::UnsetTableOptions(options) => {
+                    options.keys.iter().any(|key| key == TTL_KEY)
+                }
+                _ => false,
+            });
+            if alters_ttl {
+                return CreateLogicalTablesSnafu {
+                    reason: format!(
+                        "TTL is not supported on metric logical tables; set `{TTL_KEY}` on the physical table instead"
+                    ),
+                }
+                .fail();
+            }
             let annotation_alter = match expr.kind.as_ref() {
                 Some(kind) => common_grpc_expr::annotation_alter_family(kind)
                     .context(AlterExprToRequestSnafu)?

--- a/tests/cases/standalone/common/create/metric_logical_ttl.sql
+++ b/tests/cases/standalone/common/create/metric_logical_ttl.sql
@@ -1,0 +1,14 @@
+CREATE TABLE phy (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE
+) ENGINE = metric WITH ('physical_metric_table' = '', 'ttl' = '1s');
+
+CREATE TABLE lg (
+    ts TIMESTAMP TIME INDEX,
+    val DOUBLE
+) ENGINE = metric WITH ('on_physical_table' = 'phy');
+
+INSERT INTO lg VALUES (now(), 1);
+ADMIN flush_table('phy');
+ADMIN compact_table('phy');
+SELECT count(*) FROM lg;


### PR DESCRIPTION
Metric table retention is enforced by the physical metric table. Apply ingest TTL hints when auto-creating that table and reject TTL on logical metric tables so the setting cannot be silently ignored.\n\nCloses #8951\n\nSigned-off-by: Tyagi Kumar <tyagiquamar@users.noreply.github.com>