### PR TITLE
fix: prevent catalog testing feature from leaking into production builds

### DIFF
--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -26,7 +26,7 @@ auth.workspace = true
 axum.workspace = true
 base64.workspace = true
 cache.workspace = true
-catalog = { workspace = true, features = ["testing"] }
+catalog.workspace = true
 chrono.workspace = true
 clap.workspace = true
 client = { workspace = true, features = ["testing"] }
@@ -96,6 +96,7 @@ uuid.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]
+catalog = { workspace = true, features = ["testing"] }
 common-procedure-test.workspace = true
 common-wal = { workspace = true, features = ["testing"] }
 datafusion.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Regression introduced by #8684.

## What's changed and what's your intention?

Normal nightly and release builds using `--bin greptime` without package selection unexpectedly enable `catalog/testing` through the regular dependency in `tests-integration`, exposing the built-in `numbers` table.

Move the feature-enabled catalog dependency to `[dev-dependencies]` and retain `catalog.workspace = true` in `[dependencies]`. Cargo resolver 2 keeps test helpers available to Rust tests while production builds omit the testing feature. The numbers-table gate and build commands remain unchanged.

Validation:
- Before/after Cargo unit graphs confirm nightly and release builds lose `catalog/testing`, with debug assertions disabled.
- Explicit `--features catalog/testing` nightly builds and the integration-test graph retain the feature.
- TOML formatting and `git diff --check` pass.
- Targeted integration tests could not compile because the filesystem ran out of space. Nightly server SQL smoke checks remain unverified. Full lint and test suites have not been run.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (No Rust source changes.)
- [ ] I have added the necessary unit tests and integration tests. (Existing targeted tests could not run; see validation.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible. (No API changes.)
- [x] Schema or data changes are backward compatible. (No schema or data changes.)
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
