### PR TITLE
fix(ci): avoid cross-references in PR limit comments

### DIFF
--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -12,6 +12,8 @@ const MARKER = "<!-- pr-open-limit -->";
 const COMMENT_AUTHOR = "github-actions[bot]";
 // Repository permissions that mark someone as part of the team.
 const TEAM_PERMISSIONS = ["admin", "maintain", "write"];
+// Keep the comment readable for authors who are far over the limit.
+const MAX_LISTED_PRS = 10;
 
 function summary(text) {
   if (process.env.GITHUB_STEP_SUMMARY) {
@@ -43,8 +45,20 @@ async function isTeamMember(octokit, owner, repo, username) {
   }
 }
 
-function buildComment(author, total, limit, owner, repo) {
-  // Link to search results to avoid creating backlinks on individual PRs.
+function buildComment(author, total, limit, owner, repo, openPrs) {
+  const listed = openPrs.slice(0, MAX_LISTED_PRS).map((pr) => {
+    // Escape ASCII punctuation so titles stay literal Markdown link labels.
+    const title = pr.title
+      .replace(/\s+/g, " ")
+      .replace(/[\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7e]/g, "\\$&");
+    // Redirect links avoid creating backlinks on the listed PRs.
+    return `- [PR ${pr.number}: ${title}](https://redirect.github.com/${owner}/${repo}/pull/${pr.number})`;
+  });
+  const hidden = openPrs.length - listed.length;
+  if (hidden > 0) {
+    listed.push(`- ...and ${hidden} more`);
+  }
+  const list = listed.length > 0 ? `${listed.join("\n")}\n\n` : "";
   const query = `is:pr is:open author:${author} draft:false`;
   const url = `https://github.com/${owner}/${repo}/pulls?q=${encodeURIComponent(query)}`;
 
@@ -55,7 +69,7 @@ function buildComment(author, total, limit, owner, repo) {
 Review is the scarcest resource here. Please land or close some of these before
 pushing this one forward.
 
-[View your open pull requests](${url})
+${list}[View your open pull requests](${url})
 
 This check is advisory for now and blocks nothing.`;
 }
@@ -132,7 +146,7 @@ async function upsertComment(octokit, params, body) {
   await upsertComment(
     octokit,
     { owner, repo, issue_number: prNumber },
-    buildComment(author, total, limit, owner, repo)
+    buildComment(author, total, limit, owner, repo, others)
   );
 })().catch((error) => {
   console.error(error);

--- a/.github/scripts/pr-open-limit.js
+++ b/.github/scripts/pr-open-limit.js
@@ -12,8 +12,6 @@ const MARKER = "<!-- pr-open-limit -->";
 const COMMENT_AUTHOR = "github-actions[bot]";
 // Repository permissions that mark someone as part of the team.
 const TEAM_PERMISSIONS = ["admin", "maintain", "write"];
-// Keep the comment readable for authors who are far over the limit.
-const MAX_LISTED_PRS = 10;
 
 function summary(text) {
   if (process.env.GITHUB_STEP_SUMMARY) {
@@ -45,21 +43,19 @@ async function isTeamMember(octokit, owner, repo, username) {
   }
 }
 
-function buildComment(author, total, limit, openPrs) {
-  const listed = openPrs
-    .slice(0, MAX_LISTED_PRS)
-    .map((pr) => `- #${pr.number} ${pr.title}`);
-  const hidden = openPrs.length - listed.length;
-  const list = hidden > 0 ? `${listed.join("\n")}\n- ...and ${hidden} more` : listed.join("\n");
+function buildComment(author, total, limit, owner, repo) {
+  // Link to search results to avoid creating backlinks on individual PRs.
+  const query = `is:pr is:open author:${author} draft:false`;
+  const url = `https://github.com/${owner}/${repo}/pulls?q=${encodeURIComponent(query)}`;
 
   return `${MARKER}
 > [!WARNING]
-> @${author} has **${total}** open pull requests in this repository, over the limit of **${limit}**.
+> @${author} has **${total}** open non-draft pull requests in this repository, over the limit of **${limit}**.
 
 Review is the scarcest resource here. Please land or close some of these before
-pushing this one forward:
+pushing this one forward.
 
-${list}
+[View your open pull requests](${url})
 
 This check is advisory for now and blocks nothing.`;
 }
@@ -136,7 +132,7 @@ async function upsertComment(octokit, params, body) {
   await upsertComment(
     octokit,
     { owner, repo, issue_number: prNumber },
-    buildComment(author, total, limit, others)
+    buildComment(author, total, limit, owner, repo)
   );
 })().catch((error) => {
   console.error(error);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

None.

## What's changed and what's your intention?

The PR-limit bot currently lists bare PR references, creating unwanted backlinks on the listed PRs. Render each entry with an explicit PR number and title linked through `redirect.github.com`, which GitHub supports for avoiding backlinks. These links do not provide GitHub hover previews.

Keep up to 10 other open, non-draft PRs in oldest-first order, with an overflow count when needed. Escape ASCII punctuation and normalize whitespace in titles so they remain literal Markdown link labels. Add a repository-scoped “View your open pull requests” search link below the list, filtered by author, open state, and non-draft status. The search includes the triggering PR, matching the total count; the count and listed titles are snapshots from the workflow run.

Clarify that the count excludes drafts. Counting, eligibility checks, comment updates, and advisory behavior remain unchanged. There are no public API, configuration, or data-format changes.

Validation:
- `node --check .github/scripts/pr-open-limit.js` and `git diff --check` passed.
- In-memory comment checks passed for 0, 3, 10, and 12 other PRs, verifying redirect destinations, ordering, truncation counts, search filters, warning values, and the comment marker.
- Checked title escaping with brackets, backslashes, backticks, emphasis, PR references, mentions, embedded links, HTML-like text, and line breaks.
- No live test comments were posted. No project build or Rust checks were run, as requested.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (Not applicable; JavaScript-only change.)
- [x] I have added the necessary unit tests and integration tests. (No new test files needed for this formatting change; focused validation described above.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible. (No API changes.)
- [x] Schema or data changes are backward compatible. (No schema or data changes.)
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
