### PR TITLE
perf(otlp): reuse translated attributes and row templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13584,6 +13584,7 @@ dependencies = [
  "table",
  "tempfile",
  "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,7 @@ stringprep = "0.1"
 strum = { version = "0.27", features = ["derive"] }
 sysinfo = "0.33"
 tempfile = "3"
+tikv-jemallocator = "0.6"
 tokio = { version = "1.47", features = ["full"] }
 tokio-postgres = "0.7.18"
 tokio-rustls = { version = "0.26.2", default-features = false }

--- a/src/mito-codec/benches/bench_sparse_encoding.rs
+++ b/src/mito-codec/benches/bench_sparse_encoding.rs
@@ -26,7 +26,7 @@ use store_api::storage::ColumnId;
 
 fn encode_sparse(c: &mut Criterion) {
     let num_tags = 10;
-    let codec = SparsePrimaryKeyCodec::from_columns(0..num_tags);
+    let codec = SparsePrimaryKeyCodec::schemaless();
 
     let dummy_table_id = 1024;
     let dummy_ts_id = 42;

--- a/src/mito-codec/src/row_converter/sparse.rs
+++ b/src/mito-codec/src/row_converter/sparse.rs
@@ -282,17 +282,26 @@ impl SparsePrimaryKeyCodec {
     where
         I: Iterator<Item = (ColumnId, ValueRef<'a>)>,
     {
-        let mut serializer = Serializer::new(buffer);
         for (column_id, value) in row {
             if value.is_null() {
                 continue;
             }
 
             if let Some(field) = self.get_field(column_id) {
-                column_id
-                    .serialize(&mut serializer)
-                    .context(SerializeFieldSnafu)?;
-                field.serialize(&mut serializer, &value)?;
+                if let ValueRef::String(value) = value
+                    && field.data_type().is_string()
+                {
+                    self.encode_raw_tag_value(
+                        std::iter::once((column_id, value.as_bytes())),
+                        buffer,
+                    )?;
+                } else {
+                    let mut serializer = Serializer::new(&mut *buffer);
+                    column_id
+                        .serialize(&mut serializer)
+                        .context(SerializeFieldSnafu)?;
+                    field.serialize(&mut serializer, &value)?;
+                }
             } else {
                 // TODO(weny): handle the error.
                 common_telemetry::warn!("Column {} is not in primary key, skipping", column_id);
@@ -809,6 +818,49 @@ mod tests {
             )
             .unwrap();
         assert_eq!(buffer, buffer_by_raw_encoding);
+    }
+
+    #[test]
+    fn test_encode_to_vec_preserves_memcomparable() {
+        let codec = SparsePrimaryKeyCodec::from_columns(
+            [RESERVED_COLUMN_ID_TABLE_ID, RESERVED_COLUMN_ID_TSID, 1, 2].into_iter(),
+        );
+        for len in 0..=33 {
+            for unit in ["a", "é", "中", "💡", "\0"] {
+                let value = unit.repeat(len);
+                let row = [
+                    (RESERVED_COLUMN_ID_TABLE_ID, ValueRef::UInt32(u32::MAX)),
+                    (RESERVED_COLUMN_ID_TSID, ValueRef::UInt64(u64::MAX)),
+                    (1, ValueRef::String(&value)),
+                    (2, ValueRef::Null),
+                    (3, ValueRef::String("unknown column")),
+                ];
+                let mut expected = vec![42];
+                let mut serializer = Serializer::new(&mut expected);
+                for (id, value) in &row {
+                    if !value.is_null()
+                        && let Some(field) = codec.get_field(*id)
+                    {
+                        id.serialize(&mut serializer).unwrap();
+                        field.serialize(&mut serializer, value).unwrap();
+                    }
+                }
+                let mut actual = vec![42];
+                codec.encode_to_vec(row.into_iter(), &mut actual).unwrap();
+                assert_eq!(actual, expected, "unit={unit:?}, len={len}");
+            }
+        }
+        for (id, value) in [
+            (RESERVED_COLUMN_ID_TABLE_ID, ValueRef::String("wrong type")),
+            (RESERVED_COLUMN_ID_TSID, ValueRef::String("wrong type")),
+            (1, ValueRef::UInt64(1)),
+        ] {
+            assert!(
+                codec
+                    .encode_to_vec(std::iter::once((id, value)), &mut vec![])
+                    .is_err()
+            );
+        }
     }
 
     #[test]

--- a/src/mito2/benches/bench_flat_merge.rs
+++ b/src/mito2/benches/bench_flat_merge.rs
@@ -277,5 +277,40 @@ fn bench_merge(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_merge);
+fn bench_batch_transitions(c: &mut Criterion) {
+    let shape = Shape {
+        name: "batch_transitions",
+        num_iters: 32,
+        rows_per_iter: 4096,
+        rows_per_series: 64,
+        num_pk_tags: 40,
+    };
+    let (schema, batches) = build_input(&shape);
+    let mut group = c.benchmark_group("flat_merge_batch_transitions");
+    group.sample_size(20);
+    for batch_size in [1, 64, 512] {
+        group.bench_function(BenchmarkId::from_parameter(batch_size), |b| {
+            b.iter_batched(
+                || {
+                    let iters = batches
+                        .iter()
+                        .cloned()
+                        .map(|batch| {
+                            let rows = batch.num_rows();
+                            Box::new((0..rows).step_by(batch_size).map(move |offset| {
+                                Ok(batch.slice(offset, batch_size.min(rows - offset)))
+                            })) as BoxedRecordBatchIterator
+                        })
+                        .collect();
+                    (Arc::clone(&schema), iters)
+                },
+                |(schema, iters)| run_merge(schema, iters, shape.num_iters * shape.rows_per_iter),
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_merge, bench_batch_transitions);
 criterion_main!(benches);

--- a/src/mito2/src/read/flat_merge.rs
+++ b/src/mito2/src/read/flat_merge.rs
@@ -515,10 +515,12 @@ impl<T: NodeCmp> MergeAlgo<T> {
             return;
         }
 
-        let node_is_cold = self
-            .hot
-            .peek()
-            .is_none_or(|hottest| node.is_behind(hottest));
+        // With no hot nodes, keep the returning global winner out of the
+        // cold heap: refill_hot would immediately pop it again.
+        let node_is_cold = self.hot.peek().map_or_else(
+            || self.cold.peek().is_some_and(|cold| node < *cold),
+            |hottest| node.is_behind(hottest),
+        );
         if node_is_cold {
             self.cold.push(node);
         } else {
@@ -1347,6 +1349,32 @@ mod tests {
 
         assert_eq!(1, algo.hot.peek().unwrap().id);
         assert_eq!((1, 0), (algo.hot.len(), algo.cold.len()));
+    }
+
+    #[test]
+    fn test_merge_algo_batch_transition_preserves_order() {
+        for rank in [5, 10, 12, 20, 30] {
+            for end_rank in [rank, rank + 15] {
+                let mut algo = MergeAlgo::new(vec![
+                    TestNode::new(0, 0, 4),
+                    TestNode::new(1, 10, 14),
+                    TestNode::new(2, 20, 24),
+                ]);
+                let mut returning = algo.pop_hot_for_batch_transition().unwrap();
+                returning.current_rank = Some(rank);
+                returning.end_rank = end_rank;
+                algo.reheap_after_batch_transition(returning);
+                let mut result = Vec::new();
+                while let Some(mut node) = algo.pop_hot_for_batch_transition() {
+                    result.push((node.current_rank.unwrap(), node.id));
+                    node.current_rank = None;
+                    algo.reheap_after_batch_transition(node);
+                }
+                let mut expected = vec![(rank, 0), (10, 1), (20, 2)];
+                expected.sort_unstable();
+                assert_eq!(result, expected);
+            }
+        }
     }
 
     #[test]

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -174,6 +174,9 @@ tokio-postgres-rustls = "0.14"
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
 
+[target.'cfg(not(windows))'.dev-dependencies]
+tikv-jemallocator.workspace = true
+
 [build-dependencies]
 common-version.workspace = true
 
@@ -185,6 +188,10 @@ harness = false
 name = "prom_decode"
 harness = false
 required-features = ["testing"]
+
+[[bench]]
+name = "otlp_metrics"
+harness = false
 
 [[bench]]
 name = "to_http_output"

--- a/src/servers/benches/otlp_metrics.md
+++ b/src/servers/benches/otlp_metrics.md
@@ -1,0 +1,109 @@
+# OTLP metrics ingestion benchmarks
+
+Run from the repository root. The benchmark uses deterministic requests and the
+same OTLP protobuf type and converter as HTTP ingestion. No ingestion code needs
+to change to record the baseline. It uses the production binary's jemalloc
+allocator on non-Windows platforms.
+
+## CPU baseline and comparison
+
+```sh
+cargo bench -p servers --bench otlp_metrics -- otlp_metrics --save-baseline before
+# After changing ingestion code, on the same machine and toolchain:
+cargo bench -p servers --bench otlp_metrics -- otlp_metrics --baseline before
+```
+
+Criterion stores samples, estimates and comparison reports under
+`target/criterion` (or `$CRITERION_HOME` if set). Preserve this directory between
+runs. Use a new baseline name for a new experiment; `--save-baseline` overwrites
+an existing name. To check all fixtures without collecting measurements:
+
+```sh
+cargo bench -p servers --bench otlp_metrics -- --test
+```
+
+Each workload has three measurements:
+
+| Measurement | Included work |
+| --- | --- |
+| `decode` | Protobuf bytes to a fresh request; dropping the request |
+| `convert` | Request to rows, semantic metadata and outcome; dropping the result |
+| `decode_to_rows` | Both stages together, including dropping the result |
+
+For `convert`, decoding and constructing the context happen outside the timer,
+once per iteration. All measurements release their output within the timer.
+Input serialization is outside every timer; no growing `merge()` state or
+request cloning is included in conversion measurements. A fresh context is used
+each time. The small per-iteration timer overhead is shared by before/after runs.
+
+`decode` remains the stock-protobuf control if a specialized decoder is added.
+At that point, wire `decode_to_rows` to the new production decoding entry point;
+retain the fixture bytes, workload names, throughput units and timing boundary.
+The HTTP benchmark automatically exercises whichever decoder the server uses.
+
+| Workload | Resources | Metrics/resource | Points/metric | Extra point attributes | Input points | Output rows |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `small` | 1 | 4 | 1 | 2 | 4 | 4 |
+| `shared` | 1 | 16 | 64 | 8 | 1,024 | 1,024 |
+| `resources` | 32 | 4 | 8 | 8 | 1,024 | 1,024 |
+| `wide` | 1 | 16 | 64 | 32 | 1,024 | 1,024 |
+| `delta_sum` | 1 | 16 | 64 | 8 | 1,024 | 1,024 |
+| `histogram_10` | 1 | 4 | 64 | 8 | 256 | 3,328 |
+| `histogram_50` | 1 | 4 | 64 | 8 | 256 | 13,568 |
+| `summary` | 1 | 4 | 64 | 8 | 256 | 1,280 |
+
+All cases include promoted resource attributes, promoted scope metadata, a
+per-point series identifier, and mixed string/integer point attributes. Larger
+cases introduce an optional column after initial rows to exercise schema growth
+and null filling. Repeated metric names across resources share output tables.
+Histogram cases use classic cumulative histograms; exponential histograms and
+resource descriptors are deliberately excluded from this experiment.
+
+The fixture checks run before timing and verify acceptance, emitted row/table
+counts and row/schema alignment. The benchmark prints bytes, points, rows and
+tables per request. Criterion throughput is **input data points/sec**; multiply
+by the listed output/input ratio for emitted rows/sec. These timings do not
+measure allocations, network, table lookup, DDL or storage.
+
+## HTTP write baseline and comparison
+
+Use a dedicated standalone instance and a fresh disposable database for each
+run. The benchmark only writes when both `OTLP_BENCH_URL` (the complete metrics
+endpoint) and `OTLP_BENCH_DB` are supplied. It does not start/stop servers, create
+databases or delete data. For example, after starting a local server on port
+14000:
+
+```sh
+curl --fail-with-body http://127.0.0.1:14000/v1/sql \
+  --data-urlencode 'sql=CREATE DATABASE otlp_bench_before'
+OTLP_BENCH_URL=http://127.0.0.1:14000/v1/otlp/v1/metrics \
+OTLP_BENCH_DB=otlp_bench_before \
+  cargo bench -p servers --bench otlp_metrics -- otlp_http --save-baseline http-before
+```
+
+For the candidate, restart with a fresh data directory, create
+`otlp_bench_after`, and run the same command with `OTLP_BENCH_DB=otlp_bench_after`
+and `--baseline http-before`. Keep the Criterion output directory intact.
+
+This runs scalar gauge workloads at concurrency 1 and 32. One iteration is a
+round of concurrent requests; it waits for every response before the next round.
+Criterion reports **round duration**, not individual-request p95/p99 latency.
+Throughput includes all input points in a round. Request generation/serialization
+is excluded, connections are reused, and table creation is warmed before timing.
+Timestamps advance for every request, including warm-up, to avoid benchmarking
+repeated overwrites. HTTP errors and OTLP partial failures fail the run. After
+each workload, an untimed SQL query checks the total persisted row count.
+
+Run both binaries with identical settings and synchronous acknowledgements
+(`PENDING_ROWS_BATCH_SYNC=true`, the default). Record `with_metric_engine`,
+`pending_rows_flush_interval`, row/flush limits, hardware, toolchain, commit,
+storage directory setup and workload filter alongside results. Test batching
+disabled first, then repeat with the same nonzero interval on both binaries;
+record those as separate baselines. Default batching is disabled. Comparing
+enqueue acknowledgements with completed writes would not be equivalent.
+
+Run the load generator on a separate machine for server capacity measurements.
+A local client and server share CPU and are useful for smoke checks and local
+comparisons, but not an isolated server throughput result. This harness measures
+warm-schema writes; cold DDL, fixed-rate tail latency, compression and allocation
+profiling are separate experiments.

--- a/src/servers/benches/otlp_metrics.md
+++ b/src/servers/benches/otlp_metrics.md
@@ -107,3 +107,42 @@ A local client and server share CPU and are useful for smoke checks and local
 comparisons, but not an isolated server throughput result. This harness measures
 warm-schema writes; cold DDL, fixed-rate tail latency, compression and allocation
 profiling are separate experiments.
+
+## Attribute and row reuse comparison (2026-09-08)
+
+Measured on the same Apple M4 Max (16 logical CPUs, 48 GiB RAM), macOS/aarch64,
+with `rustc 1.96.0-nightly (ac7f9ec7d 2026-03-20)` and the production jemalloc
+allocator. Before is `7fc75bab45f29c18e48aa8a272be9e92c260d4a9`; after adds the
+attribute translation and row-template reuse in `otlp/metrics.rs`. The fixtures,
+toolchain, build settings and timing boundaries are unchanged. Each measurement
+uses 20 samples, a 1-second warm-up and a 3-second measurement target.
+
+```sh
+# Before modifying the converter:
+cargo bench -p servers --bench otlp_metrics -- otlp_metrics --save-baseline item1-before
+# With the refactored converter:
+cargo bench -p servers --bench otlp_metrics -- otlp_metrics --baseline item1-before
+```
+
+The table uses Criterion's median estimates. Times include dropping the converted
+rows; the last column includes protobuf decoding as well as conversion.
+
+| Workload | Conversion before | Conversion after | Conversion time reduction | Decode-to-rows time reduction |
+| --- | ---: | ---: | ---: | ---: |
+| `small` | 13.363 µs | 11.787 µs | 11.8% | 9.6% |
+| `shared` | 2.892 ms | 1.709 ms | 40.9% | 34.2% |
+| `resources` | 2.895 ms | 1.904 ms | 34.3% | 29.8% |
+| `wide` | 6.313 ms | 5.178 ms | 18.0% | 13.3% |
+| `delta_sum` | 2.896 ms | 1.747 ms | 39.7% | 33.9% |
+| `histogram_10` | 8.894 ms | 2.080 ms | 76.6% | 75.5% |
+| `histogram_50` | 36.573 ms | 7.738 ms | 78.8% | 77.7% |
+| `summary` | 3.436 ms | 1.043 ms | 69.7% | 67.3% |
+
+All 24 CPU measurements completed with the fixture acceptance, row-count and
+schema-alignment checks passing. The unchanged decode-only controls varied from
+-1.3% to +2.2% in median time; Criterion flagged the delta-sum and summary decode
+controls as regressions of about 2%. These are local CPU measurements, not HTTP
+throughput or storage-capacity results. HTTP benchmarks were not rerun for this
+converter-only change. The saved baseline and comparison data are under
+`target/criterion/otlp_metrics_*/{decode,convert,decode_to_rows}/` in
+`item1-before/` and `new/`, respectively.

--- a/src/servers/benches/otlp_metrics.rs
+++ b/src/servers/benches/otlp_metrics.rs
@@ -1,0 +1,468 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! See `otlp_metrics.md` for baseline/comparison commands and HTTP setup.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use bytes::Bytes;
+use common_query::prelude::set_default_prefix;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use futures::future::join_all;
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceResponse;
+use otel_arrow_rust::proto::opentelemetry::collector::metrics::v1::ExportMetricsServiceRequest;
+use otel_arrow_rust::proto::opentelemetry::common::v1::{
+    AnyValue, InstrumentationScope, KeyValue, any_value,
+};
+use otel_arrow_rust::proto::opentelemetry::metrics::v1::summary_data_point::ValueAtQuantile;
+use otel_arrow_rust::proto::opentelemetry::metrics::v1::{
+    AggregationTemporality, Gauge, Histogram, HistogramDataPoint, Metric, NumberDataPoint,
+    ResourceMetrics, ScopeMetrics, Sum, Summary, SummaryDataPoint, metric, number_data_point,
+};
+use otel_arrow_rust::proto::opentelemetry::resource::v1::Resource;
+use prost::Message;
+use servers::otlp::metrics::to_grpc_insert_requests;
+use session::protocol_ctx::OtlpMetricCtx;
+
+// Match the production binary's allocator for allocation-heavy conversion.
+#[cfg(not(windows))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+const START_NANOS: u64 = 1_700_000_000_000_000_000;
+
+#[derive(Clone, Copy)]
+enum Kind {
+    Gauge,
+    Sum,
+    Histogram(usize),
+    Summary,
+}
+
+struct Workload {
+    name: &'static str,
+    kind: Kind,
+    resources: usize,
+    metrics: usize,
+    points: usize,
+    point_attrs: usize,
+}
+
+impl Workload {
+    fn point_count(&self) -> usize {
+        self.resources * self.metrics * self.points
+    }
+
+    fn row_count(&self) -> usize {
+        self.point_count()
+            * match self.kind {
+                Kind::Gauge | Kind::Sum => 1,
+                Kind::Histogram(bounds) => bounds + 3,
+                Kind::Summary => 5,
+            }
+    }
+
+    fn table_count(&self) -> usize {
+        self.metrics
+            * match self.kind {
+                Kind::Gauge | Kind::Sum => 1,
+                Kind::Histogram(_) | Kind::Summary => 3,
+            }
+    }
+
+    fn request(&self, sequence: u64) -> ExportMetricsServiceRequest {
+        // Each HTTP request gets new timestamps for the same series. Replaying
+        // identical points would benchmark overwrites instead of append ingestion.
+        let timestamp = START_NANOS
+            .checked_add(
+                sequence
+                    .checked_mul(self.points as u64)
+                    .unwrap()
+                    .checked_mul(1_000_000)
+                    .unwrap(),
+            )
+            .unwrap();
+        ExportMetricsServiceRequest {
+            resource_metrics: (0..self.resources)
+                .map(|resource| ResourceMetrics {
+                    resource: Some(Resource {
+                        attributes: vec![
+                            tag("service.name", "api"),
+                            tag("service.namespace", "benchmark"),
+                            tag("service.instance.id", &format!("instance-{resource}")),
+                            tag("service.version", "1.0"),
+                            tag("cloud.region", "region-a"),
+                            tag("k8s.namespace.name", "default"),
+                            tag("k8s.pod.name", &format!("pod-{resource}")),
+                            tag("container.name", "api"),
+                            // Exercise promotion filtering as well as retained attributes.
+                            tag("unpromoted.attribute", "ignored"),
+                        ],
+                        ..Default::default()
+                    }),
+                    scope_metrics: vec![ScopeMetrics {
+                        scope: Some(InstrumentationScope {
+                            name: "benchmark.instrumentation".to_string(),
+                            version: "1.0".to_string(),
+                            attributes: vec![tag("scope.attribute", "shared")],
+                            ..Default::default()
+                        }),
+                        metrics: (0..self.metrics)
+                            .map(|metric| Metric {
+                                name: format!("otlp_bench_{}_{metric}", self.name),
+                                unit: "s".to_string(),
+                                data: Some(self.metric_data(timestamp)),
+                                ..Default::default()
+                            })
+                            .collect(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })
+                .collect(),
+        }
+    }
+
+    fn attributes(&self, point: usize) -> Vec<KeyValue> {
+        let mut attributes = vec![tag("series.id", &point.to_string())];
+        attributes.extend((0..self.point_attrs).map(|attr| KeyValue {
+            key: format!("point.attribute.{attr}"),
+            value: Some(AnyValue {
+                value: Some(if attr % 2 == 0 {
+                    any_value::Value::StringValue(format!("value-{attr}"))
+                } else {
+                    any_value::Value::IntValue(attr as i64)
+                }),
+            }),
+        }));
+        // Later rows grow the schema, and intervening rows require null filling.
+        if point % 8 == 7 {
+            attributes.push(tag("optional.attribute", "present"));
+        }
+        attributes
+    }
+
+    fn metric_data(&self, timestamp: u64) -> metric::Data {
+        match self.kind {
+            Kind::Gauge | Kind::Sum => {
+                let data_points = (0..self.points)
+                    .map(|point| NumberDataPoint {
+                        attributes: self.attributes(point),
+                        start_time_unix_nano: START_NANOS,
+                        time_unix_nano: timestamp + point as u64 * 1_000_000,
+                        value: Some(number_data_point::Value::AsDouble(point as f64 + 1.0)),
+                        ..Default::default()
+                    })
+                    .collect();
+                if matches!(self.kind, Kind::Gauge) {
+                    metric::Data::Gauge(Gauge { data_points })
+                } else {
+                    metric::Data::Sum(Sum {
+                        data_points,
+                        aggregation_temporality: AggregationTemporality::Delta as i32,
+                        is_monotonic: true,
+                    })
+                }
+            }
+            Kind::Histogram(bounds) => metric::Data::Histogram(Histogram {
+                aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                data_points: (0..self.points)
+                    .map(|point| HistogramDataPoint {
+                        attributes: self.attributes(point),
+                        start_time_unix_nano: START_NANOS,
+                        time_unix_nano: timestamp + point as u64 * 1_000_000,
+                        count: (bounds + 1) as u64,
+                        sum: Some(((bounds + 1) * (bounds + 2)) as f64 / 2.0),
+                        explicit_bounds: (1..=bounds).map(|bound| bound as f64).collect(),
+                        bucket_counts: vec![1; bounds + 1],
+                        ..Default::default()
+                    })
+                    .collect(),
+            }),
+            Kind::Summary => metric::Data::Summary(Summary {
+                data_points: (0..self.points)
+                    .map(|point| SummaryDataPoint {
+                        attributes: self.attributes(point),
+                        start_time_unix_nano: START_NANOS,
+                        time_unix_nano: timestamp + point as u64 * 1_000_000,
+                        count: 100,
+                        sum: 100.0,
+                        quantile_values: [0.5, 0.9, 0.99]
+                            .into_iter()
+                            .map(|quantile| ValueAtQuantile {
+                                quantile,
+                                value: quantile,
+                            })
+                            .collect(),
+                        ..Default::default()
+                    })
+                    .collect(),
+            }),
+        }
+    }
+}
+
+fn tag(key: &str, value: &str) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(any_value::Value::StringValue(value.to_string())),
+        }),
+    }
+}
+
+fn context() -> OtlpMetricCtx {
+    OtlpMetricCtx {
+        promote_scope_attrs: true,
+        with_metric_engine: true,
+        ..Default::default()
+    }
+}
+
+fn workloads() -> Vec<Workload> {
+    [
+        ("small", Kind::Gauge, 1, 4, 1, 2),
+        ("shared", Kind::Gauge, 1, 16, 64, 8),
+        ("resources", Kind::Gauge, 32, 4, 8, 8),
+        ("wide", Kind::Gauge, 1, 16, 64, 32),
+        ("delta_sum", Kind::Sum, 1, 16, 64, 8),
+        ("histogram_10", Kind::Histogram(10), 1, 4, 64, 8),
+        ("histogram_50", Kind::Histogram(50), 1, 4, 64, 8),
+        ("summary", Kind::Summary, 1, 4, 64, 8),
+    ]
+    .into_iter()
+    .map(
+        |(name, kind, resources, metrics, points, point_attrs)| Workload {
+            name,
+            kind,
+            resources,
+            metrics,
+            points,
+            point_attrs,
+        },
+    )
+    .collect()
+}
+
+#[allow(clippy::print_stderr)]
+fn bench_metrics(c: &mut Criterion) {
+    set_default_prefix(None).unwrap();
+    for workload in workloads() {
+        let bytes = Bytes::from(workload.request(0).encode_to_vec());
+        let request = ExportMetricsServiceRequest::decode(bytes.clone()).unwrap();
+        let conversion = to_grpc_insert_requests(request, &mut context()).unwrap();
+        assert_eq!(
+            conversion.outcome.accepted_data_points,
+            workload.point_count() as i64
+        );
+        assert_eq!(conversion.outcome.rejected_data_points, 0);
+        assert!(conversion.outcome.error_message.is_none());
+        assert_eq!(conversion.rows, workload.row_count());
+        assert_eq!(conversion.requests.inserts.len(), workload.table_count());
+        assert_eq!(
+            conversion
+                .requests
+                .inserts
+                .iter()
+                .map(|insert| {
+                    let rows = insert.rows.as_ref().unwrap();
+                    assert!(
+                        rows.rows
+                            .iter()
+                            .all(|row| row.values.len() == rows.schema.len())
+                    );
+                    rows.rows.len()
+                })
+                .sum::<usize>(),
+            workload.row_count(),
+        );
+        assert!(conversion.resource_info.is_none());
+        drop(conversion);
+        eprintln!(
+            "{}: bytes={} points={} rows={} tables={}",
+            workload.name,
+            bytes.len(),
+            workload.point_count(),
+            workload.row_count(),
+            workload.table_count(),
+        );
+
+        let mut group = c.benchmark_group(format!("otlp_metrics/{}", workload.name));
+        group.throughput(Throughput::Elements(workload.point_count() as u64));
+        group.bench_function("decode", |b| {
+            b.iter(|| {
+                drop(black_box(
+                    ExportMetricsServiceRequest::decode(black_box(bytes.clone())).unwrap(),
+                ));
+            });
+        });
+        group.bench_function("convert", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        ExportMetricsServiceRequest::decode(bytes.clone()).unwrap(),
+                        context(),
+                    )
+                },
+                |(request, mut ctx)| {
+                    drop(black_box(
+                        to_grpc_insert_requests(black_box(request), &mut ctx).unwrap(),
+                    ));
+                },
+                BatchSize::PerIteration,
+            );
+        });
+        group.bench_function("decode_to_rows", |b| {
+            b.iter(|| {
+                let request =
+                    ExportMetricsServiceRequest::decode(black_box(bytes.clone())).unwrap();
+                drop(black_box(
+                    to_grpc_insert_requests(request, &mut context()).unwrap(),
+                ));
+            });
+        });
+        group.finish();
+    }
+}
+
+async fn post_metrics(client: &reqwest::Client, url: &str, database: &str, body: Bytes) {
+    let response = client
+        .post(url)
+        .header("content-type", "application/x-protobuf")
+        .header("x-greptime-db-name", database)
+        .header("x-greptime-otlp-metric-promote-scope-attrs", "true")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.bytes().await.unwrap();
+    assert_eq!(status, reqwest::StatusCode::OK, "{bytes:?}");
+    let response = ExportMetricsServiceResponse::decode(bytes).unwrap();
+    if let Some(partial) = response.partial_success {
+        assert_eq!(partial.rejected_data_points, 0, "{partial:?}");
+        assert!(partial.error_message.is_empty(), "{partial:?}");
+    }
+}
+
+fn bench_http(c: &mut Criterion) {
+    let Ok(url) = std::env::var("OTLP_BENCH_URL") else {
+        return;
+    };
+    let database =
+        std::env::var("OTLP_BENCH_DB").expect("set OTLP_BENCH_DB to a disposable database");
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .pool_max_idle_per_host(32)
+        .build()
+        .unwrap();
+    for workload in workloads()
+        .into_iter()
+        .filter(|w| matches!(w.kind, Kind::Gauge))
+    {
+        let mut sequence = 0u64;
+        let mut group = c.benchmark_group(format!("otlp_http/{}", workload.name));
+        for concurrency in [1, 32] {
+            group.throughput(Throughput::Elements(
+                (workload.point_count() * concurrency) as u64,
+            ));
+            group.bench_with_input(
+                BenchmarkId::new("concurrency", concurrency),
+                &concurrency,
+                |b, &concurrency| {
+                    // Create/warm tables outside the measured loop. Criterion warm-up
+                    // still performs real writes, just like the measured requests.
+                    runtime.block_on(post_metrics(
+                        &client,
+                        &url,
+                        &database,
+                        Bytes::from(workload.request(sequence).encode_to_vec()),
+                    ));
+                    sequence = sequence.checked_add(1).unwrap();
+                    b.iter_batched(
+                        || {
+                            (0..concurrency)
+                                .map(|_| {
+                                    let bytes =
+                                        Bytes::from(workload.request(sequence).encode_to_vec());
+                                    sequence = sequence.checked_add(1).unwrap();
+                                    bytes
+                                })
+                                .collect::<Vec<_>>()
+                        },
+                        |bodies| {
+                            runtime.block_on(join_all(
+                                bodies
+                                    .into_iter()
+                                    .map(|body| post_metrics(&client, &url, &database, body)),
+                            ));
+                        },
+                        BatchSize::PerIteration,
+                    );
+                },
+            );
+        }
+        group.finish();
+        if sequence > 0 {
+            // Verify acknowledged rows are queryable, outside the timed region.
+            // The benchmark database must be fresh and batching must acknowledge
+            // completed writes, not merely enqueue them.
+            let tables = to_grpc_insert_requests(workload.request(0), &mut context()).unwrap();
+            let counts = tables
+                .requests
+                .inserts
+                .iter()
+                .map(|insert| format!("SELECT COUNT(*) AS n FROM \"{}\"", insert.table_name))
+                .collect::<Vec<_>>()
+                .join(" UNION ALL ");
+            let sql = format!("SELECT SUM(n) FROM ({counts})");
+            let sql_url = reqwest::Url::parse(&url).unwrap().join("/v1/sql").unwrap();
+            let response: serde_json::Value = runtime.block_on(async {
+                client
+                    .post(sql_url)
+                    .header("x-greptime-db-name", &database)
+                    .form(&[("sql", sql)])
+                    .send()
+                    .await
+                    .unwrap()
+                    .error_for_status()
+                    .unwrap()
+                    .json()
+                    .await
+                    .unwrap()
+            });
+            assert_eq!(
+                response["output"][0]["records"]["rows"][0][0].as_u64(),
+                Some(sequence.checked_mul(workload.row_count() as u64).unwrap()),
+                "persisted row count mismatch: {response}",
+            );
+        }
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3));
+    targets = bench_metrics, bench_http
+}
+criterion_main!(benches);

--- a/src/servers/src/otlp/metrics.rs
+++ b/src/servers/src/otlp/metrics.rs
@@ -18,7 +18,7 @@ use api::greptime_proto::io::prometheus::write::v2::histogram::{
 };
 use api::greptime_proto::io::prometheus::write::v2::{BucketSpan, Histogram as PromHistogram};
 use api::v1::value::ValueData;
-use api::v1::{RowInsertRequests, SemanticType, Value};
+use api::v1::{ColumnDataType, RowInsertRequests, SemanticType, Value};
 use common_grpc::precision::Precision;
 use common_query::native_histogram::{
     encode_native_histogram, native_histogram_column_schema, native_histogram_value_type,
@@ -147,8 +147,16 @@ pub fn to_grpc_insert_requests(
             attrs
         });
 
+        let resource_attrs = Attributes::new(
+            resource_attrs.as_deref().unwrap_or_default(),
+            AttributeType::Resource,
+        );
         for scope in &resource.scope_metrics {
             let scope_attrs = process_scope_attrs(scope, metric_ctx);
+            let scope_attrs = Attributes::new(
+                scope_attrs.as_deref().unwrap_or_default(),
+                AttributeType::Scope,
+            );
 
             for metric in &scope.metrics {
                 if metric.data.is_none() {
@@ -161,8 +169,8 @@ pub fn to_grpc_insert_requests(
                 encode_metrics(
                     &mut table_writer,
                     metric,
-                    resource_attrs.as_ref(),
-                    scope_attrs.as_ref(),
+                    &resource_attrs,
+                    &scope_attrs,
                     metric_ctx,
                     &mut semantic_index,
                     &mut outcome,
@@ -459,8 +467,8 @@ fn process_scope_attrs(scope: &ScopeMetrics, metric_ctx: &OtlpMetricCtx) -> Opti
 fn encode_metrics(
     table_writer: &mut MultiTableData,
     metric: &Metric,
-    resource_attrs: Option<&Vec<KeyValue>>,
-    scope_attrs: Option<&Vec<KeyValue>>,
+    resource_attrs: &Attributes<'_>,
+    scope_attrs: &Attributes<'_>,
     metric_ctx: &OtlpMetricCtx,
     semantic_index: &mut SemanticIndex,
     outcome: &mut MetricsIngestOutcome,
@@ -625,8 +633,8 @@ fn encode_exponential_histogram(
     table_writer: &mut MultiTableData,
     name: &str,
     histogram: &ExponentialHistogram,
-    resource_attrs: Option<&Vec<KeyValue>>,
-    scope_attrs: Option<&Vec<KeyValue>>,
+    resource_attrs: &Attributes<'_>,
+    scope_attrs: &Attributes<'_>,
     metric_ctx: &OtlpMetricCtx,
     outcome: &mut MetricsIngestOutcome,
 ) -> Result<bool> {
@@ -661,15 +669,11 @@ fn encode_exponential_histogram(
             histogram.data_points.len(),
         );
         let mut row = table.alloc_one_row();
-        write_tags_and_timestamp(
-            table,
-            &mut row,
-            resource_attrs,
-            scope_attrs,
-            Some(data_point.attributes.as_ref()),
-            timestamp_nanos,
-            metric_ctx,
-        )?;
+        resource_attrs.write(table, &mut row, metric_ctx)?;
+        scope_attrs.write(table, &mut row, metric_ctx)?;
+        Attributes::new(&data_point.attributes, AttributeType::DataPoint)
+            .write(table, &mut row, metric_ctx)?;
+        write_timestamp(table, &mut row, timestamp_nanos, metric_ctx.is_legacy)?;
         row_writer::write_by_schema(
             table,
             std::iter::once((column_schema.clone(), Some(value))),
@@ -919,52 +923,145 @@ enum AttributeType {
     Resource,
     Scope,
     DataPoint,
-    Legacy,
 }
 
-fn write_attributes(
-    writer: &mut TableData,
-    row: &mut Vec<Value>,
-    attrs: Option<&Vec<KeyValue>>,
-    attribute_type: AttributeType,
-    metric_ctx: &OtlpMetricCtx,
-) -> Result<()> {
-    let Some(attrs) = attrs else {
-        return Ok(());
-    };
+/// Translation is lazy so empty or rejected metrics do not validate unused attributes.
+struct Attributes<'a> {
+    attributes: &'a [KeyValue],
+    kind: AttributeType,
+    tags: once_cell::unsync::OnceCell<Vec<(String, String)>>,
+}
 
-    let mut tags = Vec::with_capacity(attrs.len());
-    for attr in attrs {
-        // TODO(sunng87): allow different type of values
-        let Some(value) = scalar_value_string(attr.value.as_ref()) else {
-            continue;
-        };
-        let key = match attribute_type {
-            AttributeType::Resource | AttributeType::DataPoint => {
-                translate_label_name(&attr.key, metric_ctx.metric_translation_strategy)
-            }
-            AttributeType::Scope => {
-                format!(
-                    "otel_scope_{}",
-                    translate_label_name(&attr.key, metric_ctx.metric_translation_strategy)
-                )
-            }
-            AttributeType::Legacy => legacy_normalize_otlp_name(&attr.key),
-        };
-        if key == OTLP_AGGREGATION_TEMPORALITY_LABEL {
-            return Err(error::InvalidOtlpMetricInputSnafu {
-                reason: format!(
-                    "OTLP attribute `{}` resolves to reserved label `{}`",
-                    attr.key, OTLP_AGGREGATION_TEMPORALITY_LABEL
-                ),
-            }
-            .build());
+impl<'a> Attributes<'a> {
+    fn new(attributes: &'a [KeyValue], kind: AttributeType) -> Self {
+        Self {
+            attributes,
+            kind,
+            tags: once_cell::unsync::OnceCell::new(),
         }
-        tags.push((key, value));
     }
-    row_writer::write_tags(writer, tags.into_iter(), row)?;
 
-    Ok(())
+    fn write(
+        &self,
+        table: &mut TableData,
+        row: &mut Vec<Value>,
+        ctx: &OtlpMetricCtx,
+    ) -> Result<()> {
+        let tags = self.tags.get_or_try_init(|| {
+            let mut tags = Vec::with_capacity(self.attributes.len());
+            for attr in self.attributes {
+                let Some(value) = scalar_value_string(attr.value.as_ref()) else {
+                    continue;
+                };
+                let key = if ctx.is_legacy {
+                    legacy_normalize_otlp_name(&attr.key)
+                } else {
+                    let key = translate_label_name(&attr.key, ctx.metric_translation_strategy);
+                    match self.kind {
+                        AttributeType::Scope => format!("otel_scope_{key}"),
+                        AttributeType::Resource | AttributeType::DataPoint => key,
+                    }
+                };
+                if key == OTLP_AGGREGATION_TEMPORALITY_LABEL {
+                    return Err(error::InvalidOtlpMetricInputSnafu {
+                        reason: format!(
+                            "OTLP attribute `{}` resolves to reserved label `{}`",
+                            attr.key, OTLP_AGGREGATION_TEMPORALITY_LABEL
+                        ),
+                    }
+                    .build());
+                }
+                tags.push((key, value));
+            }
+            Ok(tags)
+        })?;
+        row_writer::write_tags(
+            table,
+            tags.iter()
+                .map(|(key, value)| (key.as_str(), value.clone())),
+            row,
+        )
+    }
+}
+
+/// Scoped to one metric's output table: column indices remain valid as its schema grows.
+#[derive(Default)]
+struct RowTemplate {
+    common: Option<Vec<Value>>,
+    timestamp_index: Option<usize>,
+    value_index: Option<usize>,
+}
+
+impl RowTemplate {
+    fn row(
+        &mut self,
+        table: &mut TableData,
+        resource_attrs: &Attributes<'_>,
+        scope_attrs: &Attributes<'_>,
+        point_attrs: &Attributes<'_>,
+        timestamp_nanos: i64,
+        ctx: &OtlpMetricCtx,
+    ) -> Result<Vec<Value>> {
+        let common = match &self.common {
+            Some(common) => common,
+            None => {
+                let mut row = table.alloc_one_row();
+                resource_attrs.write(table, &mut row, ctx)?;
+                scope_attrs.write(table, &mut row, ctx)?;
+                self.common.insert(row)
+            }
+        };
+        let mut row = common.clone();
+        // Point attributes must not leak to later points; newly discovered columns start null.
+        row.resize(table.num_columns(), Value::default());
+        point_attrs.write(table, &mut row, ctx)?;
+        let timestamp_index = match self.timestamp_index {
+            Some(index) => index,
+            None => {
+                let index = table.ensure_column_by_name(
+                    greptime_timestamp(),
+                    if ctx.is_legacy {
+                        ColumnDataType::TimestampNanosecond
+                    } else {
+                        ColumnDataType::TimestampMillisecond
+                    },
+                    SemanticType::Timestamp,
+                )?;
+                self.timestamp_index = Some(index);
+                index
+            }
+        };
+        row.resize(table.num_columns(), Value::default());
+        row[timestamp_index].value_data = Some(if ctx.is_legacy {
+            ValueData::TimestampNanosecondValue(timestamp_nanos)
+        } else {
+            ValueData::TimestampMillisecondValue(timestamp_nanos / 1_000_000)
+        });
+        Ok(row)
+    }
+
+    fn write_value(
+        &mut self,
+        table: &mut TableData,
+        row: &mut Vec<Value>,
+        value: f64,
+    ) -> Result<()> {
+        let index = match self.value_index {
+            Some(index) => index,
+            None => {
+                let index = table.ensure_column_by_name(
+                    greptime_value(),
+                    ColumnDataType::Float64,
+                    SemanticType::Field,
+                )?;
+                self.value_index = Some(index);
+                index
+            }
+        };
+        row.resize(table.num_columns(), Value::default());
+        row[index].value_data = Some(ValueData::F64Value(value));
+        Ok(())
+    }
 }
 
 fn write_timestamp(
@@ -992,23 +1089,12 @@ fn write_timestamp(
     }
 }
 
-fn write_data_point_value(
-    table: &mut TableData,
-    row: &mut Vec<Value>,
-    field: &str,
-    value: &Option<number_data_point::Value>,
-) -> Result<()> {
+fn data_point_value(value: &Option<number_data_point::Value>) -> Option<f64> {
     match value {
-        Some(number_data_point::Value::AsInt(val)) => {
-            // we coerce all values to f64
-            row_writer::write_f64(table, field, *val as f64, row)?;
-        }
-        Some(number_data_point::Value::AsDouble(val)) => {
-            row_writer::write_f64(table, field, *val, row)?;
-        }
-        _ => {}
+        Some(number_data_point::Value::AsInt(value)) => Some(*value as f64),
+        Some(number_data_point::Value::AsDouble(value)) => Some(*value),
+        None => None,
     }
-    Ok(())
 }
 
 fn write_temporality_tag(
@@ -1031,55 +1117,6 @@ fn has_no_recorded_value(flags: u32) -> bool {
     flags & DataPointFlags::NoRecordedValueMask as u32 != 0
 }
 
-fn write_tags_and_timestamp(
-    table: &mut TableData,
-    row: &mut Vec<Value>,
-    resource_attrs: Option<&Vec<KeyValue>>,
-    scope_attrs: Option<&Vec<KeyValue>>,
-    data_point_attrs: Option<&Vec<KeyValue>>,
-    timestamp_nanos: i64,
-    metric_ctx: &OtlpMetricCtx,
-) -> Result<()> {
-    if metric_ctx.is_legacy {
-        write_attributes(
-            table,
-            row,
-            resource_attrs,
-            AttributeType::Legacy,
-            metric_ctx,
-        )?;
-        write_attributes(table, row, scope_attrs, AttributeType::Legacy, metric_ctx)?;
-        write_attributes(
-            table,
-            row,
-            data_point_attrs,
-            AttributeType::Legacy,
-            metric_ctx,
-        )?;
-    } else {
-        // TODO(shuiyisong): check `__type__` and `__unit__` tags in prometheus
-        write_attributes(
-            table,
-            row,
-            resource_attrs,
-            AttributeType::Resource,
-            metric_ctx,
-        )?;
-        write_attributes(table, row, scope_attrs, AttributeType::Scope, metric_ctx)?;
-        write_attributes(
-            table,
-            row,
-            data_point_attrs,
-            AttributeType::DataPoint,
-            metric_ctx,
-        )?;
-    }
-
-    write_timestamp(table, row, timestamp_nanos, metric_ctx.is_legacy)?;
-
-    Ok(())
-}
-
 /// encode this gauge metric
 ///
 /// note that there can be multiple data points in the request, it's going to be
@@ -1088,8 +1125,8 @@ fn encode_gauge(
     table_writer: &mut MultiTableData,
     name: &str,
     gauge: &Gauge,
-    resource_attrs: Option<&Vec<KeyValue>>,
-    scope_attrs: Option<&Vec<KeyValue>>,
+    resource_attrs: &Attributes<'_>,
+    scope_attrs: &Attributes<'_>,
     metric_ctx: &OtlpMetricCtx,
 ) -> Result<()> {
     let table = table_writer.get_or_default_table_data(
@@ -1098,19 +1135,20 @@ fn encode_gauge(
         gauge.data_points.len(),
     );
 
+    let mut template = RowTemplate::default();
     for data_point in &gauge.data_points {
-        let mut row = table.alloc_one_row();
-        write_tags_and_timestamp(
+        let mut row = template.row(
             table,
-            &mut row,
             resource_attrs,
             scope_attrs,
-            Some(data_point.attributes.as_ref()),
+            &Attributes::new(&data_point.attributes, AttributeType::DataPoint),
             data_point.time_unix_nano as i64,
             metric_ctx,
         )?;
 
-        write_data_point_value(table, &mut row, greptime_value(), &data_point.value)?;
+        if let Some(value) = data_point_value(&data_point.value) {
+            template.write_value(table, &mut row, value)?;
+        }
         table.add_row(row);
     }
 
@@ -1123,8 +1161,8 @@ fn encode_sum(
     table_writer: &mut MultiTableData,
     name: &str,
     sum: &Sum,
-    resource_attrs: Option<&Vec<KeyValue>>,
-    scope_attrs: Option<&Vec<KeyValue>>,
+    resource_attrs: &Attributes<'_>,
+    scope_attrs: &Attributes<'_>,
     metric_ctx: &OtlpMetricCtx,
 ) -> Result<()> {
     let is_delta = matches!(
@@ -1137,27 +1175,24 @@ fn encode_sum(
         sum.data_points.len(),
     );
 
+    let mut template = RowTemplate::default();
     for data_point in &sum.data_points {
-        let mut row = table.alloc_one_row();
-        write_tags_and_timestamp(
+        let mut row = template.row(
             table,
-            &mut row,
             resource_attrs,
             scope_attrs,
-            Some(data_point.attributes.as_ref()),
+            &Attributes::new(&data_point.attributes, AttributeType::DataPoint),
             data_point.time_unix_nano as i64,
             metric_ctx,
         )?;
         write_temporality_tag(table, &mut row, is_delta)?;
-        if has_no_recorded_value(data_point.flags) {
-            row_writer::write_f64(
-                table,
-                greptime_value(),
-                f64::from_bits(PROMETHEUS_STALE_NAN_BITS),
-                &mut row,
-            )?;
+        let value = if has_no_recorded_value(data_point.flags) {
+            Some(f64::from_bits(PROMETHEUS_STALE_NAN_BITS))
         } else {
-            write_data_point_value(table, &mut row, greptime_value(), &data_point.value)?;
+            data_point_value(&data_point.value)
+        };
+        if let Some(value) = value {
+            template.write_value(table, &mut row, value)?;
         }
         table.add_row(row);
     }
@@ -1182,8 +1217,8 @@ fn encode_histogram(
     table_writer: &mut MultiTableData,
     name: &str,
     hist: &Histogram,
-    resource_attrs: Option<&Vec<KeyValue>>,
-    scope_attrs: Option<&Vec<KeyValue>>,
+    resource_attrs: &Attributes<'_>,
+    scope_attrs: &Attributes<'_>,
     metric_ctx: &OtlpMetricCtx,
     outcome: &mut MetricsIngestOutcome,
 ) -> Result<bool> {
@@ -1199,6 +1234,9 @@ fn encode_histogram(
     );
     let stale_value = f64::from_bits(PROMETHEUS_STALE_NAN_BITS);
     let mut emitted = false;
+    let mut bucket_template = RowTemplate::default();
+    let mut sum_template = RowTemplate::default();
+    let mut count_template = RowTemplate::default();
     for (index, data_point) in hist.data_points.iter().enumerate() {
         if let Some(reason) = histogram_data_point_rejection(data_point, is_delta) {
             reject_data_points(outcome, 1, || {
@@ -1207,6 +1245,7 @@ fn encode_histogram(
             continue;
         }
 
+        let point_attrs = Attributes::new(&data_point.attributes, AttributeType::DataPoint);
         let bucket_table =
             table_writer.get_or_default_table_data(&bucket_table_name, APPROXIMATE_COLUMN_COUNT, 0);
         let no_recorded_value = has_no_recorded_value(data_point.flags);
@@ -1249,22 +1288,37 @@ fn encode_histogram(
             }
             values
         };
-        for (bound, value) in bucket_values {
-            let mut bucket_row = bucket_table.alloc_one_row();
-            write_tags_and_timestamp(
+        if !bucket_values.is_empty() {
+            let mut row = bucket_template.row(
                 bucket_table,
-                &mut bucket_row,
                 resource_attrs,
                 scope_attrs,
-                Some(data_point.attributes.as_ref()),
+                &point_attrs,
                 data_point.time_unix_nano as i64,
                 metric_ctx,
             )?;
-            write_temporality_tag(bucket_table, &mut bucket_row, is_delta)?;
-            row_writer::write_tag(bucket_table, HISTOGRAM_LE_COLUMN, bound, &mut bucket_row)?;
-            row_writer::write_f64(bucket_table, greptime_value(), value, &mut bucket_row)?;
-
-            bucket_table.add_row(bucket_row);
+            write_temporality_tag(bucket_table, &mut row, is_delta)?;
+            let le_index = bucket_table.ensure_column_by_name(
+                HISTOGRAM_LE_COLUMN,
+                ColumnDataType::String,
+                SemanticType::Tag,
+            )?;
+            let value_index = bucket_table.ensure_column_by_name(
+                greptime_value(),
+                ColumnDataType::Float64,
+                SemanticType::Field,
+            )?;
+            row.resize(bucket_table.num_columns(), Value::default());
+            let last = bucket_values.len() - 1;
+            for (index, (bound, value)) in bucket_values.into_iter().enumerate() {
+                row[le_index].value_data = Some(ValueData::StringValue(bound.to_string()));
+                row[value_index].value_data = Some(ValueData::F64Value(value));
+                bucket_table.add_row(if index == last {
+                    std::mem::take(&mut row)
+                } else {
+                    row.clone()
+                });
+            }
         }
 
         if let Some(sum) = data_point.sum {
@@ -1273,22 +1327,19 @@ fn encode_histogram(
                 APPROXIMATE_COLUMN_COUNT,
                 hist.data_points.len(),
             );
-            let mut sum_row = sum_table.alloc_one_row();
-            write_tags_and_timestamp(
+            let mut sum_row = sum_template.row(
                 sum_table,
-                &mut sum_row,
                 resource_attrs,
                 scope_attrs,
-                Some(data_point.attributes.as_ref()),
+                &point_attrs,
                 data_point.time_unix_nano as i64,
                 metric_ctx,
             )?;
             write_temporality_tag(sum_table, &mut sum_row, is_delta)?;
-            row_writer::write_f64(
+            sum_template.write_value(
                 sum_table,
-                greptime_value(),
-                if no_recorded_value { stale_value } else { sum },
                 &mut sum_row,
+                if no_recorded_value { stale_value } else { sum },
             )?;
             sum_table.add_row(sum_row);
         }
@@ -1298,26 +1349,23 @@ fn encode_histogram(
             APPROXIMATE_COLUMN_COUNT,
             hist.data_points.len(),
         );
-        let mut count_row = count_table.alloc_one_row();
-        write_tags_and_timestamp(
+        let mut count_row = count_template.row(
             count_table,
-            &mut count_row,
             resource_attrs,
             scope_attrs,
-            Some(data_point.attributes.as_ref()),
+            &point_attrs,
             data_point.time_unix_nano as i64,
             metric_ctx,
         )?;
         write_temporality_tag(count_table, &mut count_row, is_delta)?;
-        row_writer::write_f64(
+        count_template.write_value(
             count_table,
-            greptime_value(),
+            &mut count_row,
             if no_recorded_value {
                 stale_value
             } else {
                 data_point.count as f64
             },
-            &mut count_row,
         )?;
         count_table.add_row(count_row);
         add_accepted_data_points(outcome, 1)?;
@@ -1383,10 +1431,11 @@ fn encode_summary(
     table_writer: &mut MultiTableData,
     name: &str,
     summary: &Summary,
-    resource_attrs: Option<&Vec<KeyValue>>,
-    scope_attrs: Option<&Vec<KeyValue>>,
+    resource_attrs: &Attributes<'_>,
+    scope_attrs: &Attributes<'_>,
     metric_ctx: &OtlpMetricCtx,
 ) -> Result<()> {
+    let mut template = RowTemplate::default();
     if metric_ctx.is_legacy {
         let table = table_writer.get_or_default_table_data(
             name,
@@ -1395,13 +1444,11 @@ fn encode_summary(
         );
 
         for data_point in &summary.data_points {
-            let mut row = table.alloc_one_row();
-            write_tags_and_timestamp(
+            let mut row = template.row(
                 table,
-                &mut row,
                 resource_attrs,
                 scope_attrs,
-                Some(data_point.attributes.as_ref()),
+                &Attributes::new(&data_point.attributes, AttributeType::DataPoint),
                 data_point.time_unix_nano as i64,
                 metric_ctx,
             )?;
@@ -1427,7 +1474,10 @@ fn encode_summary(
         let count_name = format!("{}{}", metric_name, COUNT_TABLE_SUFFIX);
         let sum_name = format!("{}{}", metric_name, SUM_TABLE_SUFFIX);
 
+        let mut count_template = RowTemplate::default();
+        let mut sum_template = RowTemplate::default();
         for data_point in &summary.data_points {
+            let point_attrs = Attributes::new(&data_point.attributes, AttributeType::DataPoint);
             {
                 let quantile_table = table_writer.get_or_default_table_data(
                     metric_name,
@@ -1435,25 +1485,37 @@ fn encode_summary(
                     summary.data_points.len(),
                 );
 
-                for quantile in &data_point.quantile_values {
-                    let mut row = quantile_table.alloc_one_row();
-                    write_tags_and_timestamp(
+                if !data_point.quantile_values.is_empty() {
+                    let mut row = template.row(
                         quantile_table,
-                        &mut row,
                         resource_attrs,
                         scope_attrs,
-                        Some(data_point.attributes.as_ref()),
+                        &point_attrs,
                         data_point.time_unix_nano as i64,
                         metric_ctx,
                     )?;
-                    row_writer::write_tag(quantile_table, "quantile", quantile.quantile, &mut row)?;
-                    row_writer::write_f64(
-                        quantile_table,
-                        greptime_value(),
-                        quantile.value,
-                        &mut row,
+                    let quantile_index = quantile_table.ensure_column_by_name(
+                        "quantile",
+                        ColumnDataType::String,
+                        SemanticType::Tag,
                     )?;
-                    quantile_table.add_row(row);
+                    let value_index = quantile_table.ensure_column_by_name(
+                        greptime_value(),
+                        ColumnDataType::Float64,
+                        SemanticType::Field,
+                    )?;
+                    row.resize(quantile_table.num_columns(), Value::default());
+                    let last = data_point.quantile_values.len() - 1;
+                    for (index, quantile) in data_point.quantile_values.iter().enumerate() {
+                        row[quantile_index].value_data =
+                            Some(ValueData::StringValue(quantile.quantile.to_string()));
+                        row[value_index].value_data = Some(ValueData::F64Value(quantile.value));
+                        quantile_table.add_row(if index == last {
+                            std::mem::take(&mut row)
+                        } else {
+                            row.clone()
+                        });
+                    }
                 }
             }
             {
@@ -1462,23 +1524,16 @@ fn encode_summary(
                     APPROXIMATE_COLUMN_COUNT,
                     summary.data_points.len(),
                 );
-                let mut row = count_table.alloc_one_row();
-                write_tags_and_timestamp(
+                let mut row = count_template.row(
                     count_table,
-                    &mut row,
                     resource_attrs,
                     scope_attrs,
-                    Some(data_point.attributes.as_ref()),
+                    &point_attrs,
                     data_point.time_unix_nano as i64,
                     metric_ctx,
                 )?;
 
-                row_writer::write_f64(
-                    count_table,
-                    greptime_value(),
-                    data_point.count as f64,
-                    &mut row,
-                )?;
+                count_template.write_value(count_table, &mut row, data_point.count as f64)?;
 
                 count_table.add_row(row);
             }
@@ -1489,18 +1544,16 @@ fn encode_summary(
                     summary.data_points.len(),
                 );
 
-                let mut row = sum_table.alloc_one_row();
-                write_tags_and_timestamp(
+                let mut row = sum_template.row(
                     sum_table,
-                    &mut row,
                     resource_attrs,
                     scope_attrs,
-                    Some(data_point.attributes.as_ref()),
+                    &point_attrs,
                     data_point.time_unix_nano as i64,
                     metric_ctx,
                 )?;
 
-                row_writer::write_f64(sum_table, greptime_value(), data_point.sum, &mut row)?;
+                sum_template.write_value(sum_table, &mut row, data_point.sum)?;
 
                 sum_table.add_row(row);
             }
@@ -1525,6 +1578,269 @@ mod tests {
     use super::*;
 
     mod delta;
+    #[test]
+    fn test_attribute_precedence_and_schema_growth_across_resources() {
+        use otel_arrow_rust::proto::opentelemetry::common::v1::InstrumentationScope;
+
+        for is_legacy in [false, true] {
+            for kind in [
+                MetricType::Gauge,
+                MetricType::MonotonicSum,
+                MetricType::Histogram,
+                MetricType::Summary,
+            ] {
+                let request = ExportMetricsServiceRequest {
+                    resource_metrics: (0..2)
+                        .map(|resource| {
+                            let points = (0..3)
+                                .map(|point| NumberDataPoint {
+                                    attributes: match point {
+                                        0 => vec![
+                                            keyvalue("shared", "point"),
+                                            keyvalue("otel_scope_shared", "point-scope"),
+                                            keyvalue("first.only", "first"),
+                                            keyvalue("first-only", "last"),
+                                        ],
+                                        1 => vec![keyvalue("late", "present")],
+                                        _ => vec![],
+                                    },
+                                    time_unix_nano: (resource * 3 + point + 1) * 1_000_000 + 99,
+                                    value: (point != 2).then_some(Value::AsDouble(10.0)),
+                                    ..Default::default()
+                                })
+                                .collect::<Vec<_>>();
+                            let data = match kind {
+                                MetricType::Gauge => metric::Data::Gauge(Gauge {
+                                    data_points: points,
+                                }),
+                                MetricType::MonotonicSum => metric::Data::Sum(Sum {
+                                    data_points: points,
+                                    aggregation_temporality: AggregationTemporality::Delta as i32,
+                                    is_monotonic: true,
+                                }),
+                                MetricType::Histogram => metric::Data::Histogram(Histogram {
+                                    data_points: points
+                                        .into_iter()
+                                        .map(|point| HistogramDataPoint {
+                                            attributes: point.attributes,
+                                            time_unix_nano: point.time_unix_nano,
+                                            count: 3,
+                                            sum: Some(4.0),
+                                            explicit_bounds: vec![1.0],
+                                            bucket_counts: vec![1, 2],
+                                            ..Default::default()
+                                        })
+                                        .collect(),
+                                    aggregation_temporality: AggregationTemporality::Cumulative
+                                        as i32,
+                                }),
+                                MetricType::Summary => metric::Data::Summary(Summary {
+                                    data_points: points
+                                        .into_iter()
+                                        .map(|point| SummaryDataPoint {
+                                            attributes: point.attributes,
+                                            time_unix_nano: point.time_unix_nano,
+                                            count: 3,
+                                            sum: 4.0,
+                                            quantile_values: vec![
+                                                ValueAtQuantile {
+                                                    quantile: 0.5,
+                                                    value: 1.0,
+                                                },
+                                                ValueAtQuantile {
+                                                    quantile: 0.9,
+                                                    value: 2.0,
+                                                },
+                                            ],
+                                            ..Default::default()
+                                        })
+                                        .collect(),
+                                }),
+                                _ => unreachable!(),
+                            };
+                            ResourceMetrics {
+                                resource: Some(Resource {
+                                    attributes: vec![
+                                        keyvalue("resource", &resource.to_string()),
+                                        keyvalue("shared", "resource"),
+                                        keyvalue("otel_scope_shared", "resource-scope"),
+                                    ],
+                                    ..Default::default()
+                                }),
+                                scope_metrics: vec![ScopeMetrics {
+                                    scope: Some(InstrumentationScope {
+                                        attributes: vec![keyvalue("shared", "scope")],
+                                        ..Default::default()
+                                    }),
+                                    metrics: vec![Metric {
+                                        name: "reuse".to_string(),
+                                        data: Some(data),
+                                        ..Default::default()
+                                    }],
+                                    ..Default::default()
+                                }],
+                                ..Default::default()
+                            }
+                        })
+                        .collect(),
+                };
+                let conversion = to_grpc_insert_requests(
+                    request,
+                    &mut OtlpMetricCtx {
+                        is_legacy,
+                        promote_all_resource_attrs: true,
+                        promote_scope_attrs: true,
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+                assert_eq!(conversion.outcome.accepted_data_points, 6);
+                assert_eq!(conversion.outcome.rejected_data_points, 0);
+                let expected_rows = match kind {
+                    MetricType::Histogram => 24,
+                    MetricType::Summary if !is_legacy => 24,
+                    _ => 6,
+                };
+                assert_eq!(conversion.rows, expected_rows);
+                for insert in &conversion.requests.inserts {
+                    let rows = insert.rows.as_ref().unwrap();
+                    for row in &rows.rows {
+                        assert_eq!(row.values.len(), rows.schema.len());
+                        let value = |name: &str| {
+                            let index = rows
+                                .schema
+                                .iter()
+                                .position(|col| col.column_name == name)
+                                .unwrap();
+                            row.values[index].value_data.clone()
+                        };
+                        let timestamp = match value(greptime_timestamp()).unwrap() {
+                            ValueData::TimestampMillisecondValue(ts) => ts,
+                            ValueData::TimestampNanosecondValue(ts) => {
+                                assert_eq!(ts % 1_000_000, 99);
+                                ts / 1_000_000
+                            }
+                            _ => unreachable!(),
+                        };
+                        let point = (timestamp - 1) % 3;
+                        let string = |s: &str| Some(ValueData::StringValue(s.to_string()));
+                        assert_eq!(
+                            value("resource"),
+                            string(&((timestamp - 1) / 3).to_string())
+                        );
+                        assert_eq!(
+                            value("shared"),
+                            string(if point == 0 {
+                                "point"
+                            } else if is_legacy {
+                                "scope"
+                            } else {
+                                "resource"
+                            })
+                        );
+                        assert_eq!(
+                            value("otel_scope_shared"),
+                            string(if point == 0 {
+                                "point-scope"
+                            } else if is_legacy {
+                                "resource-scope"
+                            } else {
+                                "scope"
+                            })
+                        );
+                        assert_eq!(
+                            value("first_only"),
+                            if point == 0 { string("last") } else { None }
+                        );
+                        assert_eq!(
+                            value("late"),
+                            if point == 1 { string("present") } else { None }
+                        );
+                        if matches!(kind, MetricType::Gauge | MetricType::MonotonicSum) {
+                            assert_eq!(
+                                value(greptime_value()),
+                                if point == 2 {
+                                    None
+                                } else {
+                                    Some(ValueData::F64Value(10.0))
+                                }
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_unused_common_attributes_remain_unvalidated() {
+        let mut request = metrics_request(vec![
+            Metric {
+                name: "empty".to_string(),
+                data: Some(metric::Data::Gauge(Gauge::default())),
+                ..Default::default()
+            },
+            Metric {
+                name: "rejected".to_string(),
+                data: Some(metric::Data::Histogram(Histogram {
+                    data_points: vec![HistogramDataPoint {
+                        explicit_bounds: vec![1.0],
+                        bucket_counts: vec![1],
+                        ..Default::default()
+                    }],
+                    aggregation_temporality: AggregationTemporality::Delta as i32,
+                })),
+                ..Default::default()
+            },
+        ]);
+        request.resource_metrics[0].resource = Some(Resource {
+            attributes: vec![keyvalue(OTLP_AGGREGATION_TEMPORALITY_LABEL, "invalid")],
+            ..Default::default()
+        });
+        let mut ctx = OtlpMetricCtx {
+            promote_all_resource_attrs: true,
+            ..Default::default()
+        };
+        let conversion = to_grpc_insert_requests(request.clone(), &mut ctx).unwrap();
+        assert_eq!(conversion.rows, 0);
+        assert_eq!(conversion.outcome.rejected_data_points, 1);
+
+        request.resource_metrics[0].scope_metrics[0].metrics[0].data =
+            Some(metric::Data::Gauge(Gauge {
+                data_points: vec![NumberDataPoint::default()],
+            }));
+        assert!(matches!(
+            to_grpc_insert_requests(request, &mut ctx),
+            Err(error::Error::InvalidOtlpMetricInput { .. })
+        ));
+    }
+
+    #[test]
+    fn test_later_point_cannot_overwrite_sample_columns_with_tags() {
+        for column in [greptime_timestamp(), greptime_value()] {
+            let request = metrics_request(vec![Metric {
+                name: "collision".to_string(),
+                data: Some(metric::Data::Gauge(Gauge {
+                    data_points: vec![
+                        NumberDataPoint {
+                            value: Some(Value::AsDouble(1.0)),
+                            ..Default::default()
+                        },
+                        NumberDataPoint {
+                            attributes: vec![keyvalue(column, "tag")],
+                            value: Some(Value::AsDouble(2.0)),
+                            ..Default::default()
+                        },
+                    ],
+                })),
+                ..Default::default()
+            }]);
+            assert!(matches!(
+                to_grpc_insert_requests(request, &mut OtlpMetricCtx::default()),
+                Err(error::Error::IncompatibleSchema { .. })
+            ));
+        }
+    }
 
     fn keyvalue(key: &str, value: &str) -> KeyValue {
         KeyValue {
@@ -1721,8 +2037,8 @@ mod tests {
             &mut tables,
             "datamon",
             &gauge,
-            Some(&vec![]),
-            Some(&vec![keyvalue("scope", "otel")]),
+            &Attributes::new(&[], AttributeType::Resource),
+            &Attributes::new(&[keyvalue("scope", "otel")], AttributeType::Scope),
             &OtlpMetricCtx::default(),
         )
         .unwrap();
@@ -1771,8 +2087,8 @@ mod tests {
             &mut tables,
             "datamon",
             &sum,
-            Some(&vec![]),
-            Some(&vec![keyvalue("scope", "otel")]),
+            &Attributes::new(&[], AttributeType::Resource),
+            &Attributes::new(&[keyvalue("scope", "otel")], AttributeType::Scope),
             &OtlpMetricCtx::default(),
         )
         .unwrap();
@@ -1821,8 +2137,8 @@ mod tests {
             &mut tables,
             "datamon",
             &summary,
-            Some(&vec![]),
-            Some(&vec![keyvalue("scope", "otel")]),
+            &Attributes::new(&[], AttributeType::Resource),
+            &Attributes::new(&[keyvalue("scope", "otel")], AttributeType::Scope),
             &OtlpMetricCtx::default(),
         )
         .unwrap();
@@ -1901,8 +2217,8 @@ mod tests {
             &mut tables,
             "datamon",
             &summary,
-            None,
-            None,
+            &Attributes::new(&[], AttributeType::Resource),
+            &Attributes::new(&[], AttributeType::Scope),
             &OtlpMetricCtx {
                 is_legacy: true,
                 ..Default::default()
@@ -1947,8 +2263,8 @@ mod tests {
             &mut tables,
             "histo",
             &histogram,
-            Some(&vec![]),
-            Some(&vec![keyvalue("scope", "otel")]),
+            &Attributes::new(&[], AttributeType::Resource),
+            &Attributes::new(&[keyvalue("scope", "otel")], AttributeType::Scope),
             &OtlpMetricCtx::default(),
             &mut outcome,
         )

--- a/src/servers/src/otlp/metrics.rs
+++ b/src/servers/src/otlp/metrics.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use ahash::HashSet;
 use api::greptime_proto::io::prometheus::write::v2::histogram::{
     Count as PromCount, ResetHint, ZeroCount as PromZeroCount,
@@ -357,11 +359,11 @@ fn from_metric_type(data: &metric::Data) -> MetricType {
 }
 
 /// Non-scalar values (bool, arrays, maps, bytes) are not representable as tags.
-fn scalar_value_string(value: Option<&AnyValue>) -> Option<String> {
+fn scalar_value_string(value: Option<&AnyValue>) -> Option<Cow<'_, str>> {
     match value.and_then(|v| v.value.as_ref())? {
-        any_value::Value::StringValue(s) => Some(s.clone()),
-        any_value::Value::IntValue(v) => Some(v.to_string()),
-        any_value::Value::DoubleValue(v) => Some(v.to_string()),
+        any_value::Value::StringValue(s) => Some(Cow::Borrowed(s)),
+        any_value::Value::IntValue(v) => Some(Cow::Owned(v.to_string())),
+        any_value::Value::DoubleValue(v) => Some(Cow::Owned(v.to_string())),
         _ => None,
     }
 }
@@ -390,9 +392,12 @@ pub(crate) fn service_identity(attrs: &[KeyValue]) -> ServiceIdentity {
     }
     let job = name.map(|name| match namespace {
         Some(ns) if !ns.is_empty() => format!("{ns}/{name}"),
-        _ => name,
+        _ => name.into_owned(),
     });
-    ServiceIdentity { job, instance }
+    ServiceIdentity {
+        job,
+        instance: instance.map(Cow::into_owned),
+    }
 }
 
 fn string_key_value(key: &str, value: String) -> KeyValue {
@@ -934,7 +939,7 @@ enum AttributeType {
 struct Attributes<'a> {
     attributes: &'a [KeyValue],
     kind: AttributeType,
-    tags: once_cell::unsync::OnceCell<Vec<(String, String)>>,
+    tags: once_cell::unsync::OnceCell<Vec<(String, Cow<'a, str>)>>,
 }
 
 impl<'a> Attributes<'a> {
@@ -983,7 +988,7 @@ impl<'a> Attributes<'a> {
         row_writer::write_tags(
             table,
             tags.iter()
-                .map(|(key, value)| (key.as_str(), value.clone())),
+                .map(|(key, value)| (key.as_str(), value.as_ref().to_owned())),
             row,
         )
     }
@@ -1868,6 +1873,7 @@ mod tests {
             .iter()
             .find(|kv| kv.key == key)
             .and_then(|kv| scalar_value_string(kv.value.as_ref()))
+            .map(Cow::into_owned)
     }
 
     fn gauge_request(

--- a/src/servers/src/otlp/metrics.rs
+++ b/src/servers/src/otlp/metrics.rs
@@ -133,16 +133,16 @@ pub fn to_grpc_insert_requests(
     let mut outcome = MetricsIngestOutcome::default();
     let mut resource_info = ResourceInfoData::default();
 
-    for resource in &request.resource_metrics {
+    for resource in request.resource_metrics {
         if metric_ctx.resource_info
             && !metric_ctx.is_legacy
             && let Some(r) = resource.resource.as_ref()
         {
-            resource_info.observe(&r.attributes, resource, metric_ctx);
+            resource_info.observe(&r.attributes, &resource, metric_ctx);
         }
 
-        let resource_attrs = resource.resource.as_ref().map(|r| {
-            let mut attrs = r.attributes.clone();
+        let resource_attrs = resource.resource.map(|r| {
+            let mut attrs = r.attributes;
             process_resource_attrs(&mut attrs, metric_ctx);
             attrs
         });
@@ -151,14 +151,14 @@ pub fn to_grpc_insert_requests(
             resource_attrs.as_deref().unwrap_or_default(),
             AttributeType::Resource,
         );
-        for scope in &resource.scope_metrics {
-            let scope_attrs = process_scope_attrs(scope, metric_ctx);
+        for mut scope in resource.scope_metrics {
+            let scope_attrs = process_scope_attrs(&mut scope, metric_ctx);
             let scope_attrs = Attributes::new(
                 scope_attrs.as_deref().unwrap_or_default(),
                 AttributeType::Scope,
             );
 
-            for metric in &scope.metrics {
+            for metric in scope.metrics {
                 if metric.data.is_none() {
                     continue;
                 }
@@ -168,7 +168,7 @@ pub fn to_grpc_insert_requests(
 
                 encode_metrics(
                     &mut table_writer,
-                    metric,
+                    &metric,
                     &resource_attrs,
                     &scope_attrs,
                     metric_ctx,
@@ -430,9 +430,12 @@ fn process_resource_attrs(attrs: &mut Vec<KeyValue>, metric_ctx: &OtlpMetricCtx)
     }
 }
 
-fn process_scope_attrs(scope: &ScopeMetrics, metric_ctx: &OtlpMetricCtx) -> Option<Vec<KeyValue>> {
+fn process_scope_attrs(
+    scope: &mut ScopeMetrics,
+    metric_ctx: &OtlpMetricCtx,
+) -> Option<Vec<KeyValue>> {
     if metric_ctx.is_legacy {
-        return scope.scope.as_ref().map(|s| s.attributes.clone());
+        return scope.scope.take().map(|s| s.attributes);
     };
 
     if !metric_ctx.promote_scope_attrs {
@@ -440,24 +443,26 @@ fn process_scope_attrs(scope: &ScopeMetrics, metric_ctx: &OtlpMetricCtx) -> Opti
     }
 
     // persist scope attrs with name, version and schema_url
-    scope.scope.as_ref().map(|s| {
-        let mut attrs = s.attributes.clone();
+    scope.scope.take().map(|s| {
+        let mut attrs = s.attributes;
         attrs.push(KeyValue {
             key: OTEL_SCOPE_NAME.to_string(),
             value: Some(AnyValue {
-                value: Some(any_value::Value::StringValue(s.name.clone())),
+                value: Some(any_value::Value::StringValue(s.name)),
             }),
         });
         attrs.push(KeyValue {
             key: OTEL_SCOPE_VERSION.to_string(),
             value: Some(AnyValue {
-                value: Some(any_value::Value::StringValue(s.version.clone())),
+                value: Some(any_value::Value::StringValue(s.version)),
             }),
         });
         attrs.push(KeyValue {
             key: OTEL_SCOPE_SCHEMA_URL.to_string(),
             value: Some(AnyValue {
-                value: Some(any_value::Value::StringValue(scope.schema_url.clone())),
+                value: Some(any_value::Value::StringValue(std::mem::take(
+                    &mut scope.schema_url,
+                ))),
             }),
         });
         attrs

--- a/src/servers/src/otlp/metrics/resource_info.rs
+++ b/src/servers/src/otlp/metrics/resource_info.rs
@@ -108,7 +108,7 @@ impl ResourceInfoData {
             if is_projected_attr(&kv.key)
                 && let Some(value) = scalar_value_string(kv.value.as_ref())
             {
-                tags.push((kv.key.clone(), value));
+                tags.push((kv.key.clone(), value.into_owned()));
             }
         }
         if tags.is_empty() {

--- a/src/servers/src/otlp/metrics/resource_info.rs
+++ b/src/servers/src/otlp/metrics/resource_info.rs
@@ -216,6 +216,10 @@ fn for_each_encoded_time(
                 Some(metric::Data::ExponentialHistogram(h))
                     if exponential_histogram_gate(h, metric_ctx).is_ok() =>
                 {
+                    // TODO: Before stabilizing exponential histogram ingestion, collect
+                    // accepted timestamps during metric encoding. This fully converts
+                    // each histogram only to discard its value, then the encoder repeats
+                    // the work. Reuse accepted timestamps without describing rejected points.
                     for point in &h.data_points {
                         if let Ok((_, ts)) = exponential_histogram_value(point) {
                             visit(ts);

--- a/src/servers/src/otlp/metrics/translator.rs
+++ b/src/servers/src/otlp/metrics/translator.rs
@@ -270,20 +270,21 @@ pub(crate) fn clean_unit_name(name: &str) -> String {
 
 // See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/145942706622aba5c276ca47f48df438228bfea4/pkg/translator/prometheus/normalize_label.go#L27
 pub fn normalize_label_name(name: &str) -> String {
-    if name.is_empty() {
-        return name.to_string();
-    }
-
-    let n = NON_ALPHA_NUM_CHAR.replace_all(name, UNDERSCORE);
-    if let Some((_, first)) = n.char_indices().next()
-        && first.is_ascii_digit()
+    let mut normalized = String::with_capacity(name.len());
+    normalized.extend(
+        name.chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' }),
+    );
+    if normalized
+        .as_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_digit)
     {
-        return format!("key_{}", n);
+        normalized.insert_str(0, "key_");
+    } else if normalized.starts_with(UNDERSCORE) && !normalized.starts_with(DOUBLE_UNDERSCORE) {
+        normalized.insert_str(0, "key");
     }
-    if n.starts_with(UNDERSCORE) && !n.starts_with(DOUBLE_UNDERSCORE) {
-        return format!("key{}", n);
-    }
-    n.to_string()
+    normalized
 }
 
 /// Normalize otlp instrumentation, metric and attribute names
@@ -512,6 +513,34 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_normalize_label_name_matches_regex() {
+        // Preserve one replacement per Unicode scalar and the prefix rules,
+        // including punctuation that becomes a leading underscore.
+        let alphabet = [
+            'a', 'Z', '0', '_', '.', '-', ':', ' ', '\0', 'é', '中', '💡',
+        ];
+        for first in alphabet {
+            for second in alphabet {
+                for suffix in ["", "_value", ".value", "💡é"] {
+                    let name = format!("{first}{second}{suffix}");
+                    let escaped = NON_ALPHA_NUM_CHAR.replace_all(&name, UNDERSCORE);
+                    let expected = if escaped.starts_with(|ch: char| ch.is_ascii_digit()) {
+                        format!("key_{escaped}")
+                    } else if escaped.starts_with('_') && !escaped.starts_with("__") {
+                        format!("key{escaped}")
+                    } else {
+                        escaped.into_owned()
+                    };
+                    assert_eq!(normalize_label_name(&name), expected, "{name:?}");
+                }
+            }
+        }
+        assert_eq!(normalize_label_name(""), "");
+        assert_eq!(normalize_label_name("é"), "key_");
+        assert_eq!(normalize_label_name("0"), "key_0");
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request improves OTLP metrics ingestion performance by reducing repeated attribute translation, schema lookups, and row construction.

- Translate resource and scope attributes once and reuse them across metrics and points.
- Reuse common row values and timestamp/value column indices while preserving attribute precedence, schema growth, and validation.
- Build histogram bucket and summary quantile rows from a shared template.
- Move owned resource and scope attributes instead of cloning them.
- Add reproducible Criterion conversion benchmarks and an optional HTTP ingestion benchmark.

### Before and after performance

Saved Criterion median results comparing `item1-before` with `item4-owned`, measured locally on an Apple M4 Max using jemalloc:

| Workload | Conversion before | Conversion after | Conversion time reduction | Decode-to-rows time reduction |
| --- | ---: | ---: | ---: | ---: |
| Small | 13.363 µs | 11.938 µs | 10.7% | 9.0% |
| Shared attributes | 2.892 ms | 1.743 ms | 39.7% | 32.5% |
| Multiple resources | 2.895 ms | 1.880 ms | 35.1% | 30.4% |
| Wide attributes | 6.313 ms | 5.405 ms | 14.4% | 11.8% |
| Delta sum | 2.896 ms | 1.789 ms | 38.2% | 32.3% |
| Histogram, 10 bounds | 8.894 ms | 2.163 ms | 75.7% | 74.1% |
| Histogram, 50 bounds | 36.573 ms | 7.935 ms | 78.3% | 77.3% |
| Summary | 3.436 ms | 1.078 ms | 68.6% | 66.1% |

Conversion is **1.12–4.61× faster** across these workloads. Moving resource/scope attributes adds a further **2.8–4.6% reduction in conversion time** over the row-reuse implementation.

These are saved local CPU measurements, including output destruction. They do not measure HTTP throughput or storage capacity; HTTP benchmarks were not rerun for these optimizations. No API, schema, or data-format changes are intended.


## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
