### PR TITLE
ci(backport): label backport PRs with their version name

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -83,11 +83,20 @@ jobs:
 
             git push origin "${head_branch}"
 
+            # Ensure the version label (e.g. "v1.2") exists before attaching it.
+            # GitHub does not create labels implicitly, so upsert it idempotently.
+            gh label create "${target}" \
+              --color 0e8a16 \
+              --description "Backport to ${release_branch}" \
+              --force \
+              || true
+
             gh pr create \
               --base "${release_branch}" \
               --head "${head_branch}" \
+              --label "${target}" \
               --title "${PR_TITLE} [Backport ${release_branch}]" \
-              --body "Backport of #${PR_NUMBER} to ${release_branch}.
+              --body "Backport of #${PR_NUMBER} to ${release_branch}."
 
           ---
           Original PR: #${PR_NUMBER}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -96,7 +96,7 @@ jobs:
               --head "${head_branch}" \
               --label "${target}" \
               --title "${PR_TITLE} [Backport ${release_branch}]" \
-              --body "Backport of #${PR_NUMBER} to ${release_branch}."
+              --body "Backport of #${PR_NUMBER} to ${release_branch}.
 
           ---
           Original PR: #${PR_NUMBER}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #9028 and #9048.

## What's changed and what's your intention?

Backport PRs created by the Backport workflow are now labeled with their version name, e.g. a PR created from the `backport-v1.2` label gets the `v1.2` label.

- GitHub does **not** create labels implicitly when they are attached to a PR creation request (verified: the API returns `not found` for unknown labels). So the workflow upserts the label first with `gh label create <target> --force` (idempotent, tolerant of failures with `|| true`), then passes `--label <target>` to `gh pr create`.
- Label details: color `0e8a16`, description `Backport to release/<target>`.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.