### PR TITLE
chore(ci): update compatibility versions

### DIFF
--- a/tests/compatibility/ci.toml
+++ b/tests/compatibility/ci.toml
@@ -6,7 +6,7 @@
 # exercised by nightly runs (--nightly-window); they are not retained in the PR
 # window. Run .github/scripts/update-compat-versions.py --update --published-only
 # after release tags land.
-from_versions = ["v1.0.2", "v1.1.4"]
+from_versions = ["v1.1.4", "v1.2.0"]
 
 # Recent releases that must be able to reopen tables written by the PR build.
 downgrade_to_versions = ["v1.1.4"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Automated after a stable release or the daily fallback.

## What's changed and what's your intention?

Updates `tests/compatibility/ci.toml` from checked-out `main` tags that have published release assets. The PR window keeps the latest patch of the two most recent stable minor lines; exact `=vX.Y.Z` case anchors are validated nightly instead of being added to the PR window.

## PR Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.