### PR TITLE
feat(auth): support per-user MySQL authentication methods

### DIFF
--- a/src/auth/src/user_provider.rs
+++ b/src/auth/src/user_provider.rs
@@ -115,6 +115,12 @@ pub trait UserProvider: Send + Sync {
         }
     }
 
+    /// Selects authentication after the MySQL handshake supplies a username.
+    /// The user is resolved in the same scope as [`authenticate`](Self::authenticate).
+    async fn mysql_auth_method_for_user(&self, _username: &str) -> Result<MysqlAuthMethod> {
+        Ok(self.mysql_auth_method())
+    }
+
     async fn postgres_auth_info(&self, _id: Identity<'_>, _catalog: &str) -> Result<PgAuthInfo> {
         Ok(PgAuthInfo::Cleartext)
     }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -374,6 +374,15 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
         if user == BEARER_TOKEN_USER.as_bytes() {
             return MysqlAuthMethod::ClearPassword.plugin_name();
         }
+        if let Some(provider) = &self.user_provider {
+            let username = String::from_utf8_lossy(user);
+            match provider.mysql_auth_method_for_user(&username).await {
+                Ok(method) => return method.plugin_name(),
+                // This hook cannot return an error. Keep the default challenge;
+                // authentication still validates the credentials separately.
+                Err(e) => warn!(e; "Failed to select MySQL authentication method"),
+            }
+        }
         self.auth_plugin()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pull request adds per-user MySQL authentication method selection so user providers can choose an authentication plugin after the handshake supplies a username.

The new `UserProvider::mysql_auth_method_for_user` hook defaults to the provider’s existing authentication method. The MySQL handler uses this hook during plugin selection and logs lookup failures before falling back to the default challenge. Credential validation remains separate, and bearer-token users retain clear-password authentication.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
