### PR TITLE
fix(ci): strip pre-release extension when creating nightly release version

### DIFF
--- a/.github/scripts/create-version.sh
+++ b/.github/scripts/create-version.sh
@@ -3,7 +3,9 @@
 set -e
 
 # - If it's a tag push release or manual dispatch on a tag with REUSE_EXISTING_RELEASE_TAG=true, the version is the tag name(${{ github.ref_name }});
-# - If it's a scheduled release, the version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-$buildTime', like 'v0.2.0-nightly-20230313';
+# - If it's a scheduled release, the version is '<base-version>-nightly-$buildTime', like 'v0.2.0-nightly-20230313';
+#   the pre-release extension of $NEXT_RELEASE_VERSION (like '-alpha.1') is stripped,
+#   'nightly' itself becomes the pre-release extension;
 # - If it's a manual non-tag release, the version is '${{ env.NEXT_RELEASE_VERSION }}-$(git rev-parse --short HEAD)-YYYYMMDDSS', like 'v0.2.0-e5b243c-2023071245';
 # - If it's a nightly build, the version is 'nightly-YYYYMMDD-$(git rev-parse --short HEAD)', like 'nightly-20230712-e5b243c'.
 # create_version ${GIHUB_EVENT_NAME} ${NEXT_RELEASE_VERSION} ${NIGHTLY_RELEASE_PREFIX}
@@ -72,7 +74,11 @@ function create_version() {
   elif [ "$GITHUB_EVENT_NAME" = workflow_dispatch ]; then
     echo "$NEXT_RELEASE_VERSION-$(git rev-parse --short HEAD)-$(date "+%Y%m%d-%s")"
   elif [ "$GITHUB_EVENT_NAME" = schedule ]; then
-    echo "$NEXT_RELEASE_VERSION-$NIGHTLY_RELEASE_PREFIX-$(date "+%Y%m%d")"
+    # Strip the pre-release extension (like '-alpha.1') from the version and use
+    # 'nightly' as the (only) pre-release extension, so 'v0.2.0-alpha.1' becomes
+    # 'v0.2.0-nightly-20230313' rather than 'v0.2.0-alpha.1-nightly-20230313'.
+    BASE_VERSION=${NEXT_RELEASE_VERSION%%-*}
+    echo "$BASE_VERSION-$NIGHTLY_RELEASE_PREFIX-$(date "+%Y%m%d")"
   else
     echo "Unsupported GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME" >&2
     exit 1
@@ -84,6 +90,7 @@ function create_version() {
 #  GITHUB_EVENT_NAME=workflow_dispatch GITHUB_REF_TYPE=tag REUSE_EXISTING_RELEASE_TAG=true GITHUB_REF_NAME=v0.3.0 NEXT_RELEASE_VERSION=v0.4.0 NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 #  GITHUB_EVENT_NAME=workflow_dispatch NEXT_RELEASE_VERSION=v0.4.0 NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 #  GITHUB_EVENT_NAME=schedule NEXT_RELEASE_VERSION=v0.4.0 NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
+#  GITHUB_EVENT_NAME=schedule NEXT_RELEASE_VERSION=v0.4.0-alpha.1 NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 #  GITHUB_EVENT_NAME=schedule NEXT_RELEASE_VERSION=nightly NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 #  GITHUB_EVENT_NAME=workflow_dispatch COMMIT_SHA=f0e7216c4bb6acce9b29a21ec2d683be2e3f984a NEXT_RELEASE_VERSION=dev NIGHTLY_RELEASE_PREFIX=nightly ./create-version.sh
 create_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 # There are two kinds of formal release:
 # 1. The tag('v*.*.*') push release: the release workflow will be triggered by the tag push event.
-# 2. The scheduled release(the version will be '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD'): the release workflow will be triggered by the schedule event.
+# 2. The scheduled release(the version will be '<base-version>-nightly-YYYYMMDD', any pre-release
+#    extension in the next release version like '-alpha.1' is stripped, so 'nightly' is the extension):
+#    the release workflow will be triggered by the schedule event.
 # A failed tag push release can be manually dispatched on the same tag to recover it without changing the formal release version.
 on:
   push:
@@ -94,7 +96,8 @@ env:
   # Controls whether to run tests, include unit-test, integration-test and sqlness.
   DISABLE_RUN_TESTS: ${{ inputs.skip_test || vars.DEFAULT_SKIP_TEST }}
 
-  # The scheduled version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD', like v0.2.0-nightly-20230313;
+  # The scheduled version is '<base-version>-nightly-YYYYMMDD', like v0.2.0-nightly-20230313;
+  # the pre-release extension of the next release version is stripped, e.g. v0.2.0-alpha.1 -> v0.2.0-nightly-20230313.
   NIGHTLY_RELEASE_PREFIX: nightly
 
 jobs:
@@ -134,7 +137,7 @@ jobs:
 
       # The create-version will create a global variable named 'version' in the global workflows.
       # - If it's a tag push release or manual dispatch on a tag with REUSE_EXISTING_RELEASE_TAG=true, the version is the tag name(${{ github.ref_name }});
-      # - If it's a scheduled release, the version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-$buildTime', like v0.2.0-nightly-20230313;
+      # - If it's a scheduled release, the version is '<base-version>-nightly-$buildTime', like v0.2.0-nightly-20230313 (pre-release extensions like '-alpha.1' are stripped);
       # - If it's a manual non-tag release, the version is '${{ env.NEXT_RELEASE_VERSION }}-<short-git-sha>-YYYYMMDDSS', like v0.2.0-e5b243c-2023071245;
       - name: Create version
         id: create-version


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

None. Evidence of the wrong pattern in existing tags: `v1.3.0-alpha.1-nightly-20260907` vs. the expected `v1.3.0-nightly-20260824`.

## What's changed and what's your intention?

**Summary:** The scheduled (weekly) nightly release version was built by appending `-nightly-YYYYMMDD` to `NEXT_RELEASE_VERSION` verbatim. In the scheduled `release.yml` run `NEXT_RELEASE_VERSION` is unset, so `create-version.sh` falls back to the Cargo.toml version — currently `v1.3.0-alpha.1` — which produced tags like `v1.3.0-alpha.1-nightly-20260907`, stacking `nightly` on top of the `alpha.1` pre-release extension.

**How it works:** In `create-version.sh`, the `schedule` branch now strips the pre-release extension before appending the nightly suffix:

```bash
BASE_VERSION=${NEXT_RELEASE_VERSION%%-*}
echo "$BASE_VERSION-$NIGHTLY_RELEASE_PREFIX-$(date +%Y%m%d)"
```

so the correct semantics apply: remove the pre-release extension and use `nightly` as the extension, e.g. `v1.3.0-alpha.1` → `v1.3.0-nightly-20260908`. Comments in `create-version.sh` and `release.yml` that document the version pattern were updated to match, plus a new usage example for the pre-release case.

**Verified locally** (all other paths unchanged):

| Path | Result |
|---|---|
| schedule + prerelease (`v1.3.0-alpha.1`) | `v1.3.0-nightly-YYYYMMDD` (fixed) |
| schedule + stable (`v0.4.0`) | `v0.4.0-nightly-YYYYMMDD` (unchanged) |
| schedule, unset `NEXT_RELEASE_VERSION` (actual release.yml path) | `v1.3.0-nightly-20260909` (fixed) |
| nightly-build.yml (`nightly-YYYYMMDD-sha`) | unchanged |
| dev-build / tag push / manual dispatch | unchanged |

Also checked downstream consumers are compatible with the corrected pattern: `check-version.sh` (strips `-nightly-.*`; nightly releases are published as GitHub pre-releases so `/releases/latest` is unaffected), `update-compat-versions.py` (matches exact stable tags only), and `upload-artifacts-to-s3.sh` (`latest-nightly-version.txt`).

**Limitations:** existing wrongly-formed tags (e.g. `v1.3.0-alpha.1-nightly-20260907`) are left as-is; only future scheduled runs pick up the fix.

**Compatibility:** CI-only change; no API, schema, or data changes.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).