### PR TITLE
fix(flow): drain frontend probe response before selecting peer

### DIFF
--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -191,10 +191,11 @@ impl DatabaseWithPeer {
                 context: format!("Failed to handle `SELECT 1` request at {:?}", self.peer),
             })?;
 
-        if let OutputData::Stream(mut stream) = output.data {
-            while let Some(item) = stream.next().await {
-                item.map_err(BoxedError::new).context(ExternalSnafu)?;
-            }
+        if let OutputData::Stream(stream) = output.data {
+            common_recordbatch::util::collect(stream)
+                .await
+                .map_err(BoxedError::new)
+                .context(ExternalSnafu)?;
         }
 
         Ok(())

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -183,13 +183,20 @@ impl DatabaseWithPeer {
     /// Try sending a "SELECT 1" to the database
     async fn try_select_one(&self) -> Result<(), Error> {
         // notice here use `sql` for `SELECT 1` return 1 row
-        let _ = self
+        let output = self
             .database
             .sql("SELECT 1")
             .await
             .with_context(|_| InvalidRequestSnafu {
                 context: format!("Failed to handle `SELECT 1` request at {:?}", self.peer),
             })?;
+
+        if let OutputData::Stream(mut stream) = output.data {
+            while let Some(item) = stream.next().await {
+                item.map_err(BoxedError::new).context(ExternalSnafu)?;
+            }
+        }
+
         Ok(())
     }
 }
@@ -698,9 +705,11 @@ mod tests {
     use api::v1::query_request::Query;
     use arrow_flight::flight_service_server::FlightServiceServer;
     use arrow_flight::{FlightData, Ticket};
+    use common_grpc::flight::FlightEncoder;
     use common_query::{Output, OutputData};
     use common_recordbatch::adapter::RecordBatchMetrics;
     use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
+    use datatypes::arrow::datatypes::Schema as ArrowSchema;
     use datatypes::prelude::{ConcreteDataType, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::Int32Vector;
@@ -774,6 +783,14 @@ mod tests {
 
     #[derive(Debug)]
     struct SlowFlight;
+
+    struct DelayedEofFlight {
+        schema_sent: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[derive(Debug)]
+    struct LateStreamErrorFlight;
 
     struct WaitForConcurrentFlight {
         barrier: Arc<tokio::sync::Barrier>,
@@ -867,6 +884,45 @@ mod tests {
         ) -> std::result::Result<TonicResponse<TonicStream<FlightData>>, Status> {
             tokio::time::sleep(Duration::from_secs(60)).await;
             Err(Status::unavailable("slow response"))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl FlightCraft for DelayedEofFlight {
+        async fn do_get(
+            &self,
+            _request: TonicRequest<Ticket>,
+        ) -> std::result::Result<TonicResponse<TonicStream<FlightData>>, Status> {
+            let schema = FlightEncoder::default().encode_schema(&ArrowSchema::empty());
+            let schema_sent = self.schema_sent.lock().unwrap().take();
+            let schema_stream = futures::stream::once(async move {
+                if let Some(schema_sent) = schema_sent {
+                    let _ = schema_sent.send(());
+                }
+                Ok(schema)
+            });
+            let release = self.release.clone();
+            let delayed_eof = futures::stream::unfold(release, |release| async move {
+                release.notified().await;
+                None::<(std::result::Result<FlightData, Status>, _)>
+            });
+
+            Ok(TonicResponse::new(Box::pin(
+                schema_stream.chain(delayed_eof),
+            )))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl FlightCraft for LateStreamErrorFlight {
+        async fn do_get(
+            &self,
+            _request: TonicRequest<Ticket>,
+        ) -> std::result::Result<TonicResponse<TonicStream<FlightData>>, Status> {
+            let schema = FlightEncoder::default().encode_schema(&ArrowSchema::empty());
+            let stream =
+                futures::stream::iter([Ok(schema), Err(Status::unavailable("late stream error"))]);
+            Ok(TonicResponse::new(Box::pin(stream)))
         }
     }
 
@@ -1054,6 +1110,71 @@ mod tests {
             .unwrap_err();
 
         assert!(format!("{err:?}").contains("Invalid value for flow.return_region_seq"));
+    }
+
+    #[tokio::test]
+    async fn test_try_select_one_waits_for_stream_eof() {
+        let (schema_sent, schema_sent_rx) = tokio::sync::oneshot::channel();
+        let release = Arc::new(tokio::sync::Notify::new());
+        let (addr, server) = start_flight_server(DelayedEofFlight {
+            schema_sent: Mutex::new(Some(schema_sent)),
+            release: release.clone(),
+        })
+        .await;
+        let database = Database::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            Client::with_urls([addr.as_str()]),
+        );
+        let db = DatabaseWithPeer::new(
+            database,
+            Peer {
+                id: 1,
+                addr: addr.clone(),
+            },
+        );
+        let mut probe = tokio::spawn(async move { db.try_select_one().await });
+
+        timeout(Duration::from_secs(1), schema_sent_rx)
+            .await
+            .expect("server should send the schema")
+            .expect("schema signal should be sent");
+        assert!(
+            timeout(Duration::from_millis(100), &mut probe)
+                .await
+                .is_err(),
+            "SELECT 1 must wait for the delayed stream tail and EOF"
+        );
+
+        release.notify_one();
+        timeout(Duration::from_secs(1), &mut probe)
+            .await
+            .expect("SELECT 1 should complete after EOF")
+            .expect("probe task should not panic")
+            .expect("SELECT 1 should succeed after EOF");
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_try_select_one_propagates_late_stream_error() {
+        let (addr, server) = start_flight_server(LateStreamErrorFlight).await;
+        let database = Database::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            Client::with_urls([addr.as_str()]),
+        );
+        let db = DatabaseWithPeer::new(
+            database,
+            Peer {
+                id: 1,
+                addr: addr.clone(),
+            },
+        );
+
+        let err = db.try_select_one().await.unwrap_err();
+        server.abort();
+
+        assert!(format!("{err:?}").contains("late stream error"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

No linked issue.

## What's changed and what's your intention?

Drain the `SELECT 1` response used by batching Flow to select an active frontend before considering the probe successful.

`Database::sql` returns a lazy record-batch stream after receiving the Flight schema. Previously, `try_select_one` immediately dropped that output. Dropping an unfinished response can send HTTP/2 `CANCEL`; late frames for a cleaned-up stream can then trigger `STREAM_CLOSED`. Accumulated internal resets can reach h2's limit and terminate the shared connection with `GOAWAY(ENHANCE_YOUR_CALM, too_many_internal_resets)`, surfacing as a Flight `ResourceExhausted` error and failing a Flow batch.

The fix reuses `common_recordbatch::util::collect` to consume streaming output through EOF, then discards the collected result. The probe is a fixed `SELECT 1` query returning one row. Tail errors propagate through the existing error types so frontend selection can continue to another peer. Initial SQL error handling and non-stream output behavior remain unchanged. No new dependencies, retry policy, timeouts, configuration, or data-format changes are introduced. The startup authentication probe is outside this change; this is not a guarantee that every stream cancellation is eliminated.

Two regression tests use the existing local Flight server helper to verify that the actual probe waits for EOF and propagates a late stream error. No existing tests are removed. The standalone A/B diagnostic example is deliberately excluded from this PR.

### Verification

On this main-based branch:
- `rustfmt --check --edition 2024 src/flow/src/batching_mode/frontend_client.rs`: passed.
- `git diff upstream/main --check`: passed.
- `cargo check -p flow --tests -j4`: passed.
- `cargo nextest run -p flow -j4`: **240 passed, 0 skipped**.
- `cargo clippy -p flow --all-targets -j4 -- -D warnings`: passed.

Cargo commands used a dedicated external target directory. Full-workspace checks and a main-based distributed smoke run were not performed.

Additional validation performed on the original v1.1.4 manual-drain patch, before the utility-reuse follow-up (not claimed as a main-branch end-to-end run):
- `cargo nextest run -p flow -j4`: 225 tests passed.
- Temporarily removing the drain made both new regressions fail; restoring it made both pass.
- `cargo build -p cmd --bin greptime -j4`: passed.
- A local four-component distributed cluster built from that patch successfully created a batching Flow; two inserts and `ADMIN FLUSH_FLOW` updated the sink aggregate from 3 to 7, with both source rows present. All four processes exited normally.
- Separate-process A/B probes, 6,000 requests each, using the v1.1.4 client and a v1.2.0 standalone server: dropping responses reproduced one internal-reset-limit GOAWAY and one RPC failure; draining completed all requests without resets or errors. This is mechanism evidence, not a long-running production or exact-topology guarantee.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).

Release-branch backports and labels are not included in this PR submission.

