### PR TITLE
feat: support request-level insert WAL skipping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=4b6057ba34b8aaf06221585199ace5002b2af92b#4b6057ba34b8aaf06221585199ace5002b2af92b"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b74667d17827481dbb6222fa0326163627211557#b74667d17827481dbb6222fa0326163627211557"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=32f467fa2ba2b3588a58381a24af83de09fbb00a#32f467fa2ba2b3588a58381a24af83de09fbb00a"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=4b6057ba34b8aaf06221585199ace5002b2af92b#4b6057ba34b8aaf06221585199ace5002b2af92b"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "4b6057ba34b8aaf06221585199ace5002b2af92b" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b74667d17827481dbb6222fa0326163627211557" }
 hex = "0.4"
 hostname = "0.4.0"
 http = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "32f467fa2ba2b3588a58381a24af83de09fbb00a" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "4b6057ba34b8aaf06221585199ace5002b2af92b" }
 hex = "0.4"
 hostname = "0.4.0"
 http = "1"

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -2018,6 +2018,7 @@ mod tests {
 
         assert!(RegionServerInner::is_ingest_request(&RegionRequest::Put(
             RegionPutRequest {
+                skip_wal: false,
                 rows: rows(),
                 hint: None,
                 partition_expr_version: None,

--- a/src/flow/src/server.rs
+++ b/src/flow/src/server.rs
@@ -124,6 +124,7 @@ impl flow_server::Flow for FlowService {
                     api::v1::region::InsertRequest {
                         region_id: insert.region_id,
                         rows: insert.rows,
+                        skip_wal: false,
                         partition_expr_version: insert.partition_expr_version,
                     }
                 })

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -636,6 +636,7 @@ mod test {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: row_schema_with_tags(&["job"]),
                         rows: build_rows(1, 5),

--- a/src/metric-engine/src/engine/bulk_insert.rs
+++ b/src/metric-engine/src/engine/bulk_insert.rs
@@ -599,6 +599,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: api::v1::Rows { schema, rows },
                     hint: None,
                     partition_expr_version: None,

--- a/src/metric-engine/src/engine/flush.rs
+++ b/src/metric-engine/src/engine/flush.rs
@@ -90,6 +90,7 @@ mod tests {
                 let schema = row_schema_with_tags(&["job"]);
                 let rows = build_rows(1, 10);
                 let request = RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows { schema, rows },
                     hint: None,
                     partition_expr_version: None,

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -143,21 +143,74 @@ impl MetricEngineInner {
         let primary_key_encoding = self.get_primary_key_encoding(data_region_id)?;
 
         // Validate all requests
-        self.validate_batch_requests(physical_region_id, &mut requests)
+        let partition_expr_version = self
+            .validate_batch_requests(physical_region_id, &mut requests)
             .await?;
 
-        // Merge requests according to encoding strategy
-        let (merged_request, total_affected_rows) = match primary_key_encoding {
-            PrimaryKeyEncoding::Sparse => self.merge_sparse_batch(physical_region_id, requests)?,
-            PrimaryKeyEncoding::Dense => self.merge_dense_batch(data_region_id, requests)?,
-        };
+        // Keep the common uniform-policy path allocation-free beyond the merge.
+        if requests
+            .iter()
+            .all(|(_, request)| request.skip_wal == requests[0].1.skip_wal)
+        {
+            let (request, affected_rows) = self.merge_batch(
+                physical_region_id,
+                primary_key_encoding,
+                requests,
+                partition_expr_version,
+            )?;
+            self.data_region
+                .write_data(data_region_id, RegionRequest::Put(request))
+                .await?;
+            return Ok(affected_rows);
+        }
 
-        // Write once to the physical region
-        self.data_region
-            .write_data(data_region_id, RegionRequest::Put(merged_request))
-            .await?;
+        // Only merge consecutive requests with the same WAL policy, preserving
+        // write order even when the same logical region occurs more than once.
+        // Prepare every batch before writing so a merge error cannot partially
+        // apply this physical-region group.
+        let batches = Self::split_batch_by_wal_policy(requests);
+        let mut merged_requests = Vec::with_capacity(batches.len());
+        let mut total_affected_rows = 0;
+        for requests in batches {
+            let (request, affected_rows) = self.merge_batch(
+                physical_region_id,
+                primary_key_encoding,
+                requests,
+                partition_expr_version,
+            )?;
+            merged_requests.push(request);
+            total_affected_rows += affected_rows;
+        }
+
+        for request in merged_requests {
+            self.data_region
+                .write_data(data_region_id, RegionRequest::Put(request))
+                .await?;
+        }
 
         Ok(total_affected_rows)
+    }
+
+    fn split_batch_by_wal_policy(
+        requests: Vec<(RegionId, RegionPutRequest)>,
+    ) -> Vec<Vec<(RegionId, RegionPutRequest)>> {
+        let run_count = requests
+            .chunk_by(|a, b| a.1.skip_wal == b.1.skip_wal)
+            .count();
+        let mut batches = Vec::with_capacity(run_count);
+        let mut requests = requests.into_iter();
+        while let Some(first) = requests.next() {
+            let remaining_run_len = requests
+                .as_slice()
+                .iter()
+                .take_while(|(_, request)| request.skip_wal == first.1.skip_wal)
+                .count();
+            let mut batch = Vec::with_capacity(remaining_run_len + 1);
+            batch.push(first);
+            batch.extend(requests.by_ref().take(remaining_run_len));
+            batches.push(batch);
+        }
+        batches
     }
 
     /// Get primary key encoding for a data region.
@@ -170,12 +223,27 @@ impl MetricEngineInner {
             })
     }
 
-    /// Validates all requests in a batch.
+    /// Validates all requests and returns the physical batch's explicit partition version.
     async fn validate_batch_requests(
         &self,
         physical_region_id: RegionId,
         requests: &mut [(RegionId, RegionPutRequest)],
-    ) -> Result<()> {
+    ) -> Result<Option<u64>> {
+        // Preserve the original physical-batch version boundary before splitting
+        // by WAL policy. A conflict must fail before any data batch is written.
+        let mut merged_version = None;
+        for (_, request) in requests.iter() {
+            if let Some(version) = request.partition_expr_version {
+                ensure!(
+                    merged_version.is_none_or(|merged| merged == version),
+                    InvalidRequestSnafu {
+                        region_id: physical_region_id,
+                        reason: "inconsistent partition expr version in batch"
+                    }
+                );
+                merged_version = Some(version);
+            }
+        }
         for (logical_region_id, request) in requests {
             self.verify_rows(
                 *logical_region_id,
@@ -185,7 +253,51 @@ impl MetricEngineInner {
             )
             .await?;
         }
-        Ok(())
+        Ok(merged_version)
+    }
+
+    /// Merges one WAL-policy run and attaches the physical batch's write options.
+    fn merge_batch(
+        &self,
+        physical_region_id: RegionId,
+        encoding: PrimaryKeyEncoding,
+        requests: Vec<(RegionId, RegionPutRequest)>,
+        partition_expr_version: Option<u64>,
+    ) -> Result<(RegionPutRequest, AffectedRows)> {
+        let skip_wal = requests
+            .first()
+            .is_some_and(|(_, request)| request.skip_wal);
+        ensure!(
+            requests
+                .iter()
+                .all(|(_, request)| request.skip_wal == skip_wal),
+            InvalidRequestSnafu {
+                region_id: physical_region_id,
+                reason: "inconsistent WAL policy in batch"
+            }
+        );
+        let (rows, hint) = match encoding {
+            PrimaryKeyEncoding::Sparse => (
+                self.merge_sparse_batch(physical_region_id, requests)?,
+                Some(WriteHint {
+                    primary_key_encoding: PrimaryKeyEncodingProto::Sparse.into(),
+                }),
+            ),
+            PrimaryKeyEncoding::Dense => (
+                self.merge_dense_batch(to_data_region_id(physical_region_id), requests)?,
+                None,
+            ),
+        };
+        let affected_rows = rows.rows.len() as AffectedRows;
+        Ok((
+            RegionPutRequest {
+                rows,
+                hint,
+                skip_wal,
+                partition_expr_version,
+            },
+            affected_rows,
+        ))
     }
 
     /// Merges multiple requests using sparse primary key encoding.
@@ -193,26 +305,11 @@ impl MetricEngineInner {
         &self,
         physical_region_id: RegionId,
         requests: Vec<(RegionId, RegionPutRequest)>,
-    ) -> Result<(RegionPutRequest, AffectedRows)> {
+    ) -> Result<Rows> {
         let total_rows: usize = requests.iter().map(|(_, req)| req.rows.rows.len()).sum();
         let mut modified_requests = Vec::with_capacity(requests.len());
-        let mut total_affected_rows: AffectedRows = 0;
-        let mut merged_version: Option<u64> = None;
 
         for (logical_region_id, mut request) in requests {
-            if let Some(request_version) = request.partition_expr_version {
-                if let Some(merged_version) = merged_version {
-                    ensure!(
-                        merged_version == request_version,
-                        InvalidRequestSnafu {
-                            region_id: physical_region_id,
-                            reason: "inconsistent partition expr version in batch"
-                        }
-                    );
-                } else {
-                    merged_version = Some(request_version);
-                }
-            }
             self.modify_rows(
                 physical_region_id,
                 logical_region_id.table_id(),
@@ -220,8 +317,6 @@ impl MetricEngineInner {
                 PrimaryKeyEncoding::Sparse,
             )?;
 
-            let row_count = request.rows.rows.len();
-            total_affected_rows += row_count as AffectedRows;
             modified_requests.push(request.rows);
         }
 
@@ -232,19 +327,10 @@ impl MetricEngineInner {
             merged_rows.extend(Self::align_rows_to_schema(rows, &schema));
         }
 
-        let merged_request = RegionPutRequest {
-            skip_wal: false,
-            rows: Rows {
-                schema,
-                rows: merged_rows,
-            },
-            hint: Some(WriteHint {
-                primary_key_encoding: PrimaryKeyEncodingProto::Sparse.into(),
-            }),
-            partition_expr_version: merged_version,
-        };
-
-        Ok((merged_request, total_affected_rows))
+        Ok(Rows {
+            schema,
+            rows: merged_rows,
+        })
     }
 
     /// Merges multiple requests using dense primary key encoding.
@@ -256,14 +342,13 @@ impl MetricEngineInner {
         &self,
         data_region_id: RegionId,
         requests: Vec<(RegionId, RegionPutRequest)>,
-    ) -> Result<(RegionPutRequest, AffectedRows)> {
+    ) -> Result<Rows> {
         // Build union schema from all requests
         let merged_schema =
             Self::build_union_schema(requests.iter().map(|(_, req)| req.rows.schema.as_slice()));
 
         // Align all rows to the merged schema and collect table_ids
-        let (merged_rows, table_ids, merged_version) =
-            Self::align_requests_to_schema(requests, &merged_schema)?;
+        let (merged_rows, table_ids) = Self::align_requests_to_schema(requests, &merged_schema);
 
         // Batch-modify all rows (add __table_id and __tsid columns)
         let final_rows = {
@@ -291,14 +376,7 @@ impl MetricEngineInner {
             )?
         };
 
-        let merged_request = RegionPutRequest {
-            skip_wal: false,
-            rows: final_rows,
-            hint: None,
-            partition_expr_version: merged_version,
-        };
-
-        Ok((merged_request, table_ids.len() as AffectedRows))
+        Ok(final_rows)
     }
 
     fn build_union_schema<'a>(
@@ -321,34 +399,20 @@ impl MetricEngineInner {
     fn align_requests_to_schema(
         requests: Vec<(RegionId, RegionPutRequest)>,
         merged_schema: &[ColumnSchema],
-    ) -> Result<(Vec<Row>, Vec<TableId>, Option<u64>)> {
+    ) -> (Vec<Row>, Vec<TableId>) {
         // Pre-calculate total capacity
         let total_rows: usize = requests.iter().map(|(_, req)| req.rows.rows.len()).sum();
         let mut merged_rows = Vec::with_capacity(total_rows);
         let mut table_ids = Vec::with_capacity(total_rows);
-        let mut merged_version: Option<u64> = None;
 
         for (logical_region_id, request) in requests {
-            if let Some(request_version) = request.partition_expr_version {
-                if let Some(merged_version) = merged_version {
-                    ensure!(
-                        merged_version == request_version,
-                        InvalidRequestSnafu {
-                            region_id: logical_region_id,
-                            reason: "inconsistent partition expr version in batch"
-                        }
-                    );
-                } else {
-                    merged_version = Some(request_version);
-                }
-            }
             let table_id = logical_region_id.table_id();
             let row_count = request.rows.rows.len();
             merged_rows.extend(Self::align_rows_to_schema(request.rows, merged_schema));
             table_ids.extend(std::iter::repeat_n(table_id, row_count));
         }
 
-        Ok((merged_rows, table_ids, merged_version))
+        (merged_rows, table_ids)
     }
 
     fn align_rows_to_schema(rows: Rows, merged_schema: &[ColumnSchema]) -> Vec<Row> {
@@ -771,24 +835,313 @@ mod tests {
     use common_function::utils::partition_expr_version;
     use common_query::prelude::{greptime_native_histogram, greptime_timestamp, greptime_value};
     use common_recordbatch::RecordBatches;
+    use datatypes::arrow::array::{Float64Array, TimestampMillisecondArray};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema};
     use datatypes::value::Value as PartitionValue;
     use partition::expr::col;
     use store_api::metadata::ColumnMetadata;
     use store_api::metric_engine_consts::{
-        DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, PRIMARY_KEY_ENCODING,
+        DATA_SCHEMA_TABLE_ID_COLUMN_NAME, DATA_SCHEMA_TSID_COLUMN_NAME, METRIC_ENGINE_NAME,
+        PHYSICAL_TABLE_METADATA_KEY, PRIMARY_KEY_ENCODING,
     };
     use store_api::path_utils::table_dir;
     use store_api::region_engine::RegionEngine;
     use store_api::region_request::{
-        EnterStagingRequest, RegionRequest, StagingPartitionDirective,
+        EnterStagingRequest, PathType, RegionCloseRequest, RegionOpenRequest, RegionRequest,
+        StagingPartitionDirective,
     };
     use store_api::storage::ScanRequest;
     use store_api::storage::consts::PRIMARY_KEY_COLUMN_NAME;
 
     use super::*;
+    use crate::engine::MetricEngine;
     use crate::test_util::{self, TestEnv};
+
+    async fn scan_timestamp_values(engine: &MetricEngine, region_id: RegionId) -> Vec<(i64, f64)> {
+        let stream = engine
+            .scan_to_stream(region_id, ScanRequest::default())
+            .await
+            .unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        let mut rows = Vec::new();
+        for batch in batches.iter() {
+            let batch = batch.df_record_batch();
+            let timestamp_index = batch.schema().index_of(greptime_timestamp()).unwrap();
+            let value_index = batch.schema().index_of(greptime_value()).unwrap();
+            let timestamps = batch
+                .column(timestamp_index)
+                .as_any()
+                .downcast_ref::<TimestampMillisecondArray>()
+                .unwrap();
+            let values = batch
+                .column(value_index)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            rows.extend(
+                timestamps
+                    .values()
+                    .iter()
+                    .copied()
+                    .zip(values.values().iter().copied()),
+            );
+        }
+        rows.sort_unstable_by_key(|(timestamp, _)| *timestamp);
+        rows
+    }
+
+    #[tokio::test]
+    async fn test_mixed_wal_batch_partition_versions() {
+        for encoding in ["sparse", "dense"] {
+            let env = TestEnv::new().await;
+            let physical_region_id = env.default_physical_region_id();
+            let logical_region_id = env.default_logical_region_id();
+            env.create_physical_region(
+                physical_region_id,
+                &TestEnv::default_table_dir(),
+                vec![(PRIMARY_KEY_ENCODING.to_string(), encoding.to_string())],
+            )
+            .await;
+            create_logical_region_with_tags(&env, physical_region_id, logical_region_id, &["job"])
+                .await;
+            let build_requests = |versions: [Option<u64>; 3]| {
+                versions
+                    .into_iter()
+                    .zip([false, true, false])
+                    .map(|(partition_expr_version, skip_wal)| {
+                        (
+                            logical_region_id,
+                            RegionPutRequest {
+                                skip_wal,
+                                rows: Rows {
+                                    schema: test_util::row_schema_with_tags(&["job"]),
+                                    rows: test_util::build_rows(1, 1),
+                                },
+                                hint: None,
+                                partition_expr_version,
+                            },
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            };
+            // The first run has no version and could otherwise be written
+            // before a later run reveals the conflicting explicit versions.
+            let err = env
+                .metric()
+                .inner
+                .put_regions_batch_single_physical(
+                    physical_region_id,
+                    build_requests([None, Some(10), Some(11)]),
+                )
+                .await
+                .unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("inconsistent partition expr version")
+            );
+            assert!(
+                scan_timestamp_values(&env.metric(), logical_region_id)
+                    .await
+                    .is_empty()
+            );
+
+            for (versions, expected) in [
+                ([None, None, None], None),
+                ([None, Some(7), None], Some(7)),
+                ([Some(7), None, Some(7)], Some(7)),
+            ] {
+                let mut requests = build_requests(versions);
+                let actual = env
+                    .metric()
+                    .inner
+                    .validate_batch_requests(physical_region_id, &mut requests)
+                    .await
+                    .unwrap();
+                assert_eq!(actual, expected);
+                for ((_, request), original_version) in requests.iter().zip(versions) {
+                    assert_eq!(request.partition_expr_version, original_version);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_put_skip_wal_mixed_batch_recovery() {
+        for encoding in ["sparse", "dense"] {
+            // Paired runs differ only in the middle request's WAL policy.
+            for middle_skip_wal in [false, true] {
+                let env = TestEnv::new().await;
+                let engine = env.metric();
+                engine.inner.flush_task.stop().await.unwrap();
+                let physical_region_id = env.default_physical_region_id();
+                let logical_region_id = env.default_logical_region_id();
+                env.create_physical_region(
+                    physical_region_id,
+                    &TestEnv::default_table_dir(),
+                    vec![(PRIMARY_KEY_ENCODING.to_string(), encoding.to_string())],
+                )
+                .await;
+                create_logical_region_with_tags(
+                    &env,
+                    physical_region_id,
+                    logical_region_id,
+                    &["job"],
+                )
+                .await;
+                let metadata_before = engine.get_metadata(logical_region_id).await.unwrap();
+
+                let requests = [false, middle_skip_wal, false].into_iter().enumerate().map(
+                    |(index, skip_wal)| {
+                        let timestamp = index as i64 + 1;
+                        let value = timestamp as f64 * 10.0;
+                        // Every request updates the same key at timestamp zero and
+                        // also inserts a distinct key, exposing both reordering and
+                        // accidental WAL-policy propagation to neighboring requests.
+                        let rows = [0, timestamp]
+                            .into_iter()
+                            .map(|timestamp| Row {
+                                values: vec![
+                                    Value {
+                                        value_data: Some(ValueData::TimestampMillisecondValue(
+                                            timestamp,
+                                        )),
+                                    },
+                                    Value {
+                                        value_data: Some(ValueData::F64Value(value)),
+                                    },
+                                    Value {
+                                        value_data: Some(ValueData::StringValue(
+                                            "tag_0".to_string(),
+                                        )),
+                                    },
+                                ],
+                            })
+                            .collect();
+                        (
+                            logical_region_id,
+                            RegionPutRequest {
+                                rows: Rows {
+                                    schema: test_util::row_schema_with_tags(&["job"]),
+                                    rows,
+                                },
+                                hint: None,
+                                partition_expr_version: None,
+                                skip_wal,
+                            },
+                        )
+                    },
+                );
+                let affected_rows = engine.inner.put_regions_batch(requests).await.unwrap();
+                assert_eq!(affected_rows, 6);
+                assert_eq!(
+                    scan_timestamp_values(&engine, logical_region_id).await,
+                    vec![(0, 30.0), (1, 10.0), (2, 20.0), (3, 30.0)]
+                );
+
+                // Neither data nor metadata has an SST to hide missing WAL.
+                for region_id in [
+                    to_data_region_id(physical_region_id),
+                    crate::utils::to_metadata_region_id(physical_region_id),
+                ] {
+                    let stat = env.mito().region_statistic(region_id).unwrap();
+                    assert!(stat.memtable_size > 0);
+                    assert_eq!(stat.sst_num, 0);
+                }
+                engine
+                    .handle_request(
+                        physical_region_id,
+                        RegionRequest::Close(RegionCloseRequest {
+                            flush_on_close: false,
+                        }),
+                    )
+                    .await
+                    .unwrap();
+
+                // Recreate the wrapper as well, discarding its metadata cache.
+                let reopened = MetricEngine::try_new(env.mito(), Default::default()).unwrap();
+                reopened.inner.flush_task.stop().await.unwrap();
+                reopened
+                    .handle_request(
+                        physical_region_id,
+                        RegionRequest::Open(RegionOpenRequest {
+                            engine: METRIC_ENGINE_NAME.to_string(),
+                            table_dir: TestEnv::default_table_dir(),
+                            path_type: PathType::Bare,
+                            options: [
+                                (PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new()),
+                                (PRIMARY_KEY_ENCODING.to_string(), encoding.to_string()),
+                            ]
+                            .into_iter()
+                            .collect(),
+                            skip_wal_replay: false,
+                            checkpoint: None,
+                            requirements: Default::default(),
+                        }),
+                    )
+                    .await
+                    .unwrap();
+                let recovered_metadata = reopened.get_metadata(logical_region_id).await.unwrap();
+                assert_eq!(
+                    metadata_before.column_metadatas,
+                    recovered_metadata.column_metadatas
+                );
+                let expected = if middle_skip_wal {
+                    vec![(0, 30.0), (1, 10.0), (3, 30.0)]
+                } else {
+                    vec![(0, 30.0), (1, 10.0), (2, 20.0), (3, 30.0)]
+                };
+                assert_eq!(
+                    scan_timestamp_values(&reopened, logical_region_id).await,
+                    expected,
+                    "encoding={encoding}, middle_skip_wal={middle_skip_wal}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_split_batch_by_wal_policy_preserves_order() {
+        let region_id = RegionId::new(1024, 1);
+        let requests = [false, false, true, false, true, true]
+            .into_iter()
+            .enumerate()
+            .map(|(index, skip_wal)| {
+                (
+                    region_id,
+                    RegionPutRequest {
+                        rows: Rows::default(),
+                        hint: None,
+                        partition_expr_version: Some(index as u64),
+                        skip_wal,
+                    },
+                )
+            })
+            .collect();
+        let batches = MetricEngineInner::split_batch_by_wal_policy(requests);
+        let actual: Vec<_> = batches
+            .iter()
+            .map(|batch| {
+                (
+                    batch[0].1.skip_wal,
+                    batch
+                        .iter()
+                        .map(|(_, request)| request.partition_expr_version.unwrap())
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            actual,
+            vec![
+                (false, vec![0, 1]),
+                (true, vec![2]),
+                (false, vec![3]),
+                (true, vec![4, 5])
+            ]
+        );
+        assert!(MetricEngineInner::split_batch_by_wal_policy(vec![]).is_empty());
+    }
 
     fn assert_merged_schema(rows: &Rows, expect_sparse: bool) {
         let column_names: HashSet<String> = rows
@@ -947,32 +1300,50 @@ mod tests {
             ]
         };
 
-        let merged_request = if expect_sparse {
-            let (merged_request, _) = env
-                .metric()
-                .inner
-                .merge_sparse_batch(physical_region_id, build_requests())
-                .unwrap();
-            let hint = merged_request
-                .hint
-                .as_ref()
-                .expect("missing sparse write hint");
+        let encoding = if expect_sparse {
+            PrimaryKeyEncoding::Sparse
+        } else {
+            PrimaryKeyEncoding::Dense
+        };
+        let (merged_request, _) = env
+            .metric()
+            .inner
+            .merge_batch(physical_region_id, encoding, build_requests(), None)
+            .unwrap();
+        if expect_sparse {
             assert_eq!(
-                hint.primary_key_encoding,
+                merged_request.hint.as_ref().unwrap().primary_key_encoding,
                 PrimaryKeyEncodingProto::Sparse as i32
             );
-            merged_request
         } else {
-            let (merged_request, _) = env
+            assert!(merged_request.hint.is_none());
+        }
+        assert_merged_schema(&merged_request.rows, expect_sparse);
+        assert!(!merged_request.skip_wal);
+
+        for skip_wal in [false, true] {
+            let mut requests = build_requests();
+            for (_, request) in &mut requests {
+                request.skip_wal = skip_wal;
+            }
+            let (merged, affected_rows) = env
                 .metric()
                 .inner
-                .merge_dense_batch(data_region_id, build_requests())
+                .merge_batch(physical_region_id, encoding, requests, Some(7))
                 .unwrap();
-            assert!(merged_request.hint.is_none());
-            merged_request
-        };
+            assert_eq!(merged.skip_wal, skip_wal);
+            assert_eq!(merged.partition_expr_version, Some(7));
+            assert_eq!(affected_rows, 5);
+        }
 
-        assert_merged_schema(&merged_request.rows, expect_sparse);
+        let mut mixed_requests = build_requests();
+        mixed_requests[1].1.skip_wal = true;
+        assert!(
+            env.metric()
+                .inner
+                .merge_batch(physical_region_id, encoding, mixed_requests, None)
+                .is_err()
+        );
 
         let affected_rows = env
             .metric()

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -849,216 +849,212 @@ mod tests {
 
     #[tokio::test]
     async fn test_batch_partition_versions() {
-        for encoding in ["sparse", "dense"] {
-            let env = TestEnv::new().await;
-            let physical_region_id = env.default_physical_region_id();
-            let logical_region_id = env.default_logical_region_id();
-            env.create_physical_region(
-                physical_region_id,
-                &TestEnv::default_table_dir(),
-                vec![(PRIMARY_KEY_ENCODING.to_string(), encoding.to_string())],
-            )
-            .await;
-            create_logical_region_with_tags(&env, physical_region_id, logical_region_id, &["job"])
-                .await;
-            let build_requests = |versions: [Option<u64>; 3]| {
-                versions
-                    .into_iter()
-                    .map(|partition_expr_version| {
-                        (
-                            logical_region_id,
-                            RegionPutRequest {
-                                skip_wal: false,
-                                rows: Rows {
-                                    schema: test_util::row_schema_with_tags(&["job"]),
-                                    rows: test_util::build_rows(1, 1),
-                                },
-                                hint: None,
-                                partition_expr_version,
-                            },
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            };
-            // Conflicting explicit versions must fail before any data is written.
-            let err = env
-                .metric()
-                .inner
-                .put_regions_batch_single_physical(
-                    physical_region_id,
-                    build_requests([None, Some(10), Some(11)]),
-                )
-                .await
-                .unwrap_err();
-            assert!(
-                err.to_string()
-                    .contains("inconsistent partition expr version")
-            );
-            assert!(
-                scan_timestamp_values(&env.metric(), logical_region_id)
-                    .await
-                    .is_empty()
-            );
+        check_batch_partition_versions("sparse").await;
+        check_batch_partition_versions("dense").await;
+    }
 
-            for (versions, expected) in [
-                ([None, None, None], None),
-                ([None, Some(7), None], Some(7)),
-                ([Some(7), None, Some(7)], Some(7)),
-            ] {
-                let mut requests = build_requests(versions);
-                let engine = env.metric();
-                engine
-                    .inner
-                    .validate_batch_requests(physical_region_id, &mut requests)
-                    .await
-                    .unwrap();
-                let (merged, _) = match encoding {
-                    "sparse" => engine
-                        .inner
-                        .merge_sparse_batch(physical_region_id, requests),
-                    "dense" => engine
-                        .inner
-                        .merge_dense_batch(to_data_region_id(physical_region_id), requests),
-                    _ => unreachable!(),
-                }
+    async fn check_batch_partition_versions(encoding: &str) {
+        let env = TestEnv::new().await;
+        let physical_region_id = env.default_physical_region_id();
+        let logical_region_id = env.default_logical_region_id();
+        env.create_physical_region(
+            physical_region_id,
+            &TestEnv::default_table_dir(),
+            vec![(PRIMARY_KEY_ENCODING.to_string(), encoding.to_string())],
+        )
+        .await;
+        create_logical_region_with_tags(&env, physical_region_id, logical_region_id, &["job"])
+            .await;
+        let build_requests = |versions: [Option<u64>; 3]| {
+            versions
+                .into_iter()
+                .map(|partition_expr_version| {
+                    (
+                        logical_region_id,
+                        RegionPutRequest {
+                            skip_wal: false,
+                            rows: Rows {
+                                schema: test_util::row_schema_with_tags(&["job"]),
+                                rows: test_util::build_rows(1, 1),
+                            },
+                            hint: None,
+                            partition_expr_version,
+                        },
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        // Conflicting explicit versions must fail before any data is written.
+        let err = env
+            .metric()
+            .inner
+            .put_regions_batch_single_physical(
+                physical_region_id,
+                build_requests([None, Some(10), Some(11)]),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("inconsistent partition expr version")
+        );
+        assert!(
+            scan_timestamp_values(&env.metric(), logical_region_id)
+                .await
+                .is_empty()
+        );
+
+        for (versions, expected) in [
+            ([None, None, None], None),
+            ([None, Some(7), None], Some(7)),
+            ([Some(7), None, Some(7)], Some(7)),
+        ] {
+            let mut requests = build_requests(versions);
+            let engine = env.metric();
+            engine
+                .inner
+                .validate_batch_requests(physical_region_id, &mut requests)
+                .await
                 .unwrap();
-                assert_eq!(merged.partition_expr_version, expected);
+            let (merged, _) = match encoding {
+                "sparse" => engine
+                    .inner
+                    .merge_sparse_batch(physical_region_id, requests),
+                "dense" => engine
+                    .inner
+                    .merge_dense_batch(to_data_region_id(physical_region_id), requests),
+                _ => unreachable!(),
             }
+            .unwrap();
+            assert_eq!(merged.partition_expr_version, expected);
         }
     }
 
     #[tokio::test]
     async fn test_put_skip_wal_batch_recovery() {
-        for encoding in ["sparse", "dense"] {
-            // Paired runs differ only in the batch's WAL policy.
-            for skip_wal in [false, true] {
-                let env = TestEnv::new().await;
-                let engine = env.metric();
-                engine.inner.flush_task.stop().await.unwrap();
-                let physical_region_id = env.default_physical_region_id();
-                let logical_region_id = env.default_logical_region_id();
-                env.create_physical_region(
-                    physical_region_id,
-                    &TestEnv::default_table_dir(),
-                    vec![(PRIMARY_KEY_ENCODING.to_string(), encoding.to_string())],
-                )
-                .await;
-                create_logical_region_with_tags(
-                    &env,
-                    physical_region_id,
-                    logical_region_id,
-                    &["job"],
-                )
-                .await;
-                let metadata_before = engine.get_metadata(logical_region_id).await.unwrap();
+        check_put_skip_wal_batch_recovery("sparse", false).await;
+        check_put_skip_wal_batch_recovery("sparse", true).await;
+        check_put_skip_wal_batch_recovery("dense", false).await;
+        check_put_skip_wal_batch_recovery("dense", true).await;
+    }
 
-                let requests = [skip_wal; 3]
+    async fn check_put_skip_wal_batch_recovery(encoding: &str, skip_wal: bool) {
+        let env = TestEnv::new().await;
+        let engine = env.metric();
+        engine.inner.flush_task.stop().await.unwrap();
+        let physical_region_id = env.default_physical_region_id();
+        let logical_region_id = env.default_logical_region_id();
+        env.create_physical_region(
+            physical_region_id,
+            &TestEnv::default_table_dir(),
+            vec![(PRIMARY_KEY_ENCODING.to_string(), encoding.to_string())],
+        )
+        .await;
+        create_logical_region_with_tags(&env, physical_region_id, logical_region_id, &["job"])
+            .await;
+        let metadata_before = engine.get_metadata(logical_region_id).await.unwrap();
+
+        let requests = [skip_wal; 3]
+            .into_iter()
+            .enumerate()
+            .map(|(index, skip_wal)| {
+                let timestamp = index as i64 + 1;
+                let value = timestamp as f64 * 10.0;
+                // Every request updates the same key at timestamp zero and
+                // also inserts a distinct key to verify merge order.
+                let rows = [0, timestamp]
                     .into_iter()
-                    .enumerate()
-                    .map(|(index, skip_wal)| {
-                        let timestamp = index as i64 + 1;
-                        let value = timestamp as f64 * 10.0;
-                        // Every request updates the same key at timestamp zero and
-                        // also inserts a distinct key to verify merge order.
-                        let rows = [0, timestamp]
-                            .into_iter()
-                            .map(|timestamp| Row {
-                                values: vec![
-                                    Value {
-                                        value_data: Some(ValueData::TimestampMillisecondValue(
-                                            timestamp,
-                                        )),
-                                    },
-                                    Value {
-                                        value_data: Some(ValueData::F64Value(value)),
-                                    },
-                                    Value {
-                                        value_data: Some(ValueData::StringValue(
-                                            "tag_0".to_string(),
-                                        )),
-                                    },
-                                ],
-                            })
-                            .collect();
-                        (
-                            logical_region_id,
-                            RegionPutRequest {
-                                rows: Rows {
-                                    schema: test_util::row_schema_with_tags(&["job"]),
-                                    rows,
-                                },
-                                hint: None,
-                                partition_expr_version: None,
-                                skip_wal,
+                    .map(|timestamp| Row {
+                        values: vec![
+                            Value {
+                                value_data: Some(ValueData::TimestampMillisecondValue(timestamp)),
                             },
-                        )
-                    });
-                let affected_rows = engine.inner.put_regions_batch(requests).await.unwrap();
-                assert_eq!(affected_rows, 6);
-                assert_eq!(
-                    scan_timestamp_values(&engine, logical_region_id).await,
-                    vec![(0, 30.0), (1, 10.0), (2, 20.0), (3, 30.0)]
-                );
+                            Value {
+                                value_data: Some(ValueData::F64Value(value)),
+                            },
+                            Value {
+                                value_data: Some(ValueData::StringValue("tag_0".to_string())),
+                            },
+                        ],
+                    })
+                    .collect();
+                (
+                    logical_region_id,
+                    RegionPutRequest {
+                        rows: Rows {
+                            schema: test_util::row_schema_with_tags(&["job"]),
+                            rows,
+                        },
+                        hint: None,
+                        partition_expr_version: None,
+                        skip_wal,
+                    },
+                )
+            });
+        let affected_rows = engine.inner.put_regions_batch(requests).await.unwrap();
+        assert_eq!(affected_rows, 6);
+        assert_eq!(
+            scan_timestamp_values(&engine, logical_region_id).await,
+            vec![(0, 30.0), (1, 10.0), (2, 20.0), (3, 30.0)]
+        );
 
-                // Neither data nor metadata has an SST to hide missing WAL.
-                for region_id in [
-                    to_data_region_id(physical_region_id),
-                    crate::utils::to_metadata_region_id(physical_region_id),
-                ] {
-                    let stat = env.mito().region_statistic(region_id).unwrap();
-                    assert!(stat.memtable_size > 0);
-                    assert_eq!(stat.sst_num, 0);
-                }
-                engine
-                    .handle_request(
-                        physical_region_id,
-                        RegionRequest::Close(RegionCloseRequest {
-                            flush_on_close: false,
-                        }),
-                    )
-                    .await
-                    .unwrap();
-
-                // Recreate the wrapper as well, discarding its metadata cache.
-                let reopened = MetricEngine::try_new(env.mito(), Default::default()).unwrap();
-                reopened.inner.flush_task.stop().await.unwrap();
-                reopened
-                    .handle_request(
-                        physical_region_id,
-                        RegionRequest::Open(RegionOpenRequest {
-                            engine: METRIC_ENGINE_NAME.to_string(),
-                            table_dir: TestEnv::default_table_dir(),
-                            path_type: PathType::Bare,
-                            options: [
-                                (PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new()),
-                                (PRIMARY_KEY_ENCODING.to_string(), encoding.to_string()),
-                            ]
-                            .into_iter()
-                            .collect(),
-                            skip_wal_replay: false,
-                            checkpoint: None,
-                            requirements: Default::default(),
-                        }),
-                    )
-                    .await
-                    .unwrap();
-                let recovered_metadata = reopened.get_metadata(logical_region_id).await.unwrap();
-                assert_eq!(
-                    metadata_before.column_metadatas,
-                    recovered_metadata.column_metadatas
-                );
-                let expected = if skip_wal {
-                    vec![]
-                } else {
-                    vec![(0, 30.0), (1, 10.0), (2, 20.0), (3, 30.0)]
-                };
-                assert_eq!(
-                    scan_timestamp_values(&reopened, logical_region_id).await,
-                    expected,
-                    "encoding={encoding}, skip_wal={skip_wal}"
-                );
-            }
+        // Neither data nor metadata has an SST to hide missing WAL.
+        for region_id in [
+            to_data_region_id(physical_region_id),
+            crate::utils::to_metadata_region_id(physical_region_id),
+        ] {
+            let stat = env.mito().region_statistic(region_id).unwrap();
+            assert!(stat.memtable_size > 0);
+            assert_eq!(stat.sst_num, 0);
         }
+        engine
+            .handle_request(
+                physical_region_id,
+                RegionRequest::Close(RegionCloseRequest {
+                    flush_on_close: false,
+                }),
+            )
+            .await
+            .unwrap();
+
+        // Recreate the wrapper as well, discarding its metadata cache.
+        let reopened = MetricEngine::try_new(env.mito(), Default::default()).unwrap();
+        reopened.inner.flush_task.stop().await.unwrap();
+        reopened
+            .handle_request(
+                physical_region_id,
+                RegionRequest::Open(RegionOpenRequest {
+                    engine: METRIC_ENGINE_NAME.to_string(),
+                    table_dir: TestEnv::default_table_dir(),
+                    path_type: PathType::Bare,
+                    options: [
+                        (PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new()),
+                        (PRIMARY_KEY_ENCODING.to_string(), encoding.to_string()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                    skip_wal_replay: false,
+                    checkpoint: None,
+                    requirements: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+        let recovered_metadata = reopened.get_metadata(logical_region_id).await.unwrap();
+        assert_eq!(
+            metadata_before.column_metadatas,
+            recovered_metadata.column_metadatas
+        );
+        let expected = if skip_wal {
+            vec![]
+        } else {
+            vec![(0, 30.0), (1, 10.0), (2, 20.0), (3, 30.0)]
+        };
+        assert_eq!(
+            scan_timestamp_values(&reopened, logical_region_id).await,
+            expected,
+            "encoding={encoding}, skip_wal={skip_wal}"
+        );
     }
 
     fn assert_merged_schema(rows: &Rows, expect_sparse: bool) {

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -1143,6 +1143,45 @@ mod tests {
             .unwrap()
     }
 
+    fn check_batch_merge_wal_policy(
+        env: &TestEnv,
+        physical_region_id: RegionId,
+        mut requests: Vec<(RegionId, RegionPutRequest)>,
+        expect_sparse: bool,
+        skip_wal: bool,
+    ) {
+        for (_, request) in &mut requests {
+            request.skip_wal = skip_wal;
+        }
+        let (merged_request, affected_rows) = if expect_sparse {
+            let (merged_request, affected_rows) = env
+                .metric()
+                .inner
+                .merge_sparse_batch(physical_region_id, requests)
+                .unwrap();
+            let hint = merged_request
+                .hint
+                .as_ref()
+                .expect("missing sparse write hint");
+            assert_eq!(
+                hint.primary_key_encoding,
+                PrimaryKeyEncodingProto::Sparse as i32
+            );
+            (merged_request, affected_rows)
+        } else {
+            let (merged_request, affected_rows) = env
+                .metric()
+                .inner
+                .merge_dense_batch(to_data_region_id(physical_region_id), requests)
+                .unwrap();
+            assert!(merged_request.hint.is_none());
+            (merged_request, affected_rows)
+        };
+        assert_merged_schema(&merged_request.rows, expect_sparse);
+        assert_eq!(merged_request.skip_wal, skip_wal);
+        assert_eq!(affected_rows, 5);
+    }
+
     async fn run_batch_write_with_schema_variants(
         env: &TestEnv,
         physical_region_id: RegionId,
@@ -1214,39 +1253,20 @@ mod tests {
             ]
         };
 
-        for skip_wal in [false, true] {
-            let mut requests = build_requests();
-            for (_, request) in &mut requests {
-                request.skip_wal = skip_wal;
-            }
-            let (merged_request, affected_rows) = if expect_sparse {
-                let (merged_request, affected_rows) = env
-                    .metric()
-                    .inner
-                    .merge_sparse_batch(physical_region_id, requests)
-                    .unwrap();
-                let hint = merged_request
-                    .hint
-                    .as_ref()
-                    .expect("missing sparse write hint");
-                assert_eq!(
-                    hint.primary_key_encoding,
-                    PrimaryKeyEncodingProto::Sparse as i32
-                );
-                (merged_request, affected_rows)
-            } else {
-                let (merged_request, affected_rows) = env
-                    .metric()
-                    .inner
-                    .merge_dense_batch(data_region_id, requests)
-                    .unwrap();
-                assert!(merged_request.hint.is_none());
-                (merged_request, affected_rows)
-            };
-            assert_merged_schema(&merged_request.rows, expect_sparse);
-            assert_eq!(merged_request.skip_wal, skip_wal);
-            assert_eq!(affected_rows, 5);
-        }
+        check_batch_merge_wal_policy(
+            env,
+            physical_region_id,
+            build_requests(),
+            expect_sparse,
+            false,
+        );
+        check_batch_merge_wal_policy(
+            env,
+            physical_region_id,
+            build_requests(),
+            expect_sparse,
+            true,
+        );
 
         for policies in [[false, true], [true, false]] {
             let mut mixed_requests = build_requests();

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -233,6 +233,7 @@ impl MetricEngineInner {
         }
 
         let merged_request = RegionPutRequest {
+            skip_wal: false,
             rows: Rows {
                 schema,
                 rows: merged_rows,
@@ -291,6 +292,7 @@ impl MetricEngineInner {
         };
 
         let merged_request = RegionPutRequest {
+            skip_wal: false,
             rows: final_rows,
             hint: None,
             partition_expr_version: merged_version,
@@ -921,6 +923,7 @@ mod tests {
                 (
                     logical_region_1,
                     RegionPutRequest {
+                        skip_wal: false,
                         rows: Rows {
                             schema: schema_1.clone(),
                             rows: rows_1,
@@ -932,6 +935,7 @@ mod tests {
                 (
                     logical_region_2,
                     RegionPutRequest {
+                        skip_wal: false,
                         rows: Rows {
                             schema: schema_2.clone(),
                             rows: rows_2,
@@ -1095,6 +1099,7 @@ mod tests {
         let schema = test_util::row_schema_with_tags(&["job"]);
         let rows = test_util::build_rows(1, 5);
         let request = RegionRequest::Put(RegionPutRequest {
+            skip_wal: false,
             rows: Rows { schema, rows },
             hint: None,
             partition_expr_version: None,
@@ -1170,6 +1175,7 @@ mod tests {
         let schema = test_util::row_schema_with_tags(columns);
         let rows = test_util::build_rows(3, 100);
         let request = RegionRequest::Put(RegionPutRequest {
+            skip_wal: false,
             rows: Rows { schema, rows },
             hint: None,
             partition_expr_version: None,
@@ -1193,6 +1199,7 @@ mod tests {
         let schema = test_util::row_schema_with_tags(&["abc"]);
         let rows = test_util::build_rows(1, 100);
         let request = RegionRequest::Put(RegionPutRequest {
+            skip_wal: false,
             rows: Rows { schema, rows },
             hint: None,
             partition_expr_version: None,
@@ -1214,6 +1221,7 @@ mod tests {
         let schema = test_util::row_schema_with_tags(&["def"]);
         let rows = test_util::build_rows(1, 100);
         let request = RegionRequest::Put(RegionPutRequest {
+            skip_wal: false,
             rows: Rows { schema, rows },
             hint: None,
             partition_expr_version: None,
@@ -1274,6 +1282,7 @@ mod tests {
             (
                 logical_region_1,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: schema.clone(),
                         rows: rows1,
@@ -1285,6 +1294,7 @@ mod tests {
             (
                 logical_region_2,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: schema.clone(),
                         rows: rows2,
@@ -1296,6 +1306,7 @@ mod tests {
             (
                 logical_region_3,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: schema.clone(),
                         rows: rows3,
@@ -1347,6 +1358,7 @@ mod tests {
             (
                 logical_region_1,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: schema.clone(),
                         rows: test_util::build_rows(1, 3),
@@ -1358,6 +1370,7 @@ mod tests {
             (
                 nonexistent_region,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: schema.clone(),
                         rows: test_util::build_rows(1, 2),
@@ -1369,6 +1382,7 @@ mod tests {
             (
                 logical_region_2,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: schema.clone(),
                         rows: test_util::build_rows(1, 5),
@@ -1407,6 +1421,7 @@ mod tests {
         let requests = vec![(
             physical_region_id,
             RegionPutRequest {
+                skip_wal: false,
                 rows: Rows {
                     schema,
                     rows: test_util::build_rows(1, 1),
@@ -1441,6 +1456,7 @@ mod tests {
             (
                 logical_region_id,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: schema.clone(),
                         rows: test_util::build_rows(1, 1),
@@ -1452,6 +1468,7 @@ mod tests {
             (
                 physical_region_id,
                 RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema,
                         rows: test_util::build_rows(1, 1),
@@ -1487,6 +1504,7 @@ mod tests {
         let requests = vec![(
             logical_region_id,
             RegionPutRequest {
+                skip_wal: false,
                 rows: Rows {
                     schema,
                     rows: test_util::build_rows(1, 5),
@@ -1565,6 +1583,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows,
                     hint: None,
                     partition_expr_version: Some(1),
@@ -1607,6 +1626,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: rows.clone(),
                     hint: None,
                     partition_expr_version: Some(expected_version.wrapping_add(1)),
@@ -1621,6 +1641,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: rows.clone(),
                     hint: None,
                     partition_expr_version: None,
@@ -1635,6 +1656,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows,
                     hint: None,
                     partition_expr_version: Some(expected_version),
@@ -1703,6 +1725,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows { schema, rows },
                     hint: None,
                     partition_expr_version: None,
@@ -1759,6 +1782,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows { schema, rows },
                     hint: None,
                     partition_expr_version: None,
@@ -1813,6 +1837,7 @@ mod tests {
             .handle_request(
                 logical_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows { schema, rows },
                     hint: None,
                     partition_expr_version: None,

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -142,6 +142,8 @@ impl MetricEngineInner {
         let data_region_id = to_data_region_id(physical_region_id);
         let primary_key_encoding = self.get_primary_key_encoding(data_region_id)?;
 
+        // TODO(weny): Consolidate validation and merging to avoid redundant request traversals,
+        // while ensuring the entire batch is validated before writing.
         // Validate all requests
         self.validate_batch_requests(physical_region_id, &mut requests)
             .await?;
@@ -862,12 +864,11 @@ mod tests {
             let build_requests = |versions: [Option<u64>; 3]| {
                 versions
                     .into_iter()
-                    .zip([false; 3])
-                    .map(|(partition_expr_version, skip_wal)| {
+                    .map(|partition_expr_version| {
                         (
                             logical_region_id,
                             RegionPutRequest {
-                                skip_wal,
+                                skip_wal: false,
                                 rows: Rows {
                                     schema: test_util::row_schema_with_tags(&["job"]),
                                     rows: test_util::build_rows(1, 1),
@@ -1217,42 +1218,37 @@ mod tests {
             ]
         };
 
-        let encoding = if expect_sparse {
-            PrimaryKeyEncoding::Sparse
-        } else {
-            PrimaryKeyEncoding::Dense
-        };
-        let merge = |requests| match encoding {
-            PrimaryKeyEncoding::Sparse => env
-                .metric()
-                .inner
-                .merge_sparse_batch(physical_region_id, requests),
-            PrimaryKeyEncoding::Dense => env
-                .metric()
-                .inner
-                .merge_dense_batch(data_region_id, requests),
-        };
-        let (merged_request, _) = merge(build_requests()).unwrap();
-        if expect_sparse {
-            assert_eq!(
-                merged_request.hint.as_ref().unwrap().primary_key_encoding,
-                PrimaryKeyEncodingProto::Sparse as i32
-            );
-        } else {
-            assert!(merged_request.hint.is_none());
-        }
-        assert_merged_schema(&merged_request.rows, expect_sparse);
-        assert!(!merged_request.skip_wal);
-
         for skip_wal in [false, true] {
             let mut requests = build_requests();
             for (_, request) in &mut requests {
                 request.skip_wal = skip_wal;
-                request.partition_expr_version = Some(7);
             }
-            let (merged, affected_rows) = merge(requests).unwrap();
-            assert_eq!(merged.skip_wal, skip_wal);
-            assert_eq!(merged.partition_expr_version, Some(7));
+            let (merged_request, affected_rows) = if expect_sparse {
+                let (merged_request, affected_rows) = env
+                    .metric()
+                    .inner
+                    .merge_sparse_batch(physical_region_id, requests)
+                    .unwrap();
+                let hint = merged_request
+                    .hint
+                    .as_ref()
+                    .expect("missing sparse write hint");
+                assert_eq!(
+                    hint.primary_key_encoding,
+                    PrimaryKeyEncodingProto::Sparse as i32
+                );
+                (merged_request, affected_rows)
+            } else {
+                let (merged_request, affected_rows) = env
+                    .metric()
+                    .inner
+                    .merge_dense_batch(data_region_id, requests)
+                    .unwrap();
+                assert!(merged_request.hint.is_none());
+                (merged_request, affected_rows)
+            };
+            assert_merged_schema(&merged_request.rows, expect_sparse);
+            assert_eq!(merged_request.skip_wal, skip_wal);
             assert_eq!(affected_rows, 5);
         }
 

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -143,74 +143,21 @@ impl MetricEngineInner {
         let primary_key_encoding = self.get_primary_key_encoding(data_region_id)?;
 
         // Validate all requests
-        let partition_expr_version = self
-            .validate_batch_requests(physical_region_id, &mut requests)
+        self.validate_batch_requests(physical_region_id, &mut requests)
             .await?;
 
-        // Keep the common uniform-policy path allocation-free beyond the merge.
-        if requests
-            .iter()
-            .all(|(_, request)| request.skip_wal == requests[0].1.skip_wal)
-        {
-            let (request, affected_rows) = self.merge_batch(
-                physical_region_id,
-                primary_key_encoding,
-                requests,
-                partition_expr_version,
-            )?;
-            self.data_region
-                .write_data(data_region_id, RegionRequest::Put(request))
-                .await?;
-            return Ok(affected_rows);
-        }
+        // Merge requests according to encoding strategy
+        let (merged_request, total_affected_rows) = match primary_key_encoding {
+            PrimaryKeyEncoding::Sparse => self.merge_sparse_batch(physical_region_id, requests)?,
+            PrimaryKeyEncoding::Dense => self.merge_dense_batch(data_region_id, requests)?,
+        };
 
-        // Only merge consecutive requests with the same WAL policy, preserving
-        // write order even when the same logical region occurs more than once.
-        // Prepare every batch before writing so a merge error cannot partially
-        // apply this physical-region group.
-        let batches = Self::split_batch_by_wal_policy(requests);
-        let mut merged_requests = Vec::with_capacity(batches.len());
-        let mut total_affected_rows = 0;
-        for requests in batches {
-            let (request, affected_rows) = self.merge_batch(
-                physical_region_id,
-                primary_key_encoding,
-                requests,
-                partition_expr_version,
-            )?;
-            merged_requests.push(request);
-            total_affected_rows += affected_rows;
-        }
-
-        for request in merged_requests {
-            self.data_region
-                .write_data(data_region_id, RegionRequest::Put(request))
-                .await?;
-        }
+        // Write once to the physical region
+        self.data_region
+            .write_data(data_region_id, RegionRequest::Put(merged_request))
+            .await?;
 
         Ok(total_affected_rows)
-    }
-
-    fn split_batch_by_wal_policy(
-        requests: Vec<(RegionId, RegionPutRequest)>,
-    ) -> Vec<Vec<(RegionId, RegionPutRequest)>> {
-        let run_count = requests
-            .chunk_by(|a, b| a.1.skip_wal == b.1.skip_wal)
-            .count();
-        let mut batches = Vec::with_capacity(run_count);
-        let mut requests = requests.into_iter();
-        while let Some(first) = requests.next() {
-            let remaining_run_len = requests
-                .as_slice()
-                .iter()
-                .take_while(|(_, request)| request.skip_wal == first.1.skip_wal)
-                .count();
-            let mut batch = Vec::with_capacity(remaining_run_len + 1);
-            batch.push(first);
-            batch.extend(requests.by_ref().take(remaining_run_len));
-            batches.push(batch);
-        }
-        batches
     }
 
     /// Get primary key encoding for a data region.
@@ -223,47 +170,12 @@ impl MetricEngineInner {
             })
     }
 
-    /// Validates all requests and returns the physical batch's explicit partition version.
+    /// Validates all requests in a batch.
     async fn validate_batch_requests(
         &self,
         physical_region_id: RegionId,
         requests: &mut [(RegionId, RegionPutRequest)],
-    ) -> Result<Option<u64>> {
-        // Preserve the original physical-batch version boundary before splitting
-        // by WAL policy. A conflict must fail before any data batch is written.
-        let mut merged_version = None;
-        for (_, request) in requests.iter() {
-            if let Some(version) = request.partition_expr_version {
-                ensure!(
-                    merged_version.is_none_or(|merged| merged == version),
-                    InvalidRequestSnafu {
-                        region_id: physical_region_id,
-                        reason: "inconsistent partition expr version in batch"
-                    }
-                );
-                merged_version = Some(version);
-            }
-        }
-        for (logical_region_id, request) in requests {
-            self.verify_rows(
-                *logical_region_id,
-                physical_region_id,
-                &mut request.rows,
-                true,
-            )
-            .await?;
-        }
-        Ok(merged_version)
-    }
-
-    /// Merges one WAL-policy run and attaches the physical batch's write options.
-    fn merge_batch(
-        &self,
-        physical_region_id: RegionId,
-        encoding: PrimaryKeyEncoding,
-        requests: Vec<(RegionId, RegionPutRequest)>,
-        partition_expr_version: Option<u64>,
-    ) -> Result<(RegionPutRequest, AffectedRows)> {
+    ) -> Result<()> {
         let skip_wal = requests
             .first()
             .is_some_and(|(_, request)| request.skip_wal);
@@ -276,28 +188,16 @@ impl MetricEngineInner {
                 reason: "inconsistent WAL policy in batch"
             }
         );
-        let (rows, hint) = match encoding {
-            PrimaryKeyEncoding::Sparse => (
-                self.merge_sparse_batch(physical_region_id, requests)?,
-                Some(WriteHint {
-                    primary_key_encoding: PrimaryKeyEncodingProto::Sparse.into(),
-                }),
-            ),
-            PrimaryKeyEncoding::Dense => (
-                self.merge_dense_batch(to_data_region_id(physical_region_id), requests)?,
-                None,
-            ),
-        };
-        let affected_rows = rows.rows.len() as AffectedRows;
-        Ok((
-            RegionPutRequest {
-                rows,
-                hint,
-                skip_wal,
-                partition_expr_version,
-            },
-            affected_rows,
-        ))
+        for (logical_region_id, request) in requests {
+            self.verify_rows(
+                *logical_region_id,
+                physical_region_id,
+                &mut request.rows,
+                true,
+            )
+            .await?;
+        }
+        Ok(())
     }
 
     /// Merges multiple requests using sparse primary key encoding.
@@ -305,11 +205,29 @@ impl MetricEngineInner {
         &self,
         physical_region_id: RegionId,
         requests: Vec<(RegionId, RegionPutRequest)>,
-    ) -> Result<Rows> {
+    ) -> Result<(RegionPutRequest, AffectedRows)> {
+        let skip_wal = requests
+            .first()
+            .is_some_and(|(_, request)| request.skip_wal);
         let total_rows: usize = requests.iter().map(|(_, req)| req.rows.rows.len()).sum();
         let mut modified_requests = Vec::with_capacity(requests.len());
+        let mut total_affected_rows: AffectedRows = 0;
+        let mut merged_version: Option<u64> = None;
 
         for (logical_region_id, mut request) in requests {
+            if let Some(request_version) = request.partition_expr_version {
+                if let Some(merged_version) = merged_version {
+                    ensure!(
+                        merged_version == request_version,
+                        InvalidRequestSnafu {
+                            region_id: physical_region_id,
+                            reason: "inconsistent partition expr version in batch"
+                        }
+                    );
+                } else {
+                    merged_version = Some(request_version);
+                }
+            }
             self.modify_rows(
                 physical_region_id,
                 logical_region_id.table_id(),
@@ -317,6 +235,8 @@ impl MetricEngineInner {
                 PrimaryKeyEncoding::Sparse,
             )?;
 
+            let row_count = request.rows.rows.len();
+            total_affected_rows += row_count as AffectedRows;
             modified_requests.push(request.rows);
         }
 
@@ -327,10 +247,19 @@ impl MetricEngineInner {
             merged_rows.extend(Self::align_rows_to_schema(rows, &schema));
         }
 
-        Ok(Rows {
-            schema,
-            rows: merged_rows,
-        })
+        let merged_request = RegionPutRequest {
+            skip_wal,
+            rows: Rows {
+                schema,
+                rows: merged_rows,
+            },
+            hint: Some(WriteHint {
+                primary_key_encoding: PrimaryKeyEncodingProto::Sparse.into(),
+            }),
+            partition_expr_version: merged_version,
+        };
+
+        Ok((merged_request, total_affected_rows))
     }
 
     /// Merges multiple requests using dense primary key encoding.
@@ -342,13 +271,17 @@ impl MetricEngineInner {
         &self,
         data_region_id: RegionId,
         requests: Vec<(RegionId, RegionPutRequest)>,
-    ) -> Result<Rows> {
+    ) -> Result<(RegionPutRequest, AffectedRows)> {
+        let skip_wal = requests
+            .first()
+            .is_some_and(|(_, request)| request.skip_wal);
         // Build union schema from all requests
         let merged_schema =
             Self::build_union_schema(requests.iter().map(|(_, req)| req.rows.schema.as_slice()));
 
         // Align all rows to the merged schema and collect table_ids
-        let (merged_rows, table_ids) = Self::align_requests_to_schema(requests, &merged_schema);
+        let (merged_rows, table_ids, merged_version) =
+            Self::align_requests_to_schema(requests, &merged_schema)?;
 
         // Batch-modify all rows (add __table_id and __tsid columns)
         let final_rows = {
@@ -376,7 +309,14 @@ impl MetricEngineInner {
             )?
         };
 
-        Ok(final_rows)
+        let merged_request = RegionPutRequest {
+            skip_wal,
+            rows: final_rows,
+            hint: None,
+            partition_expr_version: merged_version,
+        };
+
+        Ok((merged_request, table_ids.len() as AffectedRows))
     }
 
     fn build_union_schema<'a>(
@@ -399,20 +339,34 @@ impl MetricEngineInner {
     fn align_requests_to_schema(
         requests: Vec<(RegionId, RegionPutRequest)>,
         merged_schema: &[ColumnSchema],
-    ) -> (Vec<Row>, Vec<TableId>) {
+    ) -> Result<(Vec<Row>, Vec<TableId>, Option<u64>)> {
         // Pre-calculate total capacity
         let total_rows: usize = requests.iter().map(|(_, req)| req.rows.rows.len()).sum();
         let mut merged_rows = Vec::with_capacity(total_rows);
         let mut table_ids = Vec::with_capacity(total_rows);
+        let mut merged_version: Option<u64> = None;
 
         for (logical_region_id, request) in requests {
+            if let Some(request_version) = request.partition_expr_version {
+                if let Some(merged_version) = merged_version {
+                    ensure!(
+                        merged_version == request_version,
+                        InvalidRequestSnafu {
+                            region_id: logical_region_id,
+                            reason: "inconsistent partition expr version in batch"
+                        }
+                    );
+                } else {
+                    merged_version = Some(request_version);
+                }
+            }
             let table_id = logical_region_id.table_id();
             let row_count = request.rows.rows.len();
             merged_rows.extend(Self::align_rows_to_schema(request.rows, merged_schema));
             table_ids.extend(std::iter::repeat_n(table_id, row_count));
         }
 
-        (merged_rows, table_ids)
+        Ok((merged_rows, table_ids, merged_version))
     }
 
     fn align_rows_to_schema(rows: Rows, merged_schema: &[ColumnSchema]) -> Vec<Row> {
@@ -892,7 +846,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mixed_wal_batch_partition_versions() {
+    async fn test_batch_partition_versions() {
         for encoding in ["sparse", "dense"] {
             let env = TestEnv::new().await;
             let physical_region_id = env.default_physical_region_id();
@@ -908,7 +862,7 @@ mod tests {
             let build_requests = |versions: [Option<u64>; 3]| {
                 versions
                     .into_iter()
-                    .zip([false, true, false])
+                    .zip([false; 3])
                     .map(|(partition_expr_version, skip_wal)| {
                         (
                             logical_region_id,
@@ -925,8 +879,7 @@ mod tests {
                     })
                     .collect::<Vec<_>>()
             };
-            // The first run has no version and could otherwise be written
-            // before a later run reveals the conflicting explicit versions.
+            // Conflicting explicit versions must fail before any data is written.
             let err = env
                 .metric()
                 .inner
@@ -952,25 +905,32 @@ mod tests {
                 ([Some(7), None, Some(7)], Some(7)),
             ] {
                 let mut requests = build_requests(versions);
-                let actual = env
-                    .metric()
+                let engine = env.metric();
+                engine
                     .inner
                     .validate_batch_requests(physical_region_id, &mut requests)
                     .await
                     .unwrap();
-                assert_eq!(actual, expected);
-                for ((_, request), original_version) in requests.iter().zip(versions) {
-                    assert_eq!(request.partition_expr_version, original_version);
+                let (merged, _) = match encoding {
+                    "sparse" => engine
+                        .inner
+                        .merge_sparse_batch(physical_region_id, requests),
+                    "dense" => engine
+                        .inner
+                        .merge_dense_batch(to_data_region_id(physical_region_id), requests),
+                    _ => unreachable!(),
                 }
+                .unwrap();
+                assert_eq!(merged.partition_expr_version, expected);
             }
         }
     }
 
     #[tokio::test]
-    async fn test_put_skip_wal_mixed_batch_recovery() {
+    async fn test_put_skip_wal_batch_recovery() {
         for encoding in ["sparse", "dense"] {
-            // Paired runs differ only in the middle request's WAL policy.
-            for middle_skip_wal in [false, true] {
+            // Paired runs differ only in the batch's WAL policy.
+            for skip_wal in [false, true] {
                 let env = TestEnv::new().await;
                 let engine = env.metric();
                 engine.inner.flush_task.stop().await.unwrap();
@@ -991,13 +951,14 @@ mod tests {
                 .await;
                 let metadata_before = engine.get_metadata(logical_region_id).await.unwrap();
 
-                let requests = [false, middle_skip_wal, false].into_iter().enumerate().map(
-                    |(index, skip_wal)| {
+                let requests = [skip_wal; 3]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, skip_wal)| {
                         let timestamp = index as i64 + 1;
                         let value = timestamp as f64 * 10.0;
                         // Every request updates the same key at timestamp zero and
-                        // also inserts a distinct key, exposing both reordering and
-                        // accidental WAL-policy propagation to neighboring requests.
+                        // also inserts a distinct key to verify merge order.
                         let rows = [0, timestamp]
                             .into_iter()
                             .map(|timestamp| Row {
@@ -1030,8 +991,7 @@ mod tests {
                                 skip_wal,
                             },
                         )
-                    },
-                );
+                    });
                 let affected_rows = engine.inner.put_regions_batch(requests).await.unwrap();
                 assert_eq!(affected_rows, 6);
                 assert_eq!(
@@ -1086,61 +1046,18 @@ mod tests {
                     metadata_before.column_metadatas,
                     recovered_metadata.column_metadatas
                 );
-                let expected = if middle_skip_wal {
-                    vec![(0, 30.0), (1, 10.0), (3, 30.0)]
+                let expected = if skip_wal {
+                    vec![]
                 } else {
                     vec![(0, 30.0), (1, 10.0), (2, 20.0), (3, 30.0)]
                 };
                 assert_eq!(
                     scan_timestamp_values(&reopened, logical_region_id).await,
                     expected,
-                    "encoding={encoding}, middle_skip_wal={middle_skip_wal}"
+                    "encoding={encoding}, skip_wal={skip_wal}"
                 );
             }
         }
-    }
-
-    #[test]
-    fn test_split_batch_by_wal_policy_preserves_order() {
-        let region_id = RegionId::new(1024, 1);
-        let requests = [false, false, true, false, true, true]
-            .into_iter()
-            .enumerate()
-            .map(|(index, skip_wal)| {
-                (
-                    region_id,
-                    RegionPutRequest {
-                        rows: Rows::default(),
-                        hint: None,
-                        partition_expr_version: Some(index as u64),
-                        skip_wal,
-                    },
-                )
-            })
-            .collect();
-        let batches = MetricEngineInner::split_batch_by_wal_policy(requests);
-        let actual: Vec<_> = batches
-            .iter()
-            .map(|batch| {
-                (
-                    batch[0].1.skip_wal,
-                    batch
-                        .iter()
-                        .map(|(_, request)| request.partition_expr_version.unwrap())
-                        .collect::<Vec<_>>(),
-                )
-            })
-            .collect();
-        assert_eq!(
-            actual,
-            vec![
-                (false, vec![0, 1]),
-                (true, vec![2]),
-                (false, vec![3]),
-                (true, vec![4, 5])
-            ]
-        );
-        assert!(MetricEngineInner::split_batch_by_wal_policy(vec![]).is_empty());
     }
 
     fn assert_merged_schema(rows: &Rows, expect_sparse: bool) {
@@ -1305,11 +1222,17 @@ mod tests {
         } else {
             PrimaryKeyEncoding::Dense
         };
-        let (merged_request, _) = env
-            .metric()
-            .inner
-            .merge_batch(physical_region_id, encoding, build_requests(), None)
-            .unwrap();
+        let merge = |requests| match encoding {
+            PrimaryKeyEncoding::Sparse => env
+                .metric()
+                .inner
+                .merge_sparse_batch(physical_region_id, requests),
+            PrimaryKeyEncoding::Dense => env
+                .metric()
+                .inner
+                .merge_dense_batch(data_region_id, requests),
+        };
+        let (merged_request, _) = merge(build_requests()).unwrap();
         if expect_sparse {
             assert_eq!(
                 merged_request.hint.as_ref().unwrap().primary_key_encoding,
@@ -1325,25 +1248,34 @@ mod tests {
             let mut requests = build_requests();
             for (_, request) in &mut requests {
                 request.skip_wal = skip_wal;
+                request.partition_expr_version = Some(7);
             }
-            let (merged, affected_rows) = env
-                .metric()
-                .inner
-                .merge_batch(physical_region_id, encoding, requests, Some(7))
-                .unwrap();
+            let (merged, affected_rows) = merge(requests).unwrap();
             assert_eq!(merged.skip_wal, skip_wal);
             assert_eq!(merged.partition_expr_version, Some(7));
             assert_eq!(affected_rows, 5);
         }
 
-        let mut mixed_requests = build_requests();
-        mixed_requests[1].1.skip_wal = true;
-        assert!(
-            env.metric()
+        for policies in [[false, true], [true, false]] {
+            let mut mixed_requests = build_requests();
+            for ((_, request), skip_wal) in mixed_requests.iter_mut().zip(policies) {
+                request.skip_wal = skip_wal;
+            }
+            let err = env
+                .metric()
                 .inner
-                .merge_batch(physical_region_id, encoding, mixed_requests, None)
-                .is_err()
-        );
+                .put_regions_batch(mixed_requests.into_iter())
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("inconsistent WAL policy in batch"));
+            for logical_region_id in [logical_region_1, logical_region_2] {
+                assert!(
+                    scan_timestamp_values(&env.metric(), logical_region_id)
+                        .await
+                        .is_empty()
+                );
+            }
+        }
 
         let affected_rows = env
             .metric()

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -495,6 +495,7 @@ mod test {
         let schema = test_util::row_schema_with_tags(&["job"]);
         let put = |rows| {
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: Rows {
                     schema: schema.clone(),
                     rows: test_util::build_rows(1, rows),

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -585,6 +585,7 @@ impl MetadataRegion {
         };
 
         RegionPutRequest {
+            skip_wal: false,
             rows,
             hint: None,
             partition_expr_version: None,

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -585,6 +585,7 @@ impl MetadataRegion {
         };
 
         RegionPutRequest {
+            // Metadata must remain recoverable regardless of the user write policy.
             skip_wal: false,
             rows,
             hint: None,
@@ -819,6 +820,37 @@ mod test {
     use super::*;
     use crate::test_util::TestEnv;
     use crate::utils::to_metadata_region_id;
+
+    #[test]
+    fn test_metadata_put_always_writes_wal() {
+        // Both metadata put paths use this constructor rather than forwarding
+        // a user insert request, so its WAL policy must always be independent.
+        for entries in [
+            vec![],
+            vec![("region", "")],
+            vec![("region", ""), ("column", "metadata")],
+        ] {
+            let request = MetadataRegion::build_put_request_from_iter(
+                entries
+                    .iter()
+                    .map(|(key, value)| (key.to_string(), value.to_string())),
+            );
+            assert!(!request.skip_wal);
+            assert!(request.hint.is_none());
+            assert!(request.partition_expr_version.is_none());
+            let expected_rows = entries
+                .into_iter()
+                .map(|(key, value)| {
+                    row(vec![
+                        ValueData::TimestampMillisecondValue(0),
+                        ValueData::StringValue(key.to_string()),
+                        ValueData::StringValue(value.to_string()),
+                    ])
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(request.rows.rows, expected_rows);
+        }
+    }
 
     #[test]
     fn test_concat_table_key() {

--- a/src/mito2/benches/bench_wal_encode.rs
+++ b/src/mito2/benches/bench_wal_encode.rs
@@ -26,7 +26,7 @@ use std::hint::black_box;
 use api::v1::helper::{field_column_schema, tag_column_schema, time_index_column_schema};
 use api::v1::{ColumnDataType, Mutation, OpType, Row, Rows, Value, WalEntry, value};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use mito2::wal::encoder::WalEntryEncoder;
+use mito2::wal::encoder::{WalEntryEncoder, WalEntryMask};
 use prost::Message;
 
 /// Builds a `Rows` with 3 string tags + timestamp + 3 float fields, mirroring a
@@ -106,8 +106,21 @@ fn bench_wal_encode(c: &mut Criterion) {
 
     group.bench_function("wal_entry_encoder", |b| {
         let mut encoder = WalEntryEncoder::new();
-        b.iter(|| black_box(encoder.encode_to_vec(&entry)));
+        b.iter(|| black_box(encoder.encode_to_vec(&entry, &WalEntryMask::default())));
     });
+
+    // Fixed input and encoder, changing only the WAL selection. Mask setup stays
+    // outside the timed loop; payloads are never cloned by the production path.
+    for skipped_count in [0, 1, 2, 4] {
+        let mut mask = WalEntryMask::default();
+        for index in 0..entry.mutations.len() {
+            mask.push_mutation(index, index >= skipped_count);
+        }
+        group.bench_function(format!("mask_skip_{skipped_count}_of_4"), |b| {
+            let mut encoder = WalEntryEncoder::new();
+            b.iter(|| black_box(encoder.encode_to_vec(black_box(&entry), black_box(&mask))));
+        });
+    }
 
     group.finish();
 }

--- a/src/mito2/benches/bench_wal_encode.rs
+++ b/src/mito2/benches/bench_wal_encode.rs
@@ -26,7 +26,7 @@ use std::hint::black_box;
 use api::v1::helper::{field_column_schema, tag_column_schema, time_index_column_schema};
 use api::v1::{ColumnDataType, Mutation, OpType, Row, Rows, Value, WalEntry, value};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use mito2::wal::encoder::{WalEntryEncoder, WalEntryMask};
+use mito2::wal::encoder::WalEntryEncoder;
 use prost::Message;
 
 /// Builds a `Rows` with 3 string tags + timestamp + 3 float fields, mirroring a
@@ -106,21 +106,8 @@ fn bench_wal_encode(c: &mut Criterion) {
 
     group.bench_function("wal_entry_encoder", |b| {
         let mut encoder = WalEntryEncoder::new();
-        b.iter(|| black_box(encoder.encode_to_vec(&entry, &WalEntryMask::default())));
+        b.iter(|| black_box(encoder.encode_to_vec(&entry)));
     });
-
-    // Fixed input and encoder, changing only the WAL selection. Mask setup stays
-    // outside the timed loop; payloads are never cloned by the production path.
-    for skipped_count in [0, 1, 2, 4] {
-        let mut mask = WalEntryMask::default();
-        for index in 0..entry.mutations.len() {
-            mask.push_mutation(index, index >= skipped_count);
-        }
-        group.bench_function(format!("mask_skip_{skipped_count}_of_4"), |b| {
-            let mut encoder = WalEntryEncoder::new();
-            b.iter(|| black_box(encoder.encode_to_vec(black_box(&entry), black_box(&mask))));
-        });
-    }
 
     group.finish();
 }

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -3341,6 +3341,7 @@ async fn test_alter_time_index_widen_sparse_compaction() {
     };
     let put_sparse = |rows| {
         RegionRequest::Put(RegionPutRequest {
+            skip_wal: false,
             rows,
             hint: Some(WriteHint {
                 primary_key_encoding: api::v1::PrimaryKeyEncoding::Sparse.into(),

--- a/src/mito2/src/engine/apply_staging_manifest_test.rs
+++ b/src/mito2/src/engine/apply_staging_manifest_test.rs
@@ -952,6 +952,7 @@ async fn test_apply_staging_manifest_preserves_unflushed_memtable_with_format(fl
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: unflushed_rows,
                 hint: None,
                 partition_expr_version: Some(expected_version),

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -1324,149 +1324,154 @@ async fn test_all_index_metas_list_all_types_with_format(flat_format: bool, expe
 
 #[tokio::test]
 async fn test_request_skip_wal_recovery() {
-    // Identical workload, changing only the request-level WAL policy.
-    for flat_format in [false, true] {
-        for skip_wal in [false, true] {
-            let mut env = TestEnv::new().await;
-            let engine = env
-                .create_engine(MitoConfig {
-                    default_flat_format: flat_format,
-                    ..Default::default()
-                })
-                .await;
-            let region_id = RegionId::new(1, 1);
-            let request = CreateRequestBuilder::new().build();
-            let table_dir = request.table_dir.clone();
-            let schema = rows_schema(&request);
-            engine
-                .handle_request(region_id, RegionRequest::Create(request))
-                .await
-                .unwrap();
-            let affected = engine
-                .handle_request(
-                    region_id,
-                    RegionRequest::Put(RegionPutRequest {
-                        rows: Rows {
-                            schema,
-                            rows: build_rows_for_key("a", 0, 4, 0),
-                        },
-                        hint: None,
-                        partition_expr_version: None,
-                        skip_wal,
-                    }),
-                )
-                .await
-                .unwrap();
-            assert_eq!(affected.affected_rows, 4);
-            let current = engine
-                .get_region(region_id)
-                .unwrap()
-                .version_control
-                .current();
-            assert_eq!(current.committed_sequence, 4);
-            assert_eq!(current.last_entry_id, u64::from(!skip_wal));
-            let stream = engine
-                .scan_to_stream(region_id, ScanRequest::default())
-                .await
-                .unwrap();
-            let before = RecordBatches::try_collect(stream).await.unwrap();
-            assert_eq!(before.iter().map(|b| b.num_rows()).sum::<usize>(), 4);
+    check_request_skip_wal_recovery(false, false).await;
+    check_request_skip_wal_recovery(false, true).await;
+    check_request_skip_wal_recovery(true, false).await;
+    check_request_skip_wal_recovery(true, true).await;
+}
 
-            reopen_region(&engine, region_id, table_dir, false, HashMap::new()).await;
-            let stream = engine
-                .scan_to_stream(region_id, ScanRequest::default())
-                .await
-                .unwrap();
-            let after = RecordBatches::try_collect(stream).await.unwrap();
-            assert_eq!(
-                after.iter().map(|b| b.num_rows()).sum::<usize>(),
-                if skip_wal { 0 } else { 4 }
-            );
-        }
-    }
+async fn check_request_skip_wal_recovery(flat_format: bool, skip_wal: bool) {
+    let mut env = TestEnv::new().await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: flat_format,
+            ..Default::default()
+        })
+        .await;
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let table_dir = request.table_dir.clone();
+    let schema = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    let affected = engine
+        .handle_request(
+            region_id,
+            RegionRequest::Put(RegionPutRequest {
+                rows: Rows {
+                    schema,
+                    rows: build_rows_for_key("a", 0, 4, 0),
+                },
+                hint: None,
+                partition_expr_version: None,
+                skip_wal,
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(affected.affected_rows, 4);
+    let current = engine
+        .get_region(region_id)
+        .unwrap()
+        .version_control
+        .current();
+    assert_eq!(current.committed_sequence, 4);
+    assert_eq!(current.last_entry_id, u64::from(!skip_wal));
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let before = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(before.iter().map(|b| b.num_rows()).sum::<usize>(), 4);
+
+    reopen_region(&engine, region_id, table_dir, false, HashMap::new()).await;
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let after = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(
+        after.iter().map(|b| b.num_rows()).sum::<usize>(),
+        if skip_wal { 0 } else { 4 }
+    );
 }
 
 #[tokio::test]
 async fn test_request_skip_wal_flush_watermarks() {
-    for flat_format in [false, true] {
-        let mut env = TestEnv::new().await;
-        let engine = env
-            .create_engine(MitoConfig {
-                default_flat_format: flat_format,
-                ..Default::default()
-            })
-            .await;
-        let region_id = RegionId::new(1, 1);
-        let request = CreateRequestBuilder::new().build();
-        let schema = rows_schema(&request);
-        engine
-            .handle_request(region_id, RegionRequest::Create(request))
+    check_request_skip_wal_flush_watermarks(false).await;
+    check_request_skip_wal_flush_watermarks(true).await;
+}
+
+async fn check_request_skip_wal_flush_watermarks(flat_format: bool) {
+    let mut env = TestEnv::new().await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: flat_format,
+            ..Default::default()
+        })
+        .await;
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let schema = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // Establish a nonzero flushed baseline, skip one write, then resume WAL.
+    for (round, skip_wal) in [false, true, false].into_iter().enumerate() {
+        let region = engine.get_region(region_id).unwrap();
+        let before = region.version_control.current();
+        let flushed_entry_id = engine
+            .region_statistic(region_id)
+            .unwrap()
+            .manifest
+            .data_flushed_entry_id();
+        let affected = engine
+            .handle_request(
+                region_id,
+                RegionRequest::Put(RegionPutRequest {
+                    rows: Rows {
+                        schema: schema.clone(),
+                        rows: build_rows_for_key("a", 0, 4, 0),
+                    },
+                    hint: None,
+                    partition_expr_version: None,
+                    skip_wal,
+                }),
+            )
             .await
             .unwrap();
-
-        // Establish a nonzero flushed baseline, skip one write, then resume WAL.
-        for (round, skip_wal) in [false, true, false].into_iter().enumerate() {
-            let region = engine.get_region(region_id).unwrap();
-            let before = region.version_control.current();
-            let flushed_entry_id = engine
+        assert_eq!(affected.affected_rows, 4);
+        let after_write = region.version_control.current();
+        let expected_entry_id = before.last_entry_id + u64::from(!skip_wal);
+        assert_eq!(after_write.last_entry_id, expected_entry_id);
+        assert_eq!(
+            after_write.committed_sequence,
+            before.committed_sequence + 4
+        );
+        assert_eq!(after_write.version.flushed_entry_id, flushed_entry_id);
+        assert_eq!(
+            engine
                 .region_statistic(region_id)
                 .unwrap()
                 .manifest
-                .data_flushed_entry_id();
-            let affected = engine
-                .handle_request(
-                    region_id,
-                    RegionRequest::Put(RegionPutRequest {
-                        rows: Rows {
-                            schema: schema.clone(),
-                            rows: build_rows_for_key("a", 0, 4, 0),
-                        },
-                        hint: None,
-                        partition_expr_version: None,
-                        skip_wal,
-                    }),
-                )
-                .await
-                .unwrap();
-            assert_eq!(affected.affected_rows, 4);
-            let after_write = region.version_control.current();
-            let expected_entry_id = before.last_entry_id + u64::from(!skip_wal);
-            assert_eq!(after_write.last_entry_id, expected_entry_id);
-            assert_eq!(
-                after_write.committed_sequence,
-                before.committed_sequence + 4
-            );
-            assert_eq!(after_write.version.flushed_entry_id, flushed_entry_id);
-            assert_eq!(
-                engine
-                    .region_statistic(region_id)
-                    .unwrap()
-                    .manifest
-                    .data_flushed_entry_id(),
-                flushed_entry_id
-            );
-            assert_eq!(
-                after_write.version.flushed_sequence,
-                before.version.flushed_sequence
-            );
+                .data_flushed_entry_id(),
+            flushed_entry_id
+        );
+        assert_eq!(
+            after_write.version.flushed_sequence,
+            before.version.flushed_sequence
+        );
 
-            flush_region(&engine, region_id, None).await;
-            let after_flush = region.version_control.current();
-            assert_eq!(after_flush.last_entry_id, expected_entry_id);
-            assert_eq!(after_flush.version.flushed_sequence, (round as u64 + 1) * 4);
-            assert_eq!(
-                engine
-                    .region_statistic(region_id)
-                    .unwrap()
-                    .manifest
-                    .data_flushed_entry_id(),
-                expected_entry_id
-            );
-            if skip_wal {
-                assert_eq!(expected_entry_id, flushed_entry_id);
-            } else {
-                assert!(expected_entry_id > flushed_entry_id);
-            }
+        flush_region(&engine, region_id, None).await;
+        let after_flush = region.version_control.current();
+        assert_eq!(after_flush.last_entry_id, expected_entry_id);
+        assert_eq!(after_flush.version.flushed_sequence, (round as u64 + 1) * 4);
+        assert_eq!(
+            engine
+                .region_statistic(region_id)
+                .unwrap()
+                .manifest
+                .data_flushed_entry_id(),
+            expected_entry_id
+        );
+        if skip_wal {
+            assert_eq!(expected_entry_id, flushed_entry_id);
+        } else {
+            assert!(expected_entry_id > flushed_entry_id);
         }
     }
 }
@@ -1481,157 +1486,166 @@ fn region_write_watermarks(engine: &MitoEngine, region_id: RegionId) -> Option<(
 
 #[tokio::test]
 async fn test_request_skip_wal_mixed_batch_recovery() {
+    check_request_skip_wal_mixed_batch_recovery(false, false, false).await;
+    check_request_skip_wal_mixed_batch_recovery(false, false, true).await;
+    check_request_skip_wal_mixed_batch_recovery(false, true, false).await;
+    check_request_skip_wal_mixed_batch_recovery(false, true, true).await;
+    check_request_skip_wal_mixed_batch_recovery(true, false, false).await;
+    check_request_skip_wal_mixed_batch_recovery(true, false, true).await;
+    check_request_skip_wal_mixed_batch_recovery(true, true, false).await;
+    check_request_skip_wal_mixed_batch_recovery(true, true, true).await;
+}
+
+async fn check_request_skip_wal_mixed_batch_recovery(
+    flat_format: bool,
+    skip_wal: bool,
+    flush_before_reopen: bool,
+) {
     use crate::region_write_ctx::RegionWriteCtx;
     use crate::request::OptionOutputTx;
     use crate::test_util::LogStoreImpl;
     use crate::wal::Wal;
 
-    for flat_format in [false, true] {
-        for skip_wal in [false, true] {
-            for flush_before_reopen in [false, true] {
-                let mut env = TestEnv::new().await;
-                let engine = env
-                    .create_engine(MitoConfig {
-                        default_flat_format: flat_format,
-                        ..Default::default()
-                    })
-                    .await;
-                let region_id = RegionId::new(1, 1);
-                let request = CreateRequestBuilder::new().build();
-                let table_dir = request.table_dir.clone();
-                let schema = rows_schema(&request);
-                engine
-                    .handle_request(region_id, RegionRequest::Create(request))
-                    .await
-                    .unwrap();
-                let region = engine.get_region(region_id).unwrap();
-                let LogStoreImpl::RaftEngine(store) = env.get_log_store().unwrap() else {
-                    panic!("expected the default local WAL");
-                };
-                let wal = Wal::new(store);
-                // Assemble one real worker write context deterministically, instead
-                // of relying on concurrently submitted requests landing in one batch.
-                let mut ctx = RegionWriteCtx::new(
-                    region_id,
-                    &region.version_control,
-                    region.provider.clone(),
-                    None,
-                );
-                let mut receivers = Vec::with_capacity(4);
-                for (index, skip) in [false, skip_wal, false, skip_wal].into_iter().enumerate() {
-                    let (tx, rx) = tokio::sync::oneshot::channel();
-                    receivers.push(rx);
-                    ctx.push_mutation(
-                        api::v1::OpType::Put as i32,
-                        Some(Rows {
-                            schema: schema.clone(),
-                            rows: build_rows_for_key("a", index * 2, index * 2 + 2, index * 2),
-                        }),
-                        None,
-                        OptionOutputTx::from(tx),
-                        None,
-                        skip,
-                    );
-                }
-                let mut writer = wal.writer();
-                ctx.add_wal_entry(&mut writer).unwrap();
-                let response = writer.write_to_wal().await.unwrap();
-                assert_eq!(response.last_entry_ids.get(&region_id), Some(&1));
-                ctx.write_memtable().await;
-                ctx.publish_sequence_and_entry_id();
-                drop(ctx);
-                for rx in receivers {
-                    assert_eq!(rx.await.unwrap().unwrap(), 2);
-                }
-                assert_eq!(region_write_watermarks(&engine, region_id), Some((8, 1)));
-                assert_eq!(
-                    request_skip_wal_timestamps(&engine, region_id).await,
-                    (0..8).map(|i| i * 1000).collect::<Vec<_>>()
-                );
-
-                // Inspect persisted WAL mutations, not just an encoder or counter.
-                let mut reader = wal.wal_entry_reader(&region.provider, region_id, None);
-                let entries = reader
-                    .read(&region.provider, 1)
-                    .unwrap()
-                    .try_collect::<Vec<_>>()
-                    .await
-                    .unwrap();
-                assert_eq!(entries.len(), 1);
-                assert_eq!(entries[0].0, 1);
-                assert_eq!(
-                    entries[0]
-                        .1
-                        .mutations
-                        .iter()
-                        .map(|m| m.sequence)
-                        .collect::<Vec<_>>(),
-                    if skip_wal {
-                        vec![1, 5]
-                    } else {
-                        vec![1, 3, 5, 7]
-                    }
-                );
-                assert!(entries[0].1.bulk_entries.is_empty());
-                drop(region);
-                if flush_before_reopen {
-                    flush_region(&engine, region_id, None).await;
-                    let current = engine
-                        .get_region(region_id)
-                        .unwrap()
-                        .version_control
-                        .current();
-                    assert_eq!(
-                        (
-                            current.version.flushed_sequence,
-                            current.version.flushed_entry_id
-                        ),
-                        (8, 1)
-                    );
-                }
-
-                // A no-flush close discards memtables. Only WAL-backed rows recover
-                // unless an explicit flush has already persisted all requests.
-                reopen_region(&engine, region_id, table_dir, true, HashMap::new()).await;
-                let loses_skipped_rows = skip_wal && !flush_before_reopen;
-                let mut expected_timestamps = if loses_skipped_rows {
-                    vec![0, 1000, 4000, 5000]
-                } else {
-                    (0..8).map(|i| i * 1000).collect::<Vec<_>>()
-                };
-                assert_eq!(
-                    request_skip_wal_timestamps(&engine, region_id).await,
-                    expected_timestamps
-                );
-                let recovered_sequence = if loses_skipped_rows { 6 } else { 8 };
-                assert_eq!(
-                    region_write_watermarks(&engine, region_id),
-                    Some((recovered_sequence, 1))
-                );
-
-                // A subsequent default request still writes WAL, even after a
-                // trailing skipped request or a flush with sequence/entry-id gaps.
-                put_rows(
-                    &engine,
-                    region_id,
-                    Rows {
-                        schema,
-                        rows: build_rows_for_key("a", 8, 9, 8),
-                    },
-                )
-                .await;
-                assert_eq!(
-                    region_write_watermarks(&engine, region_id),
-                    Some((recovered_sequence + 1, 2))
-                );
-                expected_timestamps.push(8000);
-                assert_eq!(
-                    request_skip_wal_timestamps(&engine, region_id).await,
-                    expected_timestamps
-                );
-            }
-        }
+    let mut env = TestEnv::new().await;
+    let engine = env
+        .create_engine(MitoConfig {
+            default_flat_format: flat_format,
+            ..Default::default()
+        })
+        .await;
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let table_dir = request.table_dir.clone();
+    let schema = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+    let LogStoreImpl::RaftEngine(store) = env.get_log_store().unwrap() else {
+        panic!("expected the default local WAL");
+    };
+    let wal = Wal::new(store);
+    // Assemble one real worker write context deterministically, instead
+    // of relying on concurrently submitted requests landing in one batch.
+    let mut ctx = RegionWriteCtx::new(
+        region_id,
+        &region.version_control,
+        region.provider.clone(),
+        None,
+    );
+    let mut receivers = Vec::with_capacity(4);
+    for (index, skip) in [false, skip_wal, false, skip_wal].into_iter().enumerate() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        receivers.push(rx);
+        ctx.push_mutation(
+            api::v1::OpType::Put as i32,
+            Some(Rows {
+                schema: schema.clone(),
+                rows: build_rows_for_key("a", index * 2, index * 2 + 2, index * 2),
+            }),
+            None,
+            OptionOutputTx::from(tx),
+            None,
+            skip,
+        );
     }
+    let mut writer = wal.writer();
+    ctx.add_wal_entry(&mut writer).unwrap();
+    let response = writer.write_to_wal().await.unwrap();
+    assert_eq!(response.last_entry_ids.get(&region_id), Some(&1));
+    ctx.write_memtable().await;
+    ctx.publish_sequence_and_entry_id();
+    drop(ctx);
+    for rx in receivers {
+        assert_eq!(rx.await.unwrap().unwrap(), 2);
+    }
+    assert_eq!(region_write_watermarks(&engine, region_id), Some((8, 1)));
+    assert_eq!(
+        request_skip_wal_timestamps(&engine, region_id).await,
+        (0..8).map(|i| i * 1000).collect::<Vec<_>>()
+    );
+
+    // Inspect persisted WAL mutations, not just an encoder or counter.
+    let mut reader = wal.wal_entry_reader(&region.provider, region_id, None);
+    let entries = reader
+        .read(&region.provider, 1)
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].0, 1);
+    assert_eq!(
+        entries[0]
+            .1
+            .mutations
+            .iter()
+            .map(|m| m.sequence)
+            .collect::<Vec<_>>(),
+        if skip_wal {
+            vec![1, 5]
+        } else {
+            vec![1, 3, 5, 7]
+        }
+    );
+    assert!(entries[0].1.bulk_entries.is_empty());
+    drop(region);
+    if flush_before_reopen {
+        flush_region(&engine, region_id, None).await;
+        let current = engine
+            .get_region(region_id)
+            .unwrap()
+            .version_control
+            .current();
+        assert_eq!(
+            (
+                current.version.flushed_sequence,
+                current.version.flushed_entry_id
+            ),
+            (8, 1)
+        );
+    }
+
+    // A no-flush close discards memtables. Only WAL-backed rows recover
+    // unless an explicit flush has already persisted all requests.
+    reopen_region(&engine, region_id, table_dir, true, HashMap::new()).await;
+    let loses_skipped_rows = skip_wal && !flush_before_reopen;
+    let mut expected_timestamps = if loses_skipped_rows {
+        vec![0, 1000, 4000, 5000]
+    } else {
+        (0..8).map(|i| i * 1000).collect::<Vec<_>>()
+    };
+    assert_eq!(
+        request_skip_wal_timestamps(&engine, region_id).await,
+        expected_timestamps
+    );
+    let recovered_sequence = if loses_skipped_rows { 6 } else { 8 };
+    assert_eq!(
+        region_write_watermarks(&engine, region_id),
+        Some((recovered_sequence, 1))
+    );
+
+    // A subsequent default request still writes WAL, even after a
+    // trailing skipped request or a flush with sequence/entry-id gaps.
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema,
+            rows: build_rows_for_key("a", 8, 9, 8),
+        },
+    )
+    .await;
+    assert_eq!(
+        region_write_watermarks(&engine, region_id),
+        Some((recovered_sequence + 1, 2))
+    );
+    expected_timestamps.push(8000);
+    assert_eq!(
+        request_skip_wal_timestamps(&engine, region_id).await,
+        expected_timestamps
+    );
 }
 
 async fn request_skip_wal_timestamps(engine: &MitoEngine, region_id: RegionId) -> Vec<i64> {

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -732,6 +732,7 @@ async fn test_absent_and_invalid_columns_with_format(flat_format: bool) {
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows,
                 hint: None,
                 partition_expr_version: None,

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -1535,14 +1535,28 @@ async fn check_request_skip_wal_mixed_batch_recovery(
         None,
     );
     let mut receivers = Vec::with_capacity(4);
-    for (index, skip) in [false, skip_wal, false, skip_wal].into_iter().enumerate() {
+    for (index, (skip, timestamp)) in [(false, 0), (skip_wal, 0), (false, 0), (skip_wal, 1)]
+        .into_iter()
+        .enumerate()
+    {
         let (tx, rx) = tokio::sync::oneshot::channel();
         receivers.push(rx);
         ctx.push_mutation(
             api::v1::OpType::Put as i32,
             Some(Rows {
                 schema: schema.clone(),
-                rows: build_rows_for_key("a", index * 2, index * 2 + 2, index * 2),
+                // Timestamp zero ends with a WAL-backed update; timestamp one
+                // ends with a skipped update. Grouping mutations must not
+                // change either winner chosen by the original sequences.
+                rows: build_rows_for_key("a", timestamp, timestamp + 1, index * 10)
+                    .into_iter()
+                    .chain(build_rows_for_key(
+                        "a",
+                        index + 1,
+                        index + 2,
+                        index * 10 + 1,
+                    ))
+                    .collect(),
             }),
             None,
             OptionOutputTx::from(tx),
@@ -1562,8 +1576,14 @@ async fn check_request_skip_wal_mixed_batch_recovery(
     }
     assert_eq!(region_write_watermarks(&engine, region_id), Some((8, 1)));
     assert_eq!(
-        request_skip_wal_timestamps(&engine, region_id).await,
-        (0..8).map(|i| i * 1000).collect::<Vec<_>>()
+        request_skip_wal_values(&engine, region_id).await,
+        vec![
+            (0, 20.0),
+            (1000, 30.0),
+            (2000, 11.0),
+            (3000, 21.0),
+            (4000, 31.0)
+        ]
     );
 
     // Inspect persisted WAL mutations, not just an encoder or counter.
@@ -1611,14 +1631,20 @@ async fn check_request_skip_wal_mixed_batch_recovery(
     // unless an explicit flush has already persisted all requests.
     reopen_region(&engine, region_id, table_dir, true, HashMap::new()).await;
     let loses_skipped_rows = skip_wal && !flush_before_reopen;
-    let mut expected_timestamps = if loses_skipped_rows {
-        vec![0, 1000, 4000, 5000]
+    let mut expected_values = if loses_skipped_rows {
+        vec![(0, 20.0), (1000, 1.0), (3000, 21.0)]
     } else {
-        (0..8).map(|i| i * 1000).collect::<Vec<_>>()
+        vec![
+            (0, 20.0),
+            (1000, 30.0),
+            (2000, 11.0),
+            (3000, 21.0),
+            (4000, 31.0),
+        ]
     };
     assert_eq!(
-        request_skip_wal_timestamps(&engine, region_id).await,
-        expected_timestamps
+        request_skip_wal_values(&engine, region_id).await,
+        expected_values
     );
     let recovered_sequence = if loses_skipped_rows { 6 } else { 8 };
     assert_eq!(
@@ -1641,35 +1667,42 @@ async fn check_request_skip_wal_mixed_batch_recovery(
         region_write_watermarks(&engine, region_id),
         Some((recovered_sequence + 1, 2))
     );
-    expected_timestamps.push(8000);
+    expected_values.push((8000, 8.0));
     assert_eq!(
-        request_skip_wal_timestamps(&engine, region_id).await,
-        expected_timestamps
+        request_skip_wal_values(&engine, region_id).await,
+        expected_values
     );
 }
 
-async fn request_skip_wal_timestamps(engine: &MitoEngine, region_id: RegionId) -> Vec<i64> {
-    use datatypes::arrow::array::TimestampMillisecondArray;
+async fn request_skip_wal_values(engine: &MitoEngine, region_id: RegionId) -> Vec<(i64, f64)> {
+    use datatypes::arrow::array::{Float64Array, TimestampMillisecondArray};
 
     let stream = engine
         .scan_to_stream(region_id, ScanRequest::default())
         .await
         .unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
-    let mut timestamps = batches
+    let mut values = batches
         .iter()
         .flat_map(|batch| {
-            batch
-                .df_record_batch()
+            let batch = batch.df_record_batch();
+            let timestamps = batch
                 .column(2)
                 .as_any()
                 .downcast_ref::<TimestampMillisecondArray>()
-                .unwrap()
+                .unwrap();
+            let values = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            timestamps
                 .values()
                 .iter()
                 .copied()
+                .zip(values.values().iter().copied())
         })
         .collect::<Vec<_>>();
-    timestamps.sort_unstable();
-    timestamps
+    values.sort_unstable_by_key(|(timestamp, _)| *timestamp);
+    values
 }

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -1321,3 +1321,341 @@ async fn test_all_index_metas_list_all_types_with_format(flat_format: bool, expe
 
     assert_eq!(expect_format, debug_format);
 }
+
+#[tokio::test]
+async fn test_request_skip_wal_recovery() {
+    // Identical workload, changing only the request-level WAL policy.
+    for flat_format in [false, true] {
+        for skip_wal in [false, true] {
+            let mut env = TestEnv::new().await;
+            let engine = env
+                .create_engine(MitoConfig {
+                    default_flat_format: flat_format,
+                    ..Default::default()
+                })
+                .await;
+            let region_id = RegionId::new(1, 1);
+            let request = CreateRequestBuilder::new().build();
+            let table_dir = request.table_dir.clone();
+            let schema = rows_schema(&request);
+            engine
+                .handle_request(region_id, RegionRequest::Create(request))
+                .await
+                .unwrap();
+            let affected = engine
+                .handle_request(
+                    region_id,
+                    RegionRequest::Put(RegionPutRequest {
+                        rows: Rows {
+                            schema,
+                            rows: build_rows_for_key("a", 0, 4, 0),
+                        },
+                        hint: None,
+                        partition_expr_version: None,
+                        skip_wal,
+                    }),
+                )
+                .await
+                .unwrap();
+            assert_eq!(affected.affected_rows, 4);
+            let current = engine
+                .get_region(region_id)
+                .unwrap()
+                .version_control
+                .current();
+            assert_eq!(current.committed_sequence, 4);
+            assert_eq!(current.last_entry_id, u64::from(!skip_wal));
+            let stream = engine
+                .scan_to_stream(region_id, ScanRequest::default())
+                .await
+                .unwrap();
+            let before = RecordBatches::try_collect(stream).await.unwrap();
+            assert_eq!(before.iter().map(|b| b.num_rows()).sum::<usize>(), 4);
+
+            reopen_region(&engine, region_id, table_dir, false, HashMap::new()).await;
+            let stream = engine
+                .scan_to_stream(region_id, ScanRequest::default())
+                .await
+                .unwrap();
+            let after = RecordBatches::try_collect(stream).await.unwrap();
+            assert_eq!(
+                after.iter().map(|b| b.num_rows()).sum::<usize>(),
+                if skip_wal { 0 } else { 4 }
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_request_skip_wal_flush_watermarks() {
+    for flat_format in [false, true] {
+        let mut env = TestEnv::new().await;
+        let engine = env
+            .create_engine(MitoConfig {
+                default_flat_format: flat_format,
+                ..Default::default()
+            })
+            .await;
+        let region_id = RegionId::new(1, 1);
+        let request = CreateRequestBuilder::new().build();
+        let schema = rows_schema(&request);
+        engine
+            .handle_request(region_id, RegionRequest::Create(request))
+            .await
+            .unwrap();
+
+        // Establish a nonzero flushed baseline, skip one write, then resume WAL.
+        for (round, skip_wal) in [false, true, false].into_iter().enumerate() {
+            let region = engine.get_region(region_id).unwrap();
+            let before = region.version_control.current();
+            let flushed_entry_id = engine
+                .region_statistic(region_id)
+                .unwrap()
+                .manifest
+                .data_flushed_entry_id();
+            let affected = engine
+                .handle_request(
+                    region_id,
+                    RegionRequest::Put(RegionPutRequest {
+                        rows: Rows {
+                            schema: schema.clone(),
+                            rows: build_rows_for_key("a", 0, 4, 0),
+                        },
+                        hint: None,
+                        partition_expr_version: None,
+                        skip_wal,
+                    }),
+                )
+                .await
+                .unwrap();
+            assert_eq!(affected.affected_rows, 4);
+            let after_write = region.version_control.current();
+            let expected_entry_id = before.last_entry_id + u64::from(!skip_wal);
+            assert_eq!(after_write.last_entry_id, expected_entry_id);
+            assert_eq!(
+                after_write.committed_sequence,
+                before.committed_sequence + 4
+            );
+            assert_eq!(after_write.version.flushed_entry_id, flushed_entry_id);
+            assert_eq!(
+                engine
+                    .region_statistic(region_id)
+                    .unwrap()
+                    .manifest
+                    .data_flushed_entry_id(),
+                flushed_entry_id
+            );
+            assert_eq!(
+                after_write.version.flushed_sequence,
+                before.version.flushed_sequence
+            );
+
+            flush_region(&engine, region_id, None).await;
+            let after_flush = region.version_control.current();
+            assert_eq!(after_flush.last_entry_id, expected_entry_id);
+            assert_eq!(after_flush.version.flushed_sequence, (round as u64 + 1) * 4);
+            assert_eq!(
+                engine
+                    .region_statistic(region_id)
+                    .unwrap()
+                    .manifest
+                    .data_flushed_entry_id(),
+                expected_entry_id
+            );
+            if skip_wal {
+                assert_eq!(expected_entry_id, flushed_entry_id);
+            } else {
+                assert!(expected_entry_id > flushed_entry_id);
+            }
+        }
+    }
+}
+
+/// Returns `(committed_sequence, last_entry_id)` from one region version snapshot.
+/// Returns `None` if the region is not open.
+fn region_write_watermarks(engine: &MitoEngine, region_id: RegionId) -> Option<(u64, u64)> {
+    let region = engine.find_region(region_id)?;
+    let current = region.version_control.current();
+    Some((current.committed_sequence, current.last_entry_id))
+}
+
+#[tokio::test]
+async fn test_request_skip_wal_mixed_batch_recovery() {
+    use crate::region_write_ctx::RegionWriteCtx;
+    use crate::request::OptionOutputTx;
+    use crate::test_util::LogStoreImpl;
+    use crate::wal::Wal;
+
+    for flat_format in [false, true] {
+        for skip_wal in [false, true] {
+            for flush_before_reopen in [false, true] {
+                let mut env = TestEnv::new().await;
+                let engine = env
+                    .create_engine(MitoConfig {
+                        default_flat_format: flat_format,
+                        ..Default::default()
+                    })
+                    .await;
+                let region_id = RegionId::new(1, 1);
+                let request = CreateRequestBuilder::new().build();
+                let table_dir = request.table_dir.clone();
+                let schema = rows_schema(&request);
+                engine
+                    .handle_request(region_id, RegionRequest::Create(request))
+                    .await
+                    .unwrap();
+                let region = engine.get_region(region_id).unwrap();
+                let LogStoreImpl::RaftEngine(store) = env.get_log_store().unwrap() else {
+                    panic!("expected the default local WAL");
+                };
+                let wal = Wal::new(store);
+                // Assemble one real worker write context deterministically, instead
+                // of relying on concurrently submitted requests landing in one batch.
+                let mut ctx = RegionWriteCtx::new(
+                    region_id,
+                    &region.version_control,
+                    region.provider.clone(),
+                    None,
+                );
+                let mut receivers = Vec::with_capacity(4);
+                for (index, skip) in [false, skip_wal, false, skip_wal].into_iter().enumerate() {
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    receivers.push(rx);
+                    ctx.push_mutation(
+                        api::v1::OpType::Put as i32,
+                        Some(Rows {
+                            schema: schema.clone(),
+                            rows: build_rows_for_key("a", index * 2, index * 2 + 2, index * 2),
+                        }),
+                        None,
+                        OptionOutputTx::from(tx),
+                        None,
+                        skip,
+                    );
+                }
+                let mut writer = wal.writer();
+                ctx.add_wal_entry(&mut writer).unwrap();
+                let response = writer.write_to_wal().await.unwrap();
+                assert_eq!(response.last_entry_ids.get(&region_id), Some(&1));
+                ctx.write_memtable().await;
+                ctx.publish_sequence_and_entry_id();
+                drop(ctx);
+                for rx in receivers {
+                    assert_eq!(rx.await.unwrap().unwrap(), 2);
+                }
+                assert_eq!(region_write_watermarks(&engine, region_id), Some((8, 1)));
+                assert_eq!(
+                    request_skip_wal_timestamps(&engine, region_id).await,
+                    (0..8).map(|i| i * 1000).collect::<Vec<_>>()
+                );
+
+                // Inspect persisted WAL mutations, not just an encoder or counter.
+                let mut reader = wal.wal_entry_reader(&region.provider, region_id, None);
+                let entries = reader
+                    .read(&region.provider, 1)
+                    .unwrap()
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .unwrap();
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].0, 1);
+                assert_eq!(
+                    entries[0]
+                        .1
+                        .mutations
+                        .iter()
+                        .map(|m| m.sequence)
+                        .collect::<Vec<_>>(),
+                    if skip_wal {
+                        vec![1, 5]
+                    } else {
+                        vec![1, 3, 5, 7]
+                    }
+                );
+                assert!(entries[0].1.bulk_entries.is_empty());
+                drop(region);
+                if flush_before_reopen {
+                    flush_region(&engine, region_id, None).await;
+                    let current = engine
+                        .get_region(region_id)
+                        .unwrap()
+                        .version_control
+                        .current();
+                    assert_eq!(
+                        (
+                            current.version.flushed_sequence,
+                            current.version.flushed_entry_id
+                        ),
+                        (8, 1)
+                    );
+                }
+
+                // A no-flush close discards memtables. Only WAL-backed rows recover
+                // unless an explicit flush has already persisted all requests.
+                reopen_region(&engine, region_id, table_dir, true, HashMap::new()).await;
+                let loses_skipped_rows = skip_wal && !flush_before_reopen;
+                let mut expected_timestamps = if loses_skipped_rows {
+                    vec![0, 1000, 4000, 5000]
+                } else {
+                    (0..8).map(|i| i * 1000).collect::<Vec<_>>()
+                };
+                assert_eq!(
+                    request_skip_wal_timestamps(&engine, region_id).await,
+                    expected_timestamps
+                );
+                let recovered_sequence = if loses_skipped_rows { 6 } else { 8 };
+                assert_eq!(
+                    region_write_watermarks(&engine, region_id),
+                    Some((recovered_sequence, 1))
+                );
+
+                // A subsequent default request still writes WAL, even after a
+                // trailing skipped request or a flush with sequence/entry-id gaps.
+                put_rows(
+                    &engine,
+                    region_id,
+                    Rows {
+                        schema,
+                        rows: build_rows_for_key("a", 8, 9, 8),
+                    },
+                )
+                .await;
+                assert_eq!(
+                    region_write_watermarks(&engine, region_id),
+                    Some((recovered_sequence + 1, 2))
+                );
+                expected_timestamps.push(8000);
+                assert_eq!(
+                    request_skip_wal_timestamps(&engine, region_id).await,
+                    expected_timestamps
+                );
+            }
+        }
+    }
+}
+
+async fn request_skip_wal_timestamps(engine: &MitoEngine, region_id: RegionId) -> Vec<i64> {
+    use datatypes::arrow::array::TimestampMillisecondArray;
+
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let mut timestamps = batches
+        .iter()
+        .flat_map(|batch| {
+            batch
+                .df_record_batch()
+                .column(2)
+                .as_any()
+                .downcast_ref::<TimestampMillisecondArray>()
+                .unwrap()
+                .values()
+                .iter()
+                .copied()
+        })
+        .collect::<Vec<_>>();
+    timestamps.sort_unstable();
+    timestamps
+}

--- a/src/mito2/src/engine/edit_region_test.rs
+++ b/src/mito2/src/engine/edit_region_test.rs
@@ -286,6 +286,7 @@ async fn test_write_during_region_editing_is_queued() {
             .handle_request(
                 region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows,
                     hint: None,
                     partition_expr_version: None,
@@ -400,6 +401,7 @@ async fn test_stalled_write_fails_fast_if_region_closed_during_editing() {
             .handle_request(
                 region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows,
                     hint: None,
                     partition_expr_version: None,

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -740,6 +740,7 @@ async fn test_region_write_buffer_does_not_stall_follower_write() {
         engine.handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: Rows {
                     schema,
                     rows: build_rows_for_key("follower", 2, 4, 0),
@@ -935,6 +936,7 @@ async fn test_region_write_buffer_rejects_only_full_region_queue() {
             .handle_request(
                 hot_region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: stalled_schema,
                         rows: build_rows_for_key("hot", 2, 1026, 2),

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -478,6 +478,7 @@ async fn test_engine_open_readonly_with_format(flat_format: bool) {
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: rows.clone(),
                 hint: None,
                 partition_expr_version: None,

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -1107,6 +1107,7 @@ async fn test_two_phase_series_scan() {
     };
     let put = |rows| {
         RegionRequest::Put(RegionPutRequest {
+            skip_wal: false,
             rows,
             hint: Some(WriteHint {
                 primary_key_encoding: api::v1::PrimaryKeyEncoding::Sparse.into(),

--- a/src/mito2/src/engine/set_role_state_test.rs
+++ b/src/mito2/src/engine/set_role_state_test.rs
@@ -114,6 +114,7 @@ async fn test_set_role_state_gracefully_with_format(flat_format: bool) {
             .handle_request(
                 region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: rows.clone(),
                     hint: None,
                     partition_expr_version: None,
@@ -208,6 +209,7 @@ async fn test_write_downgrading_region_with_format(flat_format: bool) {
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: rows.clone(),
                 hint: None,
                 partition_expr_version: None,

--- a/src/mito2/src/engine/skip_wal_test.rs
+++ b/src/mito2/src/engine/skip_wal_test.rs
@@ -522,6 +522,7 @@ async fn test_close_region_skip_wal_rejects_writes_queued_after_close() {
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: Rows {
                     schema: rows_schema(&request),
                     rows: build_rows(3, 4),
@@ -553,6 +554,7 @@ async fn test_close_region_skip_wal_rejects_writes_queued_after_close() {
             .handle_request(
                 region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: rows_schema(&request_cloned),
                         rows: build_rows(4, 5),
@@ -579,6 +581,7 @@ async fn test_close_region_skip_wal_rejects_writes_queued_after_close() {
             .handle_request(
                 region_id,
                 RegionRequest::Put(RegionPutRequest {
+                    skip_wal: false,
                     rows: Rows {
                         schema: rows_schema(&request_cloned),
                         rows: build_rows(5, 6),

--- a/src/mito2/src/engine/staging_test.rs
+++ b/src/mito2/src/engine/staging_test.rs
@@ -285,6 +285,7 @@ async fn test_staging_reject_all_writes_rejects_put() {
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows,
                 hint: None,
                 partition_expr_version: None,
@@ -355,6 +356,7 @@ async fn test_staging_write_partition_expr_version_with_format(flat_format: bool
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: bad_rows,
                 hint: None,
                 partition_expr_version: Some(origin_version),
@@ -376,6 +378,7 @@ async fn test_staging_write_partition_expr_version_with_format(flat_format: bool
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: compat_rows,
                 hint: None,
                 partition_expr_version: None,
@@ -393,6 +396,7 @@ async fn test_staging_write_partition_expr_version_with_format(flat_format: bool
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: ok_rows,
                 hint: None,
                 partition_expr_version: Some(expected_version),
@@ -440,6 +444,7 @@ async fn test_staging_write_partition_expr_version_with_format(flat_format: bool
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: exit_rows,
                 hint: None,
                 partition_expr_version: Some(origin_version),
@@ -457,6 +462,7 @@ async fn test_staging_write_partition_expr_version_with_format(flat_format: bool
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: compat_rows,
                 hint: None,
                 partition_expr_version: None,
@@ -483,6 +489,7 @@ async fn test_staging_write_partition_expr_version_with_format(flat_format: bool
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows: commit_rows,
                 hint: None,
                 partition_expr_version: Some(expected_version),

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -953,6 +953,7 @@ where
                 OptionOutputTx::none(),
                 // We should respect the sequence in WAL during replay.
                 Some(mutation.sequence),
+                false,
             );
         }
 

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -96,7 +96,7 @@ pub(crate) struct RegionWriteCtx {
     /// Notifiers to send write results to waiters.
     ///
     /// The i-th notify is for the i-th mutation in `wal_entry`.
-    notifiers: Vec<WriteNotify>,
+    wal_notifiers: Vec<WriteNotify>,
     /// Notifiers for bulk requests.
     bulk_notifiers: Vec<WriteNotify>,
     /// Pending bulk write requests
@@ -137,7 +137,7 @@ impl RegionWriteCtx {
             wal_entry: WalEntry::default(),
             memtable_mutations: Vec::new(),
             provider,
-            notifiers: Vec::new(),
+            wal_notifiers: Vec::new(),
             bulk_notifiers: vec![],
             failed: false,
             put_num: 0,
@@ -176,7 +176,7 @@ impl RegionWriteCtx {
             self.memtable_mutations.push((mutation, notify));
         } else {
             self.wal_entry.mutations.push(mutation);
-            self.notifiers.push(notify);
+            self.wal_notifiers.push(notify);
         }
 
         // Increase sequence number.
@@ -225,7 +225,7 @@ impl RegionWriteCtx {
     pub(crate) fn set_error(&mut self, err: Arc<Error>) {
         // Set error for all notifiers.
         for notify in self
-            .notifiers
+            .wal_notifiers
             .iter_mut()
             .chain(self.memtable_mutations.iter_mut().map(|(_, notify)| notify))
         {
@@ -257,7 +257,7 @@ impl RegionWriteCtx {
 
     /// Consumes mutations and writes them into mutable memtable.
     pub(crate) async fn write_memtable(&mut self) {
-        debug_assert_eq!(self.notifiers.len(), self.wal_entry.mutations.len());
+        debug_assert_eq!(self.wal_notifiers.len(), self.wal_entry.mutations.len());
 
         if self.failed {
             return;
@@ -272,7 +272,7 @@ impl RegionWriteCtx {
 
         let mut mutations = mem::take(&mut self.wal_entry.mutations)
             .into_iter()
-            .zip(&mut self.notifiers)
+            .zip(&mut self.wal_notifiers)
             .chain(
                 self.memtable_mutations
                     .iter_mut()
@@ -587,11 +587,17 @@ mod tests {
             );
         }
         // Unequal row counts make a notifier/mutation pairing mismatch visible.
-        for (mutation, notify) in ctx.wal_entry.mutations.iter().zip(&ctx.notifiers).chain(
-            ctx.memtable_mutations
-                .iter()
-                .map(|(mutation, notify)| (mutation, notify)),
-        ) {
+        for (mutation, notify) in ctx
+            .wal_entry
+            .mutations
+            .iter()
+            .zip(&ctx.wal_notifiers)
+            .chain(
+                ctx.memtable_mutations
+                    .iter()
+                    .map(|(mutation, notify)| (mutation, notify)),
+            )
+        {
             assert_eq!(mutation.rows.as_ref().unwrap().rows.len(), notify.num_rows);
         }
         assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None));

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -29,7 +29,6 @@ use crate::memtable::bulk::part::BulkPart;
 use crate::metrics;
 use crate::region::version::{VersionControlData, VersionControlRef, VersionRef};
 use crate::request::OptionOutputTx;
-use crate::wal::encoder::WalEntryMask;
 use crate::wal::{EntryId, WalWriter};
 
 /// Notifier to notify write result on drop.
@@ -90,13 +89,13 @@ pub(crate) struct RegionWriteCtx {
     /// We keep [WalEntry] instead of mutations to avoid taking mutations
     /// out of the context to construct the wal entry when we write to the wal.
     wal_entry: WalEntry,
-    /// In-memory WAL selection; the entry itself retains every request in order.
-    wal_mask: WalEntryMask,
+    /// Mutations that skip WAL, paired with their write notifiers.
+    memtable_mutations: Vec<(Mutation, WriteNotify)>,
     /// Wal options of the region being written to.
     provider: Provider,
     /// Notifiers to send write results to waiters.
     ///
-    /// The i-th notify is for i-th mutation.
+    /// The i-th notify is for the i-th mutation in `wal_entry`.
     notifiers: Vec<WriteNotify>,
     /// Notifiers for bulk requests.
     bulk_notifiers: Vec<WriteNotify>,
@@ -136,7 +135,7 @@ impl RegionWriteCtx {
             next_sequence: committed_sequence + 1,
             next_entry_id: last_entry_id + 1,
             wal_entry: WalEntry::default(),
-            wal_mask: WalEntryMask::default(),
+            memtable_mutations: Vec::new(),
             provider,
             notifiers: Vec::new(),
             bulk_notifiers: vec![],
@@ -170,11 +169,15 @@ impl RegionWriteCtx {
             write_hint,
         };
 
-        self.wal_mask
-            .push_mutation(self.wal_entry.mutations.len(), !skip_wal);
-        self.wal_entry.mutations.push(mutation);
-        // Notifiers are a 1:1 map to the complete, unfiltered mutation list.
-        self.notifiers.push(WriteNotify::new(tx, num_rows));
+        // Assign sequences before routing so concurrent memtable writes retain
+        // their logical order regardless of the WAL policy.
+        let notify = WriteNotify::new(tx, num_rows);
+        if skip_wal {
+            self.memtable_mutations.push((mutation, notify));
+        } else {
+            self.wal_entry.mutations.push(mutation);
+            self.notifiers.push(notify);
+        }
 
         // Increase sequence number.
         self.next_sequence += num_rows as u64;
@@ -192,11 +195,10 @@ impl RegionWriteCtx {
         &mut self,
         wal_writer: &mut WalWriter<S>,
     ) -> Result<()> {
-        wal_writer.add_entry_with_mask(
+        wal_writer.add_entry(
             self.region_id,
             self.next_entry_id,
             &self.wal_entry,
-            &self.wal_mask,
             &self.provider,
         )?;
         self.next_entry_id += 1;
@@ -216,13 +218,17 @@ impl RegionWriteCtx {
     pub(crate) fn skip_wal(&self) -> bool {
         self.provider == Provider::Noop
             || self.version.options.skip_wal
-            || !self.wal_mask.has_entries(&self.wal_entry)
+            || (self.wal_entry.mutations.is_empty() && self.wal_entry.bulk_entries.is_empty())
     }
 
     /// Sets error and marks all write operations are failed.
     pub(crate) fn set_error(&mut self, err: Arc<Error>) {
         // Set error for all notifiers.
-        for notify in &mut self.notifiers {
+        for notify in self
+            .notifiers
+            .iter_mut()
+            .chain(self.memtable_mutations.iter_mut().map(|(_, notify)| notify))
+        {
             notify.err = Some(err.clone());
         }
         for notify in &mut self.bulk_notifiers {
@@ -264,34 +270,38 @@ impl RegionWriteCtx {
             None
         };
 
-        let mutations = mem::take(&mut self.wal_entry.mutations)
+        let mut mutations = mem::take(&mut self.wal_entry.mutations)
             .into_iter()
-            .enumerate()
-            .filter_map(|(i, mutation)| {
+            .zip(&mut self.notifiers)
+            .chain(
+                self.memtable_mutations
+                    .iter_mut()
+                    // Keep notifiers in the context until all writes complete.
+                    .map(|(mutation, notify)| (mem::take(mutation), notify)),
+            )
+            .filter_map(|(mutation, notify)| {
                 let kvs = KeyValues::new(&self.version.metadata, mutation)?;
-                Some((i, kvs))
+                Some((notify, kvs))
             })
             .collect::<Vec<_>>();
 
         if mutations.len() == 1 {
             if let Err(err) = mutable_memtable.write(&mutations[0].1) {
-                self.notifiers[mutations[0].0].err = Some(Arc::new(err));
+                mutations[0].0.err = Some(Arc::new(err));
             }
         } else {
             let mut tasks = FuturesUnordered::new();
-            for (i, kvs) in mutations {
+            for (notify, kvs) in mutations {
                 let mutable = mutable_memtable.clone();
                 // use tokio runtime to schedule tasks.
-                tasks.push(common_runtime::spawn_blocking_global(move || {
-                    (i, mutable.write(&kvs))
-                }));
+                let task = common_runtime::spawn_blocking_global(move || mutable.write(&kvs));
+                tasks.push(async move { (notify, task.await) });
             }
 
-            while let Some(result) = tasks.next().await {
-                // first unwrap the result from `spawn` above
-                let (i, result) = result.unwrap();
-                if let Err(err) = result {
-                    self.notifiers[i].err = Some(Arc::new(err));
+            while let Some((notify, result)) = tasks.next().await {
+                // First unwrap the result from `spawn` above.
+                if let Err(err) = result.unwrap() {
+                    notify.err = Some(Arc::new(err));
                 }
             }
         }
@@ -555,16 +565,16 @@ mod tests {
                 Provider::raft_engine_provider(region_id.as_u64()),
                 None,
             );
-            for (op_type, skip) in [
-                (OpType::Put, skip_wal),
-                (OpType::Put, false),
-                (OpType::Delete, false),
+            for (op_type, skip, num_rows) in [
+                (OpType::Put, skip_wal, 2),
+                (OpType::Put, false, 3),
+                (OpType::Delete, false, 1),
             ] {
                 ctx.push_mutation(
                     op_type as i32,
                     Some(Rows {
                         schema: vec![],
-                        rows: vec![api::v1::Row::default(); 2],
+                        rows: vec![api::v1::Row::default(); num_rows],
                     }),
                     None,
                     OptionOutputTx::none(),
@@ -572,20 +582,23 @@ mod tests {
                     skip,
                 );
             }
+            // Unequal row counts make a notifier/mutation pairing mismatch visible.
+            for (mutation, notify) in ctx.wal_entry.mutations.iter().zip(&ctx.notifiers).chain(
+                ctx.memtable_mutations
+                    .iter()
+                    .map(|(mutation, notify)| (mutation, notify)),
+            ) {
+                assert_eq!(mutation.rows.as_ref().unwrap().rows.len(), notify.num_rows);
+            }
             assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None));
             assert!(!ctx.skip_wal());
             assert_eq!(ctx.next_sequence, 9);
             assert_eq!(ctx.wal_entry.bulk_entries.len(), 1);
             assert_eq!(ctx.bulk_parts[0].sequence, 7);
-            let sequences: Vec<_> = ctx
-                .wal_mask
-                .mutations(&ctx.wal_entry.mutations)
-                .map(|m| m.sequence)
-                .collect();
-            assert_eq!(sequences, if skip_wal { vec![3, 5] } else { vec![1, 3, 5] });
-            // Check the actual wire bytes, not only the mask's bookkeeping.
-            let encoded = crate::wal::encoder::WalEntryEncoder::new()
-                .encode_to_vec(&ctx.wal_entry, &ctx.wal_mask);
+            let sequences: Vec<_> = ctx.wal_entry.mutations.iter().map(|m| m.sequence).collect();
+            assert_eq!(sequences, if skip_wal { vec![3, 6] } else { vec![1, 3, 6] });
+            // Check the actual WAL bytes after routing the mutations.
+            let encoded = crate::wal::encoder::WalEntryEncoder::new().encode_to_vec(&ctx.wal_entry);
             let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
             assert_eq!(
                 decoded
@@ -596,8 +609,11 @@ mod tests {
                 sequences
             );
             assert_eq!(decoded.bulk_entries, ctx.wal_entry.bulk_entries);
-            assert_eq!(ctx.wal_entry.mutations.len(), 3);
-            assert_eq!(ctx.wal_entry.mutations[0].sequence, 1);
+            assert_eq!(ctx.wal_entry.mutations.len(), if skip_wal { 2 } else { 3 });
+            assert_eq!(ctx.memtable_mutations.len(), usize::from(skip_wal));
+            if skip_wal {
+                assert_eq!(ctx.memtable_mutations[0].0.sequence, 1);
+            }
             assert_eq!(
                 ctx.wal_entry.mutations.last().unwrap().op_type,
                 OpType::Delete as i32
@@ -631,9 +647,9 @@ mod tests {
             assert_eq!(ctx.skip_wal(), skip_wal);
             assert_eq!(ctx.next_sequence, 3);
             assert_eq!(ctx.delete_num, 2);
-            assert_eq!(ctx.wal_entry.mutations.len(), 1);
-            let encoded = crate::wal::encoder::WalEntryEncoder::new()
-                .encode_to_vec(&ctx.wal_entry, &ctx.wal_mask);
+            assert_eq!(ctx.wal_entry.mutations.len(), usize::from(!skip_wal));
+            assert_eq!(ctx.memtable_mutations.len(), usize::from(skip_wal));
+            let encoded = crate::wal::encoder::WalEntryEncoder::new().encode_to_vec(&ctx.wal_entry);
             let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
             if skip_wal {
                 assert!(decoded.mutations.is_empty());
@@ -667,8 +683,8 @@ mod tests {
             true,
         );
         assert!(ctx.skip_wal());
-        assert_eq!(ctx.wal_entry.mutations.len(), 1);
-        assert_eq!(ctx.wal_mask.mutations(&ctx.wal_entry.mutations).count(), 0);
+        assert!(ctx.wal_entry.mutations.is_empty());
+        assert_eq!(ctx.memtable_mutations.len(), 1);
         assert_eq!(ctx.next_entry_id(), 1);
         assert_eq!(ctx.next_sequence, 3);
         ctx.set_error(Arc::new(

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -29,6 +29,7 @@ use crate::memtable::bulk::part::BulkPart;
 use crate::metrics;
 use crate::region::version::{VersionControlData, VersionControlRef, VersionRef};
 use crate::request::OptionOutputTx;
+use crate::wal::encoder::WalEntryMask;
 use crate::wal::{EntryId, WalWriter};
 
 /// Notifier to notify write result on drop.
@@ -89,6 +90,8 @@ pub(crate) struct RegionWriteCtx {
     /// We keep [WalEntry] instead of mutations to avoid taking mutations
     /// out of the context to construct the wal entry when we write to the wal.
     wal_entry: WalEntry,
+    /// In-memory WAL selection; the entry itself retains every request in order.
+    wal_mask: WalEntryMask,
     /// Wal options of the region being written to.
     provider: Provider,
     /// Notifiers to send write results to waiters.
@@ -133,6 +136,7 @@ impl RegionWriteCtx {
             next_sequence: committed_sequence + 1,
             next_entry_id: last_entry_id + 1,
             wal_entry: WalEntry::default(),
+            wal_mask: WalEntryMask::default(),
             provider,
             notifiers: Vec::new(),
             bulk_notifiers: vec![],
@@ -153,21 +157,24 @@ impl RegionWriteCtx {
         write_hint: Option<WriteHint>,
         tx: OptionOutputTx,
         sequence: Option<SequenceNumber>,
+        skip_wal: bool,
     ) {
         if let Some(sequence) = sequence {
             self.next_sequence = sequence;
         }
         let num_rows = rows.as_ref().map(|rows| rows.rows.len()).unwrap_or(0);
-        self.wal_entry.mutations.push(Mutation {
+        let mutation = Mutation {
             op_type,
             sequence: self.next_sequence,
             rows,
             write_hint,
-        });
+        };
 
-        let notify = WriteNotify::new(tx, num_rows);
-        // Notifiers are 1:1 map to mutations.
-        self.notifiers.push(notify);
+        self.wal_mask
+            .push_mutation(self.wal_entry.mutations.len(), !skip_wal);
+        self.wal_entry.mutations.push(mutation);
+        // Notifiers are a 1:1 map to the complete, unfiltered mutation list.
+        self.notifiers.push(WriteNotify::new(tx, num_rows));
 
         // Increase sequence number.
         self.next_sequence += num_rows as u64;
@@ -185,10 +192,11 @@ impl RegionWriteCtx {
         &mut self,
         wal_writer: &mut WalWriter<S>,
     ) -> Result<()> {
-        wal_writer.add_entry(
+        wal_writer.add_entry_with_mask(
             self.region_id,
             self.next_entry_id,
             &self.wal_entry,
+            &self.wal_mask,
             &self.provider,
         )?;
         self.next_entry_id += 1;
@@ -206,7 +214,9 @@ impl RegionWriteCtx {
 
     /// Returns whether writes in this context should skip WAL.
     pub(crate) fn skip_wal(&self) -> bool {
-        self.provider == Provider::Noop || self.version.options.skip_wal
+        self.provider == Provider::Noop
+            || self.version.options.skip_wal
+            || !self.wal_mask.has_entries(&self.wal_entry)
     }
 
     /// Sets error and marks all write operations are failed.
@@ -523,6 +533,7 @@ mod tests {
     use common_recordbatch::DfRecordBatch;
     use datatypes::arrow::array::{ArrayRef, TimestampMillisecondArray};
     use datatypes::arrow::datatypes::{DataType, Field, Schema};
+    use prost::Message;
     use store_api::logstore::provider::Provider;
     use tokio::sync::oneshot;
 
@@ -530,6 +541,145 @@ mod tests {
     use crate::error::UnexpectedSnafu;
     use crate::memtable::bulk::part::BulkPart;
     use crate::test_util::version_util::VersionControlBuilder;
+
+    #[test]
+    fn test_request_skip_wal_preserves_sequences_and_other_writes() {
+        // Ablate only the request flag: the workload and sequence allocation stay identical.
+        for skip_wal in [false, true] {
+            let builder = VersionControlBuilder::new();
+            let region_id = builder.region_id();
+            let version_control = Arc::new(builder.build());
+            let mut ctx = RegionWriteCtx::new(
+                region_id,
+                &version_control,
+                Provider::raft_engine_provider(region_id.as_u64()),
+                None,
+            );
+            for (op_type, skip) in [
+                (OpType::Put, skip_wal),
+                (OpType::Put, false),
+                (OpType::Delete, false),
+            ] {
+                ctx.push_mutation(
+                    op_type as i32,
+                    Some(Rows {
+                        schema: vec![],
+                        rows: vec![api::v1::Row::default(); 2],
+                    }),
+                    None,
+                    OptionOutputTx::none(),
+                    None,
+                    skip,
+                );
+            }
+            assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None));
+            assert!(!ctx.skip_wal());
+            assert_eq!(ctx.next_sequence, 9);
+            assert_eq!(ctx.wal_entry.bulk_entries.len(), 1);
+            assert_eq!(ctx.bulk_parts[0].sequence, 7);
+            let sequences: Vec<_> = ctx
+                .wal_mask
+                .mutations(&ctx.wal_entry.mutations)
+                .map(|m| m.sequence)
+                .collect();
+            assert_eq!(sequences, if skip_wal { vec![3, 5] } else { vec![1, 3, 5] });
+            // Check the actual wire bytes, not only the mask's bookkeeping.
+            let encoded = crate::wal::encoder::WalEntryEncoder::new()
+                .encode_to_vec(&ctx.wal_entry, &ctx.wal_mask);
+            let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
+            assert_eq!(
+                decoded
+                    .mutations
+                    .iter()
+                    .map(|m| m.sequence)
+                    .collect::<Vec<_>>(),
+                sequences
+            );
+            assert_eq!(decoded.bulk_entries, ctx.wal_entry.bulk_entries);
+            assert_eq!(ctx.wal_entry.mutations.len(), 3);
+            assert_eq!(ctx.wal_entry.mutations[0].sequence, 1);
+            assert_eq!(
+                ctx.wal_entry.mutations.last().unwrap().op_type,
+                OpType::Delete as i32
+            );
+        }
+    }
+
+    #[test]
+    fn test_internal_delete_respects_skip_wal_flag() {
+        for skip_wal in [false, true] {
+            let builder = VersionControlBuilder::new();
+            let region_id = builder.region_id();
+            let version_control = Arc::new(builder.build());
+            let mut ctx = RegionWriteCtx::new(
+                region_id,
+                &version_control,
+                Provider::raft_engine_provider(region_id.as_u64()),
+                None,
+            );
+            ctx.push_mutation(
+                OpType::Delete as i32,
+                Some(Rows {
+                    schema: vec![],
+                    rows: vec![api::v1::Row::default(); 2],
+                }),
+                None,
+                OptionOutputTx::none(),
+                None,
+                skip_wal,
+            );
+            assert_eq!(ctx.skip_wal(), skip_wal);
+            assert_eq!(ctx.next_sequence, 3);
+            assert_eq!(ctx.delete_num, 2);
+            assert_eq!(ctx.wal_entry.mutations.len(), 1);
+            let encoded = crate::wal::encoder::WalEntryEncoder::new()
+                .encode_to_vec(&ctx.wal_entry, &ctx.wal_mask);
+            let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
+            if skip_wal {
+                assert!(decoded.mutations.is_empty());
+            } else {
+                assert_eq!(decoded, ctx.wal_entry);
+            }
+        }
+    }
+
+    #[test]
+    fn test_all_request_skip_wal_keeps_entry_id_and_propagates_errors() {
+        let builder = VersionControlBuilder::new();
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let mut ctx = RegionWriteCtx::new(
+            region_id,
+            &version_control,
+            Provider::raft_engine_provider(region_id.as_u64()),
+            None,
+        );
+        let (tx, rx) = oneshot::channel();
+        ctx.push_mutation(
+            OpType::Put as i32,
+            Some(Rows {
+                schema: vec![],
+                rows: vec![api::v1::Row::default(); 2],
+            }),
+            None,
+            OptionOutputTx::from(tx),
+            None,
+            true,
+        );
+        assert!(ctx.skip_wal());
+        assert_eq!(ctx.wal_entry.mutations.len(), 1);
+        assert_eq!(ctx.wal_mask.mutations(&ctx.wal_entry.mutations).count(), 0);
+        assert_eq!(ctx.next_entry_id(), 1);
+        assert_eq!(ctx.next_sequence, 3);
+        ctx.set_error(Arc::new(
+            UnexpectedSnafu {
+                reason: "wal failed".to_string(),
+            }
+            .build(),
+        ));
+        drop(ctx);
+        assert!(rx.blocking_recv().unwrap().is_err());
+    }
 
     #[test]
     fn test_set_error_marks_bulk_notifiers_failed() {

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -555,107 +555,113 @@ mod tests {
     #[test]
     fn test_request_skip_wal_preserves_sequences_and_other_writes() {
         // Ablate only the request flag: the workload and sequence allocation stay identical.
-        for skip_wal in [false, true] {
-            let builder = VersionControlBuilder::new();
-            let region_id = builder.region_id();
-            let version_control = Arc::new(builder.build());
-            let mut ctx = RegionWriteCtx::new(
-                region_id,
-                &version_control,
-                Provider::raft_engine_provider(region_id.as_u64()),
-                None,
-            );
-            for (op_type, skip, num_rows) in [
-                (OpType::Put, skip_wal, 2),
-                (OpType::Put, false, 3),
-                (OpType::Delete, false, 1),
-            ] {
-                ctx.push_mutation(
-                    op_type as i32,
-                    Some(Rows {
-                        schema: vec![],
-                        rows: vec![api::v1::Row::default(); num_rows],
-                    }),
-                    None,
-                    OptionOutputTx::none(),
-                    None,
-                    skip,
-                );
-            }
-            // Unequal row counts make a notifier/mutation pairing mismatch visible.
-            for (mutation, notify) in ctx.wal_entry.mutations.iter().zip(&ctx.notifiers).chain(
-                ctx.memtable_mutations
-                    .iter()
-                    .map(|(mutation, notify)| (mutation, notify)),
-            ) {
-                assert_eq!(mutation.rows.as_ref().unwrap().rows.len(), notify.num_rows);
-            }
-            assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None));
-            assert!(!ctx.skip_wal());
-            assert_eq!(ctx.next_sequence, 9);
-            assert_eq!(ctx.wal_entry.bulk_entries.len(), 1);
-            assert_eq!(ctx.bulk_parts[0].sequence, 7);
-            let sequences: Vec<_> = ctx.wal_entry.mutations.iter().map(|m| m.sequence).collect();
-            assert_eq!(sequences, if skip_wal { vec![3, 6] } else { vec![1, 3, 6] });
-            // Check the actual WAL bytes after routing the mutations.
-            let encoded = crate::wal::encoder::WalEntryEncoder::new().encode_to_vec(&ctx.wal_entry);
-            let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
-            assert_eq!(
-                decoded
-                    .mutations
-                    .iter()
-                    .map(|m| m.sequence)
-                    .collect::<Vec<_>>(),
-                sequences
-            );
-            assert_eq!(decoded.bulk_entries, ctx.wal_entry.bulk_entries);
-            assert_eq!(ctx.wal_entry.mutations.len(), if skip_wal { 2 } else { 3 });
-            assert_eq!(ctx.memtable_mutations.len(), usize::from(skip_wal));
-            if skip_wal {
-                assert_eq!(ctx.memtable_mutations[0].0.sequence, 1);
-            }
-            assert_eq!(
-                ctx.wal_entry.mutations.last().unwrap().op_type,
-                OpType::Delete as i32
-            );
-        }
+        check_request_skip_wal_preserves_sequences_and_other_writes(false);
+        check_request_skip_wal_preserves_sequences_and_other_writes(true);
     }
 
-    #[test]
-    fn test_internal_delete_respects_skip_wal_flag() {
-        for skip_wal in [false, true] {
-            let builder = VersionControlBuilder::new();
-            let region_id = builder.region_id();
-            let version_control = Arc::new(builder.build());
-            let mut ctx = RegionWriteCtx::new(
-                region_id,
-                &version_control,
-                Provider::raft_engine_provider(region_id.as_u64()),
-                None,
-            );
+    fn check_request_skip_wal_preserves_sequences_and_other_writes(skip_wal: bool) {
+        let builder = VersionControlBuilder::new();
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let mut ctx = RegionWriteCtx::new(
+            region_id,
+            &version_control,
+            Provider::raft_engine_provider(region_id.as_u64()),
+            None,
+        );
+        for (op_type, skip, num_rows) in [
+            (OpType::Put, skip_wal, 2),
+            (OpType::Put, false, 3),
+            (OpType::Delete, false, 1),
+        ] {
             ctx.push_mutation(
-                OpType::Delete as i32,
+                op_type as i32,
                 Some(Rows {
                     schema: vec![],
-                    rows: vec![api::v1::Row::default(); 2],
+                    rows: vec![api::v1::Row::default(); num_rows],
                 }),
                 None,
                 OptionOutputTx::none(),
                 None,
-                skip_wal,
+                skip,
             );
-            assert_eq!(ctx.skip_wal(), skip_wal);
-            assert_eq!(ctx.next_sequence, 3);
-            assert_eq!(ctx.delete_num, 2);
-            assert_eq!(ctx.wal_entry.mutations.len(), usize::from(!skip_wal));
-            assert_eq!(ctx.memtable_mutations.len(), usize::from(skip_wal));
-            let encoded = crate::wal::encoder::WalEntryEncoder::new().encode_to_vec(&ctx.wal_entry);
-            let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
-            if skip_wal {
-                assert!(decoded.mutations.is_empty());
-            } else {
-                assert_eq!(decoded, ctx.wal_entry);
-            }
+        }
+        // Unequal row counts make a notifier/mutation pairing mismatch visible.
+        for (mutation, notify) in ctx.wal_entry.mutations.iter().zip(&ctx.notifiers).chain(
+            ctx.memtable_mutations
+                .iter()
+                .map(|(mutation, notify)| (mutation, notify)),
+        ) {
+            assert_eq!(mutation.rows.as_ref().unwrap().rows.len(), notify.num_rows);
+        }
+        assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None));
+        assert!(!ctx.skip_wal());
+        assert_eq!(ctx.next_sequence, 9);
+        assert_eq!(ctx.wal_entry.bulk_entries.len(), 1);
+        assert_eq!(ctx.bulk_parts[0].sequence, 7);
+        let sequences: Vec<_> = ctx.wal_entry.mutations.iter().map(|m| m.sequence).collect();
+        assert_eq!(sequences, if skip_wal { vec![3, 6] } else { vec![1, 3, 6] });
+        // Check the actual WAL bytes after routing the mutations.
+        let encoded = crate::wal::encoder::WalEntryEncoder::new().encode_to_vec(&ctx.wal_entry);
+        let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
+        assert_eq!(
+            decoded
+                .mutations
+                .iter()
+                .map(|m| m.sequence)
+                .collect::<Vec<_>>(),
+            sequences
+        );
+        assert_eq!(decoded.bulk_entries, ctx.wal_entry.bulk_entries);
+        assert_eq!(ctx.wal_entry.mutations.len(), if skip_wal { 2 } else { 3 });
+        assert_eq!(ctx.memtable_mutations.len(), usize::from(skip_wal));
+        if skip_wal {
+            assert_eq!(ctx.memtable_mutations[0].0.sequence, 1);
+        }
+        assert_eq!(
+            ctx.wal_entry.mutations.last().unwrap().op_type,
+            OpType::Delete as i32
+        );
+    }
+
+    #[test]
+    fn test_internal_delete_respects_skip_wal_flag() {
+        check_internal_delete_respects_skip_wal_flag(false);
+        check_internal_delete_respects_skip_wal_flag(true);
+    }
+
+    fn check_internal_delete_respects_skip_wal_flag(skip_wal: bool) {
+        let builder = VersionControlBuilder::new();
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let mut ctx = RegionWriteCtx::new(
+            region_id,
+            &version_control,
+            Provider::raft_engine_provider(region_id.as_u64()),
+            None,
+        );
+        ctx.push_mutation(
+            OpType::Delete as i32,
+            Some(Rows {
+                schema: vec![],
+                rows: vec![api::v1::Row::default(); 2],
+            }),
+            None,
+            OptionOutputTx::none(),
+            None,
+            skip_wal,
+        );
+        assert_eq!(ctx.skip_wal(), skip_wal);
+        assert_eq!(ctx.next_sequence, 3);
+        assert_eq!(ctx.delete_num, 2);
+        assert_eq!(ctx.wal_entry.mutations.len(), usize::from(!skip_wal));
+        assert_eq!(ctx.memtable_mutations.len(), usize::from(skip_wal));
+        let encoded = crate::wal::encoder::WalEntryEncoder::new().encode_to_vec(&ctx.wal_entry);
+        let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
+        if skip_wal {
+            assert!(decoded.mutations.is_empty());
+        } else {
+            assert_eq!(decoded, ctx.wal_entry);
         }
     }
 

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -76,6 +76,8 @@ pub struct WriteRequest {
     pub name_to_index: HashMap<String, usize>,
     /// Whether each column has null.
     pub has_null: Vec<bool>,
+    /// Whether this insert should skip WAL. Never applies to deletes.
+    pub skip_wal: bool,
     /// Write hint.
     pub hint: Option<WriteHint>,
     /// Region metadata on the time of this request is created.
@@ -137,6 +139,7 @@ impl WriteRequest {
             name_to_index,
             has_null,
             hint: None,
+            skip_wal: false,
             region_metadata,
             partition_expr_version: None,
         })

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -145,6 +145,12 @@ impl WriteRequest {
         })
     }
 
+    /// Sets the request-level WAL policy.
+    pub fn with_skip_wal(mut self, skip_wal: bool) -> Self {
+        self.skip_wal = skip_wal;
+        self
+    }
+
     /// Sets the write hint.
     pub fn with_hint(mut self, hint: Option<WriteHint>) -> Self {
         self.hint = hint;
@@ -675,6 +681,7 @@ impl WorkerRequest {
                 let mut write_request =
                     WriteRequest::new(region_id, OpType::Put, v.rows, region_metadata.clone())?
                         .with_hint(v.hint)
+                        .with_skip_wal(v.skip_wal)
                         .with_partition_expr_version(v.partition_expr_version);
                 if write_request.primary_key_encoding() == PrimaryKeyEncoding::Dense
                     && let Some(region_metadata) = &region_metadata
@@ -1874,6 +1881,25 @@ mod tests {
             &err,
             "column f1 expect type Int64(Int64Type), given: STRING(12)",
         );
+    }
+
+    #[test]
+    fn test_delete_request_defaults_to_writing_wal() {
+        let (request, _receiver) = WorkerRequest::try_from_region_request(
+            RegionId::new(1, 1),
+            RegionRequest::Delete(store_api::region_request::RegionDeleteRequest {
+                rows: Rows::default(),
+                hint: None,
+                partition_expr_version: None,
+            }),
+            None,
+        )
+        .unwrap();
+        let WorkerRequest::Write(request) = request else {
+            panic!("expected a write request");
+        };
+        assert_eq!(request.request.op_type, OpType::Delete);
+        assert!(!request.request.skip_wal);
     }
 
     #[test]

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -1351,6 +1351,7 @@ pub async fn put_rows(engine: &MitoEngine, region_id: RegionId, rows: Rows) {
         .handle_request(
             region_id,
             RegionRequest::Put(RegionPutRequest {
+                skip_wal: false,
                 rows,
                 hint: None,
                 partition_expr_version: None,

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use api::v1::WalEntry;
 use common_error::ext::BoxedError;
 use common_telemetry::debug;
-use encoder::WalEntryEncoder;
+use encoder::{WalEntryEncoder, WalEntryMask};
 use entry_reader::NoopEntryReader;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -204,13 +204,31 @@ impl<S: LogStore> WalWriter<S> {
         wal_entry: &WalEntry,
         provider: &Provider,
     ) -> Result<()> {
+        self.add_entry_with_mask(
+            region_id,
+            entry_id,
+            wal_entry,
+            &WalEntryMask::default(),
+            provider,
+        )
+    }
+
+    /// Adds only the entries selected by an in-memory WAL mask.
+    pub fn add_entry_with_mask(
+        &mut self,
+        region_id: RegionId,
+        entry_id: EntryId,
+        wal_entry: &WalEntry,
+        mask: &WalEntryMask,
+        provider: &Provider,
+    ) -> Result<()> {
         // Gets or inserts with a newly built provider.
         let provider = self
             .providers
             .entry(region_id)
             .or_insert_with(|| provider.clone());
 
-        let data = self.encoder.encode_to_vec(wal_entry);
+        let data = self.encoder.encode_to_vec(wal_entry, mask);
         let entry = self
             .store
             .entry(data, entry_id, region_id, provider)

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use api::v1::WalEntry;
 use common_error::ext::BoxedError;
 use common_telemetry::debug;
-use encoder::{WalEntryEncoder, WalEntryMask};
+use encoder::WalEntryEncoder;
 use entry_reader::NoopEntryReader;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -204,31 +204,13 @@ impl<S: LogStore> WalWriter<S> {
         wal_entry: &WalEntry,
         provider: &Provider,
     ) -> Result<()> {
-        self.add_entry_with_mask(
-            region_id,
-            entry_id,
-            wal_entry,
-            &WalEntryMask::default(),
-            provider,
-        )
-    }
-
-    /// Adds only the entries selected by an in-memory WAL mask.
-    pub fn add_entry_with_mask(
-        &mut self,
-        region_id: RegionId,
-        entry_id: EntryId,
-        wal_entry: &WalEntry,
-        mask: &WalEntryMask,
-        provider: &Provider,
-    ) -> Result<()> {
         // Gets or inserts with a newly built provider.
         let provider = self
             .providers
             .entry(region_id)
             .or_insert_with(|| provider.clone());
 
-        let data = self.encoder.encode_to_vec(wal_entry, mask);
+        let data = self.encoder.encode_to_vec(wal_entry);
         let entry = self
             .store
             .entry(data, entry_id, region_id, provider)

--- a/src/mito2/src/wal/encoder.rs
+++ b/src/mito2/src/wal/encoder.rs
@@ -55,6 +55,8 @@
 //! Leaf messages are delegated to prost, so changes to them need no update here.
 
 use api::v1::{Mutation, Row, Rows, Value, WalEntry};
+use common_base::BitVec;
+use itertools::Either;
 use prost::Message;
 use prost::encoding::{WireType, encode_key, encode_varint, encoded_len_varint, key_len};
 
@@ -76,6 +78,58 @@ fn msg_field_len(tag: u32, body_len: usize) -> usize {
     key_len(tag) + encoded_len_varint(body_len as u64) + body_len
 }
 
+/// An in-memory selection of mutations to persist. Bulk entries are always selected.
+///
+/// No bitmap is allocated until the first excluded mutation. Once allocated,
+/// each bit corresponds to a mutation in the original entry: true includes it
+/// in WAL, false skips it. The mask is never persisted.
+#[derive(Debug, Default)]
+pub struct WalEntryMask {
+    selected_mutations: Option<BitVec>,
+}
+
+impl WalEntryMask {
+    /// Appends the WAL selection for the mutation at `index` in arrival order.
+    pub fn push_mutation(&mut self, index: usize, write_wal: bool) {
+        if let Some(selected) = &mut self.selected_mutations {
+            debug_assert_eq!(selected.len(), index);
+            selected.push(write_wal);
+        } else if !write_wal {
+            let mut selected = BitVec::with_capacity(index + 1);
+            selected.resize(index, true);
+            selected.push(false);
+            self.selected_mutations = Some(selected);
+        }
+    }
+
+    /// Returns whether any data remains to write to WAL after applying the mask.
+    /// Bulk entries are always included, regardless of the mutation mask.
+    pub fn has_entries(&self, entry: &WalEntry) -> bool {
+        !entry.bulk_entries.is_empty()
+            || match &self.selected_mutations {
+                Some(selected) => {
+                    debug_assert_eq!(selected.len(), entry.mutations.len());
+                    selected.any()
+                }
+                None => !entry.mutations.is_empty(),
+            }
+    }
+
+    /// Borrows selected mutations without cloning payloads or reordering entries.
+    pub fn mutations<'a>(
+        &'a self,
+        mutations: &'a [Mutation],
+    ) -> impl Iterator<Item = &'a Mutation> {
+        match &self.selected_mutations {
+            Some(selected) => {
+                debug_assert_eq!(selected.len(), mutations.len());
+                Either::Left(selected.iter_ones().map(|index| &mutations[index]))
+            }
+            None => Either::Right(mutations.iter()),
+        }
+    }
+}
+
 /// A reusable encoder that caches message body sizes between its size pass and
 /// its encode pass.
 #[derive(Default)]
@@ -90,13 +144,13 @@ impl WalEntryEncoder {
     }
 
     /// Encodes `entry` to a new `Vec<u8>`, byte-for-byte identical to
-    /// `entry.encode_to_vec()`.
-    pub fn encode_to_vec(&mut self, entry: &WalEntry) -> Vec<u8> {
+    /// encoding the selected entries with prost. The default mask selects all entries.
+    pub fn encode_to_vec(&mut self, entry: &WalEntry, mask: &WalEntryMask) -> Vec<u8> {
         self.sizes.clear();
-        let body_len = self.size_entry(entry);
+        let body_len = self.size_entry(entry, mask);
         let mut buf = Vec::with_capacity(body_len);
         let mut cursor = 0;
-        self.encode_entry(entry, &mut buf, &mut cursor);
+        self.encode_entry(entry, mask, &mut buf, &mut cursor);
         // Invariants of the two-pass design. Kept as `debug_assert` to avoid any
         // overhead on the hot write path; correctness is covered by the
         // byte-for-byte equality tests against prost.
@@ -121,7 +175,7 @@ impl WalEntryEncoder {
 
     /// Returns the body length of the `WalEntry` (no length delimiter; it is
     /// the root). Pushes cached slots for all nested message nodes.
-    fn size_entry(&mut self, entry: &WalEntry) -> usize {
+    fn size_entry(&mut self, entry: &WalEntry, mask: &WalEntryMask) -> usize {
         // Exhaustive destructure (no `..`): adding a field to `WalEntry` in
         // greptime-proto makes this fail to compile, forcing this encoder to be
         // updated rather than silently dropping the new field from the WAL.
@@ -130,7 +184,7 @@ impl WalEntryEncoder {
             bulk_entries,
         } = entry;
         let mut body = 0;
-        for m in mutations {
+        for m in mask.mutations(mutations) {
             let mb = self.size_mutation(m);
             body += msg_field_len(MUTATION_TAG, mb);
         }
@@ -234,13 +288,19 @@ impl WalEntryEncoder {
     // `next_size`, consuming that child's slot in pre-order) and writes the
     // key + length delimiter; the callee then writes only the body.
 
-    fn encode_entry(&self, entry: &WalEntry, buf: &mut Vec<u8>, cursor: &mut usize) {
+    fn encode_entry(
+        &self,
+        entry: &WalEntry,
+        mask: &WalEntryMask,
+        buf: &mut Vec<u8>,
+        cursor: &mut usize,
+    ) {
         // Exhaustive destructure: see note in `size_entry`.
         let WalEntry {
             mutations,
             bulk_entries,
         } = entry;
-        for m in mutations {
+        for m in mask.mutations(mutations) {
             let mb = self.next_size(cursor);
             encode_key(MUTATION_TAG, WireType::LengthDelimited, buf);
             encode_varint(mb as u64, buf);
@@ -369,7 +429,7 @@ mod tests {
 
     fn assert_byte_identical(entry: &WalEntry) {
         let expected = entry.encode_to_vec();
-        let actual = WalEntryEncoder::new().encode_to_vec(entry);
+        let actual = WalEntryEncoder::new().encode_to_vec(entry, &WalEntryMask::default());
         assert_eq!(
             expected,
             actual,
@@ -377,6 +437,145 @@ mod tests {
             expected.len(),
             actual.len()
         );
+    }
+
+    #[test]
+    fn test_mask_matches_prost_for_every_mutation_subset() {
+        let entry = WalEntry {
+            mutations: (0..4)
+                .map(|i| Mutation {
+                    op_type: if i == 2 { OpType::Delete } else { OpType::Put } as i32,
+                    sequence: 1 + i * 3,
+                    rows: Some(sample_rows(3, i % 2 == 0)),
+                    write_hint: Some(WriteHint {
+                        primary_key_encoding: 1,
+                    }),
+                })
+                .collect(),
+            bulk_entries: vec![BulkWalEntry {
+                sequence: 13,
+                max_ts: 100,
+                min_ts: 10,
+                timestamp_index: 3,
+                body: None,
+            }],
+        };
+        // Reuse one encoder across every mask to catch stale cached-size slots.
+        let mut encoder = WalEntryEncoder::new();
+        for bits in 0..16 {
+            let mut mask = WalEntryMask::default();
+            for index in 0..4 {
+                mask.push_mutation(index, bits & (1 << index) == 0);
+            }
+            let expected = WalEntry {
+                mutations: entry
+                    .mutations
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| bits & (1 << index) == 0)
+                    .map(|(_, mutation)| mutation.clone())
+                    .collect(),
+                bulk_entries: entry.bulk_entries.clone(),
+            };
+            let actual = encoder.encode_to_vec(&entry, &mask);
+            assert_eq!(actual, expected.encode_to_vec(), "mask {bits:04b}");
+            assert_eq!(WalEntry::decode(actual.as_slice()).unwrap(), expected);
+            assert!(mask.has_entries(&entry), "bulk is never masked out");
+            assert_eq!(entry.mutations.len(), 4, "mask must not consume the input");
+            // Even when every ordinary mutation is skipped, bulk still consumes
+            // exactly one cached size slot and is encoded normally.
+            if bits == 15 {
+                assert_eq!(encoder.sizes.len(), 1);
+            }
+        }
+    }
+
+    #[test]
+    fn test_mask_growth_across_byte_boundaries() {
+        let mut encoder = WalEntryEncoder::new();
+        for count in [17, 65] {
+            let entry = WalEntry {
+                mutations: (0..count)
+                    .map(|index| Mutation {
+                        op_type: OpType::Put as i32,
+                        sequence: index as u64 + 1,
+                        rows: Some(sample_rows(1, false)),
+                        write_hint: None,
+                    })
+                    .collect(),
+                bulk_entries: vec![],
+            };
+            let mut all_selected = WalEntryMask::default();
+            for index in 0..count {
+                all_selected.push_mutation(index, true);
+            }
+            assert!(all_selected.selected_mutations.is_none());
+            assert_eq!(
+                encoder.encode_to_vec(&entry, &all_selected),
+                entry.encode_to_vec()
+            );
+
+            for skip_last in [false, true] {
+                let expected_bits: Vec<_> = (0..count)
+                    .map(|index| {
+                        if index == count - 1 {
+                            !skip_last
+                        } else {
+                            ![0, 8, 16].contains(&index)
+                        }
+                    })
+                    .collect();
+                let mut mask = WalEntryMask::default();
+                for (index, &write_wal) in expected_bits.iter().enumerate() {
+                    mask.push_mutation(index, write_wal);
+                    assert_eq!(mask.selected_mutations.as_ref().unwrap().len(), index + 1);
+                }
+                let selected = mask.selected_mutations.as_ref().unwrap();
+                for (index, &expected) in expected_bits.iter().enumerate() {
+                    assert_eq!(
+                        selected[index], expected,
+                        "count={count}, index={index}, skip_last={skip_last}"
+                    );
+                }
+                let expected = WalEntry {
+                    mutations: entry
+                        .mutations
+                        .iter()
+                        .zip(&expected_bits)
+                        .filter(|(_, selected)| **selected)
+                        .map(|(mutation, _)| mutation.clone())
+                        .collect(),
+                    bulk_entries: vec![],
+                };
+                assert!(mask.has_entries(&entry));
+                let encoded = encoder.encode_to_vec(&entry, &mask);
+                assert_eq!(encoded, expected.encode_to_vec());
+                assert_eq!(WalEntry::decode(encoded.as_slice()).unwrap(), expected);
+            }
+        }
+    }
+
+    #[test]
+    fn test_all_skip_mask_does_not_size_or_allocate_output() {
+        let entry = WalEntry {
+            mutations: vec![Mutation {
+                op_type: OpType::Put as i32,
+                sequence: 1,
+                rows: Some(sample_rows(100, true)),
+                write_hint: None,
+            }],
+            bulk_entries: vec![],
+        };
+        let mut mask = WalEntryMask::default();
+        assert!(mask.selected_mutations.is_none());
+        assert!(mask.has_entries(&entry));
+        mask.push_mutation(0, false);
+        assert!(!mask.has_entries(&entry));
+        let mut encoder = WalEntryEncoder::new();
+        let encoded = encoder.encode_to_vec(&entry, &mask);
+        assert_eq!(encoded, WalEntry::default().encode_to_vec());
+        assert_eq!(encoded.capacity(), 0);
+        assert_eq!(encoder.sizes.capacity(), 0);
     }
 
     #[test]
@@ -451,7 +650,10 @@ mod tests {
                 }],
                 bulk_entries: vec![],
             };
-            assert_eq!(entry.encode_to_vec(), enc.encode_to_vec(&entry));
+            assert_eq!(
+                entry.encode_to_vec(),
+                enc.encode_to_vec(&entry, &WalEntryMask::default())
+            );
         }
     }
 

--- a/src/mito2/src/wal/encoder.rs
+++ b/src/mito2/src/wal/encoder.rs
@@ -55,8 +55,6 @@
 //! Leaf messages are delegated to prost, so changes to them need no update here.
 
 use api::v1::{Mutation, Row, Rows, Value, WalEntry};
-use common_base::BitVec;
-use itertools::Either;
 use prost::Message;
 use prost::encoding::{WireType, encode_key, encode_varint, encoded_len_varint, key_len};
 
@@ -78,58 +76,6 @@ fn msg_field_len(tag: u32, body_len: usize) -> usize {
     key_len(tag) + encoded_len_varint(body_len as u64) + body_len
 }
 
-/// An in-memory selection of mutations to persist. Bulk entries are always selected.
-///
-/// No bitmap is allocated until the first excluded mutation. Once allocated,
-/// each bit corresponds to a mutation in the original entry: true includes it
-/// in WAL, false skips it. The mask is never persisted.
-#[derive(Debug, Default)]
-pub struct WalEntryMask {
-    selected_mutations: Option<BitVec>,
-}
-
-impl WalEntryMask {
-    /// Appends the WAL selection for the mutation at `index` in arrival order.
-    pub fn push_mutation(&mut self, index: usize, write_wal: bool) {
-        if let Some(selected) = &mut self.selected_mutations {
-            debug_assert_eq!(selected.len(), index);
-            selected.push(write_wal);
-        } else if !write_wal {
-            let mut selected = BitVec::with_capacity(index + 1);
-            selected.resize(index, true);
-            selected.push(false);
-            self.selected_mutations = Some(selected);
-        }
-    }
-
-    /// Returns whether any data remains to write to WAL after applying the mask.
-    /// Bulk entries are always included, regardless of the mutation mask.
-    pub fn has_entries(&self, entry: &WalEntry) -> bool {
-        !entry.bulk_entries.is_empty()
-            || match &self.selected_mutations {
-                Some(selected) => {
-                    debug_assert_eq!(selected.len(), entry.mutations.len());
-                    selected.any()
-                }
-                None => !entry.mutations.is_empty(),
-            }
-    }
-
-    /// Borrows selected mutations without cloning payloads or reordering entries.
-    pub fn mutations<'a>(
-        &'a self,
-        mutations: &'a [Mutation],
-    ) -> impl Iterator<Item = &'a Mutation> {
-        match &self.selected_mutations {
-            Some(selected) => {
-                debug_assert_eq!(selected.len(), mutations.len());
-                Either::Left(selected.iter_ones().map(|index| &mutations[index]))
-            }
-            None => Either::Right(mutations.iter()),
-        }
-    }
-}
-
 /// A reusable encoder that caches message body sizes between its size pass and
 /// its encode pass.
 #[derive(Default)]
@@ -144,13 +90,13 @@ impl WalEntryEncoder {
     }
 
     /// Encodes `entry` to a new `Vec<u8>`, byte-for-byte identical to
-    /// encoding the selected entries with prost. The default mask selects all entries.
-    pub fn encode_to_vec(&mut self, entry: &WalEntry, mask: &WalEntryMask) -> Vec<u8> {
+    /// `entry.encode_to_vec()`.
+    pub fn encode_to_vec(&mut self, entry: &WalEntry) -> Vec<u8> {
         self.sizes.clear();
-        let body_len = self.size_entry(entry, mask);
+        let body_len = self.size_entry(entry);
         let mut buf = Vec::with_capacity(body_len);
         let mut cursor = 0;
-        self.encode_entry(entry, mask, &mut buf, &mut cursor);
+        self.encode_entry(entry, &mut buf, &mut cursor);
         // Invariants of the two-pass design. Kept as `debug_assert` to avoid any
         // overhead on the hot write path; correctness is covered by the
         // byte-for-byte equality tests against prost.
@@ -175,7 +121,7 @@ impl WalEntryEncoder {
 
     /// Returns the body length of the `WalEntry` (no length delimiter; it is
     /// the root). Pushes cached slots for all nested message nodes.
-    fn size_entry(&mut self, entry: &WalEntry, mask: &WalEntryMask) -> usize {
+    fn size_entry(&mut self, entry: &WalEntry) -> usize {
         // Exhaustive destructure (no `..`): adding a field to `WalEntry` in
         // greptime-proto makes this fail to compile, forcing this encoder to be
         // updated rather than silently dropping the new field from the WAL.
@@ -184,7 +130,7 @@ impl WalEntryEncoder {
             bulk_entries,
         } = entry;
         let mut body = 0;
-        for m in mask.mutations(mutations) {
+        for m in mutations {
             let mb = self.size_mutation(m);
             body += msg_field_len(MUTATION_TAG, mb);
         }
@@ -288,19 +234,13 @@ impl WalEntryEncoder {
     // `next_size`, consuming that child's slot in pre-order) and writes the
     // key + length delimiter; the callee then writes only the body.
 
-    fn encode_entry(
-        &self,
-        entry: &WalEntry,
-        mask: &WalEntryMask,
-        buf: &mut Vec<u8>,
-        cursor: &mut usize,
-    ) {
+    fn encode_entry(&self, entry: &WalEntry, buf: &mut Vec<u8>, cursor: &mut usize) {
         // Exhaustive destructure: see note in `size_entry`.
         let WalEntry {
             mutations,
             bulk_entries,
         } = entry;
-        for m in mask.mutations(mutations) {
+        for m in mutations {
             let mb = self.next_size(cursor);
             encode_key(MUTATION_TAG, WireType::LengthDelimited, buf);
             encode_varint(mb as u64, buf);
@@ -429,7 +369,7 @@ mod tests {
 
     fn assert_byte_identical(entry: &WalEntry) {
         let expected = entry.encode_to_vec();
-        let actual = WalEntryEncoder::new().encode_to_vec(entry, &WalEntryMask::default());
+        let actual = WalEntryEncoder::new().encode_to_vec(entry);
         assert_eq!(
             expected,
             actual,
@@ -437,145 +377,6 @@ mod tests {
             expected.len(),
             actual.len()
         );
-    }
-
-    #[test]
-    fn test_mask_matches_prost_for_every_mutation_subset() {
-        let entry = WalEntry {
-            mutations: (0..4)
-                .map(|i| Mutation {
-                    op_type: if i == 2 { OpType::Delete } else { OpType::Put } as i32,
-                    sequence: 1 + i * 3,
-                    rows: Some(sample_rows(3, i % 2 == 0)),
-                    write_hint: Some(WriteHint {
-                        primary_key_encoding: 1,
-                    }),
-                })
-                .collect(),
-            bulk_entries: vec![BulkWalEntry {
-                sequence: 13,
-                max_ts: 100,
-                min_ts: 10,
-                timestamp_index: 3,
-                body: None,
-            }],
-        };
-        // Reuse one encoder across every mask to catch stale cached-size slots.
-        let mut encoder = WalEntryEncoder::new();
-        for bits in 0..16 {
-            let mut mask = WalEntryMask::default();
-            for index in 0..4 {
-                mask.push_mutation(index, bits & (1 << index) == 0);
-            }
-            let expected = WalEntry {
-                mutations: entry
-                    .mutations
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, _)| bits & (1 << index) == 0)
-                    .map(|(_, mutation)| mutation.clone())
-                    .collect(),
-                bulk_entries: entry.bulk_entries.clone(),
-            };
-            let actual = encoder.encode_to_vec(&entry, &mask);
-            assert_eq!(actual, expected.encode_to_vec(), "mask {bits:04b}");
-            assert_eq!(WalEntry::decode(actual.as_slice()).unwrap(), expected);
-            assert!(mask.has_entries(&entry), "bulk is never masked out");
-            assert_eq!(entry.mutations.len(), 4, "mask must not consume the input");
-            // Even when every ordinary mutation is skipped, bulk still consumes
-            // exactly one cached size slot and is encoded normally.
-            if bits == 15 {
-                assert_eq!(encoder.sizes.len(), 1);
-            }
-        }
-    }
-
-    #[test]
-    fn test_mask_growth_across_byte_boundaries() {
-        let mut encoder = WalEntryEncoder::new();
-        for count in [17, 65] {
-            let entry = WalEntry {
-                mutations: (0..count)
-                    .map(|index| Mutation {
-                        op_type: OpType::Put as i32,
-                        sequence: index as u64 + 1,
-                        rows: Some(sample_rows(1, false)),
-                        write_hint: None,
-                    })
-                    .collect(),
-                bulk_entries: vec![],
-            };
-            let mut all_selected = WalEntryMask::default();
-            for index in 0..count {
-                all_selected.push_mutation(index, true);
-            }
-            assert!(all_selected.selected_mutations.is_none());
-            assert_eq!(
-                encoder.encode_to_vec(&entry, &all_selected),
-                entry.encode_to_vec()
-            );
-
-            for skip_last in [false, true] {
-                let expected_bits: Vec<_> = (0..count)
-                    .map(|index| {
-                        if index == count - 1 {
-                            !skip_last
-                        } else {
-                            ![0, 8, 16].contains(&index)
-                        }
-                    })
-                    .collect();
-                let mut mask = WalEntryMask::default();
-                for (index, &write_wal) in expected_bits.iter().enumerate() {
-                    mask.push_mutation(index, write_wal);
-                    assert_eq!(mask.selected_mutations.as_ref().unwrap().len(), index + 1);
-                }
-                let selected = mask.selected_mutations.as_ref().unwrap();
-                for (index, &expected) in expected_bits.iter().enumerate() {
-                    assert_eq!(
-                        selected[index], expected,
-                        "count={count}, index={index}, skip_last={skip_last}"
-                    );
-                }
-                let expected = WalEntry {
-                    mutations: entry
-                        .mutations
-                        .iter()
-                        .zip(&expected_bits)
-                        .filter(|(_, selected)| **selected)
-                        .map(|(mutation, _)| mutation.clone())
-                        .collect(),
-                    bulk_entries: vec![],
-                };
-                assert!(mask.has_entries(&entry));
-                let encoded = encoder.encode_to_vec(&entry, &mask);
-                assert_eq!(encoded, expected.encode_to_vec());
-                assert_eq!(WalEntry::decode(encoded.as_slice()).unwrap(), expected);
-            }
-        }
-    }
-
-    #[test]
-    fn test_all_skip_mask_does_not_size_or_allocate_output() {
-        let entry = WalEntry {
-            mutations: vec![Mutation {
-                op_type: OpType::Put as i32,
-                sequence: 1,
-                rows: Some(sample_rows(100, true)),
-                write_hint: None,
-            }],
-            bulk_entries: vec![],
-        };
-        let mut mask = WalEntryMask::default();
-        assert!(mask.selected_mutations.is_none());
-        assert!(mask.has_entries(&entry));
-        mask.push_mutation(0, false);
-        assert!(!mask.has_entries(&entry));
-        let mut encoder = WalEntryEncoder::new();
-        let encoded = encoder.encode_to_vec(&entry, &mask);
-        assert_eq!(encoded, WalEntry::default().encode_to_vec());
-        assert_eq!(encoded.capacity(), 0);
-        assert_eq!(encoder.sizes.capacity(), 0);
     }
 
     #[test]
@@ -650,10 +451,7 @@ mod tests {
                 }],
                 bulk_entries: vec![],
             };
-            assert_eq!(
-                entry.encode_to_vec(),
-                enc.encode_to_vec(&entry, &WalEntryMask::default())
-            );
+            assert_eq!(entry.encode_to_vec(), enc.encode_to_vec(&entry));
         }
     }
 

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -451,6 +451,7 @@ impl<S> RegionWorkerLoop<S> {
                 sender_req.request.hint,
                 sender_req.sender,
                 None,
+                sender_req.request.skip_wal,
             );
         }
     }
@@ -613,13 +614,20 @@ async fn write_wal<S: LogStore>(
     region_ctxs: &mut HashMap<RegionId, RegionWriteCtx>,
 ) -> bool {
     let mut wal_writer = wal.writer();
+    let mut has_wal_entries = false;
     for region_ctx in region_ctxs.values_mut() {
         if region_ctx.skip_wal() {
             continue;
         }
         if let Err(e) = region_ctx.add_wal_entry(&mut wal_writer).map_err(Arc::new) {
             region_ctx.set_error(e);
+        } else {
+            has_wal_entries = true;
         }
+    }
+    // All-skipped batches should not touch the log store, even with an empty append.
+    if !has_wal_entries {
+        return true;
     }
     match wal_writer.write_to_wal().await.map_err(Arc::new) {
         Ok(response) => {
@@ -880,6 +888,7 @@ mod tests {
 
     fn new_region_ctx(
         region_id: RegionId,
+        skip_wal: bool,
     ) -> (RegionWriteCtx, oneshot::Receiver<Result<AffectedRows>>) {
         let version_control = Arc::new(VersionControlBuilder::new().build());
         let mut ctx = RegionWriteCtx::new(
@@ -908,8 +917,36 @@ mod tests {
             None,
             OptionOutputTx::from(tx),
             None,
+            skip_wal,
         );
         (ctx, rx)
+    }
+
+    #[tokio::test]
+    async fn test_request_skip_wal_does_not_append_empty_batch() {
+        // Only change the request flag. A failing log store demonstrates that
+        // the all-skipped path never invokes append_batch, including empty appends.
+        for skip_wal in [false, true] {
+            let region_id = RegionId::new(1, 1);
+            let wal = Wal::new(Arc::new(MockLogStore {
+                fail_append: true,
+                ..Default::default()
+            }));
+            let (ctx, rx) = new_region_ctx(region_id, skip_wal);
+            let version_control = ctx.version_control().clone();
+            let mut contexts = HashMap::from([(region_id, ctx)]);
+            assert_eq!(write_wal(&wal, &mut contexts).await, skip_wal);
+            if skip_wal {
+                let ctx = contexts.get_mut(&region_id).unwrap();
+                assert_eq!(ctx.next_entry_id(), 1);
+                ctx.write_memtable().await;
+                ctx.publish_sequence_and_entry_id();
+                assert_eq!(version_control.committed_sequence(), 1);
+                assert_eq!(version_control.current().last_entry_id, 0);
+            }
+            drop(contexts);
+            assert_eq!(rx.await.unwrap().is_ok(), skip_wal);
+        }
     }
 
     #[tokio::test]
@@ -922,10 +959,10 @@ mod tests {
         }));
 
         let mut region_ctxs = HashMap::new();
-        let (ctx, failing_rx) = new_region_ctx(failing_region);
+        let (ctx, failing_rx) = new_region_ctx(failing_region, false);
         let failing_committed_sequence = ctx.version_control().committed_sequence();
         region_ctxs.insert(failing_region, ctx);
-        let (ctx, ok_rx) = new_region_ctx(ok_region);
+        let (ctx, ok_rx) = new_region_ctx(ok_region, false);
         let ok_committed_sequence = ctx.version_control().committed_sequence();
         region_ctxs.insert(ok_region, ctx);
         let entry_id = region_ctxs[&ok_region].next_entry_id();
@@ -1026,7 +1063,7 @@ mod tests {
         }));
 
         let mut region_ctxs = HashMap::new();
-        let (ctx, rx) = new_region_ctx(failing_region);
+        let (ctx, rx) = new_region_ctx(failing_region, false);
         region_ctxs.insert(failing_region, ctx);
 
         // Writing an empty batch to the WAL succeeds, the failed region must not panic
@@ -1047,7 +1084,7 @@ mod tests {
         }));
 
         let mut region_ctxs = HashMap::new();
-        let (ctx, rx) = new_region_ctx(region_id);
+        let (ctx, rx) = new_region_ctx(region_id, false);
         region_ctxs.insert(region_id, ctx);
 
         assert!(!write_wal(&wal, &mut region_ctxs).await);

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -926,27 +926,30 @@ mod tests {
     async fn test_request_skip_wal_does_not_append_empty_batch() {
         // Only change the request flag. A failing log store demonstrates that
         // the all-skipped path never invokes append_batch, including empty appends.
-        for skip_wal in [false, true] {
-            let region_id = RegionId::new(1, 1);
-            let wal = Wal::new(Arc::new(MockLogStore {
-                fail_append: true,
-                ..Default::default()
-            }));
-            let (ctx, rx) = new_region_ctx(region_id, skip_wal);
-            let version_control = ctx.version_control().clone();
-            let mut contexts = HashMap::from([(region_id, ctx)]);
-            assert_eq!(write_wal(&wal, &mut contexts).await, skip_wal);
-            if skip_wal {
-                let ctx = contexts.get_mut(&region_id).unwrap();
-                assert_eq!(ctx.next_entry_id(), 1);
-                ctx.write_memtable().await;
-                ctx.publish_sequence_and_entry_id();
-                assert_eq!(version_control.committed_sequence(), 1);
-                assert_eq!(version_control.current().last_entry_id, 0);
-            }
-            drop(contexts);
-            assert_eq!(rx.await.unwrap().is_ok(), skip_wal);
+        check_request_skip_wal_does_not_append_empty_batch(false).await;
+        check_request_skip_wal_does_not_append_empty_batch(true).await;
+    }
+
+    async fn check_request_skip_wal_does_not_append_empty_batch(skip_wal: bool) {
+        let region_id = RegionId::new(1, 1);
+        let wal = Wal::new(Arc::new(MockLogStore {
+            fail_append: true,
+            ..Default::default()
+        }));
+        let (ctx, rx) = new_region_ctx(region_id, skip_wal);
+        let version_control = ctx.version_control().clone();
+        let mut contexts = HashMap::from([(region_id, ctx)]);
+        assert_eq!(write_wal(&wal, &mut contexts).await, skip_wal);
+        if skip_wal {
+            let ctx = contexts.get_mut(&region_id).unwrap();
+            assert_eq!(ctx.next_entry_id(), 1);
+            ctx.write_memtable().await;
+            ctx.publish_sequence_and_entry_id();
+            assert_eq!(version_control.committed_sequence(), 1);
+            assert_eq!(version_control.current().last_entry_id, 0);
         }
+        drop(contexts);
+        assert_eq!(rx.await.unwrap().is_ok(), skip_wal);
     }
 
     #[tokio::test]

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -358,7 +358,6 @@ impl Inserter {
         request: TableInsertRequest,
         ctx: QueryContextRef,
     ) -> Result<Output> {
-        let skip_wal = ctx.skip_wal();
         let catalog = request.catalog_name.as_str();
         let schema = request.schema_name.as_str();
         let table_name = request.table_name.as_str();
@@ -369,7 +368,7 @@ impl Inserter {
         let table_info = table.table_info();
 
         let inserts = TableToRegion::new(&table_info, &self.partition_manager)
-            .convert(request, skip_wal)
+            .convert(request)
             .await?;
 
         let table_infos = HashMap::from_iter([(table_info.table_id(), table_info.clone())]);

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -1749,17 +1749,20 @@ mod tests {
 
     #[test]
     fn test_skip_wal_does_not_change_table_options() {
-        for skip_wal in [false, true] {
-            let ctx = Arc::new(QueryContext::with(
-                DEFAULT_CATALOG_NAME,
-                DEFAULT_SCHEMA_NAME,
-            ));
-            ctx.set_skip_wal(skip_wal);
-            let mut options = Default::default();
-            fill_table_options_for_create(&mut options, &AutoCreateTableType::Physical, &ctx);
-            assert!(!options.contains_key(session::hints::INSERT_SKIP_WAL_HINT));
-            assert!(!options.contains_key("skip_wal"));
-        }
+        check_skip_wal_does_not_change_table_options(false);
+        check_skip_wal_does_not_change_table_options(true);
+    }
+
+    fn check_skip_wal_does_not_change_table_options(skip_wal: bool) {
+        let ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+        ));
+        ctx.set_skip_wal(skip_wal);
+        let mut options = Default::default();
+        fill_table_options_for_create(&mut options, &AutoCreateTableType::Physical, &ctx);
+        assert!(!options.contains_key(session::hints::INSERT_SKIP_WAL_HINT));
+        assert!(!options.contains_key("skip_wal"));
     }
 
     #[test]

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -265,6 +265,8 @@ impl Inserter {
         accommodate_existing_schema: bool,
         is_single_value: bool,
     ) -> Result<Output> {
+        let skip_wal = ctx.skip_wal();
+
         // remove empty requests
         requests.inserts.retain(|req| {
             req.rows
@@ -297,7 +299,7 @@ impl Inserter {
             instant_table_ids,
             self.partition_manager.as_ref(),
         )
-        .convert(requests)
+        .convert(requests, skip_wal)
         .await?;
 
         self.do_request(inserts, &table_infos, &ctx).await
@@ -311,6 +313,8 @@ impl Inserter {
         statement_executor: &StatementExecutor,
         physical_table: String,
     ) -> Result<Output> {
+        let skip_wal = ctx.skip_wal();
+
         // remove empty requests
         requests.inserts.retain(|req| {
             req.rows
@@ -343,7 +347,7 @@ impl Inserter {
             .map(|info| (info.name.clone(), info.clone()))
             .collect::<HashMap<_, _>>();
         let inserts = RowToRegion::new(name_to_info, instant_table_ids, &self.partition_manager)
-            .convert(requests)
+            .convert(requests, skip_wal)
             .await?;
 
         self.do_request(inserts, &table_infos, &ctx).await
@@ -354,6 +358,7 @@ impl Inserter {
         request: TableInsertRequest,
         ctx: QueryContextRef,
     ) -> Result<Output> {
+        let skip_wal = ctx.skip_wal();
         let catalog = request.catalog_name.as_str();
         let schema = request.schema_name.as_str();
         let table_name = request.table_name.as_str();
@@ -364,7 +369,7 @@ impl Inserter {
         let table_info = table.table_info();
 
         let inserts = TableToRegion::new(&table_info, &self.partition_manager)
-            .convert(request)
+            .convert(request, skip_wal)
             .await?;
 
         let table_infos = HashMap::from_iter([(table_info.table_id(), table_info.clone())]);
@@ -1741,6 +1746,21 @@ mod tests {
 
         assert!(request_is_native_histogram(&request_schema));
         assert!(table_is_native_histogram(&table));
+    }
+
+    #[test]
+    fn test_skip_wal_does_not_change_table_options() {
+        for skip_wal in [false, true] {
+            let ctx = Arc::new(QueryContext::with(
+                DEFAULT_CATALOG_NAME,
+                DEFAULT_SCHEMA_NAME,
+            ));
+            ctx.set_skip_wal(skip_wal);
+            let mut options = Default::default();
+            fill_table_options_for_create(&mut options, &AutoCreateTableType::Physical, &ctx);
+            assert!(!options.contains_key(session::hints::INSERT_SKIP_WAL_HINT));
+            assert!(!options.contains_key("skip_wal"));
+        }
     }
 
     #[test]

--- a/src/operator/src/req_convert/common/partitioner.rs
+++ b/src/operator/src/req_convert/common/partitioner.rs
@@ -44,6 +44,7 @@ impl<'a> Partitioner<'a> {
             .into_iter()
             .map(
                 |(region_number, (rows, partition_expr_version))| InsertRequest {
+                    skip_wal: false,
                     region_id: RegionId::new(table_id, region_number).into(),
                     rows: Some(rows),
                     partition_expr_version: partition_expr_version

--- a/src/operator/src/req_convert/common/partitioner.rs
+++ b/src/operator/src/req_convert/common/partitioner.rs
@@ -34,6 +34,7 @@ impl<'a> Partitioner<'a> {
         &self,
         table_info: &TableInfo,
         rows: Rows,
+        skip_wal: bool,
     ) -> Result<Vec<InsertRequest>> {
         let table_id = table_info.table_id();
         let requests = self
@@ -44,7 +45,7 @@ impl<'a> Partitioner<'a> {
             .into_iter()
             .map(
                 |(region_number, (rows, partition_expr_version))| InsertRequest {
-                    skip_wal: false,
+                    skip_wal,
                     region_id: RegionId::new(table_id, region_number).into(),
                     rows: Some(rows),
                     partition_expr_version: partition_expr_version

--- a/src/operator/src/req_convert/insert/row_to_region.rs
+++ b/src/operator/src/req_convert/insert/row_to_region.rs
@@ -98,60 +98,63 @@ mod tests {
 
     #[tokio::test]
     async fn test_partitioned_insert_skip_wal_normal_and_instant() {
+        check_partitioned_insert_skip_wal(false, false).await;
+        check_partitioned_insert_skip_wal(false, true).await;
+        check_partitioned_insert_skip_wal(true, false).await;
+        check_partitioned_insert_skip_wal(true, true).await;
+    }
+
+    async fn check_partitioned_insert_skip_wal(instant: bool, skip_wal: bool) {
         let backend = prepare_mocked_backend().await;
         let partition_manager = create_partition_rule_manager(backend).await;
         let table_info = Arc::new(new_test_table_info(1, "table_1", [1, 2, 3].into_iter()));
-        for instant in [false, true] {
-            let instant_table_ids = if instant {
-                HashSet::from_iter([1])
-            } else {
-                HashSet::default()
-            };
-            let converter = RowToRegion::new(
-                HashMap::from_iter([("table_1".to_string(), table_info.clone())]),
-                instant_table_ids,
-                &partition_manager,
-            );
-            for skip_wal in [false, true] {
-                let requests = RowInsertRequests {
-                    inserts: vec![RowInsertRequest {
-                        table_name: "table_1".to_string(),
-                        rows: Some(Rows {
-                            schema: vec![tag_column_schema("a", ColumnDataType::Int32)],
-                            rows: [1, 11, 101]
-                                .into_iter()
-                                .map(|value| Row {
-                                    values: vec![Value {
-                                        value_data: Some(ValueData::I32Value(value)),
-                                    }],
-                                })
-                                .collect(),
-                        }),
-                    }],
-                };
-                let result = converter.convert(requests, skip_wal).await.unwrap();
-                let (selected, other) = if instant {
-                    (result.instant_requests, result.normal_requests)
-                } else {
-                    (result.normal_requests, result.instant_requests)
-                };
-                assert!(other.requests.is_empty());
-                assert_eq!(selected.requests.len(), 3);
-                assert!(
-                    selected
-                        .requests
-                        .iter()
-                        .all(|request| request.skip_wal == skip_wal)
-                );
-                assert_eq!(
-                    selected
-                        .requests
-                        .iter()
-                        .map(|request| request.rows.as_ref().unwrap().rows.len())
-                        .sum::<usize>(),
-                    3
-                );
-            }
-        }
+        let instant_table_ids = if instant {
+            HashSet::from_iter([1])
+        } else {
+            HashSet::default()
+        };
+        let converter = RowToRegion::new(
+            HashMap::from_iter([("table_1".to_string(), table_info)]),
+            instant_table_ids,
+            &partition_manager,
+        );
+        let requests = RowInsertRequests {
+            inserts: vec![RowInsertRequest {
+                table_name: "table_1".to_string(),
+                rows: Some(Rows {
+                    schema: vec![tag_column_schema("a", ColumnDataType::Int32)],
+                    rows: [1, 11, 101]
+                        .into_iter()
+                        .map(|value| Row {
+                            values: vec![Value {
+                                value_data: Some(ValueData::I32Value(value)),
+                            }],
+                        })
+                        .collect(),
+                }),
+            }],
+        };
+        let result = converter.convert(requests, skip_wal).await.unwrap();
+        let (selected, other) = if instant {
+            (result.instant_requests, result.normal_requests)
+        } else {
+            (result.normal_requests, result.instant_requests)
+        };
+        assert!(other.requests.is_empty());
+        assert_eq!(selected.requests.len(), 3);
+        assert!(
+            selected
+                .requests
+                .iter()
+                .all(|request| request.skip_wal == skip_wal)
+        );
+        assert_eq!(
+            selected
+                .requests
+                .iter()
+                .map(|request| request.rows.as_ref().unwrap().rows.len())
+                .sum::<usize>(),
+            3
+        );
     }
 }

--- a/src/operator/src/req_convert/insert/row_to_region.rs
+++ b/src/operator/src/req_convert/insert/row_to_region.rs
@@ -45,6 +45,7 @@ impl<'a> RowToRegion<'a> {
     pub async fn convert(
         &self,
         requests: RowInsertRequests,
+        skip_wal: bool,
     ) -> Result<InstantAndNormalInsertRequests> {
         let mut region_request = Vec::with_capacity(requests.inserts.len());
         let mut instant_request = Vec::with_capacity(requests.inserts.len());
@@ -55,7 +56,7 @@ impl<'a> RowToRegion<'a> {
             let table_id = table_info.table_id();
 
             let requests = Partitioner::new(self.partition_manager)
-                .partition_insert_requests(table_info, rows)
+                .partition_insert_requests(table_info, rows, skip_wal)
                 .await?;
 
             if self.instant_table_ids.contains(&table_id) {
@@ -79,5 +80,78 @@ impl<'a> RowToRegion<'a> {
         self.tables_info
             .get(table_name)
             .context(TableNotFoundSnafu { table_name })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api::v1::helper::tag_column_schema;
+    use api::v1::value::ValueData;
+    use api::v1::{ColumnDataType, Row, RowInsertRequest, Rows, Value};
+
+    use super::*;
+    use crate::tests::{
+        create_partition_rule_manager, new_test_table_info, prepare_mocked_backend,
+    };
+
+    #[tokio::test]
+    async fn test_partitioned_insert_skip_wal_normal_and_instant() {
+        let backend = prepare_mocked_backend().await;
+        let partition_manager = create_partition_rule_manager(backend).await;
+        let table_info = Arc::new(new_test_table_info(1, "table_1", [1, 2, 3].into_iter()));
+        for instant in [false, true] {
+            let instant_table_ids = if instant {
+                HashSet::from_iter([1])
+            } else {
+                HashSet::default()
+            };
+            let converter = RowToRegion::new(
+                HashMap::from_iter([("table_1".to_string(), table_info.clone())]),
+                instant_table_ids,
+                &partition_manager,
+            );
+            for skip_wal in [false, true] {
+                let requests = RowInsertRequests {
+                    inserts: vec![RowInsertRequest {
+                        table_name: "table_1".to_string(),
+                        rows: Some(Rows {
+                            schema: vec![tag_column_schema("a", ColumnDataType::Int32)],
+                            rows: [1, 11, 101]
+                                .into_iter()
+                                .map(|value| Row {
+                                    values: vec![Value {
+                                        value_data: Some(ValueData::I32Value(value)),
+                                    }],
+                                })
+                                .collect(),
+                        }),
+                    }],
+                };
+                let result = converter.convert(requests, skip_wal).await.unwrap();
+                let (selected, other) = if instant {
+                    (result.instant_requests, result.normal_requests)
+                } else {
+                    (result.normal_requests, result.instant_requests)
+                };
+                assert!(other.requests.is_empty());
+                assert_eq!(selected.requests.len(), 3);
+                assert!(
+                    selected
+                        .requests
+                        .iter()
+                        .all(|request| request.skip_wal == skip_wal)
+                );
+                assert_eq!(
+                    selected
+                        .requests
+                        .iter()
+                        .map(|request| request.rows.as_ref().unwrap().rows.len())
+                        .sum::<usize>(),
+                    3
+                );
+            }
+        }
     }
 }

--- a/src/operator/src/req_convert/insert/stmt_to_region.rs
+++ b/src/operator/src/req_convert/insert/stmt_to_region.rs
@@ -154,7 +154,7 @@ impl<'a> StatementToRegion<'a> {
         }
 
         let requests = Partitioner::new(self.partition_manager)
-            .partition_insert_requests(&table_info, Rows { schema, rows })
+            .partition_insert_requests(&table_info, Rows { schema, rows }, query_ctx.skip_wal())
             .await?;
         let requests = RegionInsertRequests { requests };
         if table_info.is_ttl_instant_table() {

--- a/src/operator/src/req_convert/insert/table_to_region.rs
+++ b/src/operator/src/req_convert/insert/table_to_region.rs
@@ -160,6 +160,7 @@ mod tests {
         version: Option<u64>,
     ) -> RegionInsertRequest {
         RegionInsertRequest {
+            skip_wal: false,
             region_id,
             rows: Some(Rows {
                 schema: vec![tag_column_schema("a", ColumnDataType::Int32)],

--- a/src/operator/src/req_convert/insert/table_to_region.rs
+++ b/src/operator/src/req_convert/insert/table_to_region.rs
@@ -84,6 +84,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_insert_request_table_to_region() {
+        check_insert_request_table_to_region(false).await;
+        check_insert_request_table_to_region(true).await;
+    }
+
+    async fn check_insert_request_table_to_region(skip_wal: bool) {
         // region to datanode placement:
         // 1 -> 1
         // 2 -> 2
@@ -100,57 +105,55 @@ mod tests {
 
         let converter = TableToRegion::new(&table_info, &partition_manager);
 
-        for skip_wal in [false, true] {
-            let mut table_request = build_table_request(Arc::new(Int32Vector::from(vec![
-                Some(1),
-                None,
-                Some(11),
-                Some(101),
-            ])));
-            table_request.skip_wal = skip_wal;
-            let versions = partition_manager
-                .find_physical_partition_info(1)
-                .await
-                .unwrap()
-                .partitions
-                .iter()
-                .map(|p| (p.id.as_u64(), p.partition_expr_version))
-                .collect::<HashMap<_, _>>();
+        let mut table_request = build_table_request(Arc::new(Int32Vector::from(vec![
+            Some(1),
+            None,
+            Some(11),
+            Some(101),
+        ])));
+        table_request.skip_wal = skip_wal;
+        let versions = partition_manager
+            .find_physical_partition_info(1)
+            .await
+            .unwrap()
+            .partitions
+            .iter()
+            .map(|p| (p.id.as_u64(), p.partition_expr_version))
+            .collect::<HashMap<_, _>>();
 
-            let region_requests = converter.convert(table_request).await.unwrap();
-            let mut region_id_to_region_requests = region_requests
-                .normal_requests
-                .requests
-                .into_iter()
-                .map(|r| (r.region_id, r))
-                .collect::<HashMap<_, _>>();
+        let region_requests = converter.convert(table_request).await.unwrap();
+        let mut region_id_to_region_requests = region_requests
+            .normal_requests
+            .requests
+            .into_iter()
+            .map(|r| (r.region_id, r))
+            .collect::<HashMap<_, _>>();
 
-            let region_id = RegionId::new(1, 1).as_u64();
-            let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
-            assert_eq!(
-                region_request,
-                build_region_request(vec![Some(101)], region_id, versions[&region_id], skip_wal)
-            );
+        let region_id = RegionId::new(1, 1).as_u64();
+        let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
+        assert_eq!(
+            region_request,
+            build_region_request(vec![Some(101)], region_id, versions[&region_id], skip_wal)
+        );
 
-            let region_id = RegionId::new(1, 2).as_u64();
-            let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
-            assert_eq!(
-                region_request,
-                build_region_request(vec![Some(11)], region_id, versions[&region_id], skip_wal)
-            );
+        let region_id = RegionId::new(1, 2).as_u64();
+        let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
+        assert_eq!(
+            region_request,
+            build_region_request(vec![Some(11)], region_id, versions[&region_id], skip_wal)
+        );
 
-            let region_id = RegionId::new(1, 3).as_u64();
-            let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
-            assert_eq!(
-                region_request,
-                build_region_request(
-                    vec![Some(1), None],
-                    region_id,
-                    versions[&region_id],
-                    skip_wal
-                )
-            );
-        }
+        let region_id = RegionId::new(1, 3).as_u64();
+        let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
+        assert_eq!(
+            region_request,
+            build_region_request(
+                vec![Some(1), None],
+                region_id,
+                versions[&region_id],
+                skip_wal
+            )
+        );
     }
 
     fn build_table_request(vector: VectorRef) -> TableInsertRequest {

--- a/src/operator/src/req_convert/insert/table_to_region.rs
+++ b/src/operator/src/req_convert/insert/table_to_region.rs
@@ -39,7 +39,6 @@ impl<'a> TableToRegion<'a> {
     pub async fn convert(
         &self,
         request: TableInsertRequest,
-        skip_wal: bool,
     ) -> Result<InstantAndNormalInsertRequests> {
         let row_count = row_count(&request.columns_values)?;
         let schema = column_schema(self.table_info, &request.columns_values)?;
@@ -47,7 +46,7 @@ impl<'a> TableToRegion<'a> {
 
         let rows = Rows { schema, rows };
         let requests = Partitioner::new(self.partition_manager)
-            .partition_insert_requests(self.table_info, rows, skip_wal)
+            .partition_insert_requests(self.table_info, rows, request.skip_wal)
             .await?;
 
         let requests = RegionInsertRequests { requests };
@@ -102,12 +101,13 @@ mod tests {
         let converter = TableToRegion::new(&table_info, &partition_manager);
 
         for skip_wal in [false, true] {
-            let table_request = build_table_request(Arc::new(Int32Vector::from(vec![
+            let mut table_request = build_table_request(Arc::new(Int32Vector::from(vec![
                 Some(1),
                 None,
                 Some(11),
                 Some(101),
             ])));
+            table_request.skip_wal = skip_wal;
             let versions = partition_manager
                 .find_physical_partition_info(1)
                 .await
@@ -117,7 +117,7 @@ mod tests {
                 .map(|p| (p.id.as_u64(), p.partition_expr_version))
                 .collect::<HashMap<_, _>>();
 
-            let region_requests = converter.convert(table_request, skip_wal).await.unwrap();
+            let region_requests = converter.convert(table_request).await.unwrap();
             let mut region_id_to_region_requests = region_requests
                 .normal_requests
                 .requests
@@ -159,6 +159,7 @@ mod tests {
             schema_name: DEFAULT_SCHEMA_NAME.to_string(),
             table_name: "table_1".to_string(),
             columns_values: HashMap::from([("a".to_string(), vector)]),
+            skip_wal: false,
         }
     }
 

--- a/src/operator/src/req_convert/insert/table_to_region.rs
+++ b/src/operator/src/req_convert/insert/table_to_region.rs
@@ -39,6 +39,7 @@ impl<'a> TableToRegion<'a> {
     pub async fn convert(
         &self,
         request: TableInsertRequest,
+        skip_wal: bool,
     ) -> Result<InstantAndNormalInsertRequests> {
         let row_count = row_count(&request.columns_values)?;
         let schema = column_schema(self.table_info, &request.columns_values)?;
@@ -46,7 +47,7 @@ impl<'a> TableToRegion<'a> {
 
         let rows = Rows { schema, rows };
         let requests = Partitioner::new(self.partition_manager)
-            .partition_insert_requests(self.table_info, rows)
+            .partition_insert_requests(self.table_info, rows, skip_wal)
             .await?;
 
         let requests = RegionInsertRequests { requests };
@@ -100,49 +101,56 @@ mod tests {
 
         let converter = TableToRegion::new(&table_info, &partition_manager);
 
-        let table_request = build_table_request(Arc::new(Int32Vector::from(vec![
-            Some(1),
-            None,
-            Some(11),
-            Some(101),
-        ])));
-        let versions = partition_manager
-            .find_physical_partition_info(1)
-            .await
-            .unwrap()
-            .partitions
-            .iter()
-            .map(|p| (p.id.as_u64(), p.partition_expr_version))
-            .collect::<HashMap<_, _>>();
+        for skip_wal in [false, true] {
+            let table_request = build_table_request(Arc::new(Int32Vector::from(vec![
+                Some(1),
+                None,
+                Some(11),
+                Some(101),
+            ])));
+            let versions = partition_manager
+                .find_physical_partition_info(1)
+                .await
+                .unwrap()
+                .partitions
+                .iter()
+                .map(|p| (p.id.as_u64(), p.partition_expr_version))
+                .collect::<HashMap<_, _>>();
 
-        let region_requests = converter.convert(table_request).await.unwrap();
-        let mut region_id_to_region_requests = region_requests
-            .normal_requests
-            .requests
-            .into_iter()
-            .map(|r| (r.region_id, r))
-            .collect::<HashMap<_, _>>();
+            let region_requests = converter.convert(table_request, skip_wal).await.unwrap();
+            let mut region_id_to_region_requests = region_requests
+                .normal_requests
+                .requests
+                .into_iter()
+                .map(|r| (r.region_id, r))
+                .collect::<HashMap<_, _>>();
 
-        let region_id = RegionId::new(1, 1).as_u64();
-        let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
-        assert_eq!(
-            region_request,
-            build_region_request(vec![Some(101)], region_id, versions[&region_id])
-        );
+            let region_id = RegionId::new(1, 1).as_u64();
+            let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
+            assert_eq!(
+                region_request,
+                build_region_request(vec![Some(101)], region_id, versions[&region_id], skip_wal)
+            );
 
-        let region_id = RegionId::new(1, 2).as_u64();
-        let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
-        assert_eq!(
-            region_request,
-            build_region_request(vec![Some(11)], region_id, versions[&region_id])
-        );
+            let region_id = RegionId::new(1, 2).as_u64();
+            let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
+            assert_eq!(
+                region_request,
+                build_region_request(vec![Some(11)], region_id, versions[&region_id], skip_wal)
+            );
 
-        let region_id = RegionId::new(1, 3).as_u64();
-        let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
-        assert_eq!(
-            region_request,
-            build_region_request(vec![Some(1), None], region_id, versions[&region_id])
-        );
+            let region_id = RegionId::new(1, 3).as_u64();
+            let region_request = region_id_to_region_requests.remove(&region_id).unwrap();
+            assert_eq!(
+                region_request,
+                build_region_request(
+                    vec![Some(1), None],
+                    region_id,
+                    versions[&region_id],
+                    skip_wal
+                )
+            );
+        }
     }
 
     fn build_table_request(vector: VectorRef) -> TableInsertRequest {
@@ -158,9 +166,10 @@ mod tests {
         rows: Vec<Option<i32>>,
         region_id: u64,
         version: Option<u64>,
+        skip_wal: bool,
     ) -> RegionInsertRequest {
         RegionInsertRequest {
-            skip_wal: false,
+            skip_wal,
             region_id,
             rows: Some(Rows {
                 schema: vec![tag_column_schema("a", ColumnDataType::Int32)],

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -63,7 +63,7 @@ use query::QueryEngineRef;
 use query::parser::QueryStatement;
 use session::context::{Channel, QueryContextBuilder, QueryContextRef};
 use session::table_name::table_idents_to_full_name;
-use set::{set_query_timeout, set_read_preference};
+use set::{set_query_timeout, set_read_preference, set_skip_wal};
 use snafu::{OptionExt, ResultExt, ensure};
 use sql::ast::ObjectNamePartExt;
 use sql::statements::OptionMap;
@@ -534,6 +534,7 @@ impl StatementExecutor {
 
         match var_name.as_str() {
             "READ_PREFERENCE" => set_read_preference(set_var.value, query_ctx)?,
+            "SKIP_WAL" => set_skip_wal(set_var.value, query_ctx)?,
 
             "@@TIME_ZONE" | "@@SESSION.TIME_ZONE" | "TIMEZONE" | "TIME_ZONE" => {
                 set_timezone(set_var.value, query_ctx)?

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -487,6 +487,7 @@ impl StatementExecutor {
                         schema_name: req.schema_name.clone(),
                         table_name: req.table_name.clone(),
                         columns_values,
+                        skip_wal: query_ctx.skip_wal(),
                     },
                     query_ctx.clone(),
                 ));

--- a/src/operator/src/statement/set.rs
+++ b/src/operator/src/statement/set.rs
@@ -38,6 +38,35 @@ lazy_static! {
     static ref PG_TIME_INPUT_REGEX: Regex = Regex::new(r"^(\d+)(ms|s|min|h|d)$").unwrap();
 }
 
+/// Sets the session WAL policy for ordinary inserts without changing table options.
+pub fn set_skip_wal(exprs: Vec<Expr>, ctx: QueryContextRef) -> Result<()> {
+    let [Expr::Value(value)] = exprs.as_slice() else {
+        return NotSupportedSnafu {
+            feat: "SET skip_wal requires exactly one boolean value",
+        }
+        .fail();
+    };
+    let skip_wal = match &value.value {
+        Value::Boolean(value) => *value,
+        Value::SingleQuotedString(value) | Value::DoubleQuotedString(value) => {
+            value.parse::<bool>().map_err(|_| {
+                NotSupportedSnafu {
+                    feat: format!("Invalid skip_wal value {value:?}: expected true or false"),
+                }
+                .build()
+            })?
+        }
+        _ => {
+            return NotSupportedSnafu {
+                feat: "SET skip_wal requires true or false",
+            }
+            .fail();
+        }
+    };
+    ctx.set_skip_wal(skip_wal);
+    Ok(())
+}
+
 pub fn set_read_preference(exprs: Vec<Expr>, ctx: QueryContextRef) -> Result<()> {
     let read_preference_expr = exprs.first().context(NotSupportedSnafu {
         feat: "No read preference find in set variable statement",
@@ -381,7 +410,57 @@ fn parse_pg_query_timeout_input(input: &str) -> Result<u64> {
 
 #[cfg(test)]
 mod test {
+    use session::Session;
+    use session::context::{Channel, QueryContext};
+    use sql::ast::{Expr, Value};
+
+    use super::set_skip_wal;
     use crate::statement::set::parse_pg_query_timeout_input;
+
+    #[test]
+    fn test_set_skip_wal() {
+        let ctx = QueryContext::arc();
+        for value in [true, false] {
+            set_skip_wal(vec![Expr::Value(Value::Boolean(value).into())], ctx.clone()).unwrap();
+            assert_eq!(ctx.skip_wal(), value);
+            set_skip_wal(
+                vec![Expr::Value(
+                    Value::SingleQuotedString(value.to_string()).into(),
+                )],
+                ctx.clone(),
+            )
+            .unwrap();
+            assert_eq!(ctx.skip_wal(), value);
+        }
+        ctx.set_skip_wal(true);
+        for values in [
+            vec![],
+            vec![Expr::Value(Value::Number("1".to_string(), false).into())],
+            vec![Expr::Value(
+                Value::SingleQuotedString("invalid".to_string()).into(),
+            )],
+            vec![Expr::Value(Value::Boolean(false).into()); 2],
+        ] {
+            assert!(set_skip_wal(values, ctx.clone()).is_err());
+            assert!(ctx.skip_wal());
+        }
+    }
+
+    #[test]
+    fn test_set_skip_wal_session_isolation() {
+        for channel in [Channel::Mysql, Channel::Postgres] {
+            let session = Session::new(None, channel, Default::default(), 0);
+            let other = Session::new(None, channel, Default::default(), 1);
+            assert!(!session.new_query_context().skip_wal());
+            set_skip_wal(
+                vec![Expr::Value(Value::Boolean(true).into())],
+                session.new_query_context(),
+            )
+            .unwrap();
+            assert!(session.new_query_context().skip_wal());
+            assert!(!other.new_query_context().skip_wal());
+        }
+    }
 
     #[test]
     fn test_parse_pg_query_timeout_input() {

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -392,6 +392,7 @@ impl DatafusionQueryEngine {
             schema_name,
             table_name,
             columns_values: column_vectors,
+            skip_wal: query_ctx.skip_wal(),
         };
 
         self.state

--- a/src/servers/src/grpc/context_auth.rs
+++ b/src/servers/src/grpc/context_auth.rs
@@ -21,6 +21,7 @@ use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
 use session::context::{Channel, QueryContextBuilder, QueryContextRef};
+use session::hints::INSERT_SKIP_WAL_HINT;
 use snafu::{OptionExt, ResultExt};
 use tonic::Status;
 use tonic::metadata::MetadataMap;
@@ -28,6 +29,7 @@ use tonic::metadata::MetadataMap;
 use crate::error::Error::UnsupportedAuthScheme;
 use crate::error::{AuthSnafu, InvalidParameterSnafu, NotFoundAuthHeaderSnafu, Result};
 use crate::grpc::TonicResult;
+use crate::hint_headers;
 use crate::http::AUTHORIZATION_HEADER;
 use crate::http::header::constants::GREPTIME_DB_HEADER_NAME;
 use crate::metrics::METRIC_AUTH_FAILURE;
@@ -45,13 +47,25 @@ pub fn create_query_context_from_grpc_metadata(
         )
     };
 
-    Ok(Arc::new(
-        QueryContextBuilder::default()
-            .current_catalog(catalog)
-            .current_schema(schema)
-            .channel(Channel::Grpc)
-            .build(),
-    ))
+    let ctx = QueryContextBuilder::default()
+        .current_catalog(catalog)
+        .current_schema(schema)
+        .channel(Channel::Grpc)
+        .build();
+    // OTEL Arrow uses ordinary inserts. Accept only its request-level WAL hint,
+    // leaving unrelated hints and reserved internal extensions unchanged.
+    for (key, value) in hint_headers::extract_hints(headers) {
+        if key == INSERT_SKIP_WAL_HINT {
+            let skip_wal = value.parse::<bool>().map_err(|_| {
+                InvalidParameterSnafu {
+                    reason: format!("Invalid {key} hint: expected true or false, got {value:?}"),
+                }
+                .build()
+            })?;
+            ctx.set_skip_wal(skip_wal);
+        }
+    }
+    Ok(Arc::new(ctx))
 }
 
 /// Helper function to extract a header from the metadata map.
@@ -160,4 +174,49 @@ pub async fn auth(
             .with_label_values(&[e.status_code().as_ref()])
             .inc();
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use session::hints::{HINTS_KEY, REMOTE_QUERY_ID_EXTENSION_KEY, RESERVED_EXTENSION_KEYS};
+
+    use super::*;
+
+    #[test]
+    fn test_arrow_insert_hint_does_not_accept_reserved_extensions() {
+        let mut headers = MetadataMap::new();
+        assert_eq!(
+            create_query_context_from_grpc_metadata(&headers)
+                .unwrap()
+                .extension(INSERT_SKIP_WAL_HINT),
+            None
+        );
+        for (value, expected) in [("true", true), ("false", false)] {
+            let mut hints = format!("insert_skip_wal={value},ttl=7d");
+            for key in RESERVED_EXTENSION_KEYS {
+                hints.push_str(&format!(",{key}=external"));
+            }
+            headers.insert(HINTS_KEY, hints.parse().unwrap());
+            let ctx = create_query_context_from_grpc_metadata(&headers).unwrap();
+            assert_eq!(ctx.skip_wal(), expected);
+            assert_eq!(ctx.extension(INSERT_SKIP_WAL_HINT), None);
+            assert_eq!(ctx.extension("ttl"), None);
+            for key in RESERVED_EXTENSION_KEYS {
+                if key == REMOTE_QUERY_ID_EXTENSION_KEY {
+                    // The builder generates this ID; external hints must not replace it.
+                    assert!(ctx.remote_query_id().is_some());
+                    assert_ne!(ctx.extension(key), Some("external"));
+                } else {
+                    assert_eq!(ctx.extension(key), None);
+                }
+            }
+        }
+        for value in ["", "TRUE", "1", "invalid"] {
+            headers.insert(
+                HINTS_KEY,
+                format!("insert_skip_wal={value}").parse().unwrap(),
+            );
+            assert!(create_query_context_from_grpc_metadata(&headers).is_err());
+        }
+    }
 }

--- a/src/servers/src/grpc/context_auth.rs
+++ b/src/servers/src/grpc/context_auth.rs
@@ -54,16 +54,17 @@ pub fn create_query_context_from_grpc_metadata(
         .build();
     // OTEL Arrow uses ordinary inserts. Accept only its request-level WAL hint,
     // leaving unrelated hints and reserved internal extensions unchanged.
-    for (key, value) in hint_headers::extract_hints(headers) {
-        if key == INSERT_SKIP_WAL_HINT {
-            let skip_wal = value.parse::<bool>().map_err(|_| {
-                InvalidParameterSnafu {
-                    reason: format!("Invalid {key} hint: expected true or false, got {value:?}"),
-                }
-                .build()
-            })?;
-            ctx.set_skip_wal(skip_wal);
-        }
+    if let Some((key, value)) = hint_headers::extract_hints(headers)
+        .into_iter()
+        .find(|(key, _)| key == INSERT_SKIP_WAL_HINT)
+    {
+        let skip_wal = value.parse::<bool>().map_err(|_| {
+            InvalidParameterSnafu {
+                reason: format!("Invalid {key} hint: expected true or false, got {value:?}"),
+            }
+            .build()
+        })?;
+        ctx.set_skip_wal(skip_wal);
     }
     Ok(Arc::new(ctx))
 }
@@ -210,6 +211,16 @@ mod tests {
                     assert_eq!(ctx.extension(key), None);
                 }
             }
+        }
+        // Only the first matching hint is parsed and applied.
+        for (hints, expected) in [
+            ("insert_skip_wal=true,insert_skip_wal=false", true),
+            ("insert_skip_wal=false,insert_skip_wal=true", false),
+            ("insert_skip_wal=true,insert_skip_wal=invalid", true),
+        ] {
+            headers.insert(HINTS_KEY, hints.parse().unwrap());
+            let ctx = create_query_context_from_grpc_metadata(&headers).unwrap();
+            assert_eq!(ctx.skip_wal(), expected);
         }
         for value in ["", "TRUE", "1", "invalid"] {
             headers.insert(

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -202,7 +202,7 @@ pub fn get_request_type(request: &GreptimeRequest) -> &'static str {
 pub(crate) fn create_query_context(
     channel: Channel,
     header: Option<&RequestHeader>,
-    mut extensions: Vec<(String, String)>,
+    extensions: Vec<(String, String)>,
     snapshot_seqs: HashMap<u64, u64>,
 ) -> Result<QueryContextRef> {
     let (catalog, schema) = header
@@ -240,39 +240,36 @@ pub(crate) fn create_query_context(
         .channel(channel)
         .snapshot_seqs(Arc::new(RwLock::new(snapshot_seqs)));
 
-    if let Some(x) = extensions
-        .iter()
-        .position(|(k, _)| k == READ_PREFERENCE_HINT)
-    {
-        let (k, v) = extensions.swap_remove(x);
-        let Ok(read_preference) = ReadPreference::from_str(&v) else {
-            return UnknownHintSnafu {
-                hint: format!("{k}={v}"),
-            }
-            .fail();
-        };
-        ctx_builder = ctx_builder.read_preference(read_preference);
-    }
-
     for (key, value) in extensions {
-        if key == INSERT_SKIP_WAL_HINT {
-            let skip_wal = value.parse::<bool>().map_err(|_| {
-                UnknownHintSnafu {
-                    hint: format!("{key}={value}"),
-                }
-                .build()
-            })?;
-            ctx_builder = ctx_builder.skip_wal(skip_wal);
-            continue;
+        match key.as_str() {
+            READ_PREFERENCE_HINT => {
+                let Ok(read_preference) = ReadPreference::from_str(&value) else {
+                    return UnknownHintSnafu {
+                        hint: format!("{key}={value}"),
+                    }
+                    .fail();
+                };
+                ctx_builder = ctx_builder.read_preference(read_preference);
+            }
+            INSERT_SKIP_WAL_HINT => {
+                let skip_wal = value.parse::<bool>().map_err(|_| {
+                    UnknownHintSnafu {
+                        hint: format!("{key}={value}"),
+                    }
+                    .build()
+                })?;
+                ctx_builder = ctx_builder.skip_wal(skip_wal);
+            }
+            _ if is_reserved_extension_key(&key) => {
+                debug!(
+                    key = key.as_str(),
+                    "Ignoring reserved external query context extension key"
+                );
+            }
+            _ => {
+                ctx_builder = ctx_builder.set_extension(key, value);
+            }
         }
-        if is_reserved_extension_key(&key) {
-            debug!(
-                key = key.as_str(),
-                "Ignoring reserved external query context extension key"
-            );
-            continue;
-        }
-        ctx_builder = ctx_builder.set_extension(key, value);
     }
     Ok(ctx_builder.build().into())
 }
@@ -379,6 +376,32 @@ mod tests {
         .unwrap();
         assert!(!ctx.skip_wal());
         assert_eq!(ctx.extension(INSERT_SKIP_WAL_HINT), None);
+    }
+
+    #[test]
+    fn test_create_query_context_read_preference_duplicates() {
+        for (values, valid) in [
+            (["leader", "LEADER"], true),
+            (["invalid", "leader"], false),
+            (["leader", "invalid"], false),
+        ] {
+            let result = create_query_context(
+                Channel::Grpc,
+                None,
+                values
+                    .into_iter()
+                    .map(|value| (READ_PREFERENCE_HINT.to_string(), value.to_string()))
+                    .collect(),
+                HashMap::new(),
+            );
+            if valid {
+                let ctx = result.unwrap();
+                assert!(matches!(ctx.read_preference(), ReadPreference::Leader));
+                assert_eq!(ctx.extension(READ_PREFERENCE_HINT), None);
+            } else {
+                assert!(result.is_err());
+            }
+        }
     }
 
     #[test]

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -38,7 +38,7 @@ use common_telemetry::{debug, error, tracing, warn};
 use common_time::timezone::parse_timezone;
 use futures_util::StreamExt;
 use session::context::{Channel, QueryContextBuilder, QueryContextRef};
-use session::hints::{READ_PREFERENCE_HINT, is_reserved_extension_key};
+use session::hints::{INSERT_SKIP_WAL_HINT, READ_PREFERENCE_HINT, is_reserved_extension_key};
 use snafu::{OptionExt, ResultExt};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
@@ -255,6 +255,16 @@ pub(crate) fn create_query_context(
     }
 
     for (key, value) in extensions {
+        if key == INSERT_SKIP_WAL_HINT {
+            let skip_wal = value.parse::<bool>().map_err(|_| {
+                UnknownHintSnafu {
+                    hint: format!("{key}={value}"),
+                }
+                .build()
+            })?;
+            ctx_builder = ctx_builder.skip_wal(skip_wal);
+            continue;
+        }
         if is_reserved_extension_key(&key) {
             debug!(
                 key = key.as_str(),
@@ -321,6 +331,55 @@ mod tests {
 
     use super::*;
     use crate::error::{ExecuteGrpcRequestSnafu, InvalidParameterSnafu};
+
+    #[test]
+    fn test_create_query_context_typed_skip_wal() {
+        let ctx = create_query_context(Channel::Grpc, None, vec![], HashMap::new()).unwrap();
+        assert!(!ctx.skip_wal());
+        let legacy = create_query_context(
+            Channel::Grpc,
+            None,
+            vec![("skip_wal".to_string(), "true".to_string())],
+            HashMap::new(),
+        )
+        .unwrap();
+        assert!(!legacy.skip_wal());
+        assert_eq!(legacy.extension("skip_wal"), Some("true"));
+        for (value, expected) in [("true", true), ("false", false)] {
+            let ctx = create_query_context(
+                Channel::Grpc,
+                None,
+                vec![(INSERT_SKIP_WAL_HINT.to_string(), value.to_string())],
+                HashMap::new(),
+            )
+            .unwrap();
+            assert_eq!(ctx.skip_wal(), expected);
+            assert_eq!(ctx.extension(INSERT_SKIP_WAL_HINT), None);
+        }
+        for value in ["", "TRUE", "1", "invalid"] {
+            assert!(
+                create_query_context(
+                    Channel::Grpc,
+                    None,
+                    vec![(INSERT_SKIP_WAL_HINT.to_string(), value.to_string())],
+                    HashMap::new()
+                )
+                .is_err()
+            );
+        }
+        let ctx = create_query_context(
+            Channel::Grpc,
+            None,
+            vec![
+                (INSERT_SKIP_WAL_HINT.to_string(), "true".to_string()),
+                (INSERT_SKIP_WAL_HINT.to_string(), "false".to_string()),
+            ],
+            HashMap::new(),
+        )
+        .unwrap();
+        assert!(!ctx.skip_wal());
+        assert_eq!(ctx.extension(INSERT_SKIP_WAL_HINT), None);
+    }
 
     #[test]
     fn test_create_query_context() {

--- a/src/servers/src/hint_headers.rs
+++ b/src/servers/src/hint_headers.rs
@@ -60,6 +60,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_extract_skip_wal_hint() {
+        use session::hints::INSERT_SKIP_WAL_HINT;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(HINTS_KEY, HeaderValue::from_static("insert_skip_wal=true"));
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            HINTS_KEY,
+            MetadataValue::from_static("insert_skip_wal=true"),
+        );
+        let expected = vec![(INSERT_SKIP_WAL_HINT.to_string(), "true".to_string())];
+        assert_eq!(extract_hints(&headers), expected);
+        assert_eq!(extract_hints(&metadata), expected);
+    }
+
+    #[test]
     fn test_extract_hints_with_full_header_map() {
         let mut headers = HeaderMap::new();
         headers.insert(

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -117,6 +117,7 @@ mod client_ip;
 use crate::prom_remote_write::validation::PromValidationMode;
 mod hints;
 mod read_preference;
+mod skip_wal;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;
 
@@ -1059,7 +1060,8 @@ impl HttpServer {
                     .layer(middleware::from_fn(client_ip::log_error_with_client_ip))
                     .layer(middleware::from_fn(
                         read_preference::extract_read_preference,
-                    )),
+                    ))
+                    .layer(middleware::from_fn(skip_wal::extract_skip_wal)),
             );
 
         // Debug handlers are part of the complete router; the API listener hides

--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -44,6 +44,7 @@ pub mod constants {
     pub const GREPTIME_DB_HEADER_METRICS: &str = "x-greptime-metrics";
     pub const GREPTIME_DB_HEADER_NAME: &str = "x-greptime-db-name";
     pub const GREPTIME_DB_HEADER_READ_PREFERENCE: &str = "x-greptime-read-preference";
+    pub const GREPTIME_INSERT_SKIP_WAL_HEADER_NAME: &str = "x-greptime-insert-skip-wal";
     pub const GREPTIME_TIMEZONE_HEADER_NAME: &str = "x-greptime-timezone";
     pub const GREPTIME_DB_HEADER_ERROR_CODE: &str = common_error::GREPTIME_DB_HEADER_ERROR_CODE;
 
@@ -93,6 +94,10 @@ pub static GREPTIME_TIMEZONE_HEADER_NAME: HeaderName =
 /// Header key of query specific read preference. Example format of the header value is `leader`.
 pub static GREPTIME_DB_HEADER_READ_PREFERENCE: HeaderName =
     HeaderName::from_static(constants::GREPTIME_DB_HEADER_READ_PREFERENCE);
+
+/// Request-level WAL policy, independent of the table-level skip_wal option.
+pub static GREPTIME_INSERT_SKIP_WAL_HEADER_NAME: HeaderName =
+    HeaderName::from_static(constants::GREPTIME_INSERT_SKIP_WAL_HEADER_NAME);
 
 pub static CONTENT_TYPE_PROTOBUF_STR: &str = "application/x-protobuf";
 pub static CONTENT_TYPE_PROTOBUF: HeaderValue = HeaderValue::from_static(CONTENT_TYPE_PROTOBUF_STR);

--- a/src/servers/src/http/skip_wal.rs
+++ b/src/servers/src/http/skip_wal.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::body::Body;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use session::context::QueryContext;
+
+use crate::error::InvalidParameterSnafu;
+use crate::http::header::GREPTIME_INSERT_SKIP_WAL_HEADER_NAME;
+use crate::http::result::error_result::ErrorResponse;
+
+/// Extract the request-level WAL policy from the dedicated HTTP header.
+pub async fn extract_skip_wal(mut request: Request<Body>, next: Next) -> Response {
+    let skip_wal = match request.headers().get(&GREPTIME_INSERT_SKIP_WAL_HEADER_NAME) {
+        None => false,
+        Some(value) => match value
+            .to_str()
+            .ok()
+            .and_then(|value| value.parse::<bool>().ok())
+        {
+            Some(skip_wal) => skip_wal,
+            None => {
+                return (
+                    http::StatusCode::BAD_REQUEST,
+                    ErrorResponse::from_error(
+                        InvalidParameterSnafu {
+                            reason: format!(
+                                "{} must be true or false",
+                                GREPTIME_INSERT_SKIP_WAL_HEADER_NAME
+                            ),
+                        }
+                        .build(),
+                    ),
+                )
+                    .into_response();
+            }
+        },
+    };
+    if let Some(query_ctx) = request.extensions_mut().get_mut::<QueryContext>() {
+        query_ctx.set_skip_wal(skip_wal);
+    }
+    next.run(request).await
+}

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -980,3 +980,102 @@ async fn get_body(response: Response) -> Bytes {
         .await
         .unwrap()
 }
+
+#[tokio::test]
+async fn test_http_skip_wal_header() {
+    struct SkipWalSqlHandler {
+        inner: ServerSqlQueryHandlerRef,
+        observed: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SqlQueryHandler for SkipWalSqlHandler {
+        async fn do_query(&self, query: &str, ctx: QueryContextRef) -> Vec<Result<Output>> {
+            self.observed
+                .store(usize::from(ctx.skip_wal()), Ordering::Relaxed);
+            self.inner.do_query(query, ctx).await
+        }
+
+        async fn do_analyze_stream_query(
+            &self,
+            query: &str,
+            ctx: QueryContextRef,
+        ) -> Result<Output> {
+            self.inner.do_analyze_stream_query(query, ctx).await
+        }
+
+        async fn do_exec_plan(
+            &self,
+            plan: LogicalPlan,
+            stmt: Option<Statement>,
+            ctx: QueryContextRef,
+        ) -> Result<Output> {
+            self.inner.do_exec_plan(plan, stmt, ctx).await
+        }
+
+        async fn do_promql_query(
+            &self,
+            query: &PromQuery,
+            ctx: QueryContextRef,
+        ) -> Vec<Result<Output>> {
+            self.inner.do_promql_query(query, ctx).await
+        }
+
+        async fn do_describe(
+            &self,
+            stmt: Statement,
+            ctx: QueryContextRef,
+        ) -> Result<Option<DescribeResult>> {
+            self.inner.do_describe(stmt, ctx).await
+        }
+
+        async fn is_valid_schema(&self, catalog: &str, schema: &str) -> Result<bool> {
+            self.inner.is_valid_schema(catalog, schema).await
+        }
+    }
+
+    let handler = Arc::new(SkipWalSqlHandler {
+        inner: create_testing_sql_query_handler(MemTable::default_numbers_table()),
+        observed: AtomicUsize::new(2),
+    });
+    let server = HttpServerBuilder::new(HttpOptions::default())
+        .with_sql_handler(handler.clone())
+        .build();
+    let client = TestClient::new(server.build(server.make_app()).unwrap()).await;
+    for (header, expected) in [
+        (Some(("x-greptime-insert-skip-wal", "true")), Some(true)),
+        (Some(("x-greptime-insert-skip-wal", "false")), Some(false)),
+        (None, Some(false)),
+        (Some(("x-greptime-insert-skip-wal", "yes")), None),
+        (Some(("x-greptime-insert-skip-wal", "1")), None),
+        (Some(("x-greptime-insert-skip-wal", "")), None),
+        (Some(("x-greptime-skip-wal", "true")), Some(false)),
+        (Some(("x-greptime-hints", "skip_wal=true")), Some(false)),
+        (
+            Some(("x-greptime-hints", "insert_skip_wal=true")),
+            Some(false),
+        ),
+    ] {
+        // Sentinel also proves invalid values are rejected before the SQL handler.
+        handler.observed.store(2, Ordering::Relaxed);
+        let mut request = client.get("/v1/sql?sql=SELECT%201");
+        if let Some((key, value)) = header {
+            request = request.header(key, value);
+        }
+        let response = request.send().await;
+        match expected {
+            Some(expected) => {
+                assert_eq!(response.status(), StatusCode::OK, "{header:?}");
+                assert_eq!(
+                    handler.observed.load(Ordering::Relaxed),
+                    usize::from(expected),
+                    "{header:?}"
+                );
+            }
+            None => {
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{header:?}");
+                assert_eq!(handler.observed.load(Ordering::Relaxed), 2);
+            }
+        }
+    }
+}

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -153,6 +153,15 @@ impl QueryContextBuilder {
         self
     }
 
+    pub fn skip_wal(mut self, skip_wal: bool) -> Self {
+        self.mutable_session_data
+            .get_or_insert_default()
+            .write()
+            .unwrap()
+            .skip_wal = skip_wal;
+        self
+    }
+
     pub fn read_preference(mut self, read_preference: ReadPreference) -> Self {
         self.mutable_session_data
             .get_or_insert_default()
@@ -346,6 +355,15 @@ impl QueryContext {
 
     pub fn set_timezone(&self, timezone: Timezone) {
         self.mutable_session_data.write().unwrap().timezone = timezone;
+    }
+
+    /// Returns whether ordinary inserts in this request should skip WAL.
+    pub fn skip_wal(&self) -> bool {
+        self.mutable_session_data.read().unwrap().skip_wal
+    }
+
+    pub fn set_skip_wal(&self, skip_wal: bool) {
+        self.mutable_session_data.write().unwrap().skip_wal = skip_wal;
     }
 
     pub fn read_preference(&self) -> ReadPreference {
@@ -737,6 +755,37 @@ mod test {
 
         assert_eq!(context.current_schema(), "public");
         assert_eq!(fork.current_schema(), "private");
+    }
+
+    #[test]
+    fn test_skip_wal_default_builder_and_fork() {
+        let default_context = QueryContext::with(DEFAULT_CATALOG_NAME, "public");
+        assert!(!default_context.skip_wal());
+        assert!(!QueryContextBuilder::default().build().skip_wal());
+        let context = QueryContextBuilder::default().skip_wal(true).build();
+        assert!(context.skip_wal());
+        let fork = context.fork();
+        assert!(fork.skip_wal());
+        fork.set_skip_wal(false);
+        assert!(context.skip_wal());
+        assert!(!fork.skip_wal());
+        context.set_skip_wal(false);
+        fork.set_skip_wal(true);
+        assert!(!context.skip_wal());
+        assert!(fork.skip_wal());
+    }
+
+    #[test]
+    fn test_skip_wal_is_not_serialized_in_query_context() {
+        let context = QueryContextBuilder::default().skip_wal(true).build();
+        let api_context: api::v1::QueryContext = context.into();
+        assert!(
+            !api_context
+                .extensions
+                .contains_key(crate::hints::INSERT_SKIP_WAL_HINT)
+        );
+        let restored: QueryContext = api_context.into();
+        assert!(!restored.skip_wal());
     }
 
     #[test]

--- a/src/session/src/hints.rs
+++ b/src/session/src/hints.rs
@@ -23,6 +23,9 @@ pub const SUPPORT_FLIGHT_METRICS_BEFORE_BATCH_EXTENSION_KEY: &str =
     "query.support_flight_metrics_before_batch";
 pub const LIVE_ANALYZE_METRICS_EXTENSION_KEY: &str = "query.live_analyze_metrics";
 
+/// Skip WAL for this insert only; never persisted as a table option.
+pub const INSERT_SKIP_WAL_HINT: &str = "insert_skip_wal";
+
 pub const READ_PREFERENCE_HINT: &str = "read_preference";
 pub const RESERVED_EXTENSION_KEYS: [&str; 4] = [
     REMOTE_QUERY_ID_EXTENSION_KEY,

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -60,6 +60,8 @@ pub(crate) struct MutableInner {
     timezone: Timezone,
     query_timeout: Option<Duration>,
     read_preference: ReadPreference,
+    /// Request-level WAL policy for ordinary inserts.
+    skip_wal: bool,
     #[debug(skip)]
     pub(crate) cursors: HashMap<String, Arc<RecordBatchStreamCursor>>,
     /// Warning messages for MySQL SHOW WARNINGS support
@@ -74,6 +76,7 @@ impl Default for MutableInner {
             timezone: get_timezone(None).clone(),
             query_timeout: None,
             read_preference: ReadPreference::Leader,
+            skip_wal: false,
             cursors: HashMap::with_capacity(0),
             warnings: VecDeque::new(),
         }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -217,6 +217,7 @@ fn make_region_puts(inserts: InsertRequests) -> Result<Vec<(RegionId, RegionRequ
                 (
                     region_id,
                     RegionRequest::Put(RegionPutRequest {
+                        skip_wal: false,
                         rows,
                         hint: None,
                         partition_expr_version: r.partition_expr_version.map(|v| v.value),
@@ -522,6 +523,9 @@ pub struct RegionPutRequest {
     pub rows: Rows,
     /// Write hint.
     pub hint: Option<WriteHint>,
+    /// Skip WAL for this insert without changing region options.
+    /// Metadata writes must not inherit this option from user inserts.
+    pub skip_wal: bool,
     /// Partition expression version for the region.
     pub partition_expr_version: Option<u64>,
 }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -217,9 +217,9 @@ fn make_region_puts(inserts: InsertRequests) -> Result<Vec<(RegionId, RegionRequ
                 (
                     region_id,
                     RegionRequest::Put(RegionPutRequest {
-                        skip_wal: false,
                         rows,
                         hint: None,
+                        skip_wal: r.skip_wal,
                         partition_expr_version: r.partition_expr_version.map(|v| v.value),
                     }),
                 )
@@ -1837,6 +1837,36 @@ mod tests {
 
     use super::*;
     use crate::metadata::RegionMetadataBuilder;
+
+    #[test]
+    fn test_make_region_puts_preserves_skip_wal() {
+        let region_id = RegionId::new(42, 3);
+        let rows = Rows::default();
+        let requests = make_region_puts(InsertRequests {
+            requests: [false, true, false]
+                .into_iter()
+                .map(|skip_wal| api::v1::region::InsertRequest {
+                    region_id: region_id.as_u64(),
+                    rows: Some(rows.clone()),
+                    partition_expr_version: Some(api::v1::PartitionExprVersion { value: 7 }),
+                    skip_wal,
+                })
+                .collect(),
+        })
+        .unwrap();
+
+        assert_eq!(3, requests.len());
+        for ((id, request), skip_wal) in requests.into_iter().zip([false, true, false]) {
+            assert_eq!(region_id, id);
+            let RegionRequest::Put(request) = request else {
+                panic!("expected a put request");
+            };
+            assert_eq!(rows, request.rows);
+            assert_eq!(skip_wal, request.skip_wal);
+            assert_eq!(Some(7), request.partition_expr_version);
+            assert!(request.hint.is_none());
+        }
+    }
 
     #[test]
     fn test_make_region_compact_with_time_range() {

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -604,6 +604,8 @@ pub struct InsertRequest {
     pub schema_name: String,
     pub table_name: String,
     pub columns_values: HashMap<String, VectorRef>,
+    /// Whether this insert should skip WAL.
+    pub skip_wal: bool,
 }
 
 /// Delete (by primary key) request


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes https://github.com/GreptimeTeam/greptimedb/issues/9084

Depends on https://github.com/GreptimeTeam/greptime-proto/pull/338

## What's changed and what's your intention?

Support the request-scoped `insert_skip_wal` hint for ordinary inserts, allowing callers to skip WAL without changing table or region options. The default remains false. Unflushed writes with this hint enabled may be lost on a crash.

Accept the HTTP header `x-greptime-insert-skip-wal` and the gRPC hint `insert_skip_wal`. Store the request policy in QueryContext and propagate it through request conversion and partitioning into the region RPC `InsertRequest.skip_wal` field. COPY TABLE and COPY DATABASE inherit the policy. The existing table-level `skip_wal` hint keeps its original meaning. The proto dependency is pinned to greptime-proto #338.

In Mito, apply a separate BitVec-backed mask during WAL sizing and encoding. Keep all mutations and notifiers in their original order for memtable writes, without cloning mutation payloads. The default all-selected mask requires no bitmap allocation, and batches with no WAL entries bypass the log store. Skipped writes advance sequence numbers but not WAL entry IDs; flushing them does not advance the flushed WAL entry ID.

In Metric Engine, require a uniform WAL policy within each physical batch, then use the original sparse/dense merge path and write once. Preserve partition-version validation and request order, and always write WAL for metadata-region mutations.

MySQL and PostgreSQL sessions also support `SET skip_wal = true`; INSERT and COPY inherit the session policy.

This PR covers ordinary inserts only. Bulk inserts, including the Prometheus pending-batch path, are excluded. Delete requests retain their existing WAL behavior. The persisted WAL format is unchanged, and the additive region RPC field defaults to false.

This is the feature layer of a two-PR stack. End-to-end protocol and COPY tests are maintained separately on `test/insert-skip-wal-integration`.

Initial incremental validation:
- Mito/store-api: 31 focused tests passed; Mito all-targets check passed.
- Metric Engine: 3 focused tests passed.
- Session/servers/operator: 21 focused tests passed.
- The proto dependency commit passed a workspace all-targets check.

Latest focused validation:
- All 104 Metric Engine tests passed twice after the cleanup. Disabling WAL-policy validation or flag propagation triggered the expected failures twice; restored controls passed.
- Metric Engine all-targets clippy and formatting checks passed.
- Six gRPC context/hint tests passed after simplifying hint extraction.

Earlier full-workspace validation is reported in #9093; it was not rerun after these latest changes.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
