### PR TITLE
fix(promql): correct counter reset accumulation in rate windows

### DIFF
--- a/src/promql/benches/bench_range_fn.rs
+++ b/src/promql/benches/bench_range_fn.rs
@@ -41,9 +41,12 @@ use promql::functions::{
 };
 use promql::range_array::RangeArray;
 
+/// Builds `window_size` wide windows advancing by `window_step` samples. A step below the
+/// window size makes consecutive windows overlap, which is the normal PromQL range query shape.
 fn build_sliding_ranges(
     num_points: usize,
     window_size: u32,
+    window_step: usize,
     values: Vec<f64>,
     eval_offset_ms: i64,
 ) -> (RangeArray, RangeArray, Arc<TimestampMillisecondArray>) {
@@ -59,10 +62,12 @@ fn build_sliding_ranges(
         0
     };
 
-    let ranges: Vec<(u32, u32)> = (0..num_windows).map(|i| (i as u32, window_size)).collect();
+    let offsets: Vec<usize> = (0..num_windows).step_by(window_step).collect();
+    let ranges: Vec<(u32, u32)> = offsets.iter().map(|&i| (i as u32, window_size)).collect();
 
-    let eval_ts: Vec<i64> = (0..num_windows)
-        .map(|i| timestamps[i + window_size as usize - 1] + eval_offset_ms)
+    let eval_ts: Vec<i64> = offsets
+        .iter()
+        .map(|&i| timestamps[i + window_size as usize - 1] + eval_offset_ms)
         .collect();
     let eval_ts_array = Arc::new(TimestampMillisecondArray::from(eval_ts));
 
@@ -121,11 +126,12 @@ fn build_changing_values(num_points: usize) -> Vec<f64> {
 fn make_extrapolated_rate_input(
     num_points: usize,
     window_size: u32,
+    window_step: usize,
     values: Vec<f64>,
     eval_offset_ms: i64,
 ) -> Vec<ColumnarValue> {
     let (ts_range, val_range, eval_ts) =
-        build_sliding_ranges(num_points, window_size, values, eval_offset_ms);
+        build_sliding_ranges(num_points, window_size, window_step, values, eval_offset_ms);
     let range_length = window_size as i64 * 1000;
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
@@ -192,8 +198,13 @@ fn make_delta_rate_comparison_input(
 }
 
 fn make_idelta_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> {
-    let (ts_range, val_range, _) =
-        build_sliding_ranges(num_points, window_size, build_default_values(num_points), 0);
+    let (ts_range, val_range, _) = build_sliding_ranges(
+        num_points,
+        window_size,
+        1,
+        build_default_values(num_points),
+        0,
+    );
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
@@ -205,7 +216,7 @@ fn make_edge_count_input(
     window_size: u32,
     values: Vec<f64>,
 ) -> Vec<ColumnarValue> {
-    let (ts_range, val_range, _) = build_sliding_ranges(num_points, window_size, values, 0);
+    let (ts_range, val_range, _) = build_sliding_ranges(num_points, window_size, 1, values, 0);
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
@@ -229,8 +240,13 @@ fn make_edge_count_input_with_ranges(
 }
 
 fn make_quantile_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> {
-    let (ts_range, val_range, _) =
-        build_sliding_ranges(num_points, window_size, build_default_values(num_points), 0);
+    let (ts_range, val_range, _) = build_sliding_ranges(
+        num_points,
+        window_size,
+        1,
+        build_default_values(num_points),
+        0,
+    );
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
@@ -239,8 +255,13 @@ fn make_quantile_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue
 }
 
 fn make_predict_linear_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> {
-    let (ts_range, val_range, _) =
-        build_sliding_ranges(num_points, window_size, build_default_values(num_points), 0);
+    let (ts_range, val_range, _) = build_sliding_ranges(
+        num_points,
+        window_size,
+        1,
+        build_default_values(num_points),
+        0,
+    );
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
@@ -355,6 +376,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_monotonic_counter_values(n),
             500,
         ));
@@ -370,6 +392,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_resetting_counter_values(n),
             500,
         ));
@@ -386,6 +409,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_monotonic_counter_values(n),
             500,
         ));
@@ -401,6 +425,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_resetting_counter_values(n),
             500,
         ));
@@ -417,6 +442,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_gauge_values(n),
             500,
         ));
@@ -547,6 +573,43 @@ fn bench_delta_rate_comparison(c: &mut Criterion) {
             &(),
             |b, _| b.iter(|| invoke_prepared(&cumulative_udf, &cumulative)),
         );
+    }
+
+    group.finish();
+}
+
+/// Counter-reset correction is reduced per window, so its cost follows how much the windows
+/// overlap and how many resets each one covers. `range_fn` fixes the query step at one sample
+/// and `delta_rate_comparison` at four and twenty, so sweep both dimensions here.
+fn bench_rate_window_steps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rate_window_steps");
+    let rate_udf = Rate::scalar_udf();
+    let num_points = 20_280;
+    let window_size = 120u32;
+
+    // No resets, one reset per 24 window widths, and roughly three resets per window.
+    for reset_period in [0usize, 2_880, 37] {
+        let values: Vec<f64> = match reset_period {
+            0 => (0..num_points).map(|i| i as f64).collect(),
+            period => (0..num_points).map(|i| (i % period) as f64).collect(),
+        };
+        for window_step in [1usize, 10, 120] {
+            let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
+                num_points,
+                window_size,
+                window_step,
+                values.clone(),
+                500,
+            ));
+            group.bench_with_input(
+                BenchmarkId::new(
+                    "rate_counter",
+                    format!("reset{reset_period}_step{window_step}"),
+                ),
+                &(),
+                |b, _| b.iter(|| invoke_prepared(&rate_udf, &prepared)),
+            );
+        }
     }
 
     group.finish();
@@ -881,6 +944,7 @@ criterion_group!(
     benches,
     bench_range_functions,
     bench_delta_rate_comparison,
+    bench_rate_window_steps,
     bench_edge_count_functions,
     bench_range_manipulate_wall_time
 );

--- a/src/promql/benches/bench_range_fn.rs
+++ b/src/promql/benches/bench_range_fn.rs
@@ -41,8 +41,8 @@ use promql::functions::{
 };
 use promql::range_array::RangeArray;
 
-/// Builds `window_size` wide windows advancing by `window_step` samples. A step below the
-/// window size makes consecutive windows overlap, which is the normal PromQL range query shape.
+/// A `window_step` below `window_size` makes consecutive windows overlap, which is the normal
+/// PromQL range query shape.
 fn build_sliding_ranges(
     num_points: usize,
     window_size: u32,

--- a/src/promql/src/functions/extrapolate_rate.rs
+++ b/src/promql/src/functions/extrapolate_rate.rs
@@ -30,6 +30,7 @@
 //! Implementations of `rate`, `increase` and `delta` functions in PromQL.
 
 use std::fmt::Display;
+use std::ops::Range;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Float64Array, Float64Builder, TimestampMillisecondArray};
@@ -192,9 +193,18 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
         let range_length = self.range_length;
         let range_length_secs = range_length as f64 / 1000.0;
 
-        let mut counter_correction = 0.0;
-        let mut prev_offset = usize::MAX;
-        let mut prev_length = 0usize;
+        // Range windows normally overlap heavily, so scanning each one for counter resets costs
+        // far more than the input has samples. Pay one pass over the values to index the reset
+        // positions once that is the cheaper side of the trade.
+        let mut reset_index = if IS_COUNTER {
+            let scanned_pairs = keys.iter().fold(0usize, |total, &key| {
+                total.saturating_add(unpack(key).1.saturating_sub(1) as usize)
+            });
+            (scanned_pairs > all_values.len().saturating_sub(1))
+                .then(|| CounterResetIndex::new(all_values))
+        } else {
+            None
+        };
 
         for index in 0..num_windows {
             let (raw_offset, raw_length) = unpack(keys[index]);
@@ -203,7 +213,6 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
 
             if length < 2 {
                 result_builder.append_null();
-                prev_offset = usize::MAX;
                 continue;
             }
 
@@ -212,31 +221,14 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
             let last_value = all_values[end - 1];
 
             let result_value = if IS_COUNTER {
-                // Adjacent normalized windows usually slide forward by one sample. Reuse the
-                // previous window's accumulated reset correction and adjust only the dropped and
-                // newly added edges, falling back to a full scan when the layout changes.
-                if prev_offset != usize::MAX && offset == prev_offset + 1 && length == prev_length {
-                    if all_values[prev_offset + 1] < all_values[prev_offset] {
-                        counter_correction -= all_values[prev_offset];
-                    }
-                    if all_values[end - 1] < all_values[end - 2] {
-                        counter_correction += all_values[end - 2];
-                    }
-                } else {
-                    counter_correction = 0.0;
-                    for pair in all_values[offset..end].windows(2) {
-                        if pair[1] < pair[0] {
-                            counter_correction += pair[0];
-                        }
-                    }
-                }
+                let counter_correction = match &mut reset_index {
+                    Some(reset_index) => reset_index.correction(offset, end),
+                    None => counter_reset_correction(&all_values[offset..end]),
+                };
                 last_value - first_value + counter_correction
             } else {
                 last_value - first_value
             };
-
-            prev_offset = offset;
-            prev_length = length;
 
             let first_ts = all_timestamps[offset];
             let last_ts = all_timestamps[end - 1];
@@ -283,6 +275,55 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
 
         let result = ColumnarValue::Array(Arc::new(result_builder.finish()));
         Ok(result)
+    }
+}
+
+/// Sums the value preceding every counter reset in `values`, in sample order.
+fn counter_reset_correction(values: &[f64]) -> f64 {
+    values
+        .windows(2)
+        .filter(|pair| pair[1] < pair[0])
+        .fold(0.0, |correction, pair| correction + pair[0])
+}
+
+/// Positions of the counter resets in a value array, so that a window's correction can be
+/// reduced over the resets it contains instead of over all of its samples.
+struct CounterResetIndex<'a> {
+    values: &'a [f64],
+    /// Ascending indices `i` where `values[i] < values[i - 1]`.
+    positions: Vec<usize>,
+    /// Slice of `positions` that [`Self::correction`] last reduced.
+    active: Range<usize>,
+    correction: f64,
+}
+
+impl<'a> CounterResetIndex<'a> {
+    fn new(values: &'a [f64]) -> Self {
+        Self {
+            values,
+            positions: (1..values.len())
+                .filter(|&i| values[i] < values[i - 1])
+                .collect(),
+            active: 0..0,
+            correction: 0.0,
+        }
+    }
+
+    /// Correction for the window `values[start..end]`, identical to
+    /// [`counter_reset_correction`] on the same window.
+    fn correction(&mut self, start: usize, end: usize) -> f64 {
+        let left = self.positions.partition_point(|&i| i <= start);
+        let right = self.positions.partition_point(|&i| i < end);
+        if self.active != (left..right) {
+            // Re-reduce in sample order rather than adding and subtracting the resets that
+            // entered and left the window: `a + b - a` does not restore `b` in f64, and an
+            // expired infinity would leave a NaN in the running total forever.
+            self.correction = self.positions[left..right]
+                .iter()
+                .fold(0.0, |correction, &i| correction + self.values[i - 1]);
+            self.active = left..right;
+        }
+        self.correction
     }
 }
 
@@ -407,6 +448,84 @@ mod test {
             ColumnarValue::Array(Arc::new(value_range.into_dict())),
             ColumnarValue::Array(eval_ts),
         )
+    }
+
+    /// Evaluates `ranges` as one batch and asserts every window is bit-identical to evaluating
+    /// that window on its own, which always takes the direct per-window reduction.
+    fn assert_counter_windows_match_single(values: &[f64], ranges: &[(u32, u32)]) {
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter_values(
+            (0..values.len()).map(|i| i as i64 * 30_000 + (i % 5) as i64 * 1_000),
+        ));
+        let values = Arc::new(Float64Array::from(values.to_vec()));
+        let evaluate = |ranges: &[(u32, u32)]| {
+            let eval_ts = Arc::new(TimestampMillisecondArray::from_iter_values(
+                ranges.iter().map(|&(offset, length)| {
+                    timestamps.value((offset + length.saturating_sub(1)) as usize) + 5_000
+                }),
+            ));
+            let input = [
+                ColumnarValue::Array(Arc::new(
+                    RangeArray::from_ranges(timestamps.clone(), ranges.iter().copied())
+                        .unwrap()
+                        .into_dict(),
+                )),
+                ColumnarValue::Array(Arc::new(
+                    RangeArray::from_ranges(values.clone(), ranges.iter().copied())
+                        .unwrap()
+                        .into_dict(),
+                )),
+                ColumnarValue::Array(eval_ts),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(3_600_000))),
+            ];
+            extract_array(&Rate::new(3_600_000).calc(&input).unwrap())
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .iter()
+                .collect::<Vec<_>>()
+        };
+
+        for (range, batched) in ranges.iter().zip(evaluate(ranges)) {
+            let single = evaluate(std::slice::from_ref(range))[0];
+            match (batched, single) {
+                (None, None) => {}
+                (Some(batched), Some(single)) => assert!(
+                    batched.to_bits() == single.to_bits() || (batched.is_nan() && single.is_nan()),
+                    "range {range:?}: batched {batched} != single {single}"
+                ),
+                _ => panic!("range {range:?}: batched {batched:?} != single {single:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn counter_correction_survives_huge_and_infinite_resets() {
+        // Both series reset twice inside the first window and once inside the second, but the
+        // first reset is large enough to swallow the second one when they are summed together.
+        for values in [
+            vec![1e16, 1.0, 0.0, 1.0, 2.0],
+            vec![f64::INFINITY, 1.0, 0.0, 1.0, 2.0],
+        ] {
+            assert_counter_windows_match_single(&values, &[(0, 4), (1, 4)]);
+        }
+    }
+
+    #[test]
+    fn counter_correction_matches_single_window_on_irregular_layouts() {
+        let mut values: Vec<f64> = (0..512).map(|i| (i % 37) as f64 * 0.25).collect();
+        values[20] = f64::NAN;
+        values[70] = f64::INFINITY;
+        values[140] = f64::NEG_INFINITY;
+        values[220] = 1e300;
+        values[221] = 1e-200;
+
+        let mut ranges: Vec<(u32, u32)> = (0..390).map(|i| (i, 120)).collect();
+        // Empty, too-short, backward and disjoint windows all break a forward-only slide.
+        ranges.extend([(400, 0), (400, 1), (2, 20), (450, 30), (0, 120)]);
+        ranges.extend((0..390).rev().step_by(10).map(|i| (i, 120)));
+
+        assert_counter_windows_match_single(&values, &ranges);
     }
 
     #[test]

--- a/src/promql/src/functions/extrapolate_rate.rs
+++ b/src/promql/src/functions/extrapolate_rate.rs
@@ -294,6 +294,8 @@ struct CounterResetIndex<'a> {
     positions: Vec<usize>,
     /// Slice of `positions` that [`Self::correction`] last reduced.
     active: Range<usize>,
+    /// Window that produced `active`, so the next one can tell whether it may advance in place.
+    previous: Range<usize>,
     correction: f64,
 }
 
@@ -305,15 +307,35 @@ impl<'a> CounterResetIndex<'a> {
                 .filter(|&i| values[i] < values[i - 1])
                 .collect(),
             active: 0..0,
+            previous: 0..0,
             correction: 0.0,
         }
     }
 
     /// Correction for the window `values[start..end]`, identical to
     /// [`counter_reset_correction`] on the same window.
+    #[inline]
     fn correction(&mut self, start: usize, end: usize) -> f64 {
-        let left = self.positions.partition_point(|&i| i <= start);
-        let right = self.positions.partition_point(|&i| i < end);
+        // Windows normally advance, so walk the bounds forward from the previous window and
+        // only search when they move back. Searching every window costs more than the whole
+        // reduction once a series has enough resets to make the search deep.
+        let (left, right) = if start < self.previous.start || end < self.previous.end {
+            (
+                self.positions.partition_point(|&i| i <= start),
+                self.positions.partition_point(|&i| i < end),
+            )
+        } else {
+            let mut left = self.active.start;
+            while left < self.positions.len() && self.positions[left] <= start {
+                left += 1;
+            }
+            let mut right = self.active.end.max(left);
+            while right < self.positions.len() && self.positions[right] < end {
+                right += 1;
+            }
+            (left, right)
+        };
+        self.previous = start..end;
         if self.active != (left..right) {
             // Re-reduce in sample order rather than adding and subtracting the resets that
             // entered and left the window: `a + b - a` does not restore `b` in f64, and an

--- a/src/promql/src/functions/extrapolate_rate.rs
+++ b/src/promql/src/functions/extrapolate_rate.rs
@@ -596,6 +596,9 @@ mod test {
         values[220] = 1e300;
         values[221] = 1e-200;
 
+        // A stride of one walks both bounds across the reset positions, which sit every 37
+        // samples: `start` reaches one when that reset has to leave the window, `end` when the
+        // next one has to stay out of it, both while the cached bounds are live.
         let mut ranges: Vec<(u32, u32)> = (0..390).map(|i| (i, 120)).collect();
         // Empty, too-short, backward and disjoint windows all break a forward-only slide.
         ranges.extend([(400, 0), (400, 1), (2, 20), (450, 30), (0, 120)]);

--- a/src/promql/src/functions/extrapolate_rate.rs
+++ b/src/promql/src/functions/extrapolate_rate.rs
@@ -195,8 +195,9 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
 
         // Range windows normally overlap heavily, so scanning every one for resets costs far
         // more than a single pass over the values. Index the reset positions once that is the
-        // cheaper side. A short lookback with a long step is the case that is not, and it
-        // settles the comparison after a few windows, so stop counting there.
+        // cheaper side, and stop counting as soon as the requested pairs pass that budget,
+        // which heavy overlap does within the first few windows. A short lookback with a long
+        // step is the shape that never reaches it, and there the per-window scans do win.
         let mut reset_index = if IS_COUNTER {
             let budget = all_values.len().saturating_sub(1);
             let mut scanned_pairs = 0usize;
@@ -225,15 +226,13 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
             let first_value = all_values[offset];
             let last_value = all_values[end - 1];
 
-            let result_value = if IS_COUNTER {
-                let counter_correction = match &mut reset_index {
-                    Some(reset_index) => reset_index.correction(offset, end),
-                    None => counter_reset_correction(&all_values[offset..end]),
+            let mut result_value = last_value - first_value;
+            if IS_COUNTER {
+                result_value = match &mut reset_index {
+                    Some(reset_index) => reset_index.add_resets(result_value, offset, end),
+                    None => add_counter_resets(result_value, &all_values[offset..end]),
                 };
-                last_value - first_value + counter_correction
-            } else {
-                last_value - first_value
-            };
+            }
 
             let first_ts = all_timestamps[offset];
             let last_ts = all_timestamps[end - 1];
@@ -283,30 +282,34 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
     }
 }
 
-/// Sums the value preceding every counter reset in `values`, in sample order.
-fn counter_reset_correction(values: &[f64]) -> f64 {
+/// Adds the value preceding every counter reset in `values` to `result`, in sample order.
+///
+/// Prometheus accumulates the resets into the running result rather than summing them on
+/// their own, and the two are not interchangeable in f64: a reset large enough to swallow a
+/// later one in an isolated sum still leaves it visible once the first difference is folded
+/// in first.
+fn add_counter_resets(result: f64, values: &[f64]) -> f64 {
     values
         .windows(2)
         .filter(|pair| pair[1] < pair[0])
-        .fold(0.0, |correction, pair| correction + pair[0])
+        .fold(result, |result, pair| result + pair[0])
 }
 
-/// Positions of the counter resets in a value array, so that a window's correction can be
-/// reduced over the resets it contains instead of over all of its samples.
+/// Positions of the counter resets in a value array, so that a window can accumulate the
+/// resets it contains instead of scanning all of its samples.
 struct CounterResetIndex<'a> {
     values: &'a [f64],
     /// Ascending indices `i` where `values[i] < values[i - 1]`.
     positions: Vec<usize>,
-    /// Slice of `positions` that [`Self::reduce`] last reduced.
+    /// Slice of `positions` covered by the last window.
     active: Range<usize>,
-    /// Window that produced `active`, so the next one can tell whether it advanced.
+    /// That window, so the next one can tell whether it advanced.
     previous: Range<usize>,
     /// `positions[active.start]`: the reset a later `start` would drop. `usize::MAX` when the
     /// active slice reaches the end of `positions`.
     drops_at: usize,
     /// `positions[active.end]`: the reset a later `end` would gain, saturated the same way.
     gains_at: usize,
-    correction: f64,
 }
 
 impl<'a> CounterResetIndex<'a> {
@@ -322,31 +325,40 @@ impl<'a> CounterResetIndex<'a> {
             previous: 0..0,
             drops_at: first,
             gains_at: first,
-            correction: 0.0,
         }
     }
 
-    /// Correction for the window `values[start..end]`, identical to
-    /// [`counter_reset_correction`] on the same window.
+    /// Same additions [`add_counter_resets`] performs over `values[start..end]`, in the same
+    /// order, reached through the index instead of by scanning the window.
     #[inline]
-    fn correction(&mut self, start: usize, end: usize) -> f64 {
-        if start >= self.previous.start
-            && end >= self.previous.end
-            && start < self.drops_at
-            && end <= self.gains_at
+    fn add_resets(&mut self, result: f64, start: usize, end: usize) -> f64 {
+        // The active slice only stays put if the window advanced without reaching either of
+        // the resets that bound it.
+        if start < self.previous.start
+            || end < self.previous.end
+            || start >= self.drops_at
+            || end > self.gains_at
         {
-            // The window only advanced, and it reached neither the reset that would leave it
-            // nor the one that would enter, so it covers exactly the resets `correction` holds.
-            self.previous = start..end;
-            return self.correction;
+            self.locate(start, end);
         }
-        self.reduce(start, end)
+        self.previous = start..end;
+
+        if self.active.start == self.active.end {
+            // A counter that has not reset inside this window, which is the normal case, would
+            // otherwise pay a range bounds check and an empty iterator for nothing.
+            return result;
+        }
+
+        let values = self.values;
+        self.positions[self.active.start..self.active.end]
+            .iter()
+            .fold(result, |result, &i| result + values[i - 1])
     }
 
-    fn reduce(&mut self, start: usize, end: usize) -> f64 {
+    fn locate(&mut self, start: usize, end: usize) {
         // Walk the bounds forward from the previous window and only search when they move
-        // back. On a series that resets often the searches cost more than the reduction they
-        // locate, because they run deep and the reduction is a handful of adds.
+        // back. On a series that resets often the searches cost more than the additions they
+        // locate, because they run deep and a window holds a handful of resets.
         let (left, right) = if start < self.previous.start || end < self.previous.end {
             (
                 self.positions.partition_point(|&i| i <= start),
@@ -363,19 +375,9 @@ impl<'a> CounterResetIndex<'a> {
             }
             (left, right)
         };
-        self.previous = start..end;
-        if self.active != (left..right) {
-            // Re-reduce in sample order rather than adding and subtracting the resets that
-            // entered and left the window: `a + b - a` does not restore `b` in f64, and an
-            // expired infinity would leave a NaN in the running total forever.
-            self.correction = self.positions[left..right]
-                .iter()
-                .fold(0.0, |correction, &i| correction + self.values[i - 1]);
-            self.active = left..right;
-            self.drops_at = self.positions.get(left).copied().unwrap_or(usize::MAX);
-            self.gains_at = self.positions.get(right).copied().unwrap_or(usize::MAX);
-        }
-        self.correction
+        self.active = left..right;
+        self.drops_at = self.positions.get(left).copied().unwrap_or(usize::MAX);
+        self.gains_at = self.positions.get(right).copied().unwrap_or(usize::MAX);
     }
 }
 
@@ -549,6 +551,28 @@ mod test {
                 _ => panic!("range {range:?}: batched {batched:?} != single {single:?}"),
             }
         }
+    }
+
+    #[test]
+    fn counter_resets_accumulate_into_the_running_result() {
+        // Summed on their own, 1e16 and 1.0 round to 1e16, which then cancels against the
+        // first sample and reports no increase at all. Folding each reset into `last - first`
+        // as Prometheus does keeps the 1.0. Both paths detect the same two resets.
+        let ts_array = Arc::new(TimestampMillisecondArray::from_iter(
+            [1, 2, 3, 4].into_iter().map(Some),
+        ));
+        let values_array = Arc::new(Float64Array::from_iter([1e16, 1.0, 0.0, 1.0]));
+        let ranges = [(0, 4)];
+        let ts_range = RangeArray::from_ranges(ts_array, ranges).unwrap();
+        let value_range = RangeArray::from_ranges(values_array, ranges).unwrap();
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter([Some(4)])) as _;
+
+        extrapolated_rate_runner::<true, false>(
+            ts_range,
+            value_range,
+            timestamps,
+            vec![1.1666666666666667],
+        );
     }
 
     #[test]

--- a/src/promql/src/functions/extrapolate_rate.rs
+++ b/src/promql/src/functions/extrapolate_rate.rs
@@ -193,14 +193,19 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
         let range_length = self.range_length;
         let range_length_secs = range_length as f64 / 1000.0;
 
-        // Range windows normally overlap heavily, so scanning each one for counter resets costs
-        // far more than the input has samples. Pay one pass over the values to index the reset
-        // positions once that is the cheaper side of the trade.
+        // Range windows normally overlap heavily, so scanning every one for resets costs far
+        // more than a single pass over the values. Index the reset positions once that is the
+        // cheaper side. A short lookback with a long step is the case that is not, and it
+        // settles the comparison after a few windows, so stop counting there.
         let mut reset_index = if IS_COUNTER {
-            let scanned_pairs = keys.iter().fold(0usize, |total, &key| {
-                total.saturating_add(unpack(key).1.saturating_sub(1) as usize)
-            });
-            (scanned_pairs > all_values.len().saturating_sub(1))
+            let budget = all_values.len().saturating_sub(1);
+            let mut scanned_pairs = 0usize;
+            keys.iter()
+                .any(|&key| {
+                    scanned_pairs =
+                        scanned_pairs.saturating_add(unpack(key).1.saturating_sub(1) as usize);
+                    scanned_pairs > budget
+                })
                 .then(|| CounterResetIndex::new(all_values))
         } else {
             None
@@ -292,22 +297,31 @@ struct CounterResetIndex<'a> {
     values: &'a [f64],
     /// Ascending indices `i` where `values[i] < values[i - 1]`.
     positions: Vec<usize>,
-    /// Slice of `positions` that [`Self::correction`] last reduced.
+    /// Slice of `positions` that [`Self::reduce`] last reduced.
     active: Range<usize>,
-    /// Window that produced `active`, so the next one can tell whether it may advance in place.
+    /// Window that produced `active`, so the next one can tell whether it advanced.
     previous: Range<usize>,
+    /// `positions[active.start]`: the reset a later `start` would drop. `usize::MAX` when the
+    /// active slice reaches the end of `positions`.
+    drops_at: usize,
+    /// `positions[active.end]`: the reset a later `end` would gain, saturated the same way.
+    gains_at: usize,
     correction: f64,
 }
 
 impl<'a> CounterResetIndex<'a> {
     fn new(values: &'a [f64]) -> Self {
+        let positions: Vec<usize> = (1..values.len())
+            .filter(|&i| values[i] < values[i - 1])
+            .collect();
+        let first = positions.first().copied().unwrap_or(usize::MAX);
         Self {
             values,
-            positions: (1..values.len())
-                .filter(|&i| values[i] < values[i - 1])
-                .collect(),
+            positions,
             active: 0..0,
             previous: 0..0,
+            drops_at: first,
+            gains_at: first,
             correction: 0.0,
         }
     }
@@ -316,9 +330,23 @@ impl<'a> CounterResetIndex<'a> {
     /// [`counter_reset_correction`] on the same window.
     #[inline]
     fn correction(&mut self, start: usize, end: usize) -> f64 {
-        // Windows normally advance, so walk the bounds forward from the previous window and
-        // only search when they move back. Searching every window costs more than the whole
-        // reduction once a series has enough resets to make the search deep.
+        if start >= self.previous.start
+            && end >= self.previous.end
+            && start < self.drops_at
+            && end <= self.gains_at
+        {
+            // The window only advanced, and it reached neither the reset that would leave it
+            // nor the one that would enter, so it covers exactly the resets `correction` holds.
+            self.previous = start..end;
+            return self.correction;
+        }
+        self.reduce(start, end)
+    }
+
+    fn reduce(&mut self, start: usize, end: usize) -> f64 {
+        // Walk the bounds forward from the previous window and only search when they move
+        // back. On a series that resets often the searches cost more than the reduction they
+        // locate, because they run deep and the reduction is a handful of adds.
         let (left, right) = if start < self.previous.start || end < self.previous.end {
             (
                 self.positions.partition_point(|&i| i <= start),
@@ -344,6 +372,8 @@ impl<'a> CounterResetIndex<'a> {
                 .iter()
                 .fold(0.0, |correction, &i| correction + self.values[i - 1]);
             self.active = left..right;
+            self.drops_at = self.positions.get(left).copied().unwrap_or(usize::MAX);
+            self.gains_at = self.positions.get(right).copied().unwrap_or(usize::MAX);
         }
         self.correction
     }

--- a/tests/cases/standalone/common/promql/counter_reset_precision.result
+++ b/tests/cases/standalone/common/promql/counter_reset_precision.result
@@ -11,30 +11,31 @@ INSERT INTO counter_reset_precision VALUES
     (30000,  1.0,                 'a'),
     (60000,  0.0,                 'a'),
     (90000,  1.0,                 'a'),
-    (120000, 2.0,                 'a');
+    (120000, 2.0,                 'a'),
+    (150000, 3.0,                 'a'),
+    (180000, 4.0,                 'a');
 
-Affected Rows: 5
+Affected Rows: 7
 
--- Two adjacent windows over the same samples: (-30s, 90s] and (0s, 120s]. The second
--- one drops the 1e16 reset and keeps the 1 -> 0 one, so its correction is 1.0. Carrying
--- the first window's correction forward loses that, since 1e16 + 1.0 rounds to 1e16.
-TQL EVAL (90, 120, '30s') increase(counter_reset_precision[2m]);
+-- The counter resets twice, at 30s from 1e16 and at 60s from 1.0, and 1e16 + 1.0 is 1e16 in
+-- f64. Windows are two minutes wide and step by one sample, so every row here depends on the
+-- 1.0 reset surviving.
+--
+-- Summing the two corrections on their own drops the 1.0 and then cancels against the first
+-- sample, so the 90s window reports no increase. Carrying that sum into the next window and
+-- subtracting the 1e16 that left it reports half the increase, and the windows after that
+-- subtract a reset the sum never held, so the correction turns negative and stays there for
+-- the rest of the batch.
+TQL EVAL (90, 180, '30s') increase(counter_reset_precision[2m]);
 
 +---------------------+---------------------------------------------------------+--------+
 | ts                  | prom_increase(ts_range,greptime_value,ts,Int64(120000)) | series |
 +---------------------+---------------------------------------------------------+--------+
-| 1970-01-01T00:01:30 | 0.0                                                     | a      |
+| 1970-01-01T00:01:30 | 1.3333333333333333                                      | a      |
 | 1970-01-01T00:02:00 | 2.6666666666666665                                      | a      |
+| 1970-01-01T00:02:30 | 3.0                                                     | a      |
+| 1970-01-01T00:03:00 | 4.0                                                     | a      |
 +---------------------+---------------------------------------------------------+--------+
-
-TQL EVAL (90, 120, '30s') rate(counter_reset_precision[2m]);
-
-+---------------------+-----------------------------------------------------+--------+
-| ts                  | prom_rate(ts_range,greptime_value,ts,Int64(120000)) | series |
-+---------------------+-----------------------------------------------------+--------+
-| 1970-01-01T00:01:30 | 0.0                                                 | a      |
-| 1970-01-01T00:02:00 | 0.02222222222222222                                 | a      |
-+---------------------+-----------------------------------------------------+--------+
 
 DROP TABLE counter_reset_precision;
 

--- a/tests/cases/standalone/common/promql/counter_reset_precision.result
+++ b/tests/cases/standalone/common/promql/counter_reset_precision.result
@@ -1,0 +1,42 @@
+CREATE TABLE counter_reset_precision (
+    ts TIMESTAMP TIME INDEX,
+    greptime_value DOUBLE,
+    series STRING PRIMARY KEY
+);
+
+Affected Rows: 0
+
+INSERT INTO counter_reset_precision VALUES
+    (0,      10000000000000000.0, 'a'),
+    (30000,  1.0,                 'a'),
+    (60000,  0.0,                 'a'),
+    (90000,  1.0,                 'a'),
+    (120000, 2.0,                 'a');
+
+Affected Rows: 5
+
+-- Two adjacent windows over the same samples: (-30s, 90s] and (0s, 120s]. The second
+-- one drops the 1e16 reset and keeps the 1 -> 0 one, so its correction is 1.0. Carrying
+-- the first window's correction forward loses that, since 1e16 + 1.0 rounds to 1e16.
+TQL EVAL (90, 120, '30s') increase(counter_reset_precision[2m]);
+
++---------------------+---------------------------------------------------------+--------+
+| ts                  | prom_increase(ts_range,greptime_value,ts,Int64(120000)) | series |
++---------------------+---------------------------------------------------------+--------+
+| 1970-01-01T00:01:30 | 0.0                                                     | a      |
+| 1970-01-01T00:02:00 | 2.6666666666666665                                      | a      |
++---------------------+---------------------------------------------------------+--------+
+
+TQL EVAL (90, 120, '30s') rate(counter_reset_precision[2m]);
+
++---------------------+-----------------------------------------------------+--------+
+| ts                  | prom_rate(ts_range,greptime_value,ts,Int64(120000)) | series |
++---------------------+-----------------------------------------------------+--------+
+| 1970-01-01T00:01:30 | 0.0                                                 | a      |
+| 1970-01-01T00:02:00 | 0.02222222222222222                                 | a      |
++---------------------+-----------------------------------------------------+--------+
+
+DROP TABLE counter_reset_precision;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/counter_reset_precision.sql
+++ b/tests/cases/standalone/common/promql/counter_reset_precision.sql
@@ -1,0 +1,21 @@
+CREATE TABLE counter_reset_precision (
+    ts TIMESTAMP TIME INDEX,
+    greptime_value DOUBLE,
+    series STRING PRIMARY KEY
+);
+
+INSERT INTO counter_reset_precision VALUES
+    (0,      10000000000000000.0, 'a'),
+    (30000,  1.0,                 'a'),
+    (60000,  0.0,                 'a'),
+    (90000,  1.0,                 'a'),
+    (120000, 2.0,                 'a');
+
+-- Two adjacent windows over the same samples: (-30s, 90s] and (0s, 120s]. The second
+-- one drops the 1e16 reset and keeps the 1 -> 0 one, so its correction is 1.0. Carrying
+-- the first window's correction forward loses that, since 1e16 + 1.0 rounds to 1e16.
+TQL EVAL (90, 120, '30s') increase(counter_reset_precision[2m]);
+
+TQL EVAL (90, 120, '30s') rate(counter_reset_precision[2m]);
+
+DROP TABLE counter_reset_precision;

--- a/tests/cases/standalone/common/promql/counter_reset_precision.sql
+++ b/tests/cases/standalone/common/promql/counter_reset_precision.sql
@@ -9,13 +9,19 @@ INSERT INTO counter_reset_precision VALUES
     (30000,  1.0,                 'a'),
     (60000,  0.0,                 'a'),
     (90000,  1.0,                 'a'),
-    (120000, 2.0,                 'a');
+    (120000, 2.0,                 'a'),
+    (150000, 3.0,                 'a'),
+    (180000, 4.0,                 'a');
 
--- Two adjacent windows over the same samples: (-30s, 90s] and (0s, 120s]. The second
--- one drops the 1e16 reset and keeps the 1 -> 0 one, so its correction is 1.0. Carrying
--- the first window's correction forward loses that, since 1e16 + 1.0 rounds to 1e16.
-TQL EVAL (90, 120, '30s') increase(counter_reset_precision[2m]);
-
-TQL EVAL (90, 120, '30s') rate(counter_reset_precision[2m]);
+-- The counter resets twice, at 30s from 1e16 and at 60s from 1.0, and 1e16 + 1.0 is 1e16 in
+-- f64. Windows are two minutes wide and step by one sample, so every row here depends on the
+-- 1.0 reset surviving.
+--
+-- Summing the two corrections on their own drops the 1.0 and then cancels against the first
+-- sample, so the 90s window reports no increase. Carrying that sum into the next window and
+-- subtracting the 1e16 that left it reports half the increase, and the windows after that
+-- subtract a reset the sum never held, so the correction turns negative and stays there for
+-- the rest of the batch.
+TQL EVAL (90, 180, '30s') increase(counter_reset_precision[2m]);
 
 DROP TABLE counter_reset_precision;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes two defects from #7880. #8792 tried to generalize the first one.

## What's changed and what's your intention?

`prom_rate` and `prom_increase` correct for counter resets by adding the value that preceded each reset. #7880 changed how those additions are ordered, in two ways that do not survive f64. `prom_delta` shares the code but is not a counter function, so neither reaches it.

Over samples 30s apart, `increase(m[2m])` stepped by 30s:

```
             idx      0       1       2       3       4       5       6
          ts (s)      0      30      60      90     120     150     180
           value   1e16     1.0     0.0     1.0     2.0     3.0     4.0
                        \reset/ \reset/
```

| eval | window | main | this PR |
| ---: | --- | ---: | ---: |
| 90s | `[1e16, 1, 0, 1]` | 0.0 | 1.3333333333333333 |
| 120s | `[1, 0, 1, 2]` | 1.3333333333333333 | 2.6666666666666665 |
| 150s | `[0, 1, 2, 3]` | 2.0 | 3.0 |
| 180s | `[1, 2, 3, 4]` | 2.6666666666666665 | 4.0 |

**The corrections were summed on their own.** `resultValue` is `last - first` plus the resets, and Prometheus folds each reset into it as it walks the samples ([`promql/functions.go`](https://github.com/prometheus/prometheus/blob/v0.300.1/promql/functions.go#L110-L121)), which is what this code did before #7880 too. #7880 accumulated them into a separate variable and added it at the end. `1e16 + 1.0` is `1e16`, so the 1.0 is gone before the sum ever meets `last - first`; folded in one at a time it survives. That is the 90s row.

**The sum was then carried between windows.** When the next window started one sample later with the same length, the previous window's sum was reused, adding the entering reset and subtracting the leaving one. Addition and subtraction do not cancel in f64: at 120s the 1e16 that left takes the 1.0 with it, and at 150s the code subtracts a reset the sum never held, so the correction turns negative and stays there for the rest of the batch. An infinity is worse, since `inf - inf` leaves a NaN that every later window inherits.

Changes:

- Fold each reset into the running result, as Prometheus does. Restores the pre-#7880 order.
- Replace the carried sum with a reset index. The positions where `values[i] < values[i - 1]` are collected once for the value array, and each window adds the resets inside it, in sample order — the same sequence of additions a direct scan of that window performs, so the two are bit-identical.

  ```
  positions = [1, 2]           built once, indices i where values[i] < values[i-1]

  window @90s  -> positions[0..2]   each window advances the two bounds into
  window @120s -> positions[1..2]   `positions` instead of rescanning its samples
  ```

- Keep the direct scan when the windows together request fewer sample pairs than the input has. `RangeManipulate` builds windows over the whole scanned batch, so a short lookback with a long step leaves most of the input outside every window and the index would not pay for itself.
- Cache the two reset positions that bound the active slice, so a window that only advanced and reached neither of them skips the lookup.
- Add a sqlness case for the query above, unit tests comparing batched windows against evaluating each window on its own, and one pinning the accumulation order.
- Give `build_sliding_ranges` a window step and add a `rate_window_steps` benchmark group. The existing rate benchmarks only advance windows by one sample, which is the shape where the old code took its fast path on every window.

## Benchmarks

`cargo bench -p promql --bench bench_main`, M-series laptop, run as before / after / before to bound drift. The two `before` runs agree within 2.7%.

| benchmark | before | after | |
| --- | ---: | ---: | ---: |
| `cumulative_rate` 2h window, 60s step | 3961 µs | 70 µs | −98.2% |
| `cumulative_rate` 2h window, 300s step | 802 µs | 37 µs | −95.4% |
| `rate_window_steps` step 10, no resets | 187 µs | 19 µs | −89.6% |
| `rate_window_steps` step 10, reset every 2880 | 185 µs | 20 µs | −88.9% |
| `rate_window_steps` step 10, reset every 37 | 185 µs | 25 µs | −86.5% |
| `rate_window_steps` step 120, all densities | 17 µs | 17 µs | −1.3% to +0.5% |
| `rate_window_steps` step 1, no resets | 104 µs | 117 µs | +12.3% |
| `rate_window_steps` step 1, reset every 2880 | 105 µs | 117 µs | +11.6% |
| `rate_window_steps` step 1, reset every 37 | 109 µs | 146 µs | +33.8% |

### Why the one-sample step is worth it

The removed fast path fired on any window that advanced by exactly one sample with the same length. A query step equal to the scrape interval does that on every window, which is where the regression concentrates. Nearby ratios do it on part of them: at half the scrape interval the offset alternates between 0 and 1, at 1.5x between 1 and 2. Windows that advanced by anything else took the full scan and get faster here, so the cost should fall off either side of the peak, but the sweep does not measure those ratios.

Per window the cost is 0.6 ns when the counter never resets and 1.8 ns when it resets every 37 samples, and a window is one series at one step. It tracks reset density because every reset inside a window is an addition the previous window can no longer supply. The 37-sample series is a stress shape rather than an upper bound: a denser one adds more per window and converges on the direct scan it replaced. Real counters reset when a process restarts, so they sit at the 0.6 ns end.

The wins are not simply "overlapping windows" — step 1 is the most overlapping layout there is, and it is the one that regresses. They are the overlapping layouts that advance by more than one sample, 86% to 98% at a ten-sample step and on the two-hour windows, while layouts that do not overlap at all come out unchanged. And both defects above report a wrong rate rather than a slow one.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [x] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
