### PR TITLE
perf(query): check Substrait encodability once per plan

### DIFF
--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -248,7 +248,7 @@ impl DistPlannerAnalyzer {
     /// Try push down as many nodes as possible
     fn try_push_down(&self, plan: LogicalPlan) -> DfResult<LogicalPlan> {
         let plan = plan.transform(&Self::inspect_plan_with_subquery)?;
-        let mut rewriter = PlanRewriter::default();
+        let mut rewriter = PlanRewriter::new(&plan.data);
         let result = plan.data.rewrite(&mut rewriter)?.data;
         Self::assign_merge_scan_remote_dyn_filter_producer_ids(result)
     }
@@ -302,7 +302,7 @@ impl DistPlannerAnalyzer {
     }
 
     fn handle_subquery(subquery: Subquery) -> DfResult<Subquery> {
-        let mut rewriter = PlanRewriter::default();
+        let mut rewriter = PlanRewriter::new(&subquery.subquery);
         let mut rewrote_subquery = subquery
             .subquery
             .as_ref()
@@ -391,6 +391,9 @@ enum RewriterStatus {
 
 #[derive(Debug, Default)]
 struct PlanRewriter {
+    /// Whether the whole plan this rewriter walks can be encoded to Substrait.
+    /// Used by [`PlanRewriter::should_expand`] to skip the per-node encoding check.
+    whole_plan_encodable: bool,
     /// Current level in the tree
     level: usize,
     /// Simulated stack for the `rewrite` recursion
@@ -447,6 +450,17 @@ struct PlanRewriter {
 }
 
 impl PlanRewriter {
+    /// `plan` must be the root of the tree that is about to be rewritten, otherwise
+    /// [`PlanRewriter::should_expand`] may skip a check it has to perform.
+    fn new(plan: &LogicalPlan) -> Self {
+        Self {
+            whole_plan_encodable: DFLogicalSubstraitConvertor
+                .encode(plan, DefaultSerializer)
+                .is_ok(),
+            ..Default::default()
+        }
+    }
+
     fn get_parent(&self) -> Option<&LogicalPlan> {
         // level starts from 1, it's safe to minus by 1
         self.stack
@@ -467,7 +481,16 @@ impl PlanRewriter {
                 .collect::<Vec<String>>()
                 .join("\n"),
         );
-        if let Err(e) = DFLogicalSubstraitConvertor.encode(plan, DefaultSerializer) {
+        // Substrait encoding recurses from the root to the leaves, so a root that encodes
+        // proves that every node below it encodes as well. `plan` here always comes from
+        // `self.stack`, which holds untouched sub-trees of that root, so one check on the
+        // root covers the whole descent. Each check builds a fresh `SessionState`, which
+        // is the dominant cost on deep PromQL plans.
+        // When the root does not encode, the plan holds at least one node that has to stay
+        // on the frontend and only the per-node check locates it.
+        if !self.whole_plan_encodable
+            && let Err(e) = DFLogicalSubstraitConvertor.encode(plan, DefaultSerializer)
+        {
             debug!(
                 "PlanRewriter: plan cannot be converted to substrait with error={e:?}, expanding now: {plan}"
             );

--- a/src/query/src/dist_plan/analyzer/test.rs
+++ b/src/query/src/dist_plan/analyzer/test.rs
@@ -28,6 +28,7 @@ use datafusion::datasource::DefaultTableSource;
 use datafusion::execution::SessionState;
 use datafusion::functions_aggregate::expr_fn::avg;
 use datafusion::functions_aggregate::min_max::{max, min};
+use datafusion::functions_nested::expr_fn::make_array;
 use datafusion::prelude::SessionContext;
 use datafusion_common::tree_node::TreeNodeRecursion;
 use datafusion_common::{ExprSchema, JoinType, ScalarValue};
@@ -365,6 +366,47 @@ fn frontend_only_histogram_folds_stay_above_merge_scan() {
             .encode(remote_input, DefaultSerializer)
             .unwrap();
     }
+}
+
+/// `Categorizer` calls `Unnest` commutative, so the Substrait check in `should_expand` is
+/// the only thing keeping it on the frontend. It also sits above an encodable projection,
+/// which pins the rewriter to the whole-plan check rather than to the root node alone.
+#[test]
+fn unencodable_unnest_stays_above_merge_scan() {
+    let table = TestTable::table_with_name(0, "t".to_string());
+    let table_source = Arc::new(DefaultTableSource::new(Arc::new(
+        DfTableProviderAdapter::new(table),
+    )));
+    let plan = LogicalPlanBuilder::scan_with_filters("t", table_source, None, vec![])
+        .unwrap()
+        .project(vec![
+            col("pk1"),
+            make_array(vec![col("number")]).alias("numbers"),
+        ])
+        .unwrap()
+        .unnest_column("numbers")
+        .unwrap()
+        .build()
+        .unwrap();
+    assert!(
+        DFLogicalSubstraitConvertor
+            .encode(&plan, DefaultSerializer)
+            .is_err()
+    );
+
+    let result = DistPlannerAnalyzer {}
+        .analyze(plan, &ConfigOptions::default())
+        .unwrap();
+    let result_text = result.to_string();
+    assert!(result_text.contains("Unnest:"), "{result_text}");
+
+    let remote_input = find_merge_scan(&result).unwrap().input();
+    let remote_text = remote_input.to_string();
+    assert!(!remote_text.contains("Unnest:"), "{remote_text}");
+    assert!(remote_text.contains("make_array"), "{remote_text}");
+    DFLogicalSubstraitConvertor
+        .encode(remote_input, DefaultSerializer)
+        .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

`PlanRewriter` walks up from the leaf and asks `should_expand(parent)` at every step, to find out how far the plan can be pushed to a datanode. Part of that answer is whether the node can be encoded to Substrait, and until now every step ran a full encode:

```
  Projection              <- encode #7
    Sort                  <- encode #6
      Aggregate           <- encode #5
        RangeManipulate   <- encode #4
          SeriesNormalize <- encode #3
            SeriesDivide  <- encode #2
              Sort        <- encode #1
                TableScan    (walk starts here)
```

One encode is `plan.clone()`, one analyzer pass, and a fresh `SessionState` built with every default feature, so the last item dominates. A PromQL range query pays that once per level.

Substrait encoding is a recursion over the tree: `to_substrait_rel` sends every child through the same producer. So encode #7 above already encoded everything that encode #1 to #6 looked at, and the seven calls carry the information of one. This PR does that one call:

```
  PlanRewriter::new(root)
    encode(root) ok   -> should_expand skips its own encode
    encode(root) err  -> should_expand keeps encoding per node, which is
                         what locates the node that must stay local
```

The nodes reaching `should_expand` all come off `PlanRewriter::stack`, which `f_down` fills while returning `Transformed::no`, so they are untouched sub-trees of that same root. Nothing reaches the check that the root call did not cover.

Dropping the check outright would not work. `Categorizer` and the Substrait producer disagree about `Unnest`:

```
  Unnest              Categorizer: Commutative      (fine to push down)
    Projection        Substrait:   not_impl_err     (cannot be encoded)
      TableScan
```

Without the encode check `Unnest` lands inside a `MergeScan` remote input, and the query then fails when that input is serialized for the datanode. `unencodable_unnest_stays_above_merge_scan` covers this. It fails if the whole-plan result is assumed rather than computed from the root.

One gap worth writing down: `to_substrait_plan` also converts the root schema to a Substrait named struct, and a sub-tree's own output schema only goes through that step when the sub-tree is the root. GreptimeDB rejects the Arrow types the producer cannot map (`src/datatypes/src/data_type.rs`), so normal planning cannot produce an intermediate schema that would fail there.

Plans that do not encode pay one extra whole-plan encode. Plans that do encode go from one encode per level to one per query.

### Measurement

Standalone, warm cache, 1w range at 300s step, five PromQL queries from the VictoriaMetrics benchmark set over 1,720 series and 39.6M samples. Phases interleaved `a1 b1 b2 a2`, 15 fixed tries and 64 shifted windows per phase; each number is the mean of the two phase P50s for that version. Local smoke measurement on a shared machine, not a capacity number.

| Query | fixed | shifted |
| --- | ---: | ---: |
| Q1 network rate by region, az | 11.16 -> 10.53 ms (-5.6%) | 15.05 -> 13.98 ms (-7.1%) |
| Q2 CPU idle rate by host | 31.07 -> 29.82 ms (-4.0%) | 40.05 -> 38.74 ms (-3.3%) |
| Q3 filesystem ratio | 18.11 -> 16.60 ms (-8.4%) | 22.03 -> 20.32 ms (-7.8%) |
| Q4 network rate topk by host | 15.74 -> 14.95 ms (-5.0%) | 18.79 -> 17.77 ms (-5.5%) |
| Q5 network rate by host, device | 44.01 -> 43.22 ms (-1.8%) | 46.97 -> 46.43 ms (-1.1%) |

Q5 sits inside the spread of the two baseline phases, so read it as no change. The other four separate cleanly. Saving per request is 0.6 to 1.5 ms, which is the right order for removing a handful of `SessionState` constructions.

21 Prometheus responses captured from both binaries match: 18 byte for byte, and 3 `sort`/`sort_desc` instant queries as series multisets. Those three already differ between two runs of the baseline.

No API, wire format or persisted format change.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
