### PR TITLE
fix(mito2): preserve JSON2 values during compaction

### DIFF
--- a/src/datatypes/src/json.rs
+++ b/src/datatypes/src/json.rs
@@ -79,6 +79,9 @@ impl<'de> Deserialize<'de> for JsonSettings {
 /// These hints let JSON2 encode frequently used subpaths in a typed layout, so
 /// queries over those subpaths can get behavior and performance closer to
 /// ordinary columns.
+///
+/// New writes strictly apply all hint properties. Compaction may ignore some
+/// properties, such as defaults and nullability, when rewriting historical values.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonTypeHint {
     /// JSON2 subpath for a typed field.

--- a/src/datatypes/src/json.rs
+++ b/src/datatypes/src/json.rs
@@ -80,8 +80,9 @@ impl<'de> Deserialize<'de> for JsonSettings {
 /// queries over those subpaths can get behavior and performance closer to
 /// ordinary columns.
 ///
-/// New writes strictly apply all hint properties. Compaction may ignore some
-/// properties, such as defaults and nullability, when rewriting historical values.
+/// New writes strictly apply all hint properties. During compaction, type hints
+/// guide physical layout rewriting and may ignore some constraint properties,
+/// such as defaults and nullability.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JsonTypeHint {
     /// JSON2 subpath for a typed field.

--- a/src/mito2/src/compaction/json2.rs
+++ b/src/mito2/src/compaction/json2.rs
@@ -132,8 +132,8 @@ pub(crate) fn collect_json2_rewrite_plans(
         );
 
         let logical_settings = extension.metadata().json_settings();
-        let rewrite_settings = generalized_json_settings(&logical_settings)?;
-        let hint_paths = rewrite_settings
+        let json_settings_for_compaction = json_settings_for_compaction(&logical_settings)?;
+        let hint_paths = json_settings_for_compaction
             .type_hints()
             .iter()
             .map(|hint| hint.path.iter().map(String::as_str).collect::<Vec<_>>())
@@ -146,8 +146,12 @@ pub(crate) fn collect_json2_rewrite_plans(
             collect_json2_path_stats(field, *rows, &hint_paths, &mut stats)?;
         }
 
-        let mut hints = rewrite_settings.type_hints().to_vec();
-        hints.extend(select_dynamic_hints(&rewrite_settings, &hint_paths, &stats));
+        let mut hints = json_settings_for_compaction.type_hints().to_vec();
+        hints.extend(select_dynamic_hints(
+            &json_settings_for_compaction,
+            &hint_paths,
+            &stats,
+        ));
         let target_layout = JsonSettings::try_new(hints, Some(0)).context(DataTypeMismatchSnafu)?;
         plans.insert(
             column.name.clone(),
@@ -250,7 +254,7 @@ fn select_dynamic_hints(
         .filter(|(path, stat)| {
             !stat.is_type_conflicted
                 // TODO(LFC): Instead of "primitive only", consider retaining stable compound types
-                // that are safe to write to Parquet, as flush does. Or better, unite the two 
+                // that are safe to write to Parquet, as flush does. Or better, unite the two
                 // selection process.
                 && stat.data_type.is_primitive()
                 && !has_ancestor_path(path)
@@ -277,12 +281,12 @@ fn select_dynamic_hints(
         .collect()
 }
 
-/// Generalizes JSON2 type hints before rewriting historical values.
+/// Derives JSON2 settings for compaction rewriting.
 ///
 /// Type hints retain their paths and data types for the physical layout, but
 /// defaults and non-null constraints must not be reapplied to values written
 /// before an ALTER.
-fn generalized_json_settings(settings: &JsonSettings) -> Result<JsonSettings> {
+fn json_settings_for_compaction(settings: &JsonSettings) -> Result<JsonSettings> {
     let type_hints = settings
         .type_hints()
         .iter()
@@ -338,7 +342,7 @@ pub(crate) fn rewrite_json2_batch(
             continue;
         };
 
-        let rewrite_settings = generalized_json_settings(&plan.logical_settings)?;
+        let rewrite_settings = json_settings_for_compaction(&plan.logical_settings)?;
         let array = JsonArray::from(array)
             .rewrite_to_v2(field, &rewrite_settings, &plan.target_layout)
             .context(ConvertValueSnafu)?;
@@ -447,7 +451,7 @@ mod tests {
             }],
             Some(0),
         )?;
-        let rewrite_settings = generalized_json_settings(&logical_settings)?;
+        let rewrite_settings = json_settings_for_compaction(&logical_settings)?;
         let target = json2_physical_data_type(&rewrite_settings);
         let plans = HashMap::from([(
             "j".to_string(),
@@ -456,10 +460,7 @@ mod tests {
                 target_layout: rewrite_settings,
             },
         )]);
-        let values = [
-            json!({"extra": {"x": 1}}),
-            json!({"extra": {"x": 2}}),
-        ];
+        let values = [json!({"extra": {"x": 1}}), json!({"extra": {"x": 2}})];
         let source_settings = JsonSettings::default();
         let source_extension =
             Json2ExtensionType::new(Arc::new(JsonMetadata::new_v1(source_settings.clone())));

--- a/src/mito2/src/compaction/json2.rs
+++ b/src/mito2/src/compaction/json2.rs
@@ -40,7 +40,7 @@ use crate::error::{
 /// decoded and rewritten. It therefore prevents source-only paths from expanding the output
 /// schema without a bound.
 pub(crate) struct Json2RewritePlan {
-    /// User-defined settings used to encode logical values.
+    /// User-defined settings retained in the rewritten SST metadata.
     logical_settings: JsonSettings,
     /// Fixed settings used to build the target physical layout.
     pub(super) target_layout: JsonSettings,
@@ -58,8 +58,9 @@ struct Json2LeafPathStats {
 
 /// Builds the JSON2 rewrite plans for a compaction.
 ///
-/// Type hints from current region metadata are always retained. Existing explicit dynamic paths
-/// from all input SST schemas are ranked once to produce a fixed layout; paths found only in a v2
+/// The current region settings remain in output metadata, but their defaults and non-null
+/// constraints are not used to rewrite historical values. Existing explicit dynamic paths from
+/// all input SST schemas are ranked once to produce a fixed layout; paths found only in a v2
 /// remainder are deliberately not promoted. [`rewrite_json2_batch`] decodes inputs and rewrites
 /// them according to these plans. Non-JSON2 columns are omitted from the returned map.
 ///
@@ -130,8 +131,9 @@ pub(crate) fn collect_json2_rewrite_plans(
             }
         );
 
-        let settings = extension.metadata().json_settings();
-        let hint_paths = settings
+        let logical_settings = extension.metadata().json_settings();
+        let rewrite_settings = generalized_json_settings(&logical_settings)?;
+        let hint_paths = rewrite_settings
             .type_hints()
             .iter()
             .map(|hint| hint.path.iter().map(String::as_str).collect::<Vec<_>>())
@@ -144,13 +146,13 @@ pub(crate) fn collect_json2_rewrite_plans(
             collect_json2_path_stats(field, *rows, &hint_paths, &mut stats)?;
         }
 
-        let mut hints = settings.type_hints().to_vec();
-        hints.extend(select_dynamic_hints(settings, &hint_paths, &stats));
+        let mut hints = rewrite_settings.type_hints().to_vec();
+        hints.extend(select_dynamic_hints(&rewrite_settings, &hint_paths, &stats));
         let target_layout = JsonSettings::try_new(hints, Some(0)).context(DataTypeMismatchSnafu)?;
         plans.insert(
             column.name.clone(),
             Json2RewritePlan {
-                logical_settings: settings.clone(),
+                logical_settings: logical_settings.clone(),
                 target_layout,
             },
         );
@@ -275,6 +277,26 @@ fn select_dynamic_hints(
         .collect()
 }
 
+/// Generalizes JSON2 type hints before rewriting historical values.
+///
+/// Type hints retain their paths and data types for the physical layout, but
+/// defaults and non-null constraints must not be reapplied to values written
+/// before an ALTER.
+fn generalized_json_settings(settings: &JsonSettings) -> Result<JsonSettings> {
+    let type_hints = settings
+        .type_hints()
+        .iter()
+        .cloned()
+        .map(|mut hint| {
+            hint.nullable = true;
+            hint.default_constraint = None;
+            hint
+        })
+        .collect();
+    JsonSettings::try_new(type_hints, settings.max_auto_expanded_paths())
+        .context(DataTypeMismatchSnafu)
+}
+
 /// Replaces JSON2 physical field types according to the computed rewrite plans.
 pub(crate) fn rewrite_json2_schema(schema: &SchemaRef, plans: &Json2RewritePlans) -> SchemaRef {
     if plans.is_empty() {
@@ -316,8 +338,9 @@ pub(crate) fn rewrite_json2_batch(
             continue;
         };
 
+        let rewrite_settings = generalized_json_settings(&plan.logical_settings)?;
         let array = JsonArray::from(array)
-            .rewrite_to_v2(field, &plan.logical_settings, &plan.target_layout)
+            .rewrite_to_v2(field, &rewrite_settings, &plan.target_layout)
             .context(ConvertValueSnafu)?;
         debug_assert_eq!(
             &json2_physical_data_type(&plan.target_layout),
@@ -347,8 +370,9 @@ mod tests {
     };
     use datatypes::json::JsonTypeHint;
     use datatypes::prelude::{ConcreteDataType, DataType};
-    use datatypes::schema::ColumnSchema;
+    use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema};
     use datatypes::types::json_type::{JsonNativeType, JsonObjectType};
+    use datatypes::value::Value;
     use serde_json::json;
 
     use super::*;
@@ -413,27 +437,28 @@ mod tests {
 
     #[test]
     fn test_rewrite_json2_v1_batch_to_target_layout() -> Result<(), Box<dyn std::error::Error>> {
-        let settings = JsonSettings::try_new(
+        let logical_settings = JsonSettings::try_new(
             vec![JsonTypeHint {
-                path: vec!["kind".to_string()],
-                data_type: ConcreteDataType::string_datatype(),
-                nullable: true,
-                default_constraint: None,
+                path: vec!["a".to_string()],
+                data_type: ConcreteDataType::int64_datatype(),
+                nullable: false,
+                default_constraint: Some(ColumnDefaultConstraint::Value(Value::Int64(7))),
                 inverted_index: false,
             }],
             Some(0),
         )?;
-        let target = json2_physical_data_type(&settings);
+        let rewrite_settings = generalized_json_settings(&logical_settings)?;
+        let target = json2_physical_data_type(&rewrite_settings);
         let plans = HashMap::from([(
             "j".to_string(),
             Json2RewritePlan {
-                logical_settings: settings.clone(),
-                target_layout: settings,
+                logical_settings,
+                target_layout: rewrite_settings,
             },
         )]);
         let values = [
-            json!({"kind": "a", "extra": {"x": 1}}),
-            json!({"kind": "b", "extra": {"x": 2}}),
+            json!({"extra": {"x": 1}}),
+            json!({"extra": {"x": 2}}),
         ];
         let source_settings = JsonSettings::default();
         let source_extension =


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Currently, JSON2 compaction re-encodes values already stored in SSTs using the latest column settings. If an ALTER adds a NOT NULL type hint or default, values written before the ALTER may fail compaction or be rewritten with the new default value.

This PR prevents compaction from reapplying default and nullable constraints to existing values. JSON2 type hints remain strict validation rules for new writes; during compaction, they guide physical layout rewriting while logical constraints such as defaults and nullability may be ignored.

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
