### PR TITLE
fix(query): prevent incomplete aggregate dynamic filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,7 +3768,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "futures",
  "log",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4033,12 +4033,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4450,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,7 +3768,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "futures",
  "log",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4033,12 +4033,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4450,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,7 +3768,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "futures",
  "log",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4033,12 +4033,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4421,7 +4421,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4450,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=127df0938f8476d15e52ea9402fc6064adec098b#127df0938f8476d15e52ea9402fc6064adec098b"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=b12e8aea00767e38ecd899b0c9eb337f5b88959e#b12e8aea00767e38ecd899b0c9eb337f5b88959e"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,21 +353,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,21 +353,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,21 +353,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "127df0938f8476d15e52ea9402fc6064adec098b" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "b12e8aea00767e38ecd899b0c9eb337f5b88959e" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/tests/cases/standalone/common/aggregate/max_abs_regression.result
+++ b/tests/cases/standalone/common/aggregate/max_abs_regression.result
@@ -11,9 +11,6 @@ CREATE TABLE t (
     ts TIMESTAMP TIME INDEX,
     v INT,
     PRIMARY KEY (v),
-) PARTITION ON COLUMNS (v) (
-    v < 0,
-    v >= 0
 ) ENGINE = mito;
 
 Affected Rows: 0
@@ -52,28 +49,73 @@ SELECT MAX(v), MAX(ts) FROM t;
 | 5        | 2024-01-01T00:03:00 |
 +----------+---------------------+
 
--- The plan must retain Partial and Final aggregation without an incomplete filter.
+-- A mixed expression/column MAX must not send an incomplete dynamic filter to DN SeqScans.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
 -- SQLNESS REPLACE (peers.*) REDACTED
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
-EXPLAIN SELECT MAX(ABS(v)), MAX(ts) FROM t;
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(ABS(v)), MAX(ts) FROM t;
 
-+-+-+
-| plan_type_| plan_|
-+-+-+
-| logical_plan_| Aggregate: groupBy=[[]], aggr=[[__max_merge(__max_state(abs(t.v))) AS max(abs(t.v)), __max_merge(__max_state(t.ts)) AS max(t.ts)]] |
-|_|_MergeScan [is_placeholder=false, remote_input=[_|
-|_| Aggregate: groupBy=[[]], aggr=[[__max_state(abs(t.v)), __max_state(t.ts)]]_|
-|_|_TableScan: t_|
-|_| ]]_|
-| physical_plan | AggregateExec: mode=Final, gby=[], aggr=[max(abs(t.v)), max(t.ts)]_|
-|_|_CoalescePartitionsExec_|
-|_|_AggregateExec: mode=Partial, gby=[], aggr=[max(abs(t.v)), max(t.ts)]_|
-|_|_RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2_|
-|_|_MergeScanExec: REDACTED
-|_|_|
-+-+-+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_CooperativeExec metrics=REDACTED_|
+|_|_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[max(abs(t.v)), max(t.ts)] metrics=REDACTED_|
+|_|_|_CoalescePartitionsExec metrics=REDACTED_|
+|_|_|_AggregateExec: mode=Partial, gby=[], aggr=[max(abs(t.v)), max(t.ts)] metrics=REDACTED_|
+|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts", "v"], "flat_format":REDACTED, "metrics_per_partition": REDACTED metrics=REDACTED_|
+|_|_|_|
+|_|_| Total rows: REDACTED_|
++-+-+-+
+
+-- A column-only multiple-MAX query remains a dynamic-filter positive control.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(v), MAX(ts) FROM t;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_CooperativeExec metrics=REDACTED_|
+|_|_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[max(t.v), max(t.ts)] metrics=REDACTED_|
+|_|_|_CoalescePartitionsExec metrics=REDACTED_|
+|_|_|_AggregateExec: mode=Partial, gby=[], aggr=[max(t.v), max(t.ts)] metrics=REDACTED_|
+|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts", "v"], "dyn_filters": ["DynamicFilter [ REDACTED ]"], "flat_format":REDACTED, "metrics_per_partition": REDACTED metrics=REDACTED_|
+|_|_|_|
+|_|_| Total rows: REDACTED_|
++-+-+-+
 
 DROP TABLE t;
 

--- a/tests/cases/standalone/common/aggregate/max_abs_regression.result
+++ b/tests/cases/standalone/common/aggregate/max_abs_regression.result
@@ -1,0 +1,89 @@
+-- Regression coverage for aggregate expressions with multiple MAX aggregates.
+CREATE DATABASE max_abs_regression;
+
+Affected Rows: 1
+
+USE max_abs_regression;
+
+Affected Rows: 0
+
+CREATE TABLE t (
+    ts TIMESTAMP TIME INDEX,
+    v INT,
+    PRIMARY KEY (v),
+) PARTITION ON COLUMNS (v) (
+    v < 0,
+    v >= 0
+) ENGINE = mito;
+
+Affected Rows: 0
+
+INSERT INTO t VALUES
+    ('2024-01-01 00:00:00', -11),
+    ('2024-01-01 00:01:00', 3),
+    ('2024-01-01 00:02:00', -7),
+    ('2024-01-01 00:03:00', 5);
+
+Affected Rows: 4
+
+-- Expression aggregate regression.
+SELECT MAX(ABS(v)), MAX(ts) FROM t;
+
++---------------+---------------------+
+| max(abs(t.v)) | max(t.ts)           |
++---------------+---------------------+
+| 11            | 2024-01-01T00:03:00 |
++---------------+---------------------+
+
+SELECT MAX(ts), MAX(ABS(v)) FROM t;
+
++---------------------+---------------+
+| max(t.ts)           | max(abs(t.v)) |
++---------------------+---------------+
+| 2024-01-01T00:03:00 | 11            |
++---------------------+---------------+
+
+-- Column-only multiple-MAX positive control.
+SELECT MAX(v), MAX(ts) FROM t;
+
++----------+---------------------+
+| max(t.v) | max(t.ts)           |
++----------+---------------------+
+| 5        | 2024-01-01T00:03:00 |
++----------+---------------------+
+
+-- The plan must retain Partial and Final aggregation without an incomplete filter.
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN SELECT MAX(ABS(v)), MAX(ts) FROM t;
+
++-+-+
+| plan_type_| plan_|
++-+-+
+| logical_plan_| Aggregate: groupBy=[[]], aggr=[[__max_merge(__max_state(abs(t.v))) AS max(abs(t.v)), __max_merge(__max_state(t.ts)) AS max(t.ts)]] |
+|_|_MergeScan [is_placeholder=false, remote_input=[_|
+|_| Aggregate: groupBy=[[]], aggr=[[__max_state(abs(t.v)), __max_state(t.ts)]]_|
+|_|_TableScan: t_|
+|_| ]]_|
+| physical_plan | AggregateExec: mode=Final, gby=[], aggr=[max(abs(t.v)), max(t.ts)]_|
+|_|_CoalescePartitionsExec_|
+|_|_AggregateExec: mode=Partial, gby=[], aggr=[max(abs(t.v)), max(t.ts)]_|
+|_|_RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=2_|
+|_|_MergeScanExec: REDACTED
+|_|_|
++-+-+
+
+DROP TABLE t;
+
+Affected Rows: 0
+
+USE public;
+
+Affected Rows: 0
+
+DROP DATABASE max_abs_regression;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/aggregate/max_abs_regression.sql
+++ b/tests/cases/standalone/common/aggregate/max_abs_regression.sql
@@ -1,0 +1,39 @@
+-- Regression coverage for aggregate expressions with multiple MAX aggregates.
+CREATE DATABASE max_abs_regression;
+
+USE max_abs_regression;
+
+CREATE TABLE t (
+    ts TIMESTAMP TIME INDEX,
+    v INT,
+    PRIMARY KEY (v),
+) PARTITION ON COLUMNS (v) (
+    v < 0,
+    v >= 0
+) ENGINE = mito;
+
+INSERT INTO t VALUES
+    ('2024-01-01 00:00:00', -11),
+    ('2024-01-01 00:01:00', 3),
+    ('2024-01-01 00:02:00', -7),
+    ('2024-01-01 00:03:00', 5);
+
+-- Expression aggregate regression.
+SELECT MAX(ABS(v)), MAX(ts) FROM t;
+SELECT MAX(ts), MAX(ABS(v)) FROM t;
+
+-- Column-only multiple-MAX positive control.
+SELECT MAX(v), MAX(ts) FROM t;
+
+-- The plan must retain Partial and Final aggregation without an incomplete filter.
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+EXPLAIN SELECT MAX(ABS(v)), MAX(ts) FROM t;
+
+DROP TABLE t;
+
+USE public;
+
+DROP DATABASE max_abs_regression;

--- a/tests/cases/standalone/common/aggregate/max_abs_regression.sql
+++ b/tests/cases/standalone/common/aggregate/max_abs_regression.sql
@@ -7,9 +7,6 @@ CREATE TABLE t (
     ts TIMESTAMP TIME INDEX,
     v INT,
     PRIMARY KEY (v),
-) PARTITION ON COLUMNS (v) (
-    v < 0,
-    v >= 0
 ) ENGINE = mito;
 
 INSERT INTO t VALUES
@@ -25,12 +22,45 @@ SELECT MAX(ts), MAX(ABS(v)) FROM t;
 -- Column-only multiple-MAX positive control.
 SELECT MAX(v), MAX(ts) FROM t;
 
--- The plan must retain Partial and Final aggregation without an incomplete filter.
+-- A mixed expression/column MAX must not send an incomplete dynamic filter to DN SeqScans.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
 -- SQLNESS REPLACE (peers.*) REDACTED
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
-EXPLAIN SELECT MAX(ABS(v)), MAX(ts) FROM t;
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(ABS(v)), MAX(ts) FROM t;
+
+-- A column-only multiple-MAX query remains a dynamic-filter positive control.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(v), MAX(ts) FROM t;
 
 DROP TABLE t;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Merged dependency fix: https://github.com/GreptimeTeam/datafusion/pull/33

Upstream fix for the same issue: https://github.com/apache/datafusion/pull/24817

## What's changed and what's your intention?

Update the DataFusion fork revision to `bb531e754b3b36d7a4d3222f35ebc88204dafd2b` to fix incorrect results from mixed expression/column MIN/MAX aggregation.

For example, `SELECT MAX(ABS(v)), MAX(ts) FROM t` could generate a dynamic filter only for `MAX(ts)`. That filter may prune older rows still needed by `MAX(ABS(v))`, making results depend on scan timing. The fork fix rejects aggregate dynamic filtering unless every aggregate argument qualifies; supported direct-column MIN/MAX filtering remains enabled.

The revision adds only the eligibility fix, focused both-order and upstream Parquet numerical regression coverage, and comment correction on top of the currently pinned fork revision. No local path dependencies, query-option controls, public API changes or persisted-format changes are included.

Validation completed before this dependency-update PR:
- The new DataFusion regression fails on the unpatched implementation and passes with the fix; all 9 aggregate dynamic-filter tests passed on the original fix checkpoint.
- An official GreptimeDB 1.2.0 HTTP reproduction returned an incorrect maximum in one of 20 identical queries against immutable data. A local GreptimeDB build with the fix returned correct results in all 20 repetitions, and its executed plan no longer contained the incomplete filter.

The previous dependency revision `127df09` (identical production code; the new revision adds only an upstream regression test) passes `cargo check -p query` and `cargo build -p cmd --bin greptime`. This PR also includes a generated SQLness regression covering both aggregate orders and a column-only control. Standalone and distributed SQLness runs both passed against the exact published-dependency build. The fork PR is merged, and this PR now pins its merge commit on the target branch. The merge commit has the same tree as the tested fork head. The strengthened single-region SQLness regression uses EXPLAIN ANALYZE VERBOSE to assert no dynamic filter on mixed-aggregate DN scans while retaining it for the column-only control. It passes in standalone and distributed with the fix, and fails in both modes with the official 1.2.0 binary because the mixed scan still has an incomplete filter. CI for the updated dependency commit is pending. Release backport selection is not included in this initial submission.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
