### PR TITLE
fix: bump jemalloc crates to 0.7 and patch tikv-jemalloc-sys with tcache init fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,7 +1623,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.0.7",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -9173,7 +9173,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12995,7 +12995,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13909,7 +13909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14912,7 +14912,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15171,9 +15171,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -15182,9 +15182,8 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+version = "0.7.0+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "git+https://github.com/GreptimeTeam/jemallocator?rev=07f74b6100a7c8ca2e48828d143caa5eb61b6762#07f74b6100a7c8ca2e48828d143caa5eb61b6762"
 dependencies = [
  "cc",
  "libc",
@@ -15192,9 +15191,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15183,7 +15183,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemalloc-sys"
 version = "0.7.0+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
-source = "git+https://github.com/GreptimeTeam/jemallocator?rev=a3b9ad8a41ff7ee14c7ddec06f5864f310d2d245#a3b9ad8a41ff7ee14c7ddec06f5864f310d2d245"
+source = "git+https://github.com/GreptimeTeam/jemallocator?rev=e1846d8c12bbb65c39dcd224a86b24586478e264#e1846d8c12bbb65c39dcd224a86b24586478e264"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11381,7 +11381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -11401,7 +11401,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -13880,7 +13880,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15183,7 +15183,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemalloc-sys"
 version = "0.7.0+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
-source = "git+https://github.com/GreptimeTeam/jemallocator?rev=07f74b6100a7c8ca2e48828d143caa5eb61b6762#07f74b6100a7c8ca2e48828d143caa5eb61b6762"
+source = "git+https://github.com/GreptimeTeam/jemallocator?rev=a3b9ad8a41ff7ee14c7ddec06f5864f310d2d245#a3b9ad8a41ff7ee14c7ddec06f5864f310d2d245"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,6 +369,13 @@ datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev =
 datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
+# Temporary: use the GreptimeTeam fork of tikv-jemalloc-sys embedding
+# jemalloc 5.3.1 + backport of 54f22c83 ("Initialize TSD tcache before
+# enabling it"), fixing the TSD/tcache enable-before-init reentrancy
+# window. Remove once tikv/jemallocator ships a jemalloc snapshot that
+# includes the fix. See GreptimeTeam/jemalloc#1.
+tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "07f74b6100a7c8ca2e48828d143caa5eb61b6762" }
+
 [profile.release]
 debug = 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,7 @@ sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2
 # enabling it"), fixing the TSD/tcache enable-before-init reentrancy
 # window. Remove once tikv/jemallocator ships a jemalloc snapshot that
 # includes the fix. See GreptimeTeam/jemalloc#1.
-tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "a3b9ad8a41ff7ee14c7ddec06f5864f310d2d245" }
+tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "e1846d8c12bbb65c39dcd224a86b24586478e264" }
 
 [profile.release]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,7 @@ sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2
 # enabling it"), fixing the TSD/tcache enable-before-init reentrancy
 # window. Remove once tikv/jemallocator ships a jemalloc snapshot that
 # includes the fix. See GreptimeTeam/jemalloc#1.
-tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "07f74b6100a7c8ca2e48828d143caa5eb61b6762" }
+tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "a3b9ad8a41ff7ee14c7ddec06f5864f310d2d245" }
 
 [profile.release]
 debug = 1

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -124,7 +124,7 @@ pprof = { version = "0.14", features = [
 ] }
 
 [target.'cfg(not(windows))'.dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = "0.7"
 
 [dev-dependencies]
 api.workspace = true

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -16,7 +16,7 @@ tempfile = "3.4"
 tokio.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tikv-jemalloc-ctl = { version = "0.6", features = ["use_std", "stats"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["use_std", "stats"] }
 jemalloc-pprof-utils = { version = "0.8", package = "pprof_util", features = [
     "flamegraph",
     "symbolize",
@@ -25,4 +25,4 @@ jemalloc-pprof-mappings = { version = "0.7", package = "mappings" } # for get th
 
 [target.'cfg(not(windows))'.dependencies.tikv-jemalloc-sys]
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
-version = "0.6"
+version = "0.7"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -146,7 +146,7 @@ vrl.workspace = true
 zstd.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tikv-jemalloc-ctl = { version = "0.6", features = ["use_std", "stats"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["use_std", "stats"] }
 
 [dev-dependencies]
 auth = { workspace = true, features = ["testing"] }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -175,7 +175,7 @@ tokio-postgres-rustls = "0.14"
 pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
 
 [target.'cfg(not(windows))'.dev-dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = "0.7"
 
 [build-dependencies]
 common-version.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- GreptimeTeam/jemalloc#1 — backport of jemalloc 54f22c83 onto 5.3.1
- GreptimeTeam/jemallocator#1 — repoints `jemalloc-sys/jemalloc` submodule at the backport

## What's changed and what's your intention?

**Summary.** Bump `tikv-jemallocator` / `tikv-jemalloc-ctl` / `tikv-jemalloc-sys` from 0.6 to 0.7, and add a `[patch.crates-io]` entry replacing `tikv-jemalloc-sys` with the GreptimeTeam fork that embeds jemalloc 5.3.1 + a backport of upstream commit `54f22c83` ("Initialize TSD tcache before enabling it").

**Why.** The previously embedded jemalloc (5.3.0-1-ge13ca993 via tikv-jemalloc-sys 0.6.0) initializes a thread's TSD tcache in the wrong order: it marks the tcache `enabled` before initializing its bins backing storage, and ignores initialization failures. A reentrant allocation during that window — e.g. heap-profiling `prof_tdata` init or sampled backtrace collection when `prof:true` is active — can observe an enabled-but-uninitialized tcache, corrupt per-thread tcache metadata, and crash the process (observed in production as SIGSEGV in `arena_stats_merge` when serving `/metrics`, in `calloc`, and as a `#GP` inside the libgcc unwinder).

**How.**

- The 0.7 crates embed jemalloc **5.3.1**, which already includes `a056c20d` ("Handle tcache init failures gracefully" — disable tcache when init fails).
- 5.3.1 does **not** include `54f22c83` (it landed on jemalloc dev ~96 commits after 5.3.1 was tagged). The `[patch.crates-io]` entry points `tikv-jemalloc-sys` at `GreptimeTeam/jemallocator` rev `07f74b61`, whose submodule carries 5.3.1 + `54f22c83`. The backported `tsd_tcache_enabled_data_init` / `tcache_enabled_set` are byte-identical to upstream dev after the fix.
- The patch is temporary and should be dropped once `tikv/jemallocator` ships a jemalloc snapshot that includes `54f22c83`.

**Compatibility.** No API or data compatibility impact: allocator internals only. `tikv-jemalloc-ctl` 0.7's `epoch` / `stats::*` / `raw::*` APIs used by `servers` and `common-mem-prof` are unchanged (`cargo check -p common-mem-prof -p servers -p cmd` passes). The patch is pinned by `rev` for reproducible builds.

**Verification.**

- jemalloc unit tests on the backport: `test/unit/tsd` 6/6 (incl. the new `test_tsd_reentrant_bootstrap`), `test/unit/tcache_init` 6/6 (OOM injection degrades gracefully instead of crashing)
- Fault-injection reproducer against the same jemalloc version family: unpatched builds SIGSEGV within seconds when tcache backing-store allocation fails; patched builds and `tcache:false` runs survive millions of thread bootstraps
- `cargo check -p common-mem-prof -p servers -p cmd` passes with the patched crate, and the compiled `libjemalloc.a` is built from the patched submodule source

## PR Checklist

- [x] I have written the necessary rustdoc comments. (no new Rust APIs)
- [x] I have added the necessary unit tests and integration tests. (covered by jemalloc's own tsd/tcache_init suites on the backport)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).