### PR TITLE
test(perf): cover rate and increase window and reset shapes

### DIFF
--- a/tests/perf/query_cases/promql_rate_dense_resets/case.toml
+++ b/tests/perf/query_cases/promql_rate_dense_resets/case.toml
@@ -1,0 +1,163 @@
+# PromQL rate/increase window-width and evaluation-step benchmark with dense resets.
+#
+# Remote-write `modulo` values use cardinality 15 and step 1. Because 780 is
+# divisible by 15, every one of the 128 series resets from 14 to 0 exactly every
+# 15 local samples (225 seconds) at the 15-second cadence: 51 resets
+# per series in 780 samples. The `resets` HTTP control is manually inspected in
+# its retained response: each aligned one-hour window contains 240 samples and
+# should report 16 resets per series. The runner does not assert numeric values.
+
+[case]
+name = "promql_rate_dense_resets"
+description = "PromQL rate and increase across windows and steps for counters resetting every 15 samples"
+issue = "https://github.com/GreptimeTeam/greptimedb/pull/9089"
+
+[scenario]
+kind = "prom_remote_write_then_query"
+
+[scenario.remote_write]
+database = "public"
+metric = "promql_rate_dense_resets"
+physical_table = "greptime_physical_table"
+series_count = 128
+samples_per_series = 780
+sample_chunk_size = 195
+flush_every_sample_chunks = 1
+start_unix_millis = 1704067200000
+step_millis = 15000
+chunk_series_count = 128
+timeout_seconds = 180
+visibility_timeout_seconds = 120
+
+[scenario.remote_write.value]
+pattern = "modulo"
+base = 0
+step = 1
+cardinality = 15
+
+[scenario.remote_write.prom_store]
+pending_rows_flush_interval = "1s"
+max_batch_rows = 100000
+
+[[scenario.queries]]
+name = "selector_control_2h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') promql_rate_dense_resets{host=~'host.*'}"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_1m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_dense_resets{host=~'host.*'}[1m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_1m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_dense_resets{host=~'host.*'}[1m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_5m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_dense_resets{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_5m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_dense_resets{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_1h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_dense_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_1h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_dense_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# Twelve evaluations per 1h window: representative larger overlapping step.
+[[scenario.queries]]
+name = "rate_1h_5m_overlapping"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '5m') rate(promql_rate_dense_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# One evaluation per 1h window: representative non-overlapping step.
+[[scenario.queries]]
+name = "increase_1h_1h_non_overlapping"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '1h') increase(promql_rate_dense_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "resets_1h_1h_expected_sixteen"
+kind = "prom_http"
+query = "resets(promql_rate_dense_resets{host=~\"host.*\"}[1h])"
+start = "1704070800"
+end = "1704078000"
+step = "1h"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# Manual response check: at 1704070800, 1704074400, and 1704078000, the
+# left-open 1h windows contain samples 1..240, 241..480, and 481..720. Each has
+# 16 resets and extrapolated increase 53520 / 239 = 223.93305439330544. The runner
+# retains but does not assert it.
+
+[[scenario.queries]]
+name = "increase_1h_host0000_manual_response_check"
+kind = "prom_http"
+query = "increase(promql_rate_dense_resets{host=\"host0000\"}[1h])"
+start = "1704070800"
+end = "1704078000"
+step = "1h"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10

--- a/tests/perf/query_cases/promql_rate_no_resets/case.toml
+++ b/tests/perf/query_cases/promql_rate_no_resets/case.toml
@@ -1,0 +1,160 @@
+# PromQL rate/increase window-width and evaluation-step benchmark without resets.
+#
+# Remote-write `linear` values increase by one at every 15-second sample for
+# each series. 128 series × 780 samples = 99,840 rows over 3h14m45s.
+# The `resets` HTTP control below is manually inspected in its retained response:
+# it should report 0 for every series at all three one-hour, non-overlapping
+# evaluations. The runner records the response but does not assert its numeric values.
+
+[case]
+name = "promql_rate_no_resets"
+description = "PromQL rate and increase across windows and steps for monotonic counters without resets"
+issue = "https://github.com/GreptimeTeam/greptimedb/pull/9089"
+
+[scenario]
+kind = "prom_remote_write_then_query"
+
+[scenario.remote_write]
+database = "public"
+metric = "promql_rate_no_resets"
+physical_table = "greptime_physical_table"
+series_count = 128
+samples_per_series = 780
+sample_chunk_size = 195
+flush_every_sample_chunks = 1
+start_unix_millis = 1704067200000
+step_millis = 15000
+chunk_series_count = 128
+timeout_seconds = 180
+visibility_timeout_seconds = 120
+
+[scenario.remote_write.value]
+pattern = "linear"
+base = 0
+step = 1
+
+[scenario.remote_write.prom_store]
+pending_rows_flush_interval = "1s"
+max_batch_rows = 100000
+
+[[scenario.queries]]
+name = "selector_control_2h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') promql_rate_no_resets{host=~'host.*'}"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_1m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_no_resets{host=~'host.*'}[1m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_1m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_no_resets{host=~'host.*'}[1m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_5m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_no_resets{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_5m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_no_resets{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_1h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_no_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_1h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_no_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# Twelve evaluations per 1h window: representative larger overlapping step.
+[[scenario.queries]]
+name = "rate_1h_5m_overlapping"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '5m') rate(promql_rate_no_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# One evaluation per 1h window: representative non-overlapping step.
+[[scenario.queries]]
+name = "increase_1h_1h_non_overlapping"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '1h') increase(promql_rate_no_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "resets_1h_1h_expected_zero"
+kind = "prom_http"
+query = "resets(promql_rate_no_resets{host=~\"host.*\"}[1h])"
+start = "1704070800"
+end = "1704078000"
+step = "1h"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# Manual response check: at 1704070800, 1704074400, and 1704078000, the
+# left-open 1h windows contain samples 1..240, 241..480, and 481..720. Each
+# extrapolated increase is exactly 240. The runner retains but does not assert it.
+
+[[scenario.queries]]
+name = "increase_1h_host0000_manual_response_check"
+kind = "prom_http"
+query = "increase(promql_rate_no_resets{host=\"host0000\"}[1h])"
+start = "1704070800"
+end = "1704078000"
+step = "1h"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10

--- a/tests/perf/query_cases/promql_rate_sparse_resets/case.toml
+++ b/tests/perf/query_cases/promql_rate_sparse_resets/case.toml
@@ -1,0 +1,163 @@
+# PromQL rate/increase window-width and evaluation-step benchmark with sparse resets.
+#
+# Remote-write `modulo` values use cardinality 195 and step 1. Because 780 is
+# divisible by 195, every one of the 128 series resets from 194 to 0 exactly at
+# local sample indexes 195, 390, and 585 (15-second cadence): three resets per
+# series. The `resets` HTTP control is manually inspected in its retained response:
+# each aligned one-hour window should report 1 reset per series. The runner does
+# not assert numeric response values.
+
+[case]
+name = "promql_rate_sparse_resets"
+description = "PromQL rate and increase across windows and steps for counters resetting every 195 samples"
+issue = "https://github.com/GreptimeTeam/greptimedb/pull/9089"
+
+[scenario]
+kind = "prom_remote_write_then_query"
+
+[scenario.remote_write]
+database = "public"
+metric = "promql_rate_sparse_resets"
+physical_table = "greptime_physical_table"
+series_count = 128
+samples_per_series = 780
+sample_chunk_size = 195
+flush_every_sample_chunks = 1
+start_unix_millis = 1704067200000
+step_millis = 15000
+chunk_series_count = 128
+timeout_seconds = 180
+visibility_timeout_seconds = 120
+
+[scenario.remote_write.value]
+pattern = "modulo"
+base = 0
+step = 1
+cardinality = 195
+
+[scenario.remote_write.prom_store]
+pending_rows_flush_interval = "1s"
+max_batch_rows = 100000
+
+[[scenario.queries]]
+name = "selector_control_2h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') promql_rate_sparse_resets{host=~'host.*'}"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_1m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_sparse_resets{host=~'host.*'}[1m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_1m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_sparse_resets{host=~'host.*'}[1m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_5m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_sparse_resets{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_5m_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_sparse_resets{host=~'host.*'}[5m])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "rate_1h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') rate(promql_rate_sparse_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "increase_1h_15s"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '15s') increase(promql_rate_sparse_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# Twelve evaluations per 1h window: representative larger overlapping step.
+[[scenario.queries]]
+name = "rate_1h_5m_overlapping"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '5m') rate(promql_rate_sparse_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# One evaluation per 1h window: representative non-overlapping step.
+[[scenario.queries]]
+name = "increase_1h_1h_non_overlapping"
+kind = "tql"
+query = "TQL ANALYZE VERBOSE (1704070800, 1704078000, '1h') increase(promql_rate_sparse_resets{host=~'host.*'}[1h])"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+[[scenario.queries]]
+name = "resets_1h_1h_expected_one"
+kind = "prom_http"
+query = "resets(promql_rate_sparse_resets{host=~\"host.*\"}[1h])"
+start = "1704070800"
+end = "1704078000"
+step = "1h"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10
+
+# Manual response check: at 1704070800, 1704074400, and 1704078000, the
+# left-open 1h windows contain samples 1..240, 241..480, and 481..720. Each has
+# one reset and extrapolated increase 57120 / 239 = 238.9958158995816. The runner
+# retains but does not assert it.
+
+[[scenario.queries]]
+name = "increase_1h_host0000_manual_response_check"
+kind = "prom_http"
+query = "increase(promql_rate_sparse_resets{host=\"host0000\"}[1h])"
+start = "1704070800"
+end = "1704078000"
+step = "1h"
+warmup = 3
+iterations = 9
+
+[scenario.queries.thresholds]
+max_candidate_latency_regression_pct = 10


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up performance coverage for #9089.

## What's changed and what's your intention?

Add performance regression cases for PromQL `rate` and `increase` across window widths, evaluation steps, and counter-reset densities. This is a **test-only draft**: there are no production, DSL, or workflow changes. The measured comparison found no threshold regressions, so this coverage is not urgent to merge.

### Added cases

- `tests/perf/query_cases/promql_rate_no_resets/case.toml`
- `tests/perf/query_cases/promql_rate_sparse_resets/case.toml`
- `tests/perf/query_cases/promql_rate_dense_resets/case.toml`

Each fixture contains 128 series × 780 samples at a 15-second cadence (99,840 rows), ingested through remote write. Values are linear with no resets, modulo 195 for sparse resets, or modulo 15 for dense resets.

Each case has 11 queries:

- A selector control.
- `rate` and `increase` over 1m, 5m, and 1h windows at a 15s evaluation step.
- A 1h `rate` window with a 5m overlapping step.
- A 1h `increase` window with a 1h non-overlapping step.
- Prometheus HTTP controls for reset counts and a host-specific hourly increase.

All queries use three warmups, nine measured iterations, and a 10% maximum candidate latency-regression threshold. Existing cases and thresholds are unchanged.

### Nightly evidence

[Query regression run 34460709232](https://github.com/GreptimeTeam/greptimedb/actions/runs/34460709232), `nightly` profile, compares the parent of #9089 (`adda50e03f1f4946c581281425fffbdfcfddf58f`) with `29870a776ac1efa130ce76f62e079325bef56d27` (#9089 plus these cases).

| Reset density | Rate/increase query median-latency changes¹ | Gates passed |
| --- | ---: | ---: |
| None | −3.7% to +1.5% | 11/11 |
| Sparse | −3.3% to +0.0% | 11/11 |
| Dense | −5.1% to +1.4% | 11/11 |

¹ Excludes the selector and HTTP controls. These results provide regression coverage, not evidence of a new optimization.

All 33 gates passed. Both targets were measured with zero validation errors, all 297 measured samples per target succeeded, and teardown succeeded.

The retained JSON responses were also checked for both targets across all nine measured repetitions and all three aligned hourly timestamps:

| Fixture | Hourly resets for each of 128 series | Hourly increase for host0000 |
| --- | ---: | ---: |
| No resets | 0 | 240 |
| Sparse resets | 1 | 238.9958158995816 |
| Dense resets | 16 | 223.93305439330544 |

The case comments document these numerical expectations for manual inspection. The performance runner checks query success and latency; it does not automatically assert numerical equality. These bounded-integer fixtures are not substitutes for the floating-point precision regression tests in #9089.

### Verification

- `cargo build -p cmd --bin query_perf_fixture --bin query_regression_runner --features dev-tools` — passed.
- `query_perf_fixture plan --case tests/perf/query_cases/promql_rate_no_resets/case.toml` — passed; the same command passed for the sparse and dense cases.
- `taplo fmt --check --no-auto-config tests/perf/query_cases/promql_rate_no_resets/case.toml tests/perf/query_cases/promql_rate_sparse_resets/case.toml tests/perf/query_cases/promql_rate_dense_resets/case.toml` — passed.
- `cargo fmt --all -- --check` — passed.
- The six Python suites in the query-regression workflow's `test-tooling` job — 20 tests passed; the slash-command suite also passed 31 tests.
- Independent fixture arithmetic checks confirmed reset counts and extrapolated increases; retained CI responses matched those expectations.

No API, schema, or persisted-format changes. Full workspace tests and clippy were not run for this TOML-only change.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. (No Rust changes.)
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
