### PR TITLE
docs: fix README canary release badge resolving to stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ One engine, on your infrastructure.</h2>
 </h3>
 
 <a href="https://github.com/GreptimeTeam/greptimedb/releases/latest">
-<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?filter=!*-*&label=stable&color=brightgreen" alt="Stable"/>
+<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?filter=!*-*&sort=semver&label=stable&color=brightgreen" alt="Stable"/>
 </a>
 <a href="https://github.com/GreptimeTeam/greptimedb/releases">
-<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=!*-*-*&label=canary&color=blueviolet" alt="Canary"/>
+<img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=!*-*-*&sort=semver&label=canary&color=blueviolet" alt="Canary"/>
 </a>
 <a href="https://github.com/GreptimeTeam/greptimedb/releases">
 <img src="https://img.shields.io/github/v/release/GreptimeTeam/greptimedb?include_prereleases&filter=*-nightly-*&label=nightly&color=orange" alt="Nightly"/>


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Introduced by #8743 (docs: rework README release badges).

## What's changed and what's your intention?

**Summary:** Fix the `canary` release badge in README.md, which currently shows the stable version `v1.2.0` instead of the latest prerelease `v1.3.0-alpha.1`.

**Why it breaks:** The shields.io `filter` param supports only `*` wildcards plus whole-pattern `!` negation. The canary filter `!*-*-*` excludes tags with **two or more** dashes (nightly snapshots and commit-hash dev builds) but also lets **zero-dash** stable tags pass. Since shields selects the newest matching release *by date* and the `v1.2.0` GA release was created (Sep 8) after `v1.3.0-alpha.1` (Sep 3), the stable release wins the date sort and the badge shows `v1.2.0` — duplicating the stable badge.

**The fix:** Add `sort=semver` to the badge URL so shields picks the semver-greatest matching tag instead of the newest-by-date. `v1.3.0-alpha.1` ranks above `v1.2.0` (base version `1.3.0 > 1.2.0`), so canary now shows the prerelease. Nightly/dev tags remain excluded by the existing filter — every nightly tag in the repo's history has at least two dashes (`-nightly-<date>`), verified against all 272 tags.

Also applies `sort=semver` to the **stable** badge, which is vulnerable to the same date-order failure: a patch of an older minor released after a newer GA (e.g. `v1.1.5` after `v1.2.0`) would take over the stable badge.

Verified against the live shields.io JSON endpoint with the exact final URLs:

| Badge | Before | After |
|---|---|---|
| stable | `v1.2.0` | `v1.2.0` (unchanged) |
| canary | `v1.2.0` ❌ | `v1.3.0-alpha.1` ✅ |
| nightly | `v1.3.0-alpha.1-nightly-20260907` | unchanged |

**Limitation:** a single shields glob cannot express "exactly one dash", so between the GA of a version and the first prerelease of the next one, the canary badge converges to the GA version — consistent with its caption "canary includes pre-releases".

README-only change; no code, API, or data impact.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments. *(N/A — docs-only change)*
- [x] I have added the necessary unit tests and integration tests. *(N/A — docs-only change; verified against live shields.io endpoint)*
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible. *(N/A)*
- [x] Schema or data changes are backward compatible. *(N/A)*
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).