### PR TITLE
feat: support request-level WAL skipping for bulk inserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b74667d17827481dbb6222fa0326163627211557#b74667d17827481dbb6222fa0326163627211557"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=39187785e4fcc96fb4ce3f08516f25602acca10a#39187785e4fcc96fb4ce3f08516f25602acca10a"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ fs2 = "0.4"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b74667d17827481dbb6222fa0326163627211557" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "39187785e4fcc96fb4ce3f08516f25602acca10a" }
 hex = "0.4"
 hostname = "0.4.0"
 http = "1"

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -825,7 +825,17 @@ impl Database {
     /// Ingest a stream of [RecordBatch]es that belong to a table, using Arrow Flight's "`DoPut`"
     /// method. The return value is also a stream, produces [DoPutResponse]s.
     pub async fn do_put(&self, stream: FlightDataStream) -> Result<DoPutResponseStream> {
+        self.do_put_with_hints(stream, &[]).await
+    }
+
+    /// Ingest a stream of [RecordBatch]es using Arrow Flight's `DoPut` with request hints.
+    pub async fn do_put_with_hints(
+        &self,
+        stream: FlightDataStream,
+        hints: &[(&str, &str)],
+    ) -> Result<DoPutResponseStream> {
         let mut request = tonic::Request::new(stream);
+        Self::put_hints(request.metadata_mut(), hints)?;
 
         if let Some(AuthHeader {
             auth_scheme: Some(AuthScheme::Basic(Basic { username, password })),

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -453,6 +453,7 @@ impl Instance {
                         request.flight_data,
                         request.record_batch,
                         request.schema_bytes,
+                        ctx.skip_wal(),
                     )
                     .await
                     .context(TableOperationSnafu)?;

--- a/src/metric-engine/src/engine/bulk_insert.rs
+++ b/src/metric-engine/src/engine/bulk_insert.rs
@@ -124,6 +124,7 @@ impl MetricEngineInner {
         let aligned_schema_version = Some(self.physical_schema_version(data_region_id).await?);
 
         let request = RegionBulkInsertsRequest {
+            skip_wal: request.skip_wal,
             region_id: data_region_id,
             payload: modified_batch,
             raw_data: ArrowIpc {
@@ -245,14 +246,20 @@ mod tests {
     use datatypes::arrow::datatypes::{DataType, Field, Schema as ArrowSchema, TimeUnit};
     use datatypes::arrow::record_batch::RecordBatch;
     use mito2::config::MitoConfig;
-    use store_api::metric_engine_consts::PRIMARY_KEY_ENCODING;
+    use store_api::metric_engine_consts::{
+        METRIC_ENGINE_NAME, PHYSICAL_TABLE_METADATA_KEY, PRIMARY_KEY_ENCODING,
+    };
     use store_api::path_utils::table_dir;
     use store_api::region_engine::RegionEngine;
-    use store_api::region_request::{RegionBulkInsertsRequest, RegionPutRequest, RegionRequest};
+    use store_api::region_request::{
+        PathType, RegionBulkInsertsRequest, RegionCloseRequest, RegionOpenRequest,
+        RegionPutRequest, RegionRequest,
+    };
     use store_api::storage::{RegionId, ScanRequest};
 
     use super::record_batch_to_ipc;
     use crate::batch_modifier::{TagColumnInfo, modify_batch_sparse};
+    use crate::engine::MetricEngine;
     use crate::error::Error;
     use crate::test_util::{self, TestEnv};
 
@@ -287,9 +294,14 @@ mod tests {
         .unwrap()
     }
 
-    fn build_bulk_request(logical_region_id: RegionId, batch: RecordBatch) -> RegionRequest {
+    fn build_bulk_request(
+        logical_region_id: RegionId,
+        batch: RecordBatch,
+        skip_wal: bool,
+    ) -> RegionRequest {
         let (schema, data_header, payload) = record_batch_to_ipc(&batch).unwrap();
         RegionRequest::BulkInserts(RegionBulkInsertsRequest {
+            skip_wal,
             region_id: logical_region_id,
             payload: batch,
             raw_data: ArrowIpc {
@@ -332,6 +344,7 @@ mod tests {
 
         let batch = build_logical_batch(0, 0);
         let request = RegionRequest::BulkInserts(RegionBulkInsertsRequest {
+            skip_wal: false,
             region_id: logical_region_id,
             payload: batch,
             raw_data: ArrowIpc::default(),
@@ -348,6 +361,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_insert_physical_region_passthrough() {
+        check_bulk_insert_physical_region_passthrough(false).await;
+        check_bulk_insert_physical_region_passthrough(true).await;
+    }
+
+    async fn check_bulk_insert_physical_region_passthrough(skip_wal: bool) {
         // Use flat format so that BulkMemtable is used (supports write_bulk).
         let mito_config = MitoConfig {
             default_flat_format: true,
@@ -355,12 +373,13 @@ mod tests {
         };
         let env = TestEnv::with_mito_config("", mito_config, Default::default()).await;
         env.init_metric_region().await;
+        env.metric().inner.flush_task.stop().await.unwrap();
         let physical_region_id = env.default_physical_region_id();
         let logical_region_id = env.default_logical_region_id();
 
         // First, do a normal logical bulk insert so we can compare results.
         let logical_batch = build_logical_batch(0, 3);
-        let logical_request = build_bulk_request(logical_region_id, logical_batch.clone());
+        let logical_request = build_bulk_request(logical_region_id, logical_batch, skip_wal);
         let response = env
             .metric()
             .handle_request(logical_region_id, logical_request)
@@ -385,7 +404,7 @@ mod tests {
             &non_tag_indices,
         )
         .unwrap();
-        let request = build_bulk_request(physical_region_id, physical_batch);
+        let request = build_bulk_request(physical_region_id, physical_batch, skip_wal);
         let response = env
             .metric()
             .handle_request(physical_region_id, request)
@@ -401,6 +420,48 @@ mod tests {
             .unwrap();
         let batches = RecordBatches::try_collect(stream).await.unwrap();
         assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 6);
+
+        // Closing without a flush must recover only WAL-backed data. Recreate
+        // the wrapper too, so its metadata cache cannot hide missing metadata.
+        let stat = env.mito().region_statistic(physical_region_id).unwrap();
+        assert_eq!(stat.sst_num, 0);
+        env.metric()
+            .handle_request(
+                physical_region_id,
+                RegionRequest::Close(RegionCloseRequest {
+                    flush_on_close: false,
+                }),
+            )
+            .await
+            .unwrap();
+        let reopened = MetricEngine::try_new(env.mito(), Default::default()).unwrap();
+        reopened.inner.flush_task.stop().await.unwrap();
+        reopened
+            .handle_request(
+                physical_region_id,
+                RegionRequest::Open(RegionOpenRequest {
+                    engine: METRIC_ENGINE_NAME.to_string(),
+                    table_dir: TestEnv::default_table_dir(),
+                    path_type: PathType::Bare,
+                    options: [(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new())]
+                        .into_iter()
+                        .collect(),
+                    skip_wal_replay: false,
+                    checkpoint: None,
+                    requirements: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+        let stream = reopened
+            .scan_to_stream(logical_region_id, ScanRequest::default())
+            .await
+            .unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        assert_eq!(
+            batches.iter().map(|b| b.num_rows()).sum::<usize>(),
+            if skip_wal { 0 } else { 6 },
+        );
     }
 
     #[tokio::test]
@@ -415,7 +476,7 @@ mod tests {
         let physical_region_id = env.default_physical_region_id();
 
         let batch = build_logical_batch(0, 0);
-        let request = build_bulk_request(physical_region_id, batch);
+        let request = build_bulk_request(physical_region_id, batch, false);
         let response = env
             .metric()
             .handle_request(physical_region_id, request)
@@ -449,7 +510,7 @@ mod tests {
         )
         .unwrap();
 
-        let request = build_bulk_request(logical_region_id, batch);
+        let request = build_bulk_request(logical_region_id, batch, false);
         let err = env
             .metric()
             .handle_request(logical_region_id, request)
@@ -499,7 +560,7 @@ mod tests {
         )
         .unwrap();
 
-        let request = build_bulk_request(logical_region_id, batch);
+        let request = build_bulk_request(logical_region_id, batch, false);
         let response = env
             .metric()
             .handle_request(logical_region_id, request)
@@ -522,7 +583,7 @@ mod tests {
         env.init_metric_region().await;
         let logical_region_id = env.default_logical_region_id();
 
-        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 3));
+        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 3), false);
         let response = env
             .metric()
             .handle_request(logical_region_id, request)
@@ -530,7 +591,7 @@ mod tests {
             .unwrap();
         assert_eq!(response.affected_rows, 3);
 
-        let request = build_bulk_request(logical_region_id, build_logical_batch(3, 5));
+        let request = build_bulk_request(logical_region_id, build_logical_batch(3, 5), false);
         let response = env
             .metric()
             .handle_request(logical_region_id, request)
@@ -553,7 +614,7 @@ mod tests {
         env.init_metric_region().await;
         let logical_region_id = env.default_logical_region_id();
 
-        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 4));
+        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 4), false);
         let response = env
             .metric()
             .handle_request(logical_region_id, request)
@@ -575,7 +636,7 @@ mod tests {
         let env = TestEnv::new().await;
         let logical_region_id = init_dense_metric_region(&env).await;
 
-        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 2));
+        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 2), false);
         let err = env
             .metric()
             .handle_request(logical_region_id, request)
@@ -617,7 +678,7 @@ mod tests {
 
         let env_bulk = TestEnv::new().await;
         env_bulk.init_metric_region().await;
-        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 5));
+        let request = build_bulk_request(logical_region_id, build_logical_batch(0, 5), false);
         env_bulk
             .metric()
             .handle_request(logical_region_id, request)

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -3003,6 +3003,7 @@ fn build_schema_v0_bulk_request(region_id: RegionId) -> RegionBulkInsertsRequest
     let raw_data = encode_arrow_ipc(&payload);
 
     RegionBulkInsertsRequest {
+        skip_wal: false,
         region_id,
         payload,
         raw_data,

--- a/src/mito2/src/engine/edit_region_test.rs
+++ b/src/mito2/src/engine/edit_region_test.rs
@@ -700,6 +700,7 @@ fn build_bulk_insert_request(
     let (schema, record_batch) = encode_to_flight_data(payload.clone());
 
     RegionBulkInsertsRequest {
+        skip_wal: false,
         region_id,
         payload,
         raw_data: ArrowIpc {

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -2387,6 +2387,7 @@ fn build_bulk_insert_request(
     let (schema, record_batch) = encode_to_flight_data(payload.clone());
 
     RegionBulkInsertsRequest {
+        skip_wal: false,
         region_id,
         payload,
         raw_data: ArrowIpc {
@@ -2396,6 +2397,139 @@ fn build_bulk_insert_request(
         },
         partition_expr_version: None,
         aligned_schema_version: None,
+    }
+}
+
+#[tokio::test]
+async fn test_bulk_skip_wal_recovery() {
+    check_bulk_skip_wal_recovery(false, false).await;
+    check_bulk_skip_wal_recovery(false, true).await;
+    check_bulk_skip_wal_recovery(true, false).await;
+    check_bulk_skip_wal_recovery(true, true).await;
+}
+
+async fn check_bulk_skip_wal_recovery(skip_wal: bool, flush: bool) {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("memtable.type", "bulk")
+        .build();
+    let table_dir = request.table_dir.clone();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    let mut request = build_bulk_insert_request(region_id, 0, 4);
+    request.skip_wal = skip_wal;
+    let affected = engine
+        .handle_request(region_id, RegionRequest::BulkInserts(request))
+        .await
+        .unwrap();
+    assert_eq!(affected.affected_rows, 4);
+    let region = engine.get_region(region_id).unwrap();
+    let current = region.version_control.current();
+    assert_eq!(current.committed_sequence, 4);
+    assert_eq!(current.last_entry_id, u64::from(!skip_wal));
+    assert_eq!(current.version.flushed_entry_id, 0);
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        RecordBatches::try_collect(stream)
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum::<usize>(),
+        4
+    );
+    if flush {
+        test_util::flush_region(&engine, region_id, None).await;
+        let current = region.version_control.current();
+        assert_eq!(current.last_entry_id, u64::from(!skip_wal));
+        assert_eq!(current.version.flushed_sequence, 4);
+        assert_eq!(
+            engine
+                .region_statistic(region_id)
+                .unwrap()
+                .manifest
+                .data_flushed_entry_id(),
+            u64::from(!skip_wal)
+        );
+    }
+    reopen_region(&engine, region_id, table_dir, false, HashMap::new()).await;
+    let stream = engine
+        .scan_to_stream(region_id, ScanRequest::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        RecordBatches::try_collect(stream)
+            .await
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum::<usize>(),
+        if skip_wal && !flush { 0 } else { 4 }
+    );
+}
+
+#[tokio::test]
+async fn test_bulk_skip_wal_flush_watermarks() {
+    let mut env = TestEnv::new().await;
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(
+                CreateRequestBuilder::new()
+                    .insert_option("memtable.type", "bulk")
+                    .build(),
+            ),
+        )
+        .await
+        .unwrap();
+    // Establish a persisted baseline, skip one bulk write, then resume WAL.
+    for (round, skip_wal) in [false, true, false].into_iter().enumerate() {
+        let region = engine.get_region(region_id).unwrap();
+        let before = region.version_control.current();
+        let mut request = build_bulk_insert_request(region_id, round * 4, (round + 1) * 4);
+        request.skip_wal = skip_wal;
+        let affected = engine
+            .handle_request(region_id, RegionRequest::BulkInserts(request))
+            .await
+            .unwrap();
+        assert_eq!(affected.affected_rows, 4);
+        let expected_entry_id = before.last_entry_id + u64::from(!skip_wal);
+        let after = region.version_control.current();
+        assert_eq!(after.last_entry_id, expected_entry_id);
+        assert_eq!(after.committed_sequence, before.committed_sequence + 4);
+        assert_eq!(
+            after.version.flushed_sequence,
+            before.version.flushed_sequence
+        );
+        assert_eq!(
+            engine
+                .region_statistic(region_id)
+                .unwrap()
+                .manifest
+                .data_flushed_entry_id(),
+            before.version.flushed_entry_id
+        );
+        test_util::flush_region(&engine, region_id, None).await;
+        let after = region.version_control.current();
+        assert_eq!(after.last_entry_id, expected_entry_id);
+        assert_eq!(after.version.flushed_sequence, (round as u64 + 1) * 4);
+        assert_eq!(
+            engine
+                .region_statistic(region_id)
+                .unwrap()
+                .manifest
+                .data_flushed_entry_id(),
+            expected_entry_id
+        );
     }
 }
 

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -1728,6 +1728,7 @@ mod tests {
 
         (
             SenderBulkRequest {
+                skip_wal: false,
                 sender: OptionOutputTx::from(sender),
                 region_id,
                 request: converter.convert().unwrap(),

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -975,7 +975,8 @@ where
                 region_write_ctx.push_bulk(
                     OptionOutputTx::none(),
                     part,
-                    Some(bulk_sequence_from_wal)
+                    Some(bulk_sequence_from_wal),
+                    false
                 ),
                 RegionCorruptedSnafu {
                     region_id,

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -318,24 +318,26 @@ impl RegionWriteCtx {
         sender: OptionOutputTx,
         mut bulk: BulkPart,
         sequence: Option<SequenceNumber>,
+        skip_wal: bool,
     ) -> bool {
         if let Some(sequence) = sequence {
             self.next_sequence = sequence;
         }
         bulk.sequence = self.next_sequence;
-        let entry = match BulkWalEntry::try_from(&bulk) {
-            Ok(entry) => entry,
-            Err(e) => {
-                sender.send(Err(e));
-                return false;
-            }
-        };
+        if !skip_wal {
+            let entry = match BulkWalEntry::try_from(&bulk) {
+                Ok(entry) => entry,
+                Err(e) => {
+                    sender.send(Err(e));
+                    return false;
+                }
+            };
+            self.wal_entry.bulk_entries.push(entry);
+        }
 
         self.bulk_notifiers
             .push(WriteNotify::new(sender, bulk.num_rows()));
 
-        // Add bulk wal entry
-        self.wal_entry.bulk_entries.push(entry);
         self.next_sequence += bulk.num_rows() as u64;
         self.bulk_parts.push(bulk);
         true
@@ -555,11 +557,16 @@ mod tests {
     #[test]
     fn test_request_skip_wal_preserves_sequences_and_other_writes() {
         // Ablate only the request flag: the workload and sequence allocation stay identical.
-        check_request_skip_wal_preserves_sequences_and_other_writes(false);
-        check_request_skip_wal_preserves_sequences_and_other_writes(true);
+        check_request_skip_wal_preserves_sequences_and_other_writes(false, false);
+        check_request_skip_wal_preserves_sequences_and_other_writes(false, true);
+        check_request_skip_wal_preserves_sequences_and_other_writes(true, false);
+        check_request_skip_wal_preserves_sequences_and_other_writes(true, true);
     }
 
-    fn check_request_skip_wal_preserves_sequences_and_other_writes(skip_wal: bool) {
+    fn check_request_skip_wal_preserves_sequences_and_other_writes(
+        skip_wal: bool,
+        bulk_skip_wal: bool,
+    ) {
         let builder = VersionControlBuilder::new();
         let region_id = builder.region_id();
         let version_control = Arc::new(builder.build());
@@ -600,10 +607,13 @@ mod tests {
         {
             assert_eq!(mutation.rows.as_ref().unwrap().rows.len(), notify.num_rows);
         }
-        assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None));
+        assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None, bulk_skip_wal));
         assert!(!ctx.skip_wal());
         assert_eq!(ctx.next_sequence, 9);
-        assert_eq!(ctx.wal_entry.bulk_entries.len(), 1);
+        assert_eq!(
+            ctx.wal_entry.bulk_entries.len(),
+            usize::from(!bulk_skip_wal)
+        );
         assert_eq!(ctx.bulk_parts[0].sequence, 7);
         let sequences: Vec<_> = ctx.wal_entry.mutations.iter().map(|m| m.sequence).collect();
         assert_eq!(sequences, if skip_wal { vec![3, 6] } else { vec![1, 3, 6] });
@@ -710,7 +720,53 @@ mod tests {
     }
 
     #[test]
+    fn test_bulk_skip_wal_preserves_sequences() {
+        check_bulk_skip_wal_preserves_sequences(false);
+        check_bulk_skip_wal_preserves_sequences(true);
+    }
+
+    fn check_bulk_skip_wal_preserves_sequences(skip_wal: bool) {
+        let builder = VersionControlBuilder::new();
+        let region_id = builder.region_id();
+        let version_control = Arc::new(builder.build());
+        let mut ctx = RegionWriteCtx::new(
+            region_id,
+            &version_control,
+            Provider::raft_engine_provider(region_id.as_u64()),
+            None,
+        );
+        // Alternate policies in one context, retaining all parts for the memtable.
+        for skip in [skip_wal, false, skip_wal] {
+            assert!(ctx.push_bulk(OptionOutputTx::none(), new_bulk_part(), None, skip));
+        }
+        assert_eq!(ctx.next_sequence, 7);
+        assert_eq!(ctx.bulk_notifiers.len(), 3);
+        assert_eq!(
+            ctx.bulk_parts
+                .iter()
+                .map(|p| p.sequence)
+                .collect::<Vec<_>>(),
+            vec![1, 3, 5]
+        );
+        let encoded = crate::wal::encoder::WalEntryEncoder::new().encode_to_vec(&ctx.wal_entry);
+        let decoded = WalEntry::decode(encoded.as_slice()).unwrap();
+        assert_eq!(
+            decoded
+                .bulk_entries
+                .iter()
+                .map(|e| e.sequence)
+                .collect::<Vec<_>>(),
+            if skip_wal { vec![3] } else { vec![1, 3, 5] }
+        );
+    }
+
+    #[test]
     fn test_set_error_marks_bulk_notifiers_failed() {
+        check_set_error_marks_bulk_notifiers_failed(false);
+        check_set_error_marks_bulk_notifiers_failed(true);
+    }
+
+    fn check_set_error_marks_bulk_notifiers_failed(skip_wal: bool) {
         let builder = VersionControlBuilder::new();
         let region_id = builder.region_id();
         let version_control = Arc::new(builder.build());
@@ -718,7 +774,9 @@ mod tests {
             RegionWriteCtx::new(region_id, &version_control, Provider::noop_provider(), None);
         let (tx, rx) = oneshot::channel();
 
-        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(), None));
+        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(), None, skip_wal));
+        assert_eq!(ctx.wal_entry.bulk_entries.len(), usize::from(!skip_wal));
+        assert_eq!(ctx.bulk_parts.len(), 1);
         ctx.set_error(Arc::new(
             UnexpectedSnafu {
                 reason: "wal failed".to_string(),

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -560,6 +560,7 @@ pub(crate) struct SenderWriteRequest {
 }
 
 pub(crate) struct SenderBulkRequest {
+    pub(crate) skip_wal: bool,
     pub(crate) sender: OptionOutputTx,
     pub(crate) region_id: RegionId,
     pub(crate) request: BulkPart,

--- a/src/mito2/src/worker/handle_bulk_insert.rs
+++ b/src/mito2/src/worker/handle_bulk_insert.rs
@@ -96,6 +96,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             None
         };
         pending_bulk_request.push(SenderBulkRequest {
+            skip_wal: request.skip_wal,
             sender,
             request: part,
             region_id: request.region_id,

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -561,7 +561,7 @@ impl<S> RegionWorkerLoop<S> {
             }
 
             // Collect requests by region.
-            if !region_ctx.push_bulk(bulk_req.sender, bulk_req.request, None) {
+            if !region_ctx.push_bulk(bulk_req.sender, bulk_req.request, None, bulk_req.skip_wal) {
                 return;
             }
         }
@@ -926,17 +926,32 @@ mod tests {
     async fn test_request_skip_wal_does_not_append_empty_batch() {
         // Only change the request flag. A failing log store demonstrates that
         // the all-skipped path never invokes append_batch, including empty appends.
-        check_request_skip_wal_does_not_append_empty_batch(false).await;
-        check_request_skip_wal_does_not_append_empty_batch(true).await;
+        check_request_skip_wal_does_not_append_empty_batch(false, false).await;
+        check_request_skip_wal_does_not_append_empty_batch(false, true).await;
+        check_request_skip_wal_does_not_append_empty_batch(true, false).await;
+        check_request_skip_wal_does_not_append_empty_batch(true, true).await;
     }
 
-    async fn check_request_skip_wal_does_not_append_empty_batch(skip_wal: bool) {
+    async fn check_request_skip_wal_does_not_append_empty_batch(skip_wal: bool, bulk: bool) {
         let region_id = RegionId::new(1, 1);
         let wal = Wal::new(Arc::new(MockLogStore {
             fail_append: true,
             ..Default::default()
         }));
-        let (ctx, rx) = new_region_ctx(region_id, skip_wal);
+        let (ctx, rx) = if bulk {
+            let version_control = Arc::new(VersionControlBuilder::new().build());
+            let mut ctx = RegionWriteCtx::new(
+                region_id,
+                &version_control,
+                Provider::raft_engine_provider(region_id.as_u64()),
+                None,
+            );
+            let (tx, rx) = oneshot::channel();
+            assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(1), None, skip_wal));
+            (ctx, rx)
+        } else {
+            new_region_ctx(region_id, skip_wal)
+        };
         let version_control = ctx.version_control().clone();
         let mut contexts = HashMap::from([(region_id, ctx)]);
         assert_eq!(write_wal(&wal, &mut contexts).await, skip_wal);
@@ -944,6 +959,7 @@ mod tests {
             let ctx = contexts.get_mut(&region_id).unwrap();
             assert_eq!(ctx.next_entry_id(), 1);
             ctx.write_memtable().await;
+            ctx.write_bulk().await;
             ctx.publish_sequence_and_entry_id();
             assert_eq!(version_control.committed_sequence(), 1);
             assert_eq!(version_control.current().last_entry_id, 0);
@@ -1003,6 +1019,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_write_sequence_not_committed_before_install_worker_level() {
+        check_bulk_write_sequence_not_committed_before_install_worker_level(false).await;
+        check_bulk_write_sequence_not_committed_before_install_worker_level(true).await;
+    }
+
+    async fn check_bulk_write_sequence_not_committed_before_install_worker_level(skip_wal: bool) {
         let region_id = RegionId::new(1, 1);
         let version_control = Arc::new(VersionControlBuilder::new().build());
 
@@ -1014,7 +1035,7 @@ mod tests {
             None,
         );
         let (tx, rx) = oneshot::channel();
-        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(3), None));
+        assert!(ctx.push_bulk(OptionOutputTx::from(tx), new_bulk_part(3), None, skip_wal));
         region_ctxs.insert(region_id, ctx);
 
         let wal = Wal::new(Arc::new(MockLogStore::default()));

--- a/src/operator/src/bulk_insert.rs
+++ b/src/operator/src/bulk_insert.rs
@@ -44,6 +44,7 @@ impl Inserter {
         raw_flight_data: FlightData,
         record_batch: RecordBatch,
         schema_bytes: Bytes,
+        skip_wal: bool,
     ) -> error::Result<AffectedRows> {
         let table_info = table.table_info();
         let table_id = table_info.table_id();
@@ -103,6 +104,7 @@ impl Inserter {
                     ..Default::default()
                 }),
                 body: Some(region_request::Body::BulkInsert(BulkInsertRequest {
+                    skip_wal,
                     region_id: region_id.as_u64(),
                     partition_expr_version: partition_expr_version
                         .map(|value| PartitionExprVersion { value }),
@@ -218,6 +220,7 @@ impl Inserter {
                                 ..Default::default()
                             }),
                             body: Some(region_request::Body::BulkInsert(BulkInsertRequest {
+                                skip_wal,
                                 region_id: region_id.as_u64(),
                                 partition_expr_version: partition_expr_version
                                     .map(|value| PartitionExprVersion { value }),

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -223,6 +223,7 @@ struct BatchKey {
     catalog: String,
     schema: String,
     physical_table: String,
+    skip_wal: bool,
 }
 
 /// An aligned logical record batch and its timestamp column index.
@@ -327,8 +328,7 @@ enum WorkerCommand {
     Ack { ack_tx: oneshot::Sender<()> },
 }
 
-// Batch key is derived from QueryContext; it assumes catalog/schema/physical_table fully
-// define the write target and must remain consistent across the batch.
+// Requests can share a batch only when their write target and WAL policy match.
 fn batch_key_from_ctx(ctx: &QueryContextRef) -> BatchKey {
     let physical_table = ctx
         .extension(PHYSICAL_TABLE_KEY)
@@ -338,6 +338,7 @@ fn batch_key_from_ctx(ctx: &QueryContextRef) -> BatchKey {
         catalog: ctx.current_catalog().to_string(),
         schema: ctx.current_schema(),
         physical_table,
+        skip_wal: ctx.skip_wal(),
     }
 }
 
@@ -1617,7 +1618,7 @@ pub async fn flush_batch_physical(
     )?;
 
     let resolved_batches = resolve_region_targets(planned_batches, partition_manager).await?;
-    let region_writes = encode_region_write_requests(resolved_batches)?;
+    let region_writes = encode_region_write_requests(resolved_batches, ctx.skip_wal())?;
     flush_region_writes_concurrently(node_manager, region_writes).await
 }
 
@@ -1794,6 +1795,7 @@ async fn resolve_region_targets(
 
 fn encode_region_write_requests(
     resolved_batches: Vec<ResolvedRegionBatch>,
+    skip_wal: bool,
 ) -> Result<Vec<FlushRegionWrite>> {
     let mut region_writes = Vec::with_capacity(resolved_batches.len());
     for resolved in resolved_batches {
@@ -1811,6 +1813,7 @@ fn encode_region_write_requests(
                 ..Default::default()
             }),
             body: Some(region_request::Body::BulkInsert(BulkInsertRequest {
+                skip_wal,
                 region_id: region_id.as_u64(),
                 partition_expr_version: None,
                 // Set aligned_schema_version to None so that datanode will check the batch schema again to see if any
@@ -1929,12 +1932,13 @@ mod tests {
         PendingRowsBatcher, PendingWorker, PhysicalFlushCatalogProvider,
         PhysicalFlushNodeRequester, PhysicalFlushPartitionProvider, PhysicalTableMetadata,
         PlannedRegionBatch, RecordBatchWithTsIdx, ResolvedRegionBatch, TableBatch, WorkerCommand,
-        columns_taxonomy, drain_batch, encode_region_write_requests, extract_timestamps,
-        flush_batch, flush_batch_physical, flush_region_writes_concurrently, greptime_timestamp,
-        notify_flow_dirty_windows_after_flush, plan_region_batches, remove_worker_if_same_channel,
-        should_close_worker_on_idle_timeout, should_dispatch_concurrently,
-        start_flow_notification_worker, start_worker, strip_partition_columns_from_batch,
-        transform_logical_batches_to_physical, try_enqueue_flow_notification,
+        batch_key_from_ctx, columns_taxonomy, drain_batch, encode_region_write_requests,
+        extract_timestamps, flush_batch, flush_batch_physical, flush_region_writes_concurrently,
+        greptime_timestamp, notify_flow_dirty_windows_after_flush, plan_region_batches,
+        remove_worker_if_same_channel, should_close_worker_on_idle_timeout,
+        should_dispatch_concurrently, start_flow_notification_worker, start_worker,
+        strip_partition_columns_from_batch, transform_logical_batches_to_physical,
+        try_enqueue_flow_notification,
     };
     use crate::error;
     use crate::metrics::FLOW_NOTIFICATION_DROPPED;
@@ -2902,12 +2906,38 @@ mod tests {
     }
 
     #[test]
+    fn test_batch_key_groups_by_skip_wal() {
+        let wal_ctx = session::context::QueryContext::arc();
+        let skip_wal_ctx = session::context::QueryContext::arc();
+        skip_wal_ctx.set_skip_wal(true);
+        let another_skip_wal_ctx = session::context::QueryContext::arc();
+        another_skip_wal_ctx.set_skip_wal(true);
+
+        let mut batches = HashMap::new();
+        *batches.entry(batch_key_from_ctx(&wal_ctx)).or_insert(0) += 1;
+        *batches
+            .entry(batch_key_from_ctx(&skip_wal_ctx))
+            .or_insert(0) += 1;
+        *batches
+            .entry(batch_key_from_ctx(&another_skip_wal_ctx))
+            .or_insert(0) += 1;
+        *batches
+            .entry(batch_key_from_ctx(&session::context::QueryContext::arc()))
+            .or_insert(0) += 1;
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[&batch_key_from_ctx(&wal_ctx)], 2);
+        assert_eq!(batches[&batch_key_from_ctx(&skip_wal_ctx)], 2);
+    }
+
+    #[test]
     fn test_remove_worker_if_same_channel_removes_matching_entry() {
         let workers = DashMap::new();
         let key = BatchKey {
             catalog: "greptime".to_string(),
             schema: "public".to_string(),
             physical_table: "phy".to_string(),
+            skip_wal: false,
         };
 
         let (tx, _rx) = mpsc::channel::<WorkerCommand>(1);
@@ -2924,6 +2954,7 @@ mod tests {
             catalog: "greptime".to_string(),
             schema: "public".to_string(),
             physical_table: "phy".to_string(),
+            skip_wal: false,
         };
 
         let (stale_tx, _stale_rx) = mpsc::channel::<WorkerCommand>(1);
@@ -3015,6 +3046,7 @@ mod tests {
             catalog: "greptime".to_string(),
             schema: "public".to_string(),
             physical_table: "phy".to_string(),
+            skip_wal: false,
         };
         let workers = Arc::new(DashMap::new());
         let (worker_tx, worker_rx) = mpsc::channel(1);
@@ -3745,6 +3777,11 @@ mod tests {
 
     #[test]
     fn test_encode_region_write_requests_builds_bulk_insert_requests() {
+        check_encode_region_write_requests(false);
+        check_encode_region_write_requests(true);
+    }
+
+    fn check_encode_region_write_requests(skip_wal: bool) {
         let planned_batch = PlannedRegionBatch {
             region_id: RegionId::new(1024, 1),
             batch: RecordBatch::try_new(
@@ -3772,7 +3809,7 @@ mod tests {
                 addr: "node-1".to_string(),
             },
         };
-        let writes = encode_region_write_requests(vec![resolved_batch]).unwrap();
+        let writes = encode_region_write_requests(vec![resolved_batch], skip_wal).unwrap();
 
         assert_eq!(1, writes.len());
         assert_eq!(1, writes[0].datanode.id);
@@ -3780,5 +3817,6 @@ mod tests {
             panic!("expected bulk insert request");
         };
         assert_eq!(RegionId::new(1024, 1).as_u64(), request.region_id);
+        assert_eq!(skip_wal, request.skip_wal);
     }
 }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -472,6 +472,7 @@ fn make_region_truncate(truncate: TruncateRequest) -> Result<Vec<(RegionId, Regi
 /// Convert [BulkInsertRequest] to [RegionRequest] and group by [RegionId].
 fn make_region_bulk_inserts(request: BulkInsertRequest) -> Result<Vec<(RegionId, RegionRequest)>> {
     let region_id = request.region_id.into();
+    let skip_wal = request.skip_wal;
     let partition_expr_version = request.partition_expr_version.map(|v| v.value);
     let aligned_schema_version = request.aligned_schema_version.map(|v| v.schema_version);
     let Some(Body::ArrowIpc(request)) = request.body else {
@@ -493,6 +494,7 @@ fn make_region_bulk_inserts(request: BulkInsertRequest) -> Result<Vec<(RegionId,
             region_id,
             payload,
             raw_data: request,
+            skip_wal,
             partition_expr_version,
             aligned_schema_version,
         }),
@@ -1755,6 +1757,8 @@ pub struct RegionCatchupRequest {
 
 #[derive(Debug, Clone)]
 pub struct RegionBulkInsertsRequest {
+    /// Whether this request should skip WAL.
+    pub skip_wal: bool,
     pub region_id: RegionId,
     pub payload: DfRecordBatch,
     pub raw_data: ArrowIpc,

--- a/tests-integration/src/grpc/flight.rs
+++ b/tests-integration/src/grpc/flight.rs
@@ -49,6 +49,7 @@ mod test {
     use futures_util::{Stream, StreamExt};
     use hyper_util::rt::TokioIo;
     use itertools::Itertools;
+    use rstest::rstest;
     use servers::grpc::builder::GrpcServerBuilder;
     use servers::grpc::flight::{
         FlightCraft, FlightCraftWrapper, FlightRecordBatchSource, FlightRecordBatchStream,
@@ -59,6 +60,7 @@ mod test {
     use servers::query_handler::grpc::GrpcQueryHandler;
     use servers::server::Server;
     use session::context::QueryContextRef;
+    use session::hints::INSERT_SKIP_WAL_HINT;
     use tokio::net::TcpListener;
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::transport::Server as TonicServer;
@@ -67,7 +69,7 @@ mod test {
 
     use crate::cluster::GreptimeDbClusterBuilder;
     use crate::grpc::query_and_expect;
-    use crate::test_util::{StorageType, setup_grpc_server};
+    use crate::test_util::{MockInstanceImpl, StorageType, assert_wal_delta, setup_grpc_server};
     use crate::tests::test_util::MockInstance;
 
     struct SlowFlightCraft;
@@ -399,6 +401,68 @@ mod test {
         assert!(start.elapsed() >= Duration::from_secs(1));
         assert!(matches!(output.data, OutputData::Stream(_)));
     }
+
+    #[rstest]
+    #[case::standalone_single_region(false, false)]
+    #[case::standalone_partitioned(false, true)]
+    #[case::distributed_single_region(true, false)]
+    #[case::distributed_partitioned(true, true)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_flight_bulk_skip_wal(#[case] distributed: bool, #[case] partitioned: bool) {
+        let mut db =
+            MockInstanceImpl::new(&format!("flight_bulk_skip_wal_{partitioned}"), distributed)
+                .await;
+        let runtime = common_runtime::global_runtime().clone();
+        let handler = GreptimeRequestHandler::new(
+            db.frontend(),
+            None,
+            Some(runtime.clone()),
+            FlightCompression::default(),
+        );
+        let mut server = GrpcServerBuilder::new(GrpcServerConfig::default(), runtime)
+            .flight_handler(Arc::new(handler))
+            .build();
+        server.start("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let client = Database::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            Client::with_urls(vec![server.bind_addr().unwrap().to_string()]),
+        );
+        let partition = if partitioned {
+            " PARTITION ON COLUMNS (a) (a < 0, a >= 0)"
+        } else {
+            ""
+        };
+        client.sql(&format!(
+            "CREATE TABLE foo (ts TIMESTAMP TIME INDEX, a INT NOT NULL, \"B\" STRING, PRIMARY KEY (a)){partition}"
+        )).await.unwrap();
+        let mut before = db.flush_and_snapshot_wal().await;
+        assert_eq!(before.len(), if partitioned { 2 } else { 1 });
+        // The same stream spans both partitions and includes multiple data messages.
+        // Repeated rows still exercise real writes; each round flushes before the next.
+        for hint in [None, Some("true"), Some("false"), None] {
+            let hints = hint.map(|value| [(INSERT_SKIP_WAL_HINT, value)]);
+            test_put_record_batches_with_hints(
+                &client,
+                create_record_batches(-4),
+                hints.as_ref().map_or(&[], |hints| hints.as_slice()),
+            )
+            .await;
+            let after = db.flush_and_snapshot_wal().await;
+            assert_wal_delta(&before, &after, hint == Some("true"));
+            // Both regions must receive rows, not merely exist in the catalog.
+            for (id, &(flushed_sequence, _)) in &after {
+                assert!(
+                    flushed_sequence > before[id].0,
+                    "region {id:?} received no rows"
+                );
+            }
+            before = after;
+        }
+        server.shutdown().await.unwrap();
+        db.shutdown().await;
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_standalone_flight_do_put() {
         common_telemetry::init_default_ut_logging();
@@ -735,6 +799,14 @@ mod test {
     }
 
     async fn test_put_record_batches(client: &Database, record_batches: Vec<RecordBatch>) {
+        test_put_record_batches_with_hints(client, record_batches, &[]).await;
+    }
+
+    async fn test_put_record_batches_with_hints(
+        client: &Database,
+        record_batches: Vec<RecordBatch>,
+        hints: &[(&str, &str)],
+    ) {
         let requests_count = record_batches.len();
         let schema = record_batches[0].schema.arrow_schema().clone();
 
@@ -767,7 +839,7 @@ mod test {
         )
         .boxed();
 
-        let response_stream = client.do_put(stream).await.unwrap();
+        let response_stream = client.do_put_with_hints(stream, hints).await.unwrap();
 
         let responses = response_stream.collect::<Vec<_>>().await;
         let responses_count = responses.len();

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -81,7 +81,7 @@ use store_api::storage::RegionId;
 use crate::cluster::{GreptimeDbCluster, GreptimeDbClusterBuilder};
 use crate::standalone::{GreptimeDbStandalone, GreptimeDbStandaloneBuilder};
 
-/// Maps `(node_id, region_id)` to `(written_bytes, flushed_entry_id)`.
+/// Maps `(node_id, region_id)` to `(flushed_sequence, flushed_entry_id)`.
 pub type WalSnapshot = BTreeMap<(u64, RegionId), (u64, u64)>;
 
 /// Flush user data regions before observing their persisted WAL watermarks.
@@ -101,7 +101,7 @@ async fn flush_and_snapshot_region_wal(engine: &MitoEngine) -> WalSnapshot {
         snapshot.insert(
             (0, id),
             (
-                statistic.written_bytes,
+                region.flushed_sequence(),
                 statistic.manifest.data_flushed_entry_id(),
             ),
         );
@@ -117,9 +117,9 @@ pub fn assert_wal_delta(before: &WalSnapshot, after: &WalSnapshot, skip_wal: boo
         "warm up table creation before taking the snapshot"
     );
     let mut written = 0;
-    for (id, &(written_bytes, flushed_entry_id)) in after {
-        let (previous_written_bytes, previous_flushed_entry_id) = before[id];
-        if written_bytes > previous_written_bytes {
+    for (id, &(flushed_sequence, flushed_entry_id)) in after {
+        let (previous_flushed_sequence, previous_flushed_entry_id) = before[id];
+        if flushed_sequence > previous_flushed_sequence {
             written += 1;
             if skip_wal {
                 assert_eq!(
@@ -843,11 +843,27 @@ async fn setup_test_prom_app_with_frontend_inner(
     let sql = "INSERT INTO mito(host, val, ts) VALUES (1, 1.1, 0)";
     run_sql(sql, &instance).await;
 
+    let http_server = build_test_prom_server(
+        instance.fe_instance().clone(),
+        enable_batcher,
+        experimental_enable_prometheus_native_histogram,
+    )
+    .with_greptime_config_options(instance.opts.datanode_options().to_toml().unwrap())
+    .build();
+    let app = http_server.build(http_server.make_app()).unwrap();
+    (app, instance.guard)
+}
+
+/// Builds Prometheus HTTP routes for either a standalone or distributed frontend.
+pub fn build_test_prom_server(
+    frontend_ref: Arc<Instance>,
+    enable_batcher: bool,
+    experimental_enable_prometheus_native_histogram: bool,
+) -> HttpServerBuilder {
     let http_opts = HttpOptions {
         addr: format!("127.0.0.1:{}", ports::get_port()),
         ..Default::default()
     };
-    let frontend_ref = instance.fe_instance().clone();
     // Mirror the production wiring at `frontend::server`: build the batcher from the
     // instance's managers. A short flush interval keeps the test responsive.
     let pending_rows_batcher = if enable_batcher {
@@ -868,9 +884,10 @@ async fn setup_test_prom_app_with_frontend_inner(
     } else {
         None
     };
-    let http_server = HttpServerBuilder::new(http_opts)
+    assert_eq!(pending_rows_batcher.is_some(), enable_batcher);
+    HttpServerBuilder::new(http_opts)
         .with_sql_handler(frontend_ref.clone())
-        .with_logs_handler(instance.fe_instance().clone())
+        .with_logs_handler(frontend_ref.clone())
         .with_prom_handler(
             frontend_ref.clone(),
             Some(frontend_ref.clone()),
@@ -880,10 +897,6 @@ async fn setup_test_prom_app_with_frontend_inner(
             pending_rows_batcher,
         )
         .with_prometheus_handler(frontend_ref)
-        .with_greptime_config_options(instance.opts.datanode_options().to_toml().unwrap())
-        .build();
-    let app = http_server.build(http_server.make_app()).unwrap();
-    (app, instance.guard)
 }
 
 pub async fn setup_grpc_server(

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -11328,7 +11328,7 @@ async fn check_http_skip_wal(name: &str, cases: &[HttpWalCase], distributed: boo
                 if let Some(expected_written_nodes) = case.expected_written_nodes {
                     let written_nodes = after
                         .iter()
-                        .filter(|(key, (written_bytes, _))| *written_bytes > before[*key].0)
+                        .filter(|(key, (flushed_sequence, _))| *flushed_sequence > before[*key].0)
                         .map(|((node_id, _), _)| *node_id)
                         .collect::<std::collections::BTreeSet<_>>();
                     assert_eq!(

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -80,7 +80,7 @@ use servers::request_memory_limiter::ServerMemoryLimiter;
 use standalone::options::StandaloneOptions;
 use table::table_name::TableName;
 use tests_integration::test_util::{
-    MockInstanceImpl, StorageType, assert_wal_delta, setup_test_http_app,
+    MockInstanceImpl, StorageType, assert_wal_delta, build_test_prom_server, setup_test_http_app,
     setup_test_http_app_with_frontend, setup_test_http_app_with_frontend_and_slow_query_threshold,
     setup_test_http_app_with_frontend_and_user_provider, setup_test_prom_app_with_frontend,
     setup_test_prom_app_with_frontend_batched, setup_test_prom_app_with_frontend_native_histogram,
@@ -3308,6 +3308,94 @@ pub async fn test_prometheus_remote_write_v2_native_histogram(store_type: Storag
     .await;
 
     guard.remove_all().await;
+}
+
+#[apply(both_deployment_cases)]
+async fn test_prometheus_remote_write_batched_skip_wal(distributed: bool) {
+    check_prometheus_remote_write_batched_skip_wal(distributed, false).await;
+}
+
+#[apply(both_deployment_cases)]
+async fn test_prometheus_remote_write_v2_batched_skip_wal(distributed: bool) {
+    check_prometheus_remote_write_batched_skip_wal(distributed, true).await;
+}
+
+async fn check_prometheus_remote_write_batched_skip_wal(distributed: bool, v2: bool) {
+    common_telemetry::init_default_ut_logging();
+    let mut instance =
+        MockInstanceImpl::new(&format!("prom_bulk_skip_wal_v2_{v2}"), distributed).await;
+    let server = build_test_prom_server(instance.frontend(), true, false).build();
+    let client = TestClient::new(server.build(server.make_app()).unwrap()).await;
+
+    write_prometheus_skip_wal_sample(&client, v2, 1000, None).await;
+    wait_for_data(&client, "SELECT count(*) FROM wal_prom_bulk", "[[1]]").await;
+    let mut before = instance.flush_and_snapshot_wal().await;
+    // Reuse the same batcher across policy transitions to detect leaked policy.
+    for (index, hint) in [None, Some("true"), Some("false"), None]
+        .into_iter()
+        .enumerate()
+    {
+        write_prometheus_skip_wal_sample(&client, v2, (index as i64 + 2) * 1000, hint).await;
+        wait_for_data(
+            &client,
+            "SELECT count(*) FROM wal_prom_bulk",
+            &format!("[[{}]]", index + 2),
+        )
+        .await;
+        let after = instance.flush_and_snapshot_wal().await;
+        assert_wal_delta(&before, &after, hint == Some("true"));
+        before = after;
+    }
+    instance.shutdown().await;
+}
+
+async fn write_prometheus_skip_wal_sample(
+    client: &TestClient,
+    v2: bool,
+    timestamp: i64,
+    hint: Option<&str>,
+) {
+    let payload = if v2 {
+        remote_write_v2::request_with_labels_and_samples(
+            vec![(prom_store::METRIC_NAME_LABEL, "wal_prom_bulk")],
+            vec![RemoteWriteV2Sample {
+                value: 1.0,
+                timestamp,
+                start_timestamp: 0,
+            }],
+        )
+        .encode_to_vec()
+    } else {
+        WriteRequest {
+            timeseries: vec![TimeSeries {
+                labels: vec![Label {
+                    name: prom_store::METRIC_NAME_LABEL.to_string(),
+                    value: "wal_prom_bulk".to_string(),
+                }],
+                samples: vec![Sample {
+                    value: 1.0,
+                    timestamp,
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .encode_to_vec()
+    };
+    let mut request = client
+        .post("/v1/prometheus/write")
+        .header("Content-Encoding", "snappy")
+        .body(prom_store::snappy_compress(&payload).unwrap());
+    if v2 {
+        request = request.header(
+            "Content-Type",
+            "application/x-protobuf;proto=io.prometheus.write.v2.Request",
+        );
+    }
+    if let Some(hint) = hint {
+        request = request.header("x-greptime-insert-skip-wal", hint);
+    }
+    assert_eq!(request.send().await.status(), StatusCode::NO_CONTENT);
 }
 
 /// Covers the batched (pending-rows-batcher) Prometheus remote write path, which


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #9088.
Depends on GreptimeTeam/greptime-proto#339.

## What's changed and what's your intention?

Extend request-level insert WAL skipping to bulk inserts, including Arrow Flight DoPut and batched Prometheus remote writes.

- Read the existing `insert_skip_wal` gRPC metadata hint for DoPut and apply it to the entire stream. Add `Database::do_put_with_hints()` while preserving the existing `do_put()` API.
- Forward the policy through `BulkInsertRequest.skip_wal` from frontend to datanode, including both single-region and partitioned writes.
- Include `skip_wal` in the pending-rows batch key so requests with different WAL policies cannot share a batch. Batched Prometheus writes use the existing `x-greptime-insert-skip-wal` HTTP header.
- Skip bulk WAL entry construction while retaining memtable writes, sequence assignment, and notifier handling. Region options remain unchanged, and Metric Engine metadata continues to use WAL.

The new protobuf field defaults to false when omitted. No persisted WAL or schema format changes are introduced.

Tests cover recovery, flush watermarks, mixed WAL policies, batch-key isolation, and Flight/Prometheus v1/v2 integration paths in standalone and distributed deployments. Shared test utilities verify actual writes through flushed sequence advancement and WAL behavior through flushed entry IDs.

Validation:
- Affected-crate nextest suite: 2405 passed, 1 skipped.
- Flight/Prometheus integration regression suite: 47 passed.
- Formatting and affected-package all-targets clippy passed.
- Ablation: dropping the bulk request policy caused all 8 new integration cases to fail in two runs; restoring it made all 8 pass in two runs.
- Full-workspace tests and cross-version compatibility tests were not run.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
