### PR TITLE
fix: backport v1.2.1 correctness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,7 +3742,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datafusion"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-schema 58.3.0",
@@ -3796,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3820,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3842,7 +3842,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "futures",
  "log",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-compression",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ipc 58.3.0",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4007,12 +4007,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 
 [[package]]
 name = "datafusion-execution"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4068,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "arrow-ord 58.3.0",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4256,7 +4256,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4279,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4293,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.3.0",
@@ -4358,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "chrono",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "datafusion-common",
@@ -4411,7 +4411,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -4424,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "arrow 58.3.0",
  "bigdecimal 0.4.8",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.1.0"
-source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a#a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a"
+source = "git+https://github.com/GreptimeTeam/datafusion.git?rev=bb531e754b3b36d7a4d3222f35ebc88204dafd2b#bb531e754b3b36d7a4d3222f35ebc88204dafd2b"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,21 +346,21 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "5618e779cf2bb4755b499c630fba4c35e91898cb"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
-datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "a281d9f0ea4b3fb2ec88bc3553d8dcef307e072a" }
+datafusion = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-datasource = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-functions = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-functions-aggregate-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-functions-window-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-optimizer = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-physical-expr = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-physical-expr-common = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-physical-plan = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-proto = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-sql = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
+datafusion-substrait = { git = "https://github.com/GreptimeTeam/datafusion.git", rev = "bb531e754b3b36d7a4d3222f35ebc88204dafd2b" }
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2aefa08a8d69c96eec2d6d6703598a009bba6e4c" }                           # on branch v0.61.x
 
 [profile.release]

--- a/src/cli/src/common/store.rs
+++ b/src/cli/src/common/store.rs
@@ -125,6 +125,14 @@ impl StoreConfig {
         }
     }
 
+    /// Sanitize store addrs for logging (redacts passwords in connection strings).
+    fn sanitize_store_addrs(&self) -> Vec<String> {
+        self.store_addrs
+            .iter()
+            .map(|addr| common_meta::kv_backend::util::sanitize_connection_string(addr))
+            .collect()
+    }
+
     /// Builds a [`KvBackendRef`] from the store configuration.
     pub async fn build(&self) -> Result<KvBackendRef, BoxedError> {
         let max_txn_ops = self.max_txn_ops;
@@ -134,7 +142,7 @@ impl StoreConfig {
         } else {
             common_telemetry::info!(
                 "Building kvbackend with store addrs: {:?}, backend: {:?}",
-                store_addrs,
+                &self.sanitize_store_addrs(),
                 self.backend
             );
             let kvbackend = match self.backend {

--- a/src/flow/src/batching_mode/frontend_client.rs
+++ b/src/flow/src/batching_mode/frontend_client.rs
@@ -183,13 +183,21 @@ impl DatabaseWithPeer {
     /// Try sending a "SELECT 1" to the database
     async fn try_select_one(&self) -> Result<(), Error> {
         // notice here use `sql` for `SELECT 1` return 1 row
-        let _ = self
+        let output = self
             .database
             .sql("SELECT 1")
             .await
             .with_context(|_| InvalidRequestSnafu {
                 context: format!("Failed to handle `SELECT 1` request at {:?}", self.peer),
             })?;
+
+        if let OutputData::Stream(stream) = output.data {
+            common_recordbatch::util::collect(stream)
+                .await
+                .map_err(BoxedError::new)
+                .context(ExternalSnafu)?;
+        }
+
         Ok(())
     }
 }
@@ -625,9 +633,11 @@ mod tests {
 
     use arrow_flight::flight_service_server::FlightServiceServer;
     use arrow_flight::{FlightData, Ticket};
+    use common_grpc::flight::FlightEncoder;
     use common_query::{Output, OutputData};
     use common_recordbatch::adapter::RecordBatchMetrics;
     use common_recordbatch::{OrderOption, RecordBatch, RecordBatchStream};
+    use datatypes::arrow::datatypes::Schema as ArrowSchema;
     use datatypes::prelude::{ConcreteDataType, VectorRef};
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::Int32Vector;
@@ -701,6 +711,14 @@ mod tests {
 
     #[derive(Debug)]
     struct SlowFlight;
+
+    struct DelayedEofFlight {
+        schema_sent: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[derive(Debug)]
+    struct LateStreamErrorFlight;
 
     struct WaitForConcurrentFlight {
         barrier: Arc<tokio::sync::Barrier>,
@@ -794,6 +812,45 @@ mod tests {
         ) -> std::result::Result<TonicResponse<TonicStream<FlightData>>, Status> {
             tokio::time::sleep(Duration::from_secs(60)).await;
             Err(Status::unavailable("slow response"))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl FlightCraft for DelayedEofFlight {
+        async fn do_get(
+            &self,
+            _request: TonicRequest<Ticket>,
+        ) -> std::result::Result<TonicResponse<TonicStream<FlightData>>, Status> {
+            let schema = FlightEncoder::default().encode_schema(&ArrowSchema::empty());
+            let schema_sent = self.schema_sent.lock().unwrap().take();
+            let schema_stream = futures::stream::once(async move {
+                if let Some(schema_sent) = schema_sent {
+                    let _ = schema_sent.send(());
+                }
+                Ok(schema)
+            });
+            let release = self.release.clone();
+            let delayed_eof = futures::stream::unfold(release, |release| async move {
+                release.notified().await;
+                None::<(std::result::Result<FlightData, Status>, _)>
+            });
+
+            Ok(TonicResponse::new(Box::pin(
+                schema_stream.chain(delayed_eof),
+            )))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl FlightCraft for LateStreamErrorFlight {
+        async fn do_get(
+            &self,
+            _request: TonicRequest<Ticket>,
+        ) -> std::result::Result<TonicResponse<TonicStream<FlightData>>, Status> {
+            let schema = FlightEncoder::default().encode_schema(&ArrowSchema::empty());
+            let stream =
+                futures::stream::iter([Ok(schema), Err(Status::unavailable("late stream error"))]);
+            Ok(TonicResponse::new(Box::pin(stream)))
         }
     }
 
@@ -981,6 +1038,71 @@ mod tests {
             .unwrap_err();
 
         assert!(format!("{err:?}").contains("Invalid value for flow.return_region_seq"));
+    }
+
+    #[tokio::test]
+    async fn test_try_select_one_waits_for_stream_eof() {
+        let (schema_sent, schema_sent_rx) = tokio::sync::oneshot::channel();
+        let release = Arc::new(tokio::sync::Notify::new());
+        let (addr, server) = start_flight_server(DelayedEofFlight {
+            schema_sent: Mutex::new(Some(schema_sent)),
+            release: release.clone(),
+        })
+        .await;
+        let database = Database::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            Client::with_urls([addr.as_str()]),
+        );
+        let db = DatabaseWithPeer::new(
+            database,
+            Peer {
+                id: 1,
+                addr: addr.clone(),
+            },
+        );
+        let mut probe = tokio::spawn(async move { db.try_select_one().await });
+
+        timeout(Duration::from_secs(1), schema_sent_rx)
+            .await
+            .expect("server should send the schema")
+            .expect("schema signal should be sent");
+        assert!(
+            timeout(Duration::from_millis(100), &mut probe)
+                .await
+                .is_err(),
+            "SELECT 1 must wait for the delayed stream tail and EOF"
+        );
+
+        release.notify_one();
+        timeout(Duration::from_secs(1), &mut probe)
+            .await
+            .expect("SELECT 1 should complete after EOF")
+            .expect("probe task should not panic")
+            .expect("SELECT 1 should succeed after EOF");
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_try_select_one_propagates_late_stream_error() {
+        let (addr, server) = start_flight_server(LateStreamErrorFlight).await;
+        let database = Database::new(
+            DEFAULT_CATALOG_NAME,
+            DEFAULT_SCHEMA_NAME,
+            Client::with_urls([addr.as_str()]),
+        );
+        let db = DatabaseWithPeer::new(
+            database,
+            Peer {
+                id: 1,
+                addr: addr.clone(),
+            },
+        );
+
+        let err = db.try_select_one().await.unwrap_err();
+        server.abort();
+
+        assert!(format!("{err:?}").contains("late stream error"));
     }
 
     #[tokio::test]

--- a/src/promql/benches/bench_range_fn.rs
+++ b/src/promql/benches/bench_range_fn.rs
@@ -26,9 +26,12 @@ use datatypes::arrow::datatypes::{DataType, Field};
 use promql::functions::{Delta, IDelta, Increase, PredictLinear, QuantileOverTime, Rate};
 use promql::range_array::RangeArray;
 
+/// A `window_step` below `window_size` makes consecutive windows overlap, which is the normal
+/// PromQL range query shape.
 fn build_sliding_ranges(
     num_points: usize,
     window_size: u32,
+    window_step: usize,
     values: Vec<f64>,
     eval_offset_ms: i64,
 ) -> (RangeArray, RangeArray, Arc<TimestampMillisecondArray>) {
@@ -44,10 +47,12 @@ fn build_sliding_ranges(
         0
     };
 
-    let ranges: Vec<(u32, u32)> = (0..num_windows).map(|i| (i as u32, window_size)).collect();
+    let offsets: Vec<usize> = (0..num_windows).step_by(window_step).collect();
+    let ranges: Vec<(u32, u32)> = offsets.iter().map(|&i| (i as u32, window_size)).collect();
 
-    let eval_ts: Vec<i64> = (0..num_windows)
-        .map(|i| timestamps[i + window_size as usize - 1] + eval_offset_ms)
+    let eval_ts: Vec<i64> = offsets
+        .iter()
+        .map(|&i| timestamps[i + window_size as usize - 1] + eval_offset_ms)
         .collect();
     let eval_ts_array = Arc::new(TimestampMillisecondArray::from(eval_ts));
 
@@ -94,11 +99,12 @@ fn build_default_values(num_points: usize) -> Vec<f64> {
 fn make_extrapolated_rate_input(
     num_points: usize,
     window_size: u32,
+    window_step: usize,
     values: Vec<f64>,
     eval_offset_ms: i64,
 ) -> Vec<ColumnarValue> {
     let (ts_range, val_range, eval_ts) =
-        build_sliding_ranges(num_points, window_size, values, eval_offset_ms);
+        build_sliding_ranges(num_points, window_size, window_step, values, eval_offset_ms);
     let range_length = window_size as i64 * 1000;
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
@@ -109,8 +115,13 @@ fn make_extrapolated_rate_input(
 }
 
 fn make_idelta_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> {
-    let (ts_range, val_range, _) =
-        build_sliding_ranges(num_points, window_size, build_default_values(num_points), 0);
+    let (ts_range, val_range, _) = build_sliding_ranges(
+        num_points,
+        window_size,
+        1,
+        build_default_values(num_points),
+        0,
+    );
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
@@ -118,8 +129,13 @@ fn make_idelta_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> 
 }
 
 fn make_quantile_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> {
-    let (ts_range, val_range, _) =
-        build_sliding_ranges(num_points, window_size, build_default_values(num_points), 0);
+    let (ts_range, val_range, _) = build_sliding_ranges(
+        num_points,
+        window_size,
+        1,
+        build_default_values(num_points),
+        0,
+    );
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
@@ -128,8 +144,13 @@ fn make_quantile_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue
 }
 
 fn make_predict_linear_input(num_points: usize, window_size: u32) -> Vec<ColumnarValue> {
-    let (ts_range, val_range, _) =
-        build_sliding_ranges(num_points, window_size, build_default_values(num_points), 0);
+    let (ts_range, val_range, _) = build_sliding_ranges(
+        num_points,
+        window_size,
+        1,
+        build_default_values(num_points),
+        0,
+    );
     vec![
         ColumnarValue::Array(Arc::new(ts_range.into_dict())),
         ColumnarValue::Array(Arc::new(val_range.into_dict())),
@@ -198,6 +219,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_monotonic_counter_values(n),
             500,
         ));
@@ -213,6 +235,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_resetting_counter_values(n),
             500,
         ));
@@ -229,6 +252,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_monotonic_counter_values(n),
             500,
         ));
@@ -244,6 +268,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_resetting_counter_values(n),
             500,
         ));
@@ -260,6 +285,7 @@ fn bench_range_functions(c: &mut Criterion) {
         let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
             n,
             w,
+            1,
             build_gauge_values(n),
             500,
         ));
@@ -352,4 +378,38 @@ fn bench_range_functions(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_range_functions);
+fn bench_rate_window_steps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rate_window_steps");
+    let rate_udf = Rate::scalar_udf();
+    let num_points = 20_280;
+    let window_size = 120u32;
+
+    // No resets, one reset per 24 window widths, and roughly three resets per window.
+    for reset_period in [0usize, 2_880, 37] {
+        let values: Vec<f64> = match reset_period {
+            0 => (0..num_points).map(|i| i as f64).collect(),
+            period => (0..num_points).map(|i| (i % period) as f64).collect(),
+        };
+        for window_step in [1usize, 10, 120] {
+            let prepared = PreparedUdfCall::new(make_extrapolated_rate_input(
+                num_points,
+                window_size,
+                window_step,
+                values.clone(),
+                500,
+            ));
+            group.bench_with_input(
+                BenchmarkId::new(
+                    "rate_counter",
+                    format!("reset{reset_period}_step{window_step}"),
+                ),
+                &(),
+                |b, _| b.iter(|| invoke_prepared(&rate_udf, &prepared)),
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_range_functions, bench_rate_window_steps);

--- a/src/promql/src/functions/extrapolate_rate.rs
+++ b/src/promql/src/functions/extrapolate_rate.rs
@@ -30,6 +30,7 @@
 //! Implementations of `rate`, `increase` and `delta` functions in PromQL.
 
 use std::fmt::Display;
+use std::ops::Range;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Float64Array, Float64Builder, TimestampMillisecondArray};
@@ -192,9 +193,24 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
         let range_length = self.range_length;
         let range_length_secs = range_length as f64 / 1000.0;
 
-        let mut counter_correction = 0.0;
-        let mut prev_offset = usize::MAX;
-        let mut prev_length = 0usize;
+        // Range windows normally overlap heavily, so scanning every one for resets costs far
+        // more than a single pass over the values. Index the reset positions once that is the
+        // cheaper side, and stop counting as soon as the requested pairs pass that budget,
+        // which heavy overlap does within the first few windows. A short lookback with a long
+        // step is the shape that never reaches it, and there the per-window scans do win.
+        let mut reset_index = if IS_COUNTER {
+            let budget = all_values.len().saturating_sub(1);
+            let mut scanned_pairs = 0usize;
+            keys.iter()
+                .any(|&key| {
+                    scanned_pairs =
+                        scanned_pairs.saturating_add(unpack(key).1.saturating_sub(1) as usize);
+                    scanned_pairs > budget
+                })
+                .then(|| CounterResetIndex::new(all_values))
+        } else {
+            None
+        };
 
         for index in 0..num_windows {
             let (raw_offset, raw_length) = unpack(keys[index]);
@@ -203,7 +219,6 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
 
             if length < 2 {
                 result_builder.append_null();
-                prev_offset = usize::MAX;
                 continue;
             }
 
@@ -211,32 +226,13 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
             let first_value = all_values[offset];
             let last_value = all_values[end - 1];
 
-            let result_value = if IS_COUNTER {
-                // Adjacent normalized windows usually slide forward by one sample. Reuse the
-                // previous window's accumulated reset correction and adjust only the dropped and
-                // newly added edges, falling back to a full scan when the layout changes.
-                if prev_offset != usize::MAX && offset == prev_offset + 1 && length == prev_length {
-                    if all_values[prev_offset + 1] < all_values[prev_offset] {
-                        counter_correction -= all_values[prev_offset];
-                    }
-                    if all_values[end - 1] < all_values[end - 2] {
-                        counter_correction += all_values[end - 2];
-                    }
-                } else {
-                    counter_correction = 0.0;
-                    for pair in all_values[offset..end].windows(2) {
-                        if pair[1] < pair[0] {
-                            counter_correction += pair[0];
-                        }
-                    }
-                }
-                last_value - first_value + counter_correction
-            } else {
-                last_value - first_value
-            };
-
-            prev_offset = offset;
-            prev_length = length;
+            let mut result_value = last_value - first_value;
+            if IS_COUNTER {
+                result_value = match &mut reset_index {
+                    Some(reset_index) => reset_index.add_resets(result_value, offset, end),
+                    None => add_counter_resets(result_value, &all_values[offset..end]),
+                };
+            }
 
             let first_ts = all_timestamps[offset];
             let last_ts = all_timestamps[end - 1];
@@ -283,6 +279,105 @@ impl<const IS_COUNTER: bool, const IS_RATE: bool> ExtrapolatedRate<IS_COUNTER, I
 
         let result = ColumnarValue::Array(Arc::new(result_builder.finish()));
         Ok(result)
+    }
+}
+
+/// Adds the value preceding every counter reset in `values` to `result`, in sample order.
+///
+/// Prometheus accumulates the resets into the running result rather than summing them on
+/// their own, and the two are not interchangeable in f64: a reset large enough to swallow a
+/// later one in an isolated sum still leaves it visible once the first difference is folded
+/// in first.
+fn add_counter_resets(result: f64, values: &[f64]) -> f64 {
+    values
+        .windows(2)
+        .filter(|pair| pair[1] < pair[0])
+        .fold(result, |result, pair| result + pair[0])
+}
+
+/// Positions of the counter resets in a value array, so that a window can accumulate the
+/// resets it contains instead of scanning all of its samples.
+struct CounterResetIndex<'a> {
+    values: &'a [f64],
+    /// Ascending indices `i` where `values[i] < values[i - 1]`.
+    positions: Vec<usize>,
+    /// Slice of `positions` covered by the last window.
+    active: Range<usize>,
+    /// That window, so the next one can tell whether it advanced.
+    previous: Range<usize>,
+    /// `positions[active.start]`: the reset a later `start` would drop. `usize::MAX` when the
+    /// active slice reaches the end of `positions`.
+    drops_at: usize,
+    /// `positions[active.end]`: the reset a later `end` would gain, saturated the same way.
+    gains_at: usize,
+}
+
+impl<'a> CounterResetIndex<'a> {
+    fn new(values: &'a [f64]) -> Self {
+        let positions: Vec<usize> = (1..values.len())
+            .filter(|&i| values[i] < values[i - 1])
+            .collect();
+        let first = positions.first().copied().unwrap_or(usize::MAX);
+        Self {
+            values,
+            positions,
+            active: 0..0,
+            previous: 0..0,
+            drops_at: first,
+            gains_at: first,
+        }
+    }
+
+    /// Same additions [`add_counter_resets`] performs over `values[start..end]`, in the same
+    /// order, reached through the index instead of by scanning the window.
+    #[inline]
+    fn add_resets(&mut self, result: f64, start: usize, end: usize) -> f64 {
+        // The active slice only stays put if the window advanced without reaching either of
+        // the resets that bound it.
+        if start < self.previous.start
+            || end < self.previous.end
+            || start >= self.drops_at
+            || end > self.gains_at
+        {
+            self.locate(start, end);
+        }
+        self.previous = start..end;
+
+        if self.active.start == self.active.end {
+            // A counter that has not reset inside this window, which is the normal case, would
+            // otherwise pay a range bounds check and an empty iterator for nothing.
+            return result;
+        }
+
+        let values = self.values;
+        self.positions[self.active.start..self.active.end]
+            .iter()
+            .fold(result, |result, &i| result + values[i - 1])
+    }
+
+    fn locate(&mut self, start: usize, end: usize) {
+        // Walk the bounds forward from the previous window and only search when they move
+        // back. On a series that resets often the searches cost more than the additions they
+        // locate, because they run deep and a window holds a handful of resets.
+        let (left, right) = if start < self.previous.start || end < self.previous.end {
+            (
+                self.positions.partition_point(|&i| i <= start),
+                self.positions.partition_point(|&i| i < end),
+            )
+        } else {
+            let mut left = self.active.start;
+            while left < self.positions.len() && self.positions[left] <= start {
+                left += 1;
+            }
+            let mut right = self.active.end.max(left);
+            while right < self.positions.len() && self.positions[right] < end {
+                right += 1;
+            }
+            (left, right)
+        };
+        self.active = left..right;
+        self.drops_at = self.positions.get(left).copied().unwrap_or(usize::MAX);
+        self.gains_at = self.positions.get(right).copied().unwrap_or(usize::MAX);
     }
 }
 
@@ -407,6 +502,109 @@ mod test {
             ColumnarValue::Array(Arc::new(value_range.into_dict())),
             ColumnarValue::Array(eval_ts),
         )
+    }
+
+    /// Evaluates `ranges` as one batch and asserts every window is bit-identical to evaluating
+    /// that window on its own, which always takes the direct per-window reduction.
+    fn assert_counter_windows_match_single(values: &[f64], ranges: &[(u32, u32)]) {
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter_values(
+            (0..values.len()).map(|i| i as i64 * 30_000 + (i % 5) as i64 * 1_000),
+        ));
+        let values = Arc::new(Float64Array::from(values.to_vec()));
+        let evaluate = |ranges: &[(u32, u32)]| {
+            let eval_ts = Arc::new(TimestampMillisecondArray::from_iter_values(
+                ranges.iter().map(|&(offset, length)| {
+                    timestamps.value((offset + length.saturating_sub(1)) as usize) + 5_000
+                }),
+            ));
+            let input = [
+                ColumnarValue::Array(Arc::new(
+                    RangeArray::from_ranges(timestamps.clone(), ranges.iter().copied())
+                        .unwrap()
+                        .into_dict(),
+                )),
+                ColumnarValue::Array(Arc::new(
+                    RangeArray::from_ranges(values.clone(), ranges.iter().copied())
+                        .unwrap()
+                        .into_dict(),
+                )),
+                ColumnarValue::Array(eval_ts),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(3_600_000))),
+            ];
+            extract_array(&Rate::new(3_600_000).calc(&input).unwrap())
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .iter()
+                .collect::<Vec<_>>()
+        };
+
+        for (range, batched) in ranges.iter().zip(evaluate(ranges)) {
+            let single = evaluate(std::slice::from_ref(range))[0];
+            match (batched, single) {
+                (None, None) => {}
+                (Some(batched), Some(single)) => assert!(
+                    batched.to_bits() == single.to_bits() || (batched.is_nan() && single.is_nan()),
+                    "range {range:?}: batched {batched} != single {single}"
+                ),
+                _ => panic!("range {range:?}: batched {batched:?} != single {single:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn counter_resets_accumulate_into_the_running_result() {
+        // Summed on their own, 1e16 and 1.0 round to 1e16, which then cancels against the
+        // first sample and reports no increase at all. Folding each reset into `last - first`
+        // as Prometheus does keeps the 1.0. Both paths detect the same two resets.
+        let ts_array = Arc::new(TimestampMillisecondArray::from_iter(
+            [1, 2, 3, 4].into_iter().map(Some),
+        ));
+        let values_array = Arc::new(Float64Array::from_iter([1e16, 1.0, 0.0, 1.0]));
+        let ranges = [(0, 4)];
+        let ts_range = RangeArray::from_ranges(ts_array, ranges).unwrap();
+        let value_range = RangeArray::from_ranges(values_array, ranges).unwrap();
+        let timestamps = Arc::new(TimestampMillisecondArray::from_iter([Some(4)])) as _;
+
+        extrapolated_rate_runner::<true, false>(
+            ts_range,
+            value_range,
+            timestamps,
+            vec![1.1666666666666667],
+        );
+    }
+
+    #[test]
+    fn counter_correction_survives_huge_and_infinite_resets() {
+        // Both series reset twice inside the first window and once inside the second, but the
+        // first reset is large enough to swallow the second one when they are summed together.
+        for values in [
+            vec![1e16, 1.0, 0.0, 1.0, 2.0],
+            vec![f64::INFINITY, 1.0, 0.0, 1.0, 2.0],
+        ] {
+            assert_counter_windows_match_single(&values, &[(0, 4), (1, 4)]);
+        }
+    }
+
+    #[test]
+    fn counter_correction_matches_single_window_on_irregular_layouts() {
+        let mut values: Vec<f64> = (0..512).map(|i| (i % 37) as f64 * 0.25).collect();
+        values[20] = f64::NAN;
+        values[70] = f64::INFINITY;
+        values[140] = f64::NEG_INFINITY;
+        values[220] = 1e300;
+        values[221] = 1e-200;
+
+        // A stride of one walks both bounds across the reset positions, which sit every 37
+        // samples: `start` reaches one when that reset has to leave the window, `end` when the
+        // next one has to stay out of it, both while the cached bounds are live.
+        let mut ranges: Vec<(u32, u32)> = (0..390).map(|i| (i, 120)).collect();
+        // Empty, too-short, backward and disjoint windows all break a forward-only slide.
+        ranges.extend([(400, 0), (400, 1), (2, 20), (450, 30), (0, 120)]);
+        ranges.extend((0..390).rev().step_by(10).map(|i| (i, 120)));
+
+        assert_counter_windows_match_single(&values, &ranges);
     }
 
     #[test]

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -166,6 +166,7 @@ serde_json.workspace = true
 session = { workspace = true, features = ["testing"] }
 table.workspace = true
 tempfile = "3.0.0"
+tokio = { workspace = true, features = ["test-util"] }
 tokio-postgres.workspace = true
 tokio-postgres-rustls = "0.14"
 

--- a/src/servers/src/pending_rows_batcher.rs
+++ b/src/servers/src/pending_rows_batcher.rs
@@ -291,7 +291,6 @@ struct TableResolutionPlan {
 
 struct PendingBatch {
     tables: HashMap<TableId, TableBatch>,
-    created_at: Instant,
     total_row_count: usize,
     db_string: String,
     ctx: QueryContextRef,
@@ -324,6 +323,8 @@ enum WorkerCommand {
         response_tx: oneshot::Sender<std::result::Result<(), Arc<Error>>>,
         _permit: OwnedSemaphorePermit,
     },
+    #[cfg(test)]
+    Ack { ack_tx: oneshot::Sender<()> },
 }
 
 // Batch key is derived from QueryContext; it assumes catalog/schema/physical_table fully
@@ -899,7 +900,6 @@ impl PendingBatch {
         let db_string = ctx.get_db_string();
         Self {
             tables: HashMap::new(),
-            created_at: Instant::now(),
             total_row_count: 0,
             db_string,
             ctx,
@@ -942,7 +942,8 @@ fn start_worker(
 ) {
     tokio::spawn(async move {
         let mut batch = None;
-        let mut interval = tokio::time::interval(flush_interval);
+        let flush_timer = tokio::time::sleep(flush_interval);
+        tokio::pin!(flush_timer);
         let mut shutdown_rx = shutdown.subscribe();
         let idle_deadline = tokio::time::Instant::now() + worker_idle_timeout;
         let idle_timer = tokio::time::sleep_until(idle_deadline);
@@ -955,6 +956,13 @@ fn start_worker(
                         Some(WorkerCommand::Submit { table_batches, total_rows, ctx, response_tx, _permit }) => {
                             idle_timer.as_mut().reset(tokio::time::Instant::now() + worker_idle_timeout);
 
+                            if batch.is_none() {
+                                // Anchor the flush deadline to this batch's first submission,
+                                // rather than to the worker's creation time.
+                                flush_timer
+                                    .as_mut()
+                                    .reset(tokio::time::Instant::now() + flush_interval);
+                            }
                             let pending_batch = batch.get_or_insert_with(||{
                                 PENDING_BATCHES.inc();
                                 PendingBatch::new(ctx)
@@ -993,6 +1001,10 @@ fn start_worker(
                             }
                             break;
                         }
+                        #[cfg(test)]
+                        Some(WorkerCommand::Ack { ack_tx }) => {
+                            let _ = ack_tx.send(());
+                        }
                     }
                 }
                 _ = &mut idle_timer => {
@@ -1014,19 +1026,16 @@ fn start_worker(
                     );
                     break;
                 }
-                _ = interval.tick() => {
-                    if batch
-                        .as_ref()
-                        .is_some_and(|batch| batch.created_at.elapsed() >= flush_interval)
-                        && let Some(flush) = drain_batch(&mut batch) {
-                            spawn_flush(
-                                flush,
-                                partition_manager.clone(),
-                                node_manager.clone(),
-                                catalog_manager.clone(),
-                                flow_notification_tx.clone(),
-                                flush_semaphore.clone(),
-                            ).await;
+                _ = &mut flush_timer, if batch.is_some() => {
+                    if let Some(flush) = drain_batch(&mut batch) {
+                        spawn_flush(
+                            flush,
+                            partition_manager.clone(),
+                            node_manager.clone(),
+                            catalog_manager.clone(),
+                            flow_notification_tx.clone(),
+                            flush_semaphore.clone(),
+                        ).await;
                     }
                 }
                 _ = shutdown_rx.recv() => {
@@ -1865,7 +1874,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use api::region::RegionResponse;
     use api::v1::flow::{DirtyWindowRequests, FlowRequest, FlowResponse};
@@ -1881,7 +1890,10 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use async_trait::async_trait;
     use catalog::error::Result as CatalogResult;
-    use common_meta::cache::{TableFlownodeSetCacheRef, new_table_flownode_set_cache};
+    use catalog::memory::MemoryCatalogManager;
+    use common_meta::cache::{
+        TableFlownodeSetCacheRef, new_table_flownode_set_cache, new_table_route_cache,
+    };
     use common_meta::error::Result as MetaResult;
     use common_meta::instruction::{CacheIdent, CreateFlow};
     use common_meta::kv_backend::memory::MemoryKvBackend;
@@ -1900,15 +1912,17 @@ mod tests {
     use dashmap::DashMap;
     use datatypes::schema::{ColumnSchema as DtColumnSchema, Schema as DtSchema};
     use moka::future::CacheBuilder;
+    use partition::cache::new_partition_info_cache;
     use partition::error::Result as PartitionResult;
+    use partition::manager::PartitionRuleManager;
     use partition::partition::{PartitionRule, PartitionRuleRef, RegionMask};
     use smallvec::SmallVec;
     use snafu::ResultExt;
     use store_api::storage::RegionId;
     use table::metadata::TableId;
     use table::test_util::table_info::test_table_info;
-    use tokio::sync::{Notify, Semaphore, mpsc, oneshot};
-    use tokio::time::sleep;
+    use tokio::sync::{Notify, Semaphore, broadcast, mpsc, oneshot};
+    use tokio::time::{advance, sleep};
 
     use super::{
         BatchKey, Error, FlushBatch, FlushRegionWrite, FlushWaiter, PendingBatch,
@@ -1919,7 +1933,7 @@ mod tests {
         flush_batch, flush_batch_physical, flush_region_writes_concurrently, greptime_timestamp,
         notify_flow_dirty_windows_after_flush, plan_region_batches, remove_worker_if_same_channel,
         should_close_worker_on_idle_timeout, should_dispatch_concurrently,
-        start_flow_notification_worker, strip_partition_columns_from_batch,
+        start_flow_notification_worker, start_worker, strip_partition_columns_from_batch,
         transform_logical_batches_to_physical, try_enqueue_flow_notification,
     };
     use crate::error;
@@ -2372,7 +2386,6 @@ mod tests {
                     row_count: 1,
                 },
             )]),
-            created_at: Instant::now(),
             total_row_count: 1,
             db_string: ctx.get_db_string(),
             ctx: ctx.clone(),
@@ -2932,6 +2945,169 @@ mod tests {
         assert!(should_close_worker_on_idle_timeout(0, 0));
         assert!(!should_close_worker_on_idle_timeout(1, 0));
         assert!(!should_close_worker_on_idle_timeout(0, 1));
+    }
+
+    const WORKER_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+    async fn submit_mock_worker_batch(
+        worker_tx: &mpsc::Sender<WorkerCommand>,
+        total_rows: usize,
+        timestamp: i64,
+    ) -> oneshot::Receiver<std::result::Result<(), Arc<Error>>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        let permit = Arc::new(Semaphore::new(1)).acquire_owned().await.unwrap();
+        worker_tx
+            .send(WorkerCommand::Submit {
+                table_batches: vec![(
+                    "cpu".to_string(),
+                    42,
+                    mock_aligned_tag_batch("tag1", "host-1", timestamp, 1.0),
+                )],
+                total_rows,
+                ctx: session::context::QueryContext::arc(),
+                response_tx,
+                _permit: permit,
+            })
+            .await
+            .unwrap();
+
+        // The channel is FIFO, so the ack proves the worker has dequeued and
+        // processed the submission (anchoring the flush deadline) before the
+        // caller advances virtual time.
+        let (ack_tx, ack_rx) = oneshot::channel();
+        worker_tx.send(WorkerCommand::Ack { ack_tx }).await.unwrap();
+        ack_rx
+            .await
+            .expect("worker exited before acking the submitted batch");
+
+        response_rx
+    }
+
+    async fn receive_mock_flush_result(
+        response_rx: oneshot::Receiver<std::result::Result<(), Arc<Error>>>,
+        context: &str,
+    ) -> std::result::Result<(), Arc<Error>> {
+        // Under paused time the timeout auto-advances the clock and fires
+        // deterministically if the flush never completes.
+        tokio::time::timeout(WORKER_TEST_TIMEOUT, response_rx)
+            .await
+            .unwrap_or_else(|_| panic!("{context}"))
+            .expect("flush result channel closed without a result")
+    }
+
+    fn assert_missing_physical_table(result: std::result::Result<(), Arc<Error>>) {
+        let err = result.expect_err("the empty catalog should make the flush fail");
+        assert!(
+            matches!(
+                err.as_ref(),
+                Error::Internal { err_msg }
+                    if err_msg.contains("not found during pending flush")
+            ),
+            "unexpected flush error: {err}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_worker_rearms_creation_relative_deadline_after_size_flush() {
+        let flush_interval = Duration::from_secs(10);
+        let worker_idle_timeout = Duration::from_secs(30);
+        let key = BatchKey {
+            catalog: "greptime".to_string(),
+            schema: "public".to_string(),
+            physical_table: "phy".to_string(),
+        };
+        let workers = Arc::new(DashMap::new());
+        let (worker_tx, worker_rx) = mpsc::channel(1);
+        workers.insert(
+            key.clone(),
+            PendingWorker {
+                tx: worker_tx.clone(),
+            },
+        );
+
+        let backend = Arc::new(MemoryKvBackend::default());
+        let table_route_cache = Arc::new(new_table_route_cache(
+            "pending-rows-flush-deadline-routes".to_string(),
+            CacheBuilder::new(1).build(),
+            backend.clone(),
+        ));
+        let partition_info_cache = Arc::new(new_partition_info_cache(
+            "pending-rows-flush-deadline-partitions".to_string(),
+            CacheBuilder::new(1).build(),
+            table_route_cache.clone(),
+        ));
+        let partition_manager = Arc::new(PartitionRuleManager::new(
+            backend,
+            table_route_cache,
+            partition_info_cache,
+        ));
+        let node_manager: NodeManagerRef = Arc::new(ConcurrentMockNodeManager {
+            datanodes: Arc::new(HashMap::new()),
+        });
+        let catalog_manager = MemoryCatalogManager::with_default_setup();
+        let (flow_notification_tx, _flow_notification_rx) = mpsc::channel(1);
+        let (shutdown, _) = broadcast::channel(1);
+
+        start_worker(
+            key.clone(),
+            worker_tx.clone(),
+            workers.clone(),
+            worker_rx,
+            shutdown.clone(),
+            partition_manager,
+            node_manager,
+            catalog_manager,
+            flow_notification_tx,
+            flush_interval,
+            worker_idle_timeout,
+            2,
+            Arc::new(Semaphore::new(1)),
+        );
+
+        // Start the worker, then size-flush a batch halfway to the first
+        // worker-aligned interval boundary. This arms the reusable timer and
+        // drains the batch before that deadline is reached.
+        tokio::task::yield_now().await;
+        advance(flush_interval / 2).await;
+        let size_flush_rx = submit_mock_worker_batch(&worker_tx, 2, 1000).await;
+        let size_flush_result =
+            receive_mock_flush_result(size_flush_rx, "row threshold did not flush the first batch")
+                .await;
+        assert_missing_physical_table(size_flush_result);
+
+        // Submit a low-volume batch before the first batch's old timer would
+        // expire. It must receive a fresh full interval.
+        advance(flush_interval / 5).await;
+        let mut timed_flush_rx = submit_mock_worker_batch(&worker_tx, 1, 2000).await;
+
+        advance(flush_interval - Duration::from_millis(1)).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert!(matches!(
+            timed_flush_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        advance(Duration::from_millis(1)).await;
+        let timed_flush_result = receive_mock_flush_result(
+            timed_flush_rx,
+            "batch was not flushed one interval after its creation",
+        )
+        .await;
+        assert_missing_physical_table(timed_flush_result);
+
+        let _ = shutdown.send(());
+        for _ in 0..10 {
+            if !workers.contains_key(&key) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !workers.contains_key(&key),
+            "worker did not exit after shutdown"
+        );
     }
 
     #[tokio::test]

--- a/tests/cases/standalone/common/aggregate/max_abs_regression.result
+++ b/tests/cases/standalone/common/aggregate/max_abs_regression.result
@@ -1,0 +1,131 @@
+-- Regression coverage for aggregate expressions with multiple MAX aggregates.
+CREATE DATABASE max_abs_regression;
+
+Affected Rows: 1
+
+USE max_abs_regression;
+
+Affected Rows: 0
+
+CREATE TABLE t (
+    ts TIMESTAMP TIME INDEX,
+    v INT,
+    PRIMARY KEY (v),
+) ENGINE = mito;
+
+Affected Rows: 0
+
+INSERT INTO t VALUES
+    ('2024-01-01 00:00:00', -11),
+    ('2024-01-01 00:01:00', 3),
+    ('2024-01-01 00:02:00', -7),
+    ('2024-01-01 00:03:00', 5);
+
+Affected Rows: 4
+
+-- Expression aggregate regression.
+SELECT MAX(ABS(v)), MAX(ts) FROM t;
+
++---------------+---------------------+
+| max(abs(t.v)) | max(t.ts)           |
++---------------+---------------------+
+| 11            | 2024-01-01T00:03:00 |
++---------------+---------------------+
+
+SELECT MAX(ts), MAX(ABS(v)) FROM t;
+
++---------------------+---------------+
+| max(t.ts)           | max(abs(t.v)) |
++---------------------+---------------+
+| 2024-01-01T00:03:00 | 11            |
++---------------------+---------------+
+
+-- Column-only multiple-MAX positive control.
+SELECT MAX(v), MAX(ts) FROM t;
+
++----------+---------------------+
+| max(t.v) | max(t.ts)           |
++----------+---------------------+
+| 5        | 2024-01-01T00:03:00 |
++----------+---------------------+
+
+-- A mixed expression/column MAX must not send an incomplete dynamic filter to DN SeqScans.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(ABS(v)), MAX(ts) FROM t;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_CooperativeExec metrics=REDACTED_|
+|_|_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[max(abs(t.v)), max(t.ts)] metrics=REDACTED_|
+|_|_|_CoalescePartitionsExec metrics=REDACTED_|
+|_|_|_AggregateExec: mode=Partial, gby=[], aggr=[max(abs(t.v)), max(t.ts)] metrics=REDACTED_|
+|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts", "v"], "flat_format":REDACTED, "metrics_per_partition": REDACTED metrics=REDACTED_|
+|_|_|_|
+|_|_| Total rows: REDACTED_|
++-+-+-+
+
+-- A column-only multiple-MAX query remains a dynamic-filter positive control.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(v), MAX(ts) FROM t;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_CooperativeExec metrics=REDACTED_|
+|_|_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_AggregateExec: mode=Final, gby=[], aggr=[max(t.v), max(t.ts)] metrics=REDACTED_|
+|_|_|_CoalescePartitionsExec metrics=REDACTED_|
+|_|_|_AggregateExec: mode=Partial, gby=[], aggr=[max(t.v), max(t.ts)] metrics=REDACTED_|
+|_|_|_SeqScan: region=REDACTED, {"partition_count":REDACTED, "projection": ["ts", "v"], "dyn_filters": ["DynamicFilter [ REDACTED ]"], "flat_format":REDACTED, "metrics_per_partition": REDACTED metrics=REDACTED_|
+|_|_|_|
+|_|_| Total rows: REDACTED_|
++-+-+-+
+
+DROP TABLE t;
+
+Affected Rows: 0
+
+USE public;
+
+Affected Rows: 0
+
+DROP DATABASE max_abs_regression;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/aggregate/max_abs_regression.sql
+++ b/tests/cases/standalone/common/aggregate/max_abs_regression.sql
@@ -1,0 +1,69 @@
+-- Regression coverage for aggregate expressions with multiple MAX aggregates.
+CREATE DATABASE max_abs_regression;
+
+USE max_abs_regression;
+
+CREATE TABLE t (
+    ts TIMESTAMP TIME INDEX,
+    v INT,
+    PRIMARY KEY (v),
+) ENGINE = mito;
+
+INSERT INTO t VALUES
+    ('2024-01-01 00:00:00', -11),
+    ('2024-01-01 00:01:00', 3),
+    ('2024-01-01 00:02:00', -7),
+    ('2024-01-01 00:03:00', 5);
+
+-- Expression aggregate regression.
+SELECT MAX(ABS(v)), MAX(ts) FROM t;
+SELECT MAX(ts), MAX(ABS(v)) FROM t;
+
+-- Column-only multiple-MAX positive control.
+SELECT MAX(v), MAX(ts) FROM t;
+
+-- A mixed expression/column MAX must not send an incomplete dynamic filter to DN SeqScans.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(ABS(v)), MAX(ts) FROM t;
+
+-- A column-only multiple-MAX query remains a dynamic-filter positive control.
+-- SQLNESS REPLACE ("metrics_per_partition":\s*.*metrics=) "metrics_per_partition": REDACTED metrics=
+-- SQLNESS REPLACE (metrics=\{.*\}) metrics=REDACTED
+-- SQLNESS REPLACE (metrics=\[[^\]]*\]) metrics=REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (=Hash.*) =REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE "(file_id|time_range_start|time_range_end)":"[^"]+" "$1":"REDACTED"
+-- SQLNESS REPLACE ("[a-z_]+":"[0-9\.]+(ns|us|µs|ms|s)") "DURATION": REDACTED
+-- SQLNESS REPLACE "(size|flat_format)":\s*(\d+|true|false) "$1":REDACTED
+-- SQLNESS REPLACE ,\s*filter=.*?metrics=  metrics=
+-- SQLNESS REPLACE Total\s+rows:\s+\d+ Total rows: REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+-- SQLNESS REPLACE "partition_count":\{(.*?)\} "partition_count":REDACTED
+-- SQLNESS REPLACE ,\s"dyn_filters":\s\["DynamicFilter\s\[[^"]*\]"\] , "dyn_filters": ["DynamicFilter [ REDACTED ]"]
+-- SQLNESS REPLACE metrics=REDACTED\s*\| metrics=REDACTED_|
+EXPLAIN ANALYZE VERBOSE SELECT MAX(v), MAX(ts) FROM t;
+
+DROP TABLE t;
+
+USE public;
+
+DROP DATABASE max_abs_regression;

--- a/tests/cases/standalone/common/promql/counter_reset_precision.result
+++ b/tests/cases/standalone/common/promql/counter_reset_precision.result
@@ -1,0 +1,43 @@
+CREATE TABLE counter_reset_precision (
+    ts TIMESTAMP TIME INDEX,
+    greptime_value DOUBLE,
+    series STRING PRIMARY KEY
+);
+
+Affected Rows: 0
+
+INSERT INTO counter_reset_precision VALUES
+    (0,      10000000000000000.0, 'a'),
+    (30000,  1.0,                 'a'),
+    (60000,  0.0,                 'a'),
+    (90000,  1.0,                 'a'),
+    (120000, 2.0,                 'a'),
+    (150000, 3.0,                 'a'),
+    (180000, 4.0,                 'a');
+
+Affected Rows: 7
+
+-- The counter resets twice, at 30s from 1e16 and at 60s from 1.0, and 1e16 + 1.0 is 1e16 in
+-- f64. Windows are two minutes wide and step by one sample, so every row here depends on the
+-- 1.0 reset surviving.
+--
+-- Summing the two corrections on their own drops the 1.0 and then cancels against the first
+-- sample, so the 90s window reports no increase. Carrying that sum into the next window and
+-- subtracting the 1e16 that left it reports half the increase, and the windows after that
+-- subtract a reset the sum never held, so the correction turns negative and stays there for
+-- the rest of the batch.
+TQL EVAL (90, 180, '30s') increase(counter_reset_precision[2m]);
+
++---------------------+---------------------------------------------------------+--------+
+| ts                  | prom_increase(ts_range,greptime_value,ts,Int64(120000)) | series |
++---------------------+---------------------------------------------------------+--------+
+| 1970-01-01T00:01:30 | 1.3333333333333333                                      | a      |
+| 1970-01-01T00:02:00 | 2.6666666666666665                                      | a      |
+| 1970-01-01T00:02:30 | 3.0                                                     | a      |
+| 1970-01-01T00:03:00 | 4.0                                                     | a      |
++---------------------+---------------------------------------------------------+--------+
+
+DROP TABLE counter_reset_precision;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/counter_reset_precision.sql
+++ b/tests/cases/standalone/common/promql/counter_reset_precision.sql
@@ -1,0 +1,27 @@
+CREATE TABLE counter_reset_precision (
+    ts TIMESTAMP TIME INDEX,
+    greptime_value DOUBLE,
+    series STRING PRIMARY KEY
+);
+
+INSERT INTO counter_reset_precision VALUES
+    (0,      10000000000000000.0, 'a'),
+    (30000,  1.0,                 'a'),
+    (60000,  0.0,                 'a'),
+    (90000,  1.0,                 'a'),
+    (120000, 2.0,                 'a'),
+    (150000, 3.0,                 'a'),
+    (180000, 4.0,                 'a');
+
+-- The counter resets twice, at 30s from 1e16 and at 60s from 1.0, and 1e16 + 1.0 is 1e16 in
+-- f64. Windows are two minutes wide and step by one sample, so every row here depends on the
+-- 1.0 reset surviving.
+--
+-- Summing the two corrections on their own drops the 1.0 and then cancels against the first
+-- sample, so the 90s window reports no increase. Carrying that sum into the next window and
+-- subtracting the 1e16 that left it reports half the increase, and the windows after that
+-- subtract a reset the sum never held, so the correction turns negative and stays there for
+-- the rest of the batch.
+TQL EVAL (90, 180, '30s') increase(counter_reset_precision[2m]);
+
+DROP TABLE counter_reset_precision;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Tracks #9111. Backports #9102, #9089, #9082, #8967, and #8802 to `release/v1.2`.

## What's changed and what's your intention?

Prepare the five selected correctness, availability, and credential-redaction fixes for v1.2.1:

- #9102: publish aggregate dynamic filters only when all aggregate arguments qualify, preventing incomplete mixed-expression MIN/MAX filtering while retaining eligible direct-column optimization. Advance the pinned DataFusion fork to `bb531e754b3b36d7a4d3222f35ebc88204dafd2b`.
- #9089: accumulate counter resets in sample order for PromQL `rate()` and `increase()`, eliminating incorrect floating-point correction reuse between windows.
- #9082: consume batching Flow's frontend `SELECT 1` probe through EOF and propagate late stream errors before accepting a peer.
- #8967: sanitize CLI metadata-store connection strings before logging them.
- #8802: anchor the pending Prometheus batch flush deadline to its first submission, rather than a worker-aligned periodic timer. Size-triggered flushes and shutdown handling are retained.

The commits retain the original merge-SHA attribution. Only the #9089 benchmark file needed conflict resolution: keep the release branch's existing benchmarks and add the upstream rate-window-step sweep without importing unrelated main-branch benchmark infrastructure. No existing regression tests were deleted.

The lockfile changes only the 34 DataFusion source revisions required by #9102. #8802 adds Tokio's test-util feature as a dev dependency. No other production dependencies, public configuration, wire formats, or persisted formats change. The known historical JSON2 metadata compatibility limitation is unchanged.

This PR deliberately excludes the version bump, #9103's allocator upgrade, and #9026's Kafka timeout changes. It is a backport review target, not authorization to merge or publish a release.

### Verification

On backport HEAD `1bc47e63f93c16e26b46ab8fc62e7ec03370cb2d`:

- `cargo fmt --all -- --check`: passed.
- `cargo metadata --no-deps --locked --format-version 1`: passed; separately verified the lockfile contains only the 34 required DataFusion source substitutions.
- `cargo check --locked -p query -p promql -p flow -p servers -p cli --all-targets --features servers/testing`: passed. The initial invocation without `servers/testing` could not compile the existing feature-gated servers integration-test helpers; no source change was made to bypass this.
- Independent static review of the exact backport diff passed; this is not runtime-test evidence.
- `cargo nextest run --locked -p query -p promql -p flow -p servers -p cli --features servers/testing --no-fail-fast`: **1732 passed, 11 skipped**.
- `cargo build --locked -p cmd --bin greptime -p sqlness-runner --bin sqlness-runner`: passed. Binary reports exact backport HEAD and `clean: true`; version remains 1.2.0 because the version bump is separate.
- Built `sqlness-runner bare --bins-dir <candidate-debug> -t 'max_abs_regression|counter_reset_precision|flow_basic|flow_flush' --preserve-state`: all four cases passed in standalone and distributed modes (8 executions). Expected-result hashes and the Git worktree remained unchanged.
- Real `greptime cli meta get key --backend memory-store` log checks passed for synthetic MySQL/PostgreSQL credentials and a plain etcd address. Passwords are replaced with `***`, endpoint information remains visible, and the original v1.2.0 binary exposes the same synthetic passwords. No backend connection or stored-data modification is needed for this check.
- `cargo clippy --locked -p query -p promql -p flow -p servers -p cli --all-targets --features servers/testing -- -D warnings`: passed.
- Built `sqlness-runner bare --bins-dir <candidate-debug> --enable-flat-format -t 'max_abs_regression|counter_reset_precision' --preserve-state`: both cases passed in standalone and distributed modes (4 additional executions), with the worktree unchanged.
- [Release-profile performance comparison](https://github.com/GreptimeTeam/greptimedb/actions/runs/34518845715) failed during candidate/helper compilation because the ECS runner ran out of disk space; benchmark execution was skipped, so no performance result is available. The comparison targeted exact v1.2.0 SHA `29b743ab95568a47884ef0e8c42d579f0b0222e9`, using the release branch's default `all` case set and automatic ECS cleanup.

Official v1.2.0 negative controls reproduced four incorrect `counter_reset_precision` result rows and raw synthetic credentials in the CLI store-construction log. The existing #9102-only negative controls also detect incomplete mixed-aggregate filtering. The combined-binary positive checks above now cover the selected behavior; earlier #9102-only candidate results are not substituted for combined validation.

`git diff --check` flags only the inherited terminal blank lines in the two upstream-identical generated SQLness result files; those files were not hand-edited. Local combined validation and the [initial remote CI run](https://github.com/GreptimeTeam/greptimedb/actions/runs/34518811445) passed. The [ready-for-review CI run](https://github.com/GreptimeTeam/greptimedb/actions/runs/34525024373) also passed, including recent-release compatibility, SQLness variants, fuzz tests, SDK tests, and export/import E2E. Coverage was skipped. The performance run failed with `No space left on device` before benchmarks; ECS teardown completed successfully. The [80 GiB retry](https://github.com/GreptimeTeam/greptimedb/actions/runs/34573734060) completed successfully: all five default cases reported `ok`, all configured thresholds passed, and the teardown log confirms instance deletion. Telemetry confirms a 79G filesystem. This comparison covers the five-fix HEAD `1bc47e63f93`, not #9118. No merge or release publication is authorized.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests. (Retains the upstream regressions; the CLI redaction fix reuses existing sanitizer coverage and needs release-binary log verification.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.


### 80 GiB performance retry results

Median query latency changes versus v1.2.0: seeded_random −4.82%, run_heavy +8.83%, mixed_every −14.47%, integer_counter −15.90%. All four measured selector cases passed the existing +75% median-latency regression threshold; the fifth case is a one-iteration direct-SST smoke check. These are single-run observations, not a claim that every query improves or that smaller regressions are excluded. The temporary ECS instance was deleted successfully.
