### PR TITLE
fix(ci): check Windows test targets before merge

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,6 +122,35 @@ jobs:
       - name: Run cargo check for riscv64
         run: cargo check --locked --workspace --all-targets --features servers/dashboard --target riscv64gc-unknown-linux-gnu
 
+  check-windows:
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+    name: Check Windows build
+    runs-on: windows-2022-8-cores
+    timeout-minutes: 60
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cyborg
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "check-windows"
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Run cargo check for Windows
+        run: cargo check --locked --workspace --all-targets --features servers/dashboard
+        env:
+          RUSTFLAGS: "-D warnings"
+
   conflict-check:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
     name: Check for conflict

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -147,7 +147,7 @@ jobs:
           cache-all-crates: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run cargo check for Windows
-        run: cargo check --locked --workspace --all-targets --features servers/dashboard
+        run: cargo check --locked --workspace --all-targets
         env:
           RUSTFLAGS: "-D warnings"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,7 +125,7 @@ jobs:
   check-windows:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
     name: Check Windows build
-    runs-on: windows-2022-8-cores
+    runs-on: windows-2022
     timeout-minutes: 60
     steps:
       - run: git config --global core.autocrlf false

--- a/src/common/telemetry/src/logging/file_retention.rs
+++ b/src/common/telemetry/src/logging/file_retention.rs
@@ -453,7 +453,9 @@ pub(crate) fn build_file_appender(
 
 #[cfg(test)]
 mod tests {
-    use std::fs::{self, File};
+    #[cfg(unix)]
+    use std::fs;
+    use std::fs::File;
     use std::io::Write;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
@@ -464,8 +466,11 @@ mod tests {
     use tempfile::TempDir;
 
     use super::FileIndex;
+    #[cfg(unix)]
     use crate::logging::LoggingOptions;
-    use crate::logging::file_retention::{DirectoryRetention, LogFileKind, build_file_appender};
+    #[cfg(unix)]
+    use crate::logging::file_retention::build_file_appender;
+    use crate::logging::file_retention::{DirectoryRetention, LogFileKind};
 
     fn write_file(path: &Path, contents: &[u8]) {
         let mut file = File::create(path).unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Related to #8997.

Failed nightly job: https://github.com/GreptimeTeam/greptimedb/actions/runs/34541148809/job/103083852995

## What's changed and what's your intention?

Fix Windows test compilation by gating three Unix-only imports in the log retention tests with `#[cfg(unix)]`. Their consumers were already Unix-only, leaving unused imports on Windows that failed compilation under `-D warnings`.

Add a Windows check job to Rust CI so pull requests and merge groups run `cargo check --locked --workspace --all-targets --features servers/dashboard` with `RUSTFLAGS="-D warnings"`. Checking all targets includes test code and catches this failure before merge. The job reuses the nightly Windows build prerequisites and has a separate cache, without installing nextest or WSL. Existing nightly tests remain unchanged.

No production behavior, API, or persisted data format changes.

Validation:
- All 40 common-telemetry tests passed on Linux.
- Test compilation with `-D warnings` passed on Linux.
- With Unix-only items temporarily disabled, the original source reproduced the exact three unused-import errors and the fixed source compiled successfully. This is not a native Windows build.
- Rust formatting, workflow YAML parsing and configuration assertions, and `git diff --check` passed.
- Native Windows validation and full workspace clippy, tests, and unused-dependency checks have not been run.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
