### PR TITLE
chore: bump tikv-jemalloc-sys patch to jemalloc dev (ff80bf2d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15192,7 +15192,7 @@ dependencies = [
 [[package]]
 name = "tikv-jemalloc-sys"
 version = "0.7.0+5.3.1-161-gff80bf2d0c8f162ea445533354cad8b7e5830f5c"
-source = "git+https://github.com/GreptimeTeam/jemallocator?rev=ff444d44ddc0084712f3db34977cf7c9f21f16fe#ff444d44ddc0084712f3db34977cf7c9f21f16fe"
+source = "git+https://github.com/GreptimeTeam/jemallocator?rev=e254a7eaf13a9ede04953ddefd173b5303018530#e254a7eaf13a9ede04953ddefd173b5303018530"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15191,8 +15191,8 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.7.0+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
-source = "git+https://github.com/GreptimeTeam/jemallocator?rev=e1846d8c12bbb65c39dcd224a86b24586478e264#e1846d8c12bbb65c39dcd224a86b24586478e264"
+version = "0.7.0+5.3.1-161-gff80bf2d0c8f162ea445533354cad8b7e5830f5c"
+source = "git+https://github.com/GreptimeTeam/jemallocator?rev=ff444d44ddc0084712f3db34977cf7c9f21f16fe#ff444d44ddc0084712f3db34977cf7c9f21f16fe"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2
 # enabling it"), fixing the TSD/tcache enable-before-init reentrancy
 # window. Remove once tikv/jemallocator ships a jemalloc snapshot that
 # includes the fix. See GreptimeTeam/jemalloc#1.
-tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "ff444d44ddc0084712f3db34977cf7c9f21f16fe" }
+tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "e254a7eaf13a9ede04953ddefd173b5303018530" }
 
 [profile.release]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "2
 # enabling it"), fixing the TSD/tcache enable-before-init reentrancy
 # window. Remove once tikv/jemallocator ships a jemalloc snapshot that
 # includes the fix. See GreptimeTeam/jemalloc#1.
-tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "e1846d8c12bbb65c39dcd224a86b24586478e264" }
+tikv-jemalloc-sys = { git = "https://github.com/GreptimeTeam/jemallocator", rev = "ff444d44ddc0084712f3db34977cf7c9f21f16fe" }
 
 [profile.release]
 debug = 1


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- GreptimeTeam/greptimedb#9103 — previous jemalloc patch (5.3.1 + 54f22c83 backport)
- GreptimeTeam/jemallocator branch \`bump-jemalloc-dev\` — the new patch source
- tikv/jemallocator#182 — upstream issue requesting this bump

## What's changed and what's your intention?

**Summary.** Update the \`[patch.crates-io]\` rev for \`tikv-jemalloc-sys\` from \`e1846d8c\` (5.3.1 + 54f22c83 backport) to \`ff444d4\` (upstream jemalloc dev HEAD, 161 commits ahead of 5.3.1).

**Why.** The 5.3.1 + backport approach only covered two fixes (\`a056c20d\` + \`54f22c83\`). The upstream dev branch includes additional TSD/tcache fixes that are directly relevant to the production incident:

- \`fb5499aa9c\` — Handle jemalloc calls after TSD teardown (may address stale \`cache_bin_array_descriptor\` entries in \`arena_stats_merge\`)
- \`61dc1da395\` — Fix possible tcache corruption on fiber migration
- \`1e92317014\` — Fix thread-exit TSD cleanup

Bumping to dev HEAD also eliminates the need for the GreptimeTeam/jemalloc fork, since the submodule now points directly to upstream jemalloc.

**How.**

- \`Cargo.toml\`: change \`rev\` from \`e1846d8c12bbb65c39dcd224a86b24586478e264\` to \`ff444d44ddc0084712f3db34977cf7c9f21f16fe\`
- \`Cargo.lock\`: regenerated via \`cargo update -p tikv-jemalloc-sys\`

The patched crate version is now \`0.7.0+5.3.1-161-gff80bf2d\`, reflecting the embedded jemalloc dev snapshot.

**Verification.**

- \`cargo check -p common-mem-prof -p servers -p cmd\` passes
- \`--with-version=5.3.1-161-gff80bf2d\` confirmed in build output
- Fix markers verified in the compiled jemalloc source (54f22c83 init-before-enable, fb5499aa9c TSD teardown)
- jemalloc unit tests on dev HEAD: \`test/unit/tsd\` 5/7 pass + 2/7 skip (new teardown tests), \`test/unit/tcache_init\` 6/6 pass

## PR Checklist

- [x] I have written the necessary rustdoc comments. (no new Rust APIs)
- [x] I have added the necessary unit tests and integration tests. (covered by jemalloc's own test suites)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the \`backport-<target>\` labels.