### PR TITLE
ci(backport): assign backport-failure issue to the original PR author

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -45,6 +45,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           AUTHOR: ${{ github.event.pull_request.merged_by.login }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
           git config user.name "github-actions[bot]"
@@ -76,6 +77,7 @@ jobs:
               git branch -D "${head_branch}"
               gh issue create \
                 --title "Backport failure: PR #${PR_NUMBER} to ${release_branch}" \
+                --assignee "${PR_AUTHOR}" \
                 --body "Cherry-pick of ${MERGE_COMMIT} (PR #${PR_NUMBER}) failed on ${release_branch}. Manual backport required." \
                 || true
               continue


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #9028, #9048 and #9073.

## What's changed and what's your intention?

When a backport cherry-pick conflicts and the workflow files an issue for a manual backport, the issue is now assigned to the author of the original PR:

- Adds a `PR_AUTHOR` env var from `github.event.pull_request.user.login` (the existing `AUTHOR` var is the *merger* — `merged_by` — and is still used for the "Merged by" line in backport PR bodies).
- `gh issue create` now passes `--assignee ${PR_AUTHOR}`, so the conflicted backport lands in the original author's queue.

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.