### PR TITLE
fix(ci): increase query regression ECS disk to 80 GiB

### DIFF
--- a/.github/runner-scale-sets/query-regression/README.md
+++ b/.github/runner-scale-sets/query-regression/README.md
@@ -51,10 +51,10 @@ Configuration lives in repository variables/secrets:
 | vars | `QUERY_REGRESSION_ECS_IMAGE_ID` | Custom image built by `ecs-image/build-ecs-image.py`. |
 | vars | `QUERY_REGRESSION_COMMENT_ALLOWLIST` | Comma/whitespace-separated GitHub logins allowed to comment `/query-regression` on a PR. Each login must also have repository `admin` permission. Empty denies all comment commands. |
 
-The system disk is 50 GiB, which covers the image, a 16 GiB swapfile, the
-checkout, and cold build caches (target dir, cargo registry, sccache). ENOSPC
-stops the runner itself from writing logs, which GitHub reports as `The
-operation was canceled` with no telemetry, indistinguishable from a
+The system disk is 80 GiB, providing capacity headroom for the image, a 16 GiB
+swapfile, the checkout, and cold build caches (target dir, cargo registry,
+sccache). ENOSPC stops the runner itself from writing logs, which GitHub reports
+as `The operation was canceled` with no telemetry, indistinguishable from a
 platform-side cancellation.
 cloud-init masks `systemd-oomd`, disables `unattended-upgrades` /
 `apt-daily-upgrade`, creates `/swapfile`, and sets `OOMPolicy=continue`
@@ -180,7 +180,7 @@ reintroduce those actions unless the image contract changes.
 Each run provisions its own ECS instance, so overlapping dispatches proceed
 in parallel. There is no workflow `concurrency` group. All Cargo state
 (`CARGO_HOME` including registry/git, `CARGO_TARGET_DIR`, sccache, cache
-metadata) lives on the 50 GiB system disk and is discarded with the VM.
+metadata) lives on the 80 GiB system disk and is discarded with the VM.
 `RUSTUP_HOME=/opt/rustup` and `/opt/cargo/bin` are image-owned. The runner
 sets `RUSTC_WRAPPER=/usr/local/bin/sccache`,
 `SCCACHE_DIR=/home/runner/.cache/sccache`, `SCCACHE_CACHE_SIZE=10G`, and
@@ -189,7 +189,7 @@ at 10G. Base and candidate builds share the target on that disk; Cargo
 fingerprints invalidate source and dependency changes.
 
 The workflow reports `du` / `df` in telemetry. It does not try to reclaim
-space across runs: a cold 50 GiB disk that fills up fails the build.
+space across runs: a cold 80 GiB disk that fills up fails the build.
 
 ## Future optional phases
 

--- a/.github/scripts/aliyun-ecs-runner-provision.py
+++ b/.github/scripts/aliyun-ecs-runner-provision.py
@@ -81,8 +81,8 @@ POLL_INTERVAL_SECONDS = 5
 SWAP_FILE = "/swapfile"
 SWAP_SIZE_GIB = 16
 # Image (~12G), 16G swap, checkout, base+candidate data homes, and cold
-# build caches. Deleted with the instance.
-SYSTEM_DISK_GIB = 50
+# build caches. 80 GiB provides capacity headroom. Deleted with the instance.
+SYSTEM_DISK_GIB = 80
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow-up to #8986. Unblocks performance qualification for #9112, tracked in #9111.

Failed run: https://github.com/GreptimeTeam/greptimedb/actions/runs/34518845715

## What's changed and what's your intention?

Increase the query-regression ephemeral ECS system disk from 50 GiB to 80 GiB and update its capacity documentation.

The v1.2.1 release-profile comparison already used #8986's 50 GiB setting. Its filesystem reached 100% usage while building the candidate binary and regression helpers, and the Actions runner reported `System.IO.IOException: No space left on device`. Benchmark execution was skipped; this was not a measured performance regression. The teardown job successfully deleted the instance.

This change provides additional headroom for the image, existing 16 GiB swapfile, checkout, base/candidate builds, and test data. It does not change the instance type, swap allocation, benchmark cases or thresholds, or teardown/TTL behavior. The additional disk is temporary and is deleted with each instance. It affects newly provisioned runners only; no running instance is resized.

This infrastructure change is kept separate from the five product backports in #9112. An 80 GiB retry will validate the actual capacity; the change is not a guarantee that every future workload fits.

### Verification

- `python3 tests/perf/test_aliyun_ecs_runner_scripts.py`: 7 tests passed.
- Mocked `run_instance` request construction: requests `cloud_essd` with size `80`, retaining one pay-as-you-go instance; no network calls.
- `git diff --check`: passed.

## PR Checklist

- [x] I have written the necessary rustdoc comments. (Python constant and existing capacity documentation updated; no Rust change.)
- [ ] I have added the necessary unit tests and integration tests. (No new committed tests; existing provisioning/teardown tests and a mocked request-construction check are used for this constant change.)
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`). (A separate, unmerged release-based operations branch will carry the capacity setting for the v1.2.1 performance retry.)
