### PR TITLE
fix(json2): avoid pruning JSON2 columns with wrong parquet stats

### DIFF
--- a/src/mito2/src/read/flat_projection.rs
+++ b/src/mito2/src/read/flat_projection.rs
@@ -40,7 +40,7 @@ use crate::error::{InvalidRequestSnafu, RecordBatchSnafu, Result};
 use crate::read::projection::{read_column_ids_from_projection, repeated_vector_with_cache};
 use crate::read::read_columns::{JsonTargetTypes, ReadColumns};
 use crate::sst::parquet::Json2RewriteTargets;
-use crate::sst::parquet::flat_format::sst_column_id_indices;
+use crate::sst::parquet::flat_format::sst_column_id_root_indices;
 use crate::sst::parquet::format::FormatProjection;
 use crate::sst::{
     FlatSchemaOptions, internal_fields, tag_maybe_to_dictionary_field, to_flat_sst_arrow_schema,
@@ -135,7 +135,7 @@ impl FlatProjectionMapper {
         }
 
         // Creates a map to lookup index.
-        let id_to_index = sst_column_id_indices(metadata);
+        let id_to_index = sst_column_id_root_indices(metadata);
 
         // TODO(yingwen): Support different flat schema options.
         let format_projection = FormatProjection::compute_format_projection(

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -560,7 +560,7 @@ struct ParquetFlat {
     arrow_schema: SchemaRef,
     /// Projection computed for the flat format.
     format_projection: FormatProjection,
-    /// Column id to index in SST.
+    /// Column id to logical root index in the SST schema.
     column_id_to_sst_index: HashMap<ColumnId, usize>,
 }
 
@@ -614,12 +614,14 @@ impl ParquetFlat {
         row_groups: &[impl Borrow<RowGroupMetaData>],
         column_id: ColumnId,
     ) -> StatValues {
-        let Some(index) = self.column_id_to_sst_index.get(&column_id) else {
-            // No such column in the SST.
+        if !self.column_id_to_sst_index.contains_key(&column_id) {
             return StatValues::NoColumn;
+        }
+        let Some(leaf_index) = self.physical_leaf_index(row_groups, column_id) else {
+            return StatValues::NoStats;
         };
 
-        let stats = column_null_counts(row_groups, *index);
+        let stats = column_null_counts(row_groups, leaf_index);
         StatValues::from_stats_opt(stats)
     }
 
@@ -633,16 +635,46 @@ impl ParquetFlat {
             // No such column in the SST.
             return StatValues::NoColumn;
         };
-        // Safety: `column_id_to_sst_index` is built from `metadata`.
-        let index = self.column_id_to_sst_index.get(&column_id).unwrap();
+        let Some(leaf_index) = self.physical_leaf_index(row_groups, column_id) else {
+            return StatValues::NoStats;
+        };
 
-        let stats = column_values(row_groups, column, *index, is_min);
+        let stats = column_values(row_groups, column, leaf_index, is_min);
         StatValues::from_stats_opt(stats)
+    }
+
+    /// Returns the physical Parquet leaf index for a logical root column.
+    ///
+    /// [`RowGroupMetaData::column`] is indexed by physical leaves, whereas the
+    /// SST schema indexes logical roots. They are equal only while every root
+    /// has one leaf. Nested values such as JSON2 break that assumption and
+    /// shift all following leaf positions. Statistics are only meaningful for a
+    /// root with exactly one leaf; return `None` otherwise to disable pruning
+    /// conservatively.
+    fn physical_leaf_index(
+        &self,
+        row_groups: &[impl Borrow<RowGroupMetaData>],
+        column_id: ColumnId,
+    ) -> Option<usize> {
+        let root_index = *self.column_id_to_sst_index.get(&column_id)?;
+        let row_group = row_groups.first()?.borrow();
+        let schema = row_group.schema_descr();
+        let mut leaves = schema
+            .columns()
+            .iter()
+            .enumerate()
+            .filter_map(|(leaf_index, _)| {
+                (schema.get_column_root_idx(leaf_index) == root_index).then_some(leaf_index)
+            });
+        let leaf_index = leaves.next()?;
+        leaves.next().is_none().then_some(leaf_index)
     }
 }
 
-/// Returns a map that the key is the column id and the value is the column position
-/// in the SST.
+/// Returns a map from column id to logical root-column position in the SST.
+///
+/// This is not a Parquet physical leaf index. Callers accessing
+/// [`RowGroupMetaData::column`] must resolve the root to a unique leaf first.
 /// It only supports SSTs with raw primary key columns.
 pub(crate) fn sst_column_id_indices(metadata: &RegionMetadata) -> HashMap<ColumnId, usize> {
     let mut id_to_index = HashMap::with_capacity(metadata.column_metadatas.len());

--- a/src/mito2/src/sst/parquet/flat_format.rs
+++ b/src/mito2/src/sst/parquet/flat_format.rs
@@ -42,6 +42,7 @@ use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::prelude::{ConcreteDataType, DataType};
 use mito_codec::row_converter::{CompositeValues, PrimaryKeyCodec, build_primary_key_codec};
 use parquet::file::metadata::RowGroupMetaData;
+use parquet::schema::types::SchemaDescriptor;
 use snafu::{OptionExt, ResultExt, ensure};
 use store_api::codec::PrimaryKeyEncoding;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
@@ -508,7 +509,7 @@ impl ParquetPrimaryKeyToFlat {
         });
 
         // Creates a map to lookup index based on the new format.
-        let id_to_index = sst_column_id_indices(&metadata);
+        let id_to_index = sst_column_id_root_indices(&metadata);
         let sst_column_num =
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
 
@@ -561,7 +562,7 @@ struct ParquetFlat {
     /// Projection computed for the flat format.
     format_projection: FormatProjection,
     /// Column id to logical root index in the SST schema.
-    column_id_to_sst_index: HashMap<ColumnId, usize>,
+    column_id_to_root_index: HashMap<ColumnId, usize>,
 }
 
 impl ParquetFlat {
@@ -572,7 +573,7 @@ impl ParquetFlat {
         arrow_schema: SchemaRef,
     ) -> ParquetFlat {
         // Creates a map to lookup index.
-        let id_to_index = sst_column_id_indices(&metadata);
+        let id_to_index = sst_column_id_root_indices(&metadata);
         let sst_column_num =
             flat_sst_arrow_schema_column_num(&metadata, &FlatSchemaOptions::default());
         let format_projection = FormatProjection::compute_format_projection(
@@ -586,7 +587,7 @@ impl ParquetFlat {
             metadata,
             arrow_schema,
             format_projection,
-            column_id_to_sst_index: id_to_index,
+            column_id_to_root_index: id_to_index,
         }
     }
 
@@ -614,10 +615,15 @@ impl ParquetFlat {
         row_groups: &[impl Borrow<RowGroupMetaData>],
         column_id: ColumnId,
     ) -> StatValues {
-        if !self.column_id_to_sst_index.contains_key(&column_id) {
+        if !self.column_id_to_root_index.contains_key(&column_id) {
             return StatValues::NoColumn;
         }
-        let Some(leaf_index) = self.physical_leaf_index(row_groups, column_id) else {
+        let Some(row_group) = row_groups.first() else {
+            return StatValues::NoStats;
+        };
+        let Some(leaf_index) =
+            self.physical_leaf_index(row_group.borrow().schema_descr(), column_id)
+        else {
             return StatValues::NoStats;
         };
 
@@ -635,7 +641,12 @@ impl ParquetFlat {
             // No such column in the SST.
             return StatValues::NoColumn;
         };
-        let Some(leaf_index) = self.physical_leaf_index(row_groups, column_id) else {
+        let Some(row_group) = row_groups.first() else {
+            return StatValues::NoStats;
+        };
+        let Some(leaf_index) =
+            self.physical_leaf_index(row_group.borrow().schema_descr(), column_id)
+        else {
             return StatValues::NoStats;
         };
 
@@ -643,40 +654,24 @@ impl ParquetFlat {
         StatValues::from_stats_opt(stats)
     }
 
-    /// Returns the physical Parquet leaf index for a logical root column.
-    ///
-    /// [`RowGroupMetaData::column`] is indexed by physical leaves, whereas the
-    /// SST schema indexes logical roots. They are equal only while every root
-    /// has one leaf. Nested values such as JSON2 break that assumption and
-    /// shift all following leaf positions. Statistics are only meaningful for a
-    /// root with exactly one leaf; return `None` otherwise to disable pruning
-    /// conservatively.
+    /// Returns the leaf index only when the root has one leaf.
+    /// Returns `None` if it has no leaf or multiple leaves.
     fn physical_leaf_index(
         &self,
-        row_groups: &[impl Borrow<RowGroupMetaData>],
+        schema_descr: &SchemaDescriptor,
         column_id: ColumnId,
     ) -> Option<usize> {
-        let root_index = *self.column_id_to_sst_index.get(&column_id)?;
-        let row_group = row_groups.first()?.borrow();
-        let schema = row_group.schema_descr();
-        let mut leaves = schema
-            .columns()
-            .iter()
-            .enumerate()
-            .filter_map(|(leaf_index, _)| {
-                (schema.get_column_root_idx(leaf_index) == root_index).then_some(leaf_index)
-            });
+        let root_index = *self.column_id_to_root_index.get(&column_id)?;
+        let mut leaves = (0..schema_descr.num_columns())
+            .filter(|&index| schema_descr.get_column_root_idx(index) == root_index);
         let leaf_index = leaves.next()?;
         leaves.next().is_none().then_some(leaf_index)
     }
 }
 
 /// Returns a map from column id to logical root-column position in the SST.
-///
-/// This is not a Parquet physical leaf index. Callers accessing
-/// [`RowGroupMetaData::column`] must resolve the root to a unique leaf first.
 /// It only supports SSTs with raw primary key columns.
-pub(crate) fn sst_column_id_indices(metadata: &RegionMetadata) -> HashMap<ColumnId, usize> {
+pub(crate) fn sst_column_id_root_indices(metadata: &RegionMetadata) -> HashMap<ColumnId, usize> {
     let mut id_to_index = HashMap::with_capacity(metadata.column_metadatas.len());
     let mut column_index = 0;
     // keys

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -899,7 +899,7 @@ mod tests {
     use super::*;
     use crate::error::InvalidMetadataSnafu;
     use crate::sst::parquet::flat_format::{
-        FlatReadFormat, FlatWriteFormat, sequence_column_index, sst_column_id_indices,
+        FlatReadFormat, FlatWriteFormat, sequence_column_index, sst_column_id_root_indices,
     };
     use crate::sst::{
         FlatSchemaOptions, OP_TYPE_PARQUET_FIELD_ID, PRIMARY_KEY_PARQUET_FIELD_ID,
@@ -1100,7 +1100,7 @@ mod tests {
             })
             .primary_key(vec![1]);
         let metadata = Arc::new(builder.build().context(InvalidMetadataSnafu)?);
-        let column_id_to_parquet_index = sst_column_id_indices(&metadata);
+        let column_id_to_parquet_index = sst_column_id_root_indices(&metadata);
         let projection = FormatProjection::compute_format_projection(
             &metadata,
             &column_id_to_parquet_index,

--- a/tests/cases/standalone/common/types/json/json2_statistics_pruning.result
+++ b/tests/cases/standalone/common/types/json/json2_statistics_pruning.result
@@ -1,0 +1,148 @@
+-- Regression coverage for statistics pruning with JSON2 columns.
+--
+-- A time-range query must use the event_time Parquet leaf statistics, not a
+-- JSON2 child leaf that happens to have the same logical root-column index.
+CREATE TABLE json2_statistics_time (
+    workspace_id STRING,
+    session_id STRING,
+    seq BIGINT,
+    entry_kind STRING,
+    payload JSON2,
+    schema_version INT,
+    is_error BOOLEAN,
+    event_time TIMESTAMP TIME INDEX
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+-- event_time has logical root index 7. After JSON2 expansion, physical leaf 7
+-- is payload.ordinal, whose min/max must not be used to prune event_time.
+INSERT INTO json2_statistics_time VALUES
+    ('workspace', 'session-1', 1, 'event', '{"case":"one","ordinal":1}', 1, false, 1704067200000),
+    ('workspace', 'session-2', 2, 'event', '{"case":"two","ordinal":2}', 1, false, 1704153600000),
+    ('workspace', 'session-3', 3, 'event', '{"case":"three","ordinal":3}', 1, false, 1704240000000),
+    ('workspace', 'session-1', 4, 'event', '{"case":"four","ordinal":4}', 1, false, 1704326400000);
+
+Affected Rows: 4
+
+ADMIN FLUSH_TABLE('json2_statistics_time');
+
++--------------------------------------------+
+| ADMIN FLUSH_TABLE('json2_statistics_time') |
++--------------------------------------------+
+| 0                                          |
++--------------------------------------------+
+
+SELECT COUNT(*) AS row_count_without_time_filter FROM json2_statistics_time;
+
++-------------------------------+
+| row_count_without_time_filter |
++-------------------------------+
+| 4                             |
++-------------------------------+
+
+SELECT COUNT(*) AS row_count_with_time_filter
+FROM json2_statistics_time
+WHERE event_time >= 1704067200000
+  AND event_time < 1704412800000;
+
++----------------------------+
+| row_count_with_time_filter |
++----------------------------+
+| 4                          |
++----------------------------+
+
+DROP TABLE json2_statistics_time;
+
+Affected Rows: 0
+
+-- A type-hinted child has a dedicated, typed Parquet leaf. Its predicate must
+-- keep the matching row after a flush.
+CREATE TABLE json2_statistics_type_hint (
+    ts TIMESTAMP TIME INDEX,
+    payload JSON2 (
+        service STRING,
+        latency BIGINT
+    )
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+INSERT INTO json2_statistics_type_hint VALUES
+    (1, '{"service":"api","latency":10}'),
+    (2, '{"service":"api","latency":20}'),
+    (3, '{"service":"api","latency":30}');
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('json2_statistics_type_hint');
+
++-------------------------------------------------+
+| ADMIN FLUSH_TABLE('json2_statistics_type_hint') |
++-------------------------------------------------+
+| 0                                               |
++-------------------------------------------------+
+
+SELECT COUNT(*) AS row_count_with_type_hint_filter
+FROM json2_statistics_type_hint
+WHERE payload.latency >= 20;
+
++---------------------------------+
+| row_count_with_type_hint_filter |
++---------------------------------+
+| 2                               |
++---------------------------------+
+
+DROP TABLE json2_statistics_type_hint;
+
+Affected Rows: 0
+
+-- An unhinted child is stored in the JSON2 v2 remainder. It must remain
+-- filterable after a flush even though it has no dedicated typed leaf.
+CREATE TABLE json2_statistics_remainder (
+    ts TIMESTAMP TIME INDEX,
+    payload JSON2 (
+        service STRING
+    )
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+INSERT INTO json2_statistics_remainder VALUES
+    (1, '{"service":"api","remainder_label":"discard"}'),
+    (2, '{"service":"api","remainder_label":"keep"}'),
+    (3, '{"service":"api","remainder_label":"discard"}');
+
+Affected Rows: 3
+
+ADMIN FLUSH_TABLE('json2_statistics_remainder');
+
++-------------------------------------------------+
+| ADMIN FLUSH_TABLE('json2_statistics_remainder') |
++-------------------------------------------------+
+| 0                                               |
++-------------------------------------------------+
+
+SELECT COUNT(*) AS row_count_with_remainder_filter
+FROM json2_statistics_remainder
+WHERE payload.remainder_label = 'keep';
+
++---------------------------------+
+| row_count_with_remainder_filter |
++---------------------------------+
+| 1                               |
++---------------------------------+
+
+DROP TABLE json2_statistics_remainder;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/types/json/json2_statistics_pruning.sql
+++ b/tests/cases/standalone/common/types/json/json2_statistics_pruning.sql
@@ -1,0 +1,87 @@
+-- Regression coverage for statistics pruning with JSON2 columns.
+--
+-- A time-range query must use the event_time Parquet leaf statistics, not a
+-- JSON2 child leaf that happens to have the same logical root-column index.
+CREATE TABLE json2_statistics_time (
+    workspace_id STRING,
+    session_id STRING,
+    seq BIGINT,
+    entry_kind STRING,
+    payload JSON2,
+    schema_version INT,
+    is_error BOOLEAN,
+    event_time TIMESTAMP TIME INDEX
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+-- event_time has logical root index 7. After JSON2 expansion, physical leaf 7
+-- is payload.ordinal, whose min/max must not be used to prune event_time.
+INSERT INTO json2_statistics_time VALUES
+    ('workspace', 'session-1', 1, 'event', '{"case":"one","ordinal":1}', 1, false, 1704067200000),
+    ('workspace', 'session-2', 2, 'event', '{"case":"two","ordinal":2}', 1, false, 1704153600000),
+    ('workspace', 'session-3', 3, 'event', '{"case":"three","ordinal":3}', 1, false, 1704240000000),
+    ('workspace', 'session-1', 4, 'event', '{"case":"four","ordinal":4}', 1, false, 1704326400000);
+
+ADMIN FLUSH_TABLE('json2_statistics_time');
+
+SELECT COUNT(*) AS row_count_without_time_filter FROM json2_statistics_time;
+
+SELECT COUNT(*) AS row_count_with_time_filter
+FROM json2_statistics_time
+WHERE event_time >= 1704067200000
+  AND event_time < 1704412800000;
+
+DROP TABLE json2_statistics_time;
+
+-- A type-hinted child has a dedicated, typed Parquet leaf. Its predicate must
+-- keep the matching row after a flush.
+CREATE TABLE json2_statistics_type_hint (
+    ts TIMESTAMP TIME INDEX,
+    payload JSON2 (
+        service STRING,
+        latency BIGINT
+    )
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+INSERT INTO json2_statistics_type_hint VALUES
+    (1, '{"service":"api","latency":10}'),
+    (2, '{"service":"api","latency":20}'),
+    (3, '{"service":"api","latency":30}');
+
+ADMIN FLUSH_TABLE('json2_statistics_type_hint');
+
+SELECT COUNT(*) AS row_count_with_type_hint_filter
+FROM json2_statistics_type_hint
+WHERE payload.latency >= 20;
+
+DROP TABLE json2_statistics_type_hint;
+
+-- An unhinted child is stored in the JSON2 v2 remainder. It must remain
+-- filterable after a flush even though it has no dedicated typed leaf.
+CREATE TABLE json2_statistics_remainder (
+    ts TIMESTAMP TIME INDEX,
+    payload JSON2 (
+        service STRING
+    )
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+INSERT INTO json2_statistics_remainder VALUES
+    (1, '{"service":"api","remainder_label":"discard"}'),
+    (2, '{"service":"api","remainder_label":"keep"}'),
+    (3, '{"service":"api","remainder_label":"discard"}');
+
+ADMIN FLUSH_TABLE('json2_statistics_remainder');
+
+SELECT COUNT(*) AS row_count_with_remainder_filter
+FROM json2_statistics_remainder
+WHERE payload.remainder_label = 'keep';
+
+DROP TABLE json2_statistics_remainder;

--- a/tests/cases/standalone/common/types/json/json2_swcs_time_pruning.result
+++ b/tests/cases/standalone/common/types/json/json2_swcs_time_pruning.result
@@ -1,0 +1,103 @@
+-- JSON2 expands into multiple Parquet leaf columns. The time index follows the
+-- JSON2 root column, so SWCS must use the time index's physical leaf position
+-- when applying a time-range predicate to compaction input.
+CREATE TABLE json2_swcs_time_pruning (
+    workspace_id STRING,
+    session_id STRING,
+    seq BIGINT,
+    entry_kind STRING,
+    payload JSON2,
+    schema_version INT,
+    is_error BOOLEAN,
+    event_time TIMESTAMP TIME INDEX
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+Affected Rows: 0
+
+-- The time index has logical root index 7. JSON2 expands to the physical
+-- leaves `remainder.metadata`, `remainder.value`, `case`, and `ordinal`; a
+-- broken root-to-leaf mapping therefore reads `payload.ordinal` as event_time.
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-1', 1, 'event', '{"case":"one","ordinal":1}', 1, false, 1704067200000);
+
+Affected Rows: 1
+
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
++----------------------------------------------+
+| ADMIN FLUSH_TABLE('json2_swcs_time_pruning') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
+
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-2', 2, 'event', '{"case":"two","ordinal":2}', 1, false, 1704153600000);
+
+Affected Rows: 1
+
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
++----------------------------------------------+
+| ADMIN FLUSH_TABLE('json2_swcs_time_pruning') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
+
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-3', 3, 'event', '{"case":"three","ordinal":3}', 1, false, 1704240000000);
+
+Affected Rows: 1
+
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
++----------------------------------------------+
+| ADMIN FLUSH_TABLE('json2_swcs_time_pruning') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
+
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-1', 4, 'event', '{"case":"four","ordinal":4}', 1, false, 1704326400000);
+
+Affected Rows: 1
+
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
++----------------------------------------------+
+| ADMIN FLUSH_TABLE('json2_swcs_time_pruning') |
++----------------------------------------------+
+| 0                                            |
++----------------------------------------------+
+
+SELECT COUNT(*) AS row_count_before_compaction FROM json2_swcs_time_pruning;
+
++-----------------------------+
+| row_count_before_compaction |
++-----------------------------+
+| 4                           |
++-----------------------------+
+
+ADMIN COMPACT_TABLE('json2_swcs_time_pruning', 'swcs', '86400');
+
++-----------------------------------------------------------------+
+| ADMIN COMPACT_TABLE('json2_swcs_time_pruning', 'swcs', '86400') |
++-----------------------------------------------------------------+
+| 0                                                               |
++-----------------------------------------------------------------+
+
+-- This returns fewer than four rows on the buggy path.
+SELECT COUNT(*) AS row_count_after_compaction FROM json2_swcs_time_pruning;
+
++----------------------------+
+| row_count_after_compaction |
++----------------------------+
+| 4                          |
++----------------------------+
+
+DROP TABLE json2_swcs_time_pruning;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/types/json/json2_swcs_time_pruning.sql
+++ b/tests/cases/standalone/common/types/json/json2_swcs_time_pruning.sql
@@ -1,0 +1,44 @@
+-- JSON2 expands into multiple Parquet leaf columns. The time index follows the
+-- JSON2 root column, so SWCS must use the time index's physical leaf position
+-- when applying a time-range predicate to compaction input.
+CREATE TABLE json2_swcs_time_pruning (
+    workspace_id STRING,
+    session_id STRING,
+    seq BIGINT,
+    entry_kind STRING,
+    payload JSON2,
+    schema_version INT,
+    is_error BOOLEAN,
+    event_time TIMESTAMP TIME INDEX
+) WITH (
+    'append_mode' = 'true',
+    'sst_format' = 'flat'
+);
+
+-- The time index has logical root index 7. JSON2 expands to the physical
+-- leaves `remainder.metadata`, `remainder.value`, `case`, and `ordinal`; a
+-- broken root-to-leaf mapping therefore reads `payload.ordinal` as event_time.
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-1', 1, 'event', '{"case":"one","ordinal":1}', 1, false, 1704067200000);
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-2', 2, 'event', '{"case":"two","ordinal":2}', 1, false, 1704153600000);
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-3', 3, 'event', '{"case":"three","ordinal":3}', 1, false, 1704240000000);
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
+INSERT INTO json2_swcs_time_pruning VALUES
+    ('workspace', 'session-1', 4, 'event', '{"case":"four","ordinal":4}', 1, false, 1704326400000);
+ADMIN FLUSH_TABLE('json2_swcs_time_pruning');
+
+SELECT COUNT(*) AS row_count_before_compaction FROM json2_swcs_time_pruning;
+
+ADMIN COMPACT_TABLE('json2_swcs_time_pruning', 'swcs', '86400');
+
+-- This returns fewer than four rows on the buggy path.
+SELECT COUNT(*) AS row_count_after_compaction FROM json2_swcs_time_pruning;
+
+DROP TABLE json2_swcs_time_pruning;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

<!--    
 __!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Describe if this PR will break **API or data compatibility**  (optional)
-->

## PR Checklist
Please convert it to a draft if some of the following conditions are not met.

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [ ] API changes are backward compatible.
- [ ] Schema or data changes are backward compatible.
- [ ] This PR needs to be backported to release branches, and I have added the `backport-<target>` labels (e.g. `backport-v1.3` targets `release/v1.3`).
