### PR TITLE
fix(mito): preserve mixed JSON2 types during compaction

### DIFF
--- a/src/mito2/src/compaction/json2.rs
+++ b/src/mito2/src/compaction/json2.rs
@@ -52,6 +52,8 @@ pub(crate) type Json2RewritePlans = HashMap<String, Json2RewritePlan>;
 #[derive(Clone)]
 struct Json2LeafPathStats {
     rows: u64,
+    /// Number of input schemas that explicitly represent this leaf.
+    sources: usize,
     data_type: JsonNativeType,
     is_type_conflicted: bool,
 }
@@ -59,8 +61,8 @@ struct Json2LeafPathStats {
 /// Builds the JSON2 rewrite plans for a compaction.
 ///
 /// Type hints from current region metadata are always retained. Existing explicit dynamic paths
-/// from all input SST schemas are ranked once to produce a fixed layout; paths found only in a v2
-/// remainder are deliberately not promoted. [`rewrite_json2_batch`] decodes inputs and rewrites
+/// shared by every input SST schema are ranked once to produce a fixed layout; paths that may
+/// reside in a v2 remainder are deliberately not promoted. [`rewrite_json2_batch`] decodes inputs and rewrites
 /// them according to these plans. Non-JSON2 columns are omitted from the returned map.
 ///
 /// Returns an error when a JSON2 column has invalid or missing extension metadata, or when its
@@ -144,6 +146,14 @@ pub(crate) fn collect_json2_rewrite_plans(
             collect_json2_path_stats(field, *rows, &hint_paths, &mut stats)?;
         }
 
+        // A leaf absent from an input's explicit schema may have arbitrary values
+        // (including scalar ancestors) in its remainder. Only common explicit leaves
+        // are safe to promote without inspecting rows. Keep unsafe paths opaque for
+        // the entire output SST so existing readers never miss remainder values when
+        // projecting an explicit leaf.
+        for stat in stats.values_mut() {
+            stat.is_type_conflicted |= stat.sources != schemas.len();
+        }
         let mut hints = settings.type_hints().to_vec();
         hints.extend(select_dynamic_hints(settings, &hint_paths, &stats));
         let target_layout = JsonSettings::try_new(hints, Some(0)).context(DataTypeMismatchSnafu)?;
@@ -187,12 +197,14 @@ fn collect_json2_path_stats<'a>(
                 path,
                 Json2LeafPathStats {
                     rows,
+                    sources: 1,
                     data_type,
                     is_type_conflicted: false,
                 },
             );
             continue;
         };
+        stat.sources += 1;
         if stat.data_type != data_type {
             stat.is_type_conflicted = true;
         } else {
@@ -368,6 +380,7 @@ mod tests {
         )?;
         let stat = |rows, data_type, is_type_conflicted| Json2LeafPathStats {
             rows,
+            sources: 1,
             data_type,
             is_type_conflicted,
         };

--- a/src/mito2/src/engine/scan_test.rs
+++ b/src/mito2/src/engine/scan_test.rs
@@ -392,6 +392,167 @@ async fn test_json2_v1_region_reopen_and_compaction() -> WhateverResult<()> {
 }
 
 #[tokio::test]
+async fn test_json2_mixed_subject_compaction_preserves_values() -> WhateverResult<()> {
+    let request = CreateRequestBuilder::new()
+        .field_datatype(ConcreteDataType::json2(JsonNativeType::Object(
+            JsonObjectType::new(),
+        )))
+        .insert_option("append_mode", "true")
+        .insert_option("memtable.type", "bulk")
+        .insert_option("sst_format", "flat")
+        .build();
+    let table_dir = request.table_dir.clone();
+    let schema = test_util::rows_schema(&request);
+    let mut env = TestEnv::new().await;
+    let engine = env
+        .create_engine(MitoConfig {
+            min_compaction_interval: std::time::Duration::from_secs(3600),
+            ..Default::default()
+        })
+        .await;
+    let region_id = RegionId::new(1027, 0);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await?;
+    // #9133: the second SST stores a heterogeneous subject in its remainder.
+    let values = [
+        json!({"subject": {"cid": "first", "uri": "at://first"}}),
+        json!({"subject": "did:plc:x"}),
+        json!({"subject": {"cid": "last", "uri": "at://last"}}),
+        json!({"subject": {"cid": 42}}),
+    ];
+    for (offset, batch) in [(0, &values[..1]), (1, &values[1..])] {
+        test_util::put_rows(
+            &engine,
+            region_id,
+            Rows {
+                schema: schema.clone(),
+                rows: batch
+                    .iter()
+                    .enumerate()
+                    .map(|(i, value)| {
+                        row(vec![
+                            ValueData::StringValue("tag".into()),
+                            ValueData::JsonValue(encode_json_value(JsonValue::from(value.clone()))),
+                            ValueData::TimestampMillisecondValue((offset + i) as i64 * 1000),
+                        ])
+                    })
+                    .collect(),
+            },
+        )
+        .await;
+        test_util::flush_region(&engine, region_id, None).await;
+    }
+    let old_ids = engine
+        .scanner(region_id, ScanRequest::default())
+        .await?
+        .file_ids();
+    assert_eq!(2, old_ids.len());
+    for _ in 0..2 {
+        engine
+            .handle_request(
+                region_id,
+                RegionRequest::Compact(RegionCompactRequest {
+                    options: compact_request::Options::StrictWindow(StrictWindow {
+                        window_seconds: 86400,
+                    }),
+                    ..Default::default()
+                }),
+            )
+            .await?;
+        let scanner = engine
+            .scanner(
+                region_id,
+                ScanRequest {
+                    projection: Some(vec![1]),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        assert_eq!(
+            1,
+            scanner.num_files(),
+            "a swallowed merge failure must not pass"
+        );
+        assert!(scanner.file_ids().iter().all(|id| !old_ids.contains(id)));
+        let batches = RecordBatches::try_collect(scanner.scan().await?).await?;
+        let mut actual = Vec::new();
+        for batch in batches.iter() {
+            let array = batch.column_by_name("field_0").unwrap().clone();
+            for i in 0..array.len() {
+                actual.push(JsonArray::from(&array).try_get_value(i)?);
+            }
+        }
+        assert_eq!(values.as_slice(), actual.as_slice());
+        reopen_region(&engine, region_id, table_dir.clone(), true, HashMap::new()).await;
+        let scanner = engine
+            .scanner(
+                region_id,
+                ScanRequest {
+                    projection: Some(vec![1]),
+                    json_type_hint: HashMap::from([(
+                        "field_0".into(),
+                        JsonNativeType::Object(JsonObjectType::from([(
+                            "subject".into(),
+                            JsonNativeType::String,
+                        )])),
+                    )]),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let batches = RecordBatches::try_collect(scanner.scan().await?).await?;
+        let mut subjects = Vec::new();
+        for batch in batches.iter() {
+            let array = batch.column_by_name("field_0").unwrap().clone();
+            for i in 0..array.len() {
+                subjects.push(JsonArray::from(&array).try_get_value(i)?);
+            }
+        }
+        let expected = values.iter().map(|value| {
+            let subject = &value["subject"];
+            json!({"subject": subject.as_str().map(str::to_string).unwrap_or_else(|| subject.to_string())})
+        }).collect::<Vec<_>>();
+        assert_eq!(
+            expected, subjects,
+            "projection must read values spilled to remainder"
+        );
+        let scanner = engine
+            .scanner(
+                region_id,
+                ScanRequest {
+                    projection: Some(vec![1]),
+                    json_type_hint: HashMap::from([(
+                        "field_0".into(),
+                        JsonNativeType::Object(JsonObjectType::from([(
+                            "subject".into(),
+                            JsonNativeType::Object(JsonObjectType::from([(
+                                "cid".into(),
+                                JsonNativeType::String,
+                            )])),
+                        )])),
+                    )]),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let batches = RecordBatches::try_collect(scanner.scan().await?).await?;
+        let mut cids = Vec::new();
+        for batch in batches.iter() {
+            let array = batch.column_by_name("field_0").unwrap().clone();
+            for i in 0..array.len() {
+                cids.push(JsonArray::from(&array).try_get_value(i)?["subject"]["cid"].clone());
+            }
+        }
+        assert_eq!(
+            vec![json!("first"), json!(null), json!("last"), json!("42")],
+            cids
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_flush_aligns_different_json2_layouts() -> WhateverResult<()> {
     let mut request = CreateRequestBuilder::new()
         .field_datatype(ConcreteDataType::json2(JsonNativeType::Object(

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -1807,7 +1807,7 @@ mod tests {
         let second = mock_bulk_part_with_json2_values(
             &metadata,
             vec![3000, 4000],
-            vec![json!({"b": 3}), json!({"b": 4})],
+            vec![json!({"a": 3, "b": 3}), json!({"a": 4, "b": 4})],
             200,
         )?;
         let parts = vec![
@@ -1879,9 +1879,15 @@ mod tests {
             unreachable!()
         };
         assert_eq!(
-            vec![JSON2_REMAINDER_FIELD_NAME, "a", "b"],
+            vec![JSON2_REMAINDER_FIELD_NAME],
             fields.iter().map(|x| x.name().as_str()).collect::<Vec<_>>()
         );
+        // Neither path is explicit in every source; keep both opaque without losing values.
+        let json = datatypes::vectors::json::array::JsonArray::from(batch.column(0));
+        let restored = json.project_to_v2(schema.field(0), &ArrowDataType::Binary)?;
+        let restored = datatypes::vectors::json::array::JsonArray::from(&restored);
+        assert_eq!(json!({"a": 1}), restored.try_get_value(0)?);
+        assert_eq!(json!({"a": 2}), restored.try_get_value(1)?);
         Ok(())
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #9133

## What changed and what is the intention?

JSON2 compaction previously selected dynamic explicit paths from the union of input schemas. An absent explicit path may still contain incompatible values, or scalar ancestors, in another input remainder. Rewriting those values into the selected struct layout fails.

Count how many input schemas explicitly represent each dynamic leaf and retain it only when every input represents it with a compatible type. Preserve all other dynamic paths in the existing v2 remainder. User-defined type hints remain unchanged. The shared planner also handles bulk memtable merges; their layout tests are updated accordingly.

This deliberately uses conservative whole-output layout selection rather than per-row NULL/remainder fallback: existing readers may skip the remainder when projecting an explicit leaf, so per-row fallback could hide values. Sparse but compatible paths may consequently lose columnar expansion. This fix adds no dependencies, configuration options, or physical-format version changes.

The engine regression verifies actual replacement of two SSTs with one, complete JSON value preservation, repeated compaction, close/reopen, and container/nested-leaf projections for object/string and nested string/number values. It cannot pass solely because the legacy compactor swallows a merge error.

### Validation

Passed:
- `make fmt` (no resulting changes)
- `make clippy` (workspace, all targets, all features, warnings denied)
- `cargo nextest run -p mito2 --no-fail-fast`: 1,358 passed
- `cargo sqlness bare -t jsonbench`: standalone and distributed passed; no result-file changes
- `git diff --check`

Full verification is blocked by local disk exhaustion, so this PR is a draft:
- `make test` failed during compilation/linking with `No space left on device` and mold output-write failures. `/solidigm` reached 100% usage. This was not a test assertion failure.
- `make check-udeps` and the full `cargo sqlness bare` run have not run because the validation chain stopped at the failed build. They remain pending after disk space is freed.

## PR Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
- [x] API changes are backward compatible.
- [x] Schema or data changes are backward compatible.
- [x] This PR needs to be backported to release branches, and I have added the matching backport labels.